### PR TITLE
fix: adapt filter to new metadata format + fix openearch filter handling

### DIFF
--- a/knowledge_flow_backend/app/features/metadata/controller.py
+++ b/knowledge_flow_backend/app/features/metadata/controller.py
@@ -179,7 +179,7 @@ class MetadataController:
 
             if config.type == "push":
                 filters = req.filters or {}
-                filters["source_tag"] = req.source_tag
+                filters["source"] = {"source_tag": req.source_tag}
                 docs = self.service.get_documents_metadata(user, filters)
                 sort_by = req.sort_by or [SortOption(field="document_name", direction="asc")]
 


### PR DESCRIPTION
changes:
- Adapted filter to new document mettadata format (aka: now `source_tag` is in `source`, not at root)
- Fixed opensearch filter handling: as openearch stores metadata flattened (`source.source_tag` as `source`), I handled this when filtering