### PR TITLE
Use .env for CONFIG_FILE variable

### DIFF
--- a/agentic-backend/config/.env.template
+++ b/agentic-backend/config/.env.template
@@ -1,5 +1,11 @@
 # This file contains the secret and access keys environment variables
 
+# -----------------------------------------------------------------------------
+# CONFIGURATION
+# -----------------------------------------------------------------------------
+
+CONFIG_FILE="./config/configuration.yaml"
+
 # Keycloak Agentic Token so that agentic can succesfully invoke
 # the knowledge-flow backend if keycloak is on.
 

--- a/agentic-backend/config/configuration_local.yaml
+++ b/agentic-backend/config/configuration_local.yaml
@@ -62,20 +62,18 @@ ai:
     connect: 5 # Time to wait for a connection in seconds
     read: 15 # Time to wait for a response in seconds
   default_chat_model:
-    # Required in .env:
-    # - OPENAI_API_KEY
     provider: "ollama"
     name: "granite4:3b-h"
     settings:
+      base_url: http://localhost:11434
       temperature: 0.0
       max_retries: 2
       request_timeout: 30
   default_language_model:
-    # Required in .env:
-    # - OPENAI_API_KEY
     provider: "ollama"
     name: "granite4:3b-h"
     settings:
+      base_url: http://localhost:11434
       temperature: 0.0
       max_retries: 2
       request_timeout: 30

--- a/knowledge-flow-backend/config/configuration_local.yaml
+++ b/knowledge-flow-backend/config/configuration_local.yaml
@@ -76,37 +76,11 @@ embedding_model:
   name: bge-m3:latest
   settings:
     base_url: http://localhost:11434
-# Configuration for the LLM used for summary, keyword generation
-# and other text generation tasks.
-#chat_model:
-#  provider: openai # openai | azure | ollama
-#  name: gpt-4o-mini # azure: deployment name, ollama: 'qwen2.5:3b-instruct' etc.
 chat_model:
   provider: ollama
   name: granite4:3b-h
   settings:
     base_url: http://localhost:11434
-#      temperature: 0.7                # optional, forwarded to LangChain Ollama wrapper
-# chat_model:
-#   provider: azure
-#   # azure use deployment name instead of a plain model name as OpenAI does. The principle
-#   # is the same.
-#   name: fred-gpt-4o              # Azure deployment name for your chat model
-#   settings:
-#     azure_endpoint: https://<your-azure-openai>.openai.azure.com
-#     api_version: 2024-05-01-preview
-# chat_model:
-#   provider: azure-apim        # openai | azure | ollama
-#   # azure use deployment name instead of a plain model name as openai. The principle
-#   # is the same.
-#   name: fred-gpt-4o       # azure: deployment name, ollama: 'qwen2.5:3b-instruct' etc.
-#   settings:
-#     azure_ad_client_id: "5e5d67c9-22af-4044-bc8e-5df58d7a5e6e"
-#     azure_ad_client_scope: "api://5e5d67c9-22af-4044-bc8e-5df58d7a5e6e/.default"
-#     azure_apim_base_url: "https://tehopenai.openai.azure.com/"
-#     azure_apim_resource_path: "/genai-aoai-inference/v2"
-#     azure_openai_api_version: "2024-06-01"
-#     azure_tenant_id: "737c6905-f186-4bcf-afb3-43e349ee23a3"
 storage:
   postgres:
     host: localhost

--- a/scripts/makefiles/python-vars.mk
+++ b/scripts/makefiles/python-vars.mk
@@ -12,7 +12,8 @@ UV?=$(VENV)/bin/uv
 # Needed env variable to start app
 ROOT_DIR := $(realpath $(CURDIR))
 export ENV_FILE ?= $(ROOT_DIR)/config/.env
-export CONFIG_FILE ?= $(ROOT_DIR)/config/configuration.yaml
-export CONFIG_FILE_PROD ?= $(ROOT_DIR)/config/configuration_prod.yaml
-export CONFIG_FILE_ACADEMY ?= $(ROOT_DIR)/config/configuration_academy.yaml
+#TO DETELE because of redefined in .env
+#export CONFIG_FILE ?= $(ROOT_DIR)/config/configuration.yaml
+#export CONFIG_FILE_PROD ?= $(ROOT_DIR)/config/configuration_prod.yaml
+#export CONFIG_FILE_ACADEMY ?= $(ROOT_DIR)/config/configuration_academy.yaml
 export LOG_LEVEL ?= info


### PR DESCRIPTION
.env and config improvement.
Makefile takes precedence on .env before. It was annoying because CONFIG_FILE variable can be define in user environment as well as in .env file.

Docker container shall use this .env too ! (To be verified)