### PR TITLE
fix: Update fred Chart to include support for enabling or disabling the GPU passthrough for doc processing

### DIFF
--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -506,6 +506,8 @@ applications:
           description: "Personal local documents available for pull-mode ingestion"
       embedding:
         type: "openai"
+        use_gpu: True
+        process_images: True
       storage:
         postgres:
           host: localhost


### PR DESCRIPTION
And config.embedding.process_images as well