### PR TITLE
Add documents count for collection

### DIFF
--- a/frontend/src/components/documents/libraries/DocumentLibraryTree.tsx
+++ b/frontend/src/components/documents/libraries/DocumentLibraryTree.tsx
@@ -185,7 +185,7 @@ export function DocumentLibraryTree({
                 setSelectedFolder(isSelected ? null : c.full); // toggle
               }}
             >
-              {/* Left: tri-state + folder icon + name */}
+              {/* Left: tri-state + folder icon + name + count */}
               <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0, flex: 1 }}>
                 <Checkbox
                   size="small"
@@ -200,6 +200,25 @@ export function DocumentLibraryTree({
                 />
                 {isExpanded ? <FolderOpenOutlinedIcon fontSize="small" /> : <FolderOutlinedIcon fontSize="small" />}
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.name}</span>
+                <Tooltip key={`${c.name}_count`} title={`${docsHere.length} Documents`} arrow>
+                  <Box
+                    sx={{
+                      bgcolor: "#e0e0e0",
+                      color: "#757575",
+                      width: "auto",
+                      height: 18,
+                      paddingLeft: 1.2,
+                      paddingRight: 1.2,
+                      borderRadius: 25,
+                      fontSize: "0.6rem",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {docsHere.length}
+                  </Box>
+                </Tooltip>
               </Box>
 
               {/* Right: share + delete */}


### PR DESCRIPTION
Add count pill for collections on ingestion page

<img width="585" height="311" alt="2025-11-26_09-53" src="https://github.com/user-attachments/assets/bbb1b435-e5a4-4760-a8fe-edb0abcda691" />

Bug to fix :
With lot of documents in collection, there is a dead lock for some seconds at page loading.
Tree list need skeleton/spinner mechanism at loading