### PR TITLE
feat : in memory and opensearch monitoring API

### DIFF
--- a/agentic_backend/app/core/chatbot/chat_schema.py
+++ b/agentic_backend/app/core/chatbot/chat_schema.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Literal, Optional, List, Dict, Union
+from typing import Literal, Optional, List, Dict, Union, Any
 from datetime import datetime
 from pydantic import BaseModel, Field
 
@@ -86,6 +86,17 @@ class ChatMessagePayload(BaseModel):
             ]
         self.metadata.update(extra)
         return self
+    
+
+class MetricsBucket(BaseModel):
+    timestamp: str  # truncated timestamp (per precision)
+    group: Dict[str, Any]
+    aggregations: Dict[str, Union[float, List[float]]]
+
+
+class MetricsResponse(BaseModel):
+    precision: str
+    buckets: List[MetricsBucket]
 
 
 # --- Session structure ---

--- a/agentic_backend/app/core/chatbot/chatbot_controller.py
+++ b/agentic_backend/app/core/chatbot/chatbot_controller.py
@@ -15,7 +15,7 @@
 from enum import Enum
 import json
 import logging
-from typing import List
+from typing import List, Dict
 
 from app.core.agents.agent_manager import AgentManager
 from app.core.agents.structures import AgenticFlow
@@ -27,6 +27,7 @@ from app.core.chatbot.chat_schema import (
     SessionWithFiles,
     StreamEvent,
 )
+from app.core.chatbot.chat_schema import MetricsResponse
 from app.core.chatbot.chatbot_error import ChatBotError
 from fastapi import (
     APIRouter,
@@ -37,6 +38,8 @@ from fastapi import (
     UploadFile,
     WebSocket,
     WebSocketDisconnect,
+    Query,
+    HTTPException,
 )
 
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -328,3 +331,42 @@ class ChatbotController:
             return await self.session_manager.upload_file(
                 user_id, session_id, agent_name, file
             )
+        
+        @app.get(
+            "/metrics/chatbot/numerical",
+            summary="Get aggregated numerical chatbot metrics",
+            tags=fastapi_tags,
+            response_model=MetricsResponse,
+        )
+        def get_node_numerical_metrics(
+                start: str,
+                end: str,
+                precision: str = "hour",
+                agg: List[str] = Query(default=[]),
+                groupby: List[str] = Query(default=[]),
+                user: KeycloakUser = Depends(get_current_user),
+            ):
+                SUPPORTED_OPS = {"mean", "sum", "min", "max", "values"}
+                agg_mapping: Dict[str, List[str]] = {}
+
+                for item in agg:
+                    if ":" not in item:
+                        raise HTTPException(400, detail=f"Invalid agg parameter format: {item}")
+                    field, op = item.split(":")
+                    if op not in SUPPORTED_OPS:
+                        raise HTTPException(400, detail=f"Unsupported aggregation op: {op}")
+                    if field not in agg_mapping:
+                        agg_mapping[field] = []
+                    agg_mapping[field].append(op)
+
+                logger.info(agg_mapping)
+
+                return self.session_manager.get_metrics(
+                    start=start,
+                    end=end,
+                    precision=precision,
+                    groupby=groupby,
+                    agg_mapping=agg_mapping,
+                    user_id=user.uid
+                    )
+

--- a/agentic_backend/app/core/chatbot/chatbot_utils.py
+++ b/agentic_backend/app/core/chatbot/chatbot_utils.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List
 from app.core.chatbot.chat_schema import ChatMessagePayload
 from collections import defaultdict
 from datetime import datetime
-import logging
+from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +76,12 @@ def enrich_ChatMessagePayloads_with_latencies(
         enriched_list.extend(msgs)
 
     return enriched_list
+
+def parse_date(date_str: str) -> datetime:
+    try:
+        return datetime.fromisoformat(date_str)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid date format: '{date_str}'. Expected ISO 8601 format (e.g., '2025-08-04T15:00:00')."
+        )

--- a/agentic_backend/app/core/session/session_manager.py
+++ b/agentic_backend/app/core/session/session_manager.py
@@ -33,6 +33,7 @@ from app.core.chatbot.chat_schema import (
     SessionWithFiles,
     clean_agent_metadata,
     clean_token_usage,
+    MetricsResponse,
 )
 from app.core.chatbot.chatbot_utils import enrich_ChatMessagePayloads_with_latencies
 from app.core.session.stores.abstract_session_backend import AbstractSessionStorage
@@ -544,3 +545,22 @@ class SessionManager:
         except Exception as e:
             logger.exception(e)
             raise RuntimeError("Failed to store uploaded file.")
+        
+    def get_metrics(
+        self,
+        start: str,
+        end: str,
+        user_id: str,
+        precision: str,
+        groupby: List[str],
+        agg_mapping: Dict[str, List[str]],
+    ) -> List[MetricsResponse]:
+        return self.storage.get_metrics(
+            start=start,
+            end=end,
+            precision=precision,
+            groupby=groupby,
+            agg_mapping=agg_mapping,
+            user_id=user_id)
+
+

--- a/agentic_backend/app/core/session/stores/abstract_session_backend.py
+++ b/agentic_backend/app/core/session/stores/abstract_session_backend.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Dict
 from abc import ABC, abstractmethod
+from datetime import datetime
 
-from app.core.chatbot.chat_schema import ChatMessagePayload, SessionSchema
+from app.core.chatbot.chat_schema import ChatMessagePayload, SessionSchema, MetricsResponse
 
 
 class AbstractSessionStorage(ABC):
@@ -58,5 +59,18 @@ class AbstractSessionStorage(ABC):
     def get_message_history(
         self, session_id: str, user_id: str
     ) -> List[ChatMessagePayload]:
+        """Retrieve messages for a given session."""
+        pass
+
+    @abstractmethod
+    def get_metrics(
+        self,
+        start: str,
+        end: str,
+        user_id: str,
+        precision: str,
+        groupby: List[str],
+        agg_mapping: Dict[str, List[str]],
+    ) -> List[MetricsResponse]:
         """Retrieve messages for a given session."""
         pass

--- a/agentic_backend/app/core/session/stores/in_memory_session_store.py
+++ b/agentic_backend/app/core/session/stores/in_memory_session_store.py
@@ -14,13 +14,17 @@
 
 import logging
 from typing import Dict, List
+from dateutil.parser import isoparse
+from collections import defaultdict
+from statistics import mean
 
 from app.core.session.stores.abstract_session_backend import AbstractSessionStorage
 from app.core.session.stores.abstract_user_authentication_backend import (
     AbstractSecuredResourceAccess,
 )
 from app.core.session.session_manager import SessionSchema
-from app.core.chatbot.chat_schema import ChatMessagePayload
+from app.core.chatbot.chat_schema import ChatMessagePayload, MetricsBucket, MetricsResponse
+from app.core.session.stores.utils import flatten_message, truncate_datetime
 from app.common.error import AuthorizationSentinel, SESSION_NOT_INITIALIZED
 from app.common.utils import authorization_required
 
@@ -85,3 +89,65 @@ class InMemorySessionStorage(AbstractSessionStorage, AbstractSecuredResourceAcce
     ) -> List[ChatMessagePayload]:
         history = self.history.get(session_id, [])
         return sorted(history, key=lambda m: m.rank if m.rank is not None else 0)
+
+    def get_metrics(
+        self,
+        start: str,
+        end: str,
+        user_id: str,
+        precision: str,
+        groupby: List[str],
+        agg_mapping: Dict[str, str],
+    ) -> MetricsResponse:
+        start_dt = isoparse(start)
+        end_dt = isoparse(end)
+
+        grouped = defaultdict(list)
+
+        for session_messages in self.history.values():
+            for msg in session_messages:
+                if msg.type == "human":
+                    continue
+
+                msg_dt = isoparse(msg.timestamp)
+                if not (start_dt <= msg_dt <= end_dt):
+                    continue
+
+                flat = flatten_message(msg)
+                bucket_time = truncate_datetime(msg_dt, precision)
+                flat["timestamp"] = bucket_time.isoformat()
+
+                group_key = (flat["timestamp"], *(flat.get(g) for g in groupby))
+                grouped[group_key].append(flat)
+
+        buckets = []
+        for key, group in grouped.items():
+            timestamp = key[0]
+            group_values = {g: v for g, v in zip(groupby, key[1:])}
+            aggs = {}
+
+            for field, ops in agg_mapping.items():
+                values = [row.get(field) for row in group if row.get(field) is not None]
+                if not values:
+                        continue
+                for op in ops:
+                    match op:
+                        case "sum":
+                            aggs[field+"_sum"] = sum(values)
+                        case "min":
+                            aggs[field+"_min"] = min(values)
+                        case "max":
+                            aggs[field+"_max"] = max(values)
+                        case "mean":
+                            aggs[field+"_mean"] = mean(values)
+                        case "values":
+                            aggs[field+"_values"] = values
+                        case _:
+                            raise ValueError(f"Unsupported aggregation op: {op}")
+
+            buckets.append(MetricsBucket(timestamp=timestamp, group=group_values, aggregations=aggs))
+
+        return MetricsResponse(precision=precision, buckets=buckets)
+
+
+

--- a/agentic_backend/app/core/session/stores/opensearch_session_store.py
+++ b/agentic_backend/app/core/session/stores/opensearch_session_store.py
@@ -13,14 +13,18 @@
 # limitations under the License.
 
 import logging
-from typing import List
+from typing import List, Optional, Dict
+from dateutil.parser import isoparse
+from collections import defaultdict
+from statistics import mean
 from opensearchpy import OpenSearch, RequestsHttpConnection
 from app.core.session.stores.abstract_session_backend import AbstractSessionStorage
 from app.core.session.stores.abstract_user_authentication_backend import (
     AbstractSecuredResourceAccess,
 )
 from app.core.session.session_manager import SessionSchema
-from app.core.chatbot.chat_schema import ChatMessagePayload
+from app.core.chatbot.chat_schema import ChatMessagePayload, MetricsResponse, MetricsBucket
+from app.core.session.stores.utils import flatten_message, truncate_datetime
 from app.common.utils import authorization_required
 from app.common.error import AuthorizationSentinel, SESSION_NOT_INITIALIZED
 
@@ -159,3 +163,92 @@ class OpensearchSessionStorage(AbstractSessionStorage, AbstractSecuredResourceAc
         except Exception as e:
             logger.error(f"Failed to retrieve messages for session {session_id}: {e}")
             return []
+        
+
+    def get_metrics(
+        self,
+        start: str,
+        end: str,
+        user_id: str,
+        groupby: List[str],
+        agg_mapping: Dict[str, List[str]],
+        precision: str,
+    ) -> MetricsResponse:
+
+        try:
+            # 1. Search messages in date range
+            query = {
+                "query": {
+                    "range": {
+                        "timestamp": {
+                            "gte": start,
+                            "lte": end,
+                            "format": "strict_date_optional_time"
+                        }
+                    }
+                },
+                "sort": [{"rank": {"order": "asc", "unmapped_type": "integer"}}],
+                "size": 10000,
+            }
+
+            response = self.client.search(index=self.history_index, body=query)
+            hits = response["hits"]["hits"]
+
+            # 2. Filter and flatten AI messages
+            flattened = []
+            for hit in hits:
+                msg = ChatMessagePayload(**hit["_source"])
+                if msg.type != "ai":
+                    continue
+                flat = flatten_message(msg)
+                flat["_datetime"] = isoparse(flat["timestamp"])
+                flat["_bucket"] = truncate_datetime(flat["_datetime"], precision)
+                flattened.append(flat)
+
+            # 3. Group by (bucket_time, groupby fields)
+            grouped = defaultdict(list)
+            for row in flattened:
+                group_key = tuple([row["_bucket"]] + [row.get(f) for f in groupby])
+                grouped[group_key].append(row)
+
+            # 4. Aggregate
+            buckets = []
+            
+            for key, group in grouped.items():
+                bucket_time = key[0]
+                group_fields = {field: value for field, value in zip(groupby, key[1:])}
+                aggs = {}
+
+                for field, ops in agg_mapping.items():
+                    values = [row.get(field) for row in group if row.get(field) is not None]
+                    if not values:
+                            continue
+                    for op in ops:
+                        match op:
+                            case "sum":
+                                aggs[field+"_sum"] = sum(values)
+                            case "min":
+                                aggs[field+"_min"] = min(values)
+                            case "max":
+                                aggs[field+"_max"] = max(values)
+                            case "mean":
+                                aggs[field+"_mean"] = mean(values)
+                            case "values":
+                                aggs[field+"_values"] = values
+                            case _:
+                                raise ValueError(f"Unsupported aggregation op: {op}")
+
+                buckets.append(
+                    MetricsBucket(
+                        timestamp=bucket_time if isinstance(bucket_time, str) else bucket_time.isoformat(),
+                        group=group_fields,
+                        aggregations=aggs
+                    )
+                )
+
+            return MetricsResponse(precision=precision, buckets=buckets)
+
+        except Exception as e:
+            logger.error(f"Failed to compute metrics: {e}")
+            return MetricsResponse(precision=precision, buckets=[])
+

--- a/agentic_backend/app/core/session/stores/utils.py
+++ b/agentic_backend/app/core/session/stores/utils.py
@@ -1,0 +1,34 @@
+from app.core.chatbot.chat_schema import ChatMessagePayload
+from datetime import datetime
+
+def truncate_datetime(dt: datetime, precision: str) -> datetime:
+    if precision == "minute":
+        return dt.replace(second=0, microsecond=0)
+    elif precision == "hour":
+        return dt.replace(minute=0, second=0, microsecond=0)
+    elif precision == "day":
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    else:
+        raise ValueError(f"Unsupported precision: {precision}")
+
+
+def flatten_message(msg: ChatMessagePayload) -> dict:
+    flat = {
+        "timestamp": msg.timestamp,
+        "session_id": msg.session_id,
+        "exchange_id": msg.exchange_id,
+        "type": msg.type,
+        "sender": msg.sender,
+        "rank": msg.rank,
+        "subtype": msg.subtype,
+    }
+
+    # Ajout des champs de metadata en top-level
+    for k, v in (msg.metadata or {}).items():
+        if isinstance(v, dict):
+            for sub_k, sub_v in v.items():
+                flat[f"{k}.{sub_k}"] = sub_v
+        else:
+            flat[k] = v
+
+    return flat


### PR DESCRIPTION
**Adding a new api endpoint that look like the old **
exemple of request : http://localhost:8000/agentic/v1/metrics/chatbot/numerical?start=2025-08-04T00:00:00&end=2025-10-04T23:59:59&groupby=agent_name&precision=hour&agg=token_usage.output_tokens:sum&agg=latency_seconds:mean