### PR TITLE
Move npm install in build step

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -57,6 +57,9 @@ docker-build: ## Build the Docker image
 run: check-node node_modules ## Run fred-ui front-end locally
 	npm run dev
 
+run-only:
+	npm run dev
+
 .PHONY: docker-run
 docker-run: ## Docker run
 	docker run -it --rm \

--- a/frontend/dockerfiles/Dockerfile-dev
+++ b/frontend/dockerfiles/Dockerfile-dev
@@ -11,6 +11,15 @@ ARG GROUP_ID=1000
 RUN apt-get update && \
     apt-get install -y make git
 
+# Move to project directory
+WORKDIR /app
+
+# Copy only package files first for cache efficiency
+COPY ../package*.json ./
+
+# Install node modules (at build time)
+RUN npm install
+
 # Copy project files
 COPY .. /app
 
@@ -31,4 +40,4 @@ EXPOSE 5173
 
 # Make run
 ENTRYPOINT ["make"]
-CMD ["run"]
+CMD ["run-only"]


### PR DESCRIPTION
Because the instanciation of a pod can lock when npm install is done on launch of pod + it makes the instanciation faster.