### PR TITLE
#1335 Fix Dev Container and the main README

### DIFF
--- a/.devcontainer/Dockerfile-devcontainer
+++ b/.devcontainer/Dockerfile-devcontainer
@@ -18,6 +18,7 @@ RUN apt-get update && \
     jq \
     less \
     libffi-dev \
+    libmagic-dev \
     libpq-dev \
     libsqlite3-dev \
     libssl-dev \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -86,7 +86,7 @@
         "editor.formatOnSave": true,
         "python.linting.enabled": true,
         "python.testing.pytestEnabled": true,
-        "python.defaultInterpreterPath": "${workspaceFolder}/agentic-backend/.venv/bin/python",
+        "python.defaultInterpreterPath": "/workspaces/fred/agentic-backend/.venv/bin/python",
         "terminal.integrated.defaultProfile.linux": "bash"
       }
     }

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ cd knowledge-flow-backend && make run
 
 ```bash
 # agentic backend
-cd agentic_backend && make run
+cd agentic-backend && make run
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ When the terminal prompt appears, the workspace is ready but you still need to r
 | SQLite       | Local RDBMS engine         | ≥ 3.35.0                                                                                            | Install via system package manager                                                          |
 | Pandoc       | 2.9.2.1                    | [Pandoc installation instructions](https://pandoc.org/installing.html)                              | For DOCX document ingestion                                                                 |
 | LibreOffice  | Headless doc converter     | [LibreOffice installation instructions](https://www.libreoffice.org/download/download-libreoffice/) | For PPTX conversion into PDF                                                                |
+| libmagic     | Identifies file types by content | Install via system package manager (e.g., `apt install libmagic1`, `brew install libmagic`)         | To check file type                                                                          |
 
   <details>
     <summary>Dependency details</summary>
@@ -139,6 +140,7 @@ graph TD
         Python["Python 3.12.8"]
         SQLite["SQLite"]
         Pandoc["Pandoc"]
+        libmagic["libmagic"]
         Pyenv["Pyenv (Python installer)"]
         Node["Node 22.13.0"]
         NVM["nvm (Node installer)"]
@@ -158,6 +160,7 @@ graph TD
     Knowledge -->|depends on| Venv
     Knowledge -->|depends on| Pandoc
     Knowledge -->|depends on| SQLite
+    Knowledge -->|depends on| libmagic
 
     Frontend -->|depends on| Node
 


### PR DESCRIPTION
I'm proposing some quick fixes to enhance the onboarding.

- Dev Container misses `libmagic` to run the knowledge flow backend.
- Dev Container shows a warning telling it's not able to find the default Python interperter's path.
- The main readme has a typo in "Start Fred Component" section in the path of a command.