### PR TITLE
feat: remame default agentic secret m2m env var to be coherent with KF

### DIFF
--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -185,6 +185,7 @@ applications:
           enabled: true
           client_id: "agentic"
           realm_url: "http://idp.dev.fred.thalesgroup.com/realms/app"
+          secret_env_var: KEYCLOAK_AGENTIC_CLIENT_SECRET
         user:
           enabled: true
           client_id: "app"


### PR DESCRIPTION
In the values, KF values we have `KEYCLOAK_KNOWLEDGE_FLOW_CLIENT_SECRET` but agentic doesn't have it and use `M2M_CLIENT_SECRET` by default. This PR fix this disparity.