### PR TITLE
1339 docx table content is split by character chunking no table protection markers causing partial retrieval

### DIFF
--- a/knowledge-flow-backend/config/configuration.yaml
+++ b/knowledge-flow-backend/config/configuration.yaml
@@ -209,8 +209,8 @@ document_sources:
     base_path: ~/Documents/Fred
     description: "Personal local documents available for pull-mode ingestion"
 embedding_model:
-  provider: ollama
-  name: granite-embedding:278m-fp16
+  provider: openai
+  name: text-embedding-3-large
   settings:
     max_retries: 0
     timeout:

--- a/knowledge-flow-backend/config/configuration.yaml
+++ b/knowledge-flow-backend/config/configuration.yaml
@@ -32,6 +32,10 @@ processing:
       use_gpu: true
       generate_summary: false
       process_images: false
+      text_splitter:
+        chunk_size: 1500
+        chunk_overlap: 150
+        preserve_tables: true
       pdf:
         backend: pypdfium2
         images_scale: 1.0
@@ -75,6 +79,10 @@ processing:
       use_gpu: true
       generate_summary: false
       process_images: false
+      text_splitter:
+        chunk_size: 1500
+        chunk_overlap: 150
+        preserve_tables: true
       pdf:
         backend: docling_parse
         images_scale: 2.0
@@ -118,6 +126,10 @@ processing:
       use_gpu: true
       generate_summary: false
       process_images: true
+      text_splitter:
+        chunk_size: 1500
+        chunk_overlap: 150
+        preserve_tables: true
       pdf:
         backend: docling_parse
         images_scale: 2.0
@@ -197,8 +209,8 @@ document_sources:
     base_path: ~/Documents/Fred
     description: "Personal local documents available for pull-mode ingestion"
 embedding_model:
-  provider: openai
-  name: text-embedding-3-large
+  provider: ollama
+  name: granite-embedding:278m-fp16
   settings:
     max_retries: 0
     timeout:

--- a/knowledge-flow-backend/knowledge_flow_backend/application_context.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/application_context.py
@@ -1006,7 +1006,16 @@ class ApplicationContext:
         Factory method to create a text splitter instance based on configuration.
         Currently returns RecursiveSplitter.
         """
-        return SemanticSplitter()
+        from knowledge_flow_backend.common.processing_profile_context import get_current_processing_profile
+
+        profile = get_current_processing_profile()
+        profile_cfg = self.configuration.processing.get_profile_config(profile)
+        splitter_cfg = profile_cfg.text_splitter
+        return SemanticSplitter(
+            chunk_size=splitter_cfg.chunk_size,
+            chunk_overlap=splitter_cfg.chunk_overlap,
+            preserve_tables=splitter_cfg.preserve_tables,
+        )
 
     def get_pull_provider(self, source_tag: str) -> BaseContentLoader:
         source_config = self.configuration.document_sources.get(source_tag)

--- a/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -266,6 +266,24 @@ VectorStorageConfig = Annotated[
 class ProcessingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    class TextSplitterConfig(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        chunk_size: int = Field(
+            default=1500,
+            ge=1,
+            description="Maximum number of characters per chunk for text splitting.",
+        )
+        chunk_overlap: int = Field(
+            default=150,
+            ge=0,
+            description="Number of overlapping characters between consecutive chunks.",
+        )
+        preserve_tables: bool = Field(
+            default=True,
+            description="If true, keep annotated markdown tables intact (do not split by size).",
+        )
+
     class PdfPipelineConfig(BaseModel):
         model_config = ConfigDict(extra="forbid")
 
@@ -322,6 +340,10 @@ class ProcessingConfig(BaseModel):
         pdf: "ProcessingConfig.PdfPipelineConfig" = Field(
             default_factory=lambda: ProcessingConfig.PdfPipelineConfig(),
             description="PDF processing options for this profile.",
+        )
+        text_splitter: "ProcessingConfig.TextSplitterConfig" = Field(
+            default_factory=lambda: ProcessingConfig.TextSplitterConfig(),
+            description="Text splitter configuration for vectorization and summarization.",
         )
         input_processors: List["ProcessingConfig.ProfileInputProcessorConfig"] = Field(
             default_factory=list,

--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/docx_markdown_processor/docx_markdown_processor.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/docx_markdown_processor/docx_markdown_processor.py
@@ -35,6 +35,80 @@ def default_or_unknown(value: str, default="None") -> str:
 class DocxMarkdownProcessor(BaseMarkdownProcessor):
     description = "Converts DOCX files to Markdown while preserving headings, tables, and basic formatting."
 
+    def _annotate_markdown_tables(self, md_content: str) -> str:
+        """Wrap Markdown tables with TABLE_START/END markers for downstream chunking."""
+
+        def is_pipe_separator(line: str) -> bool:
+            s = line.strip()
+            if "|" not in s or "-" not in s:
+                return False
+            return all(ch in "|-: " for ch in s)
+
+        def is_pipe_row(line: str) -> bool:
+            s = line.strip()
+            return "|" in s and not s.startswith("```")
+
+        def is_grid_border(line: str) -> bool:
+            s = line.strip()
+            return s.startswith("+") and s.endswith("+") and any(ch in s for ch in "-=")
+
+        def is_grid_row(line: str) -> bool:
+            s = line.strip()
+            return s.startswith("|") and s.endswith("|")
+
+        lines = md_content.splitlines()
+        out: list[str] = []
+        i = 0
+        table_idx = 0
+        while i < len(lines):
+            line = lines[i]
+
+            # Preserve existing annotations untouched
+            if line.strip().startswith("<!-- TABLE_START"):
+                out.append(line)
+                i += 1
+                while i < len(lines):
+                    out.append(lines[i])
+                    if lines[i].strip().startswith("<!-- TABLE_END"):
+                        i += 1
+                        break
+                    i += 1
+                continue
+
+            # Pipe table detection: header + separator
+            if i + 1 < len(lines) and is_pipe_row(line) and is_pipe_separator(lines[i + 1]):
+                start = i
+                i += 2
+                while i < len(lines) and lines[i].strip() and is_pipe_row(lines[i]):
+                    i += 1
+                table_md = "\n".join(lines[start:i]).strip()
+                if table_md:
+                    table_idx += 1
+                    out.append(f"<!-- TABLE_START:id=docx_{table_idx} -->")
+                    out.append(table_md)
+                    out.append("<!-- TABLE_END -->")
+                continue
+
+            # Grid table detection (pandoc-style)
+            if is_grid_border(line):
+                start = i
+                i += 1
+                while i < len(lines) and lines[i].strip() and (is_grid_border(lines[i]) or is_grid_row(lines[i])):
+                    i += 1
+                table_md = "\n".join(lines[start:i]).strip()
+                if table_md:
+                    table_idx += 1
+                    out.append(f"<!-- TABLE_START:id=docx_{table_idx} -->")
+                    out.append(table_md)
+                    out.append("<!-- TABLE_END -->")
+                continue
+
+            out.append(line)
+            i += 1
+
+        # Preserve trailing newline behavior
+        return "\n".join(out)
+
     def check_file_validity(self, file_path: Path) -> bool:
         try:
             with zipfile.ZipFile(file_path, "r") as docx_zip:
@@ -79,7 +153,7 @@ class DocxMarkdownProcessor(BaseMarkdownProcessor):
                 [
                     "pandoc",
                     "--to",
-                    "markdown_strict",
+                    "markdown_strict+pipe_tables",
                     str(file_path),
                     "-o",
                     str(md_path),
@@ -121,6 +195,9 @@ class DocxMarkdownProcessor(BaseMarkdownProcessor):
 
         # Change media path to use api endpoint
         md_content = md_content.replace(str(output_dir), f"knowledge-flow/v1/markdown/{document_uid}")
+
+        # Annotate tables so chunker keeps them intact
+        md_content = self._annotate_markdown_tables(md_content)
 
         with open(md_path, "w", encoding="utf-8") as f:
             f.write(md_content)

--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/vectorization_processor/semantic_splitter.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/vectorization_processor/semantic_splitter.py
@@ -50,15 +50,17 @@ def _build_ws_tolerant_pattern(needle: str) -> str:
 
 
 class SemanticSplitter(BaseTextSplitter):
-    def __init__(self, chunk_size: int = 1500, chunk_overlap: int = 150):
+    def __init__(self, chunk_size: int = 1500, chunk_overlap: int = 150, preserve_tables: bool = True):
         """
         Initializes the SemanticSplitter with specified chunk size and overlap.
         Args:
             chunk_size (int, optional): The maximum number of characters in each chunk. Defaults to 1500.
             chunk_overlap (int, optional): The number of overlapping characters between consecutive chunks. Defaults to 150.
+            preserve_tables (bool, optional): If true, keep annotated markdown tables intact. Defaults to True.
         """
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
+        self.preserve_tables = preserve_tables
 
     def _extract_and_replace_tables(self, text: str) -> Tuple[str, dict]:
         """
@@ -229,10 +231,13 @@ class SemanticSplitter(BaseTextSplitter):
 
             for table_id in placeholders:
                 table_md = table_map[table_id]
-                if len(table_md) <= self.chunk_size:
+                if self.preserve_tables:
                     final_chunks.append(Document(page_content=table_md, metadata={"is_table": True, "table_id": table_id, "table_chunk_id": 0}))
                 else:
-                    final_chunks.extend(self._split_large_table(table_md, table_id))
+                    if len(table_md) <= self.chunk_size:
+                        final_chunks.append(Document(page_content=table_md, metadata={"is_table": True, "table_id": table_id, "table_chunk_id": 0}))
+                    else:
+                        final_chunks.extend(self._split_large_table(table_md, table_id))
 
         return final_chunks
 


### PR DESCRIPTION
This makes the chuncking size configurable in the configuration.yaml instead of hardcoding.
it also add the necessary to preserve the tables.