### PR TITLE
fix: Give CRUD rights to viewer and editor for filesystem endpoint

### DIFF
--- a/fred-core/fred_core/security/rbac.py
+++ b/fred-core/fred_core/security/rbac.py
@@ -62,6 +62,8 @@ class RBACProvider(AuthorizationProvider):
                 Resource.MESSAGE_ATTACHMENTS: {Action.CREATE},
                 Resource.USER: READ_ONLY,
                 Resource.GROUP: READ_ONLY,
+                # Editor can create and use files in the filesystem endpoint
+                Resource.FILES: CRUD,
             },
             "viewer": {
                 # Viewer can only read
@@ -74,6 +76,8 @@ class RBACProvider(AuthorizationProvider):
                 Resource.PROMPT_COMPLETIONS: {Action.CREATE},
                 # Viewer can create and use Chat Context (resources)
                 Resource.RESOURCES: CRUD,
+                # Viewer can create and use files in the filesystem endpoint
+                Resource.FILES: CRUD,
             },
             "service_agent": {
                 Resource.TAGS: READ_ONLY,


### PR DESCRIPTION
No problem because the filesystem is sandboxed so a user only has access to files in its folder