### PR TITLE
Port ppt filler to v2

### DIFF
--- a/agentic-backend/agentic_backend/agents/v2/definition_refs.py
+++ b/agentic-backend/agentic_backend/agents/v2/definition_refs.py
@@ -51,7 +51,7 @@ _CLASS_PATH_BY_DEFINITION_REF = MappingProxyType(
         POSTAL_TRACKING_DEFINITION_REF: "agentic_backend.agents.v2.demos.postal_tracking.Definition",
         BID_MGR_DEFINITION_REF: "agentic_backend.agents.v2.candidate.bid_mgr.Definition",
         PPT_FILLER_REACT_DEFINITION_REF: (
-            "agentic_backend.agents.v2.production.ppt_filler_react.PptFillerReActV2Definition"
+            "agentic_backend.agents.v2.production.ppt_filler_v2.PptFillerReActV2Definition"
         ),
         ARTIFACT_REPORT_DEFINITION_REF: (
             "agentic_backend.agents.v2.demos.artifact_report.ArtifactReportDemoV2Definition"

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/__init__.py
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/__init__.py
@@ -1,0 +1,3 @@
+from .agent import PptFillerReActV2Definition
+
+__all__ = ["PptFillerReActV2Definition"]

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/agent.py
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/agent.py
@@ -1,0 +1,422 @@
+"""V2 PPT Filler agent — extracts data from documents and fills PowerPoint templates."""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+from pydantic import Field, ValidationError
+
+from agentic_backend.agents.v2.production.ppt_filler_v2.export_utils import (
+    convert_maitrise_to_emoji,
+)
+from agentic_backend.agents.v2.production.ppt_filler_v2.powerpoint_template_util import (
+    fill_slide_from_structured_response,
+)
+from agentic_backend.agents.v2.production.ppt_filler_v2.pydantic_models import (
+    CV,
+    EnjeuxBesoins,
+    PrestationFinanciere,
+    schema_without_max_length,
+)
+from agentic_backend.agents.v2.production.ppt_filler_v2.skill_mastery import (
+    extract_mastery_from_image,
+    inject_mastery_alt_text,
+    is_raster_image,
+    parse_image_refs,
+)
+from agentic_backend.core.agents.agent_spec import FieldSpec, UIHints
+from agentic_backend.core.agents.v2.authoring import (
+    ReActAgent,
+    ToolContext,
+    ToolOutput,
+    prompt_md,
+    tool,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Hardcoded search queries per extraction type
+# ---------------------------------------------------------------------------
+
+TOP_K_DEFAULT = 8
+
+ENJEUX_BESOINS_QUERIES: list[tuple[str, int]] = [
+    ("Quels sont les objectifs et les missions principales du projet ?", TOP_K_DEFAULT),
+    ("Quel est le contexte du projet ?", TOP_K_DEFAULT),
+]
+
+CV_QUERIES: list[tuple[str, int]] = [
+    ("Intitulé du poste", 5),
+    ("Trigramme de l'intervenant", 5),
+    ("Formations avec dates et établissements", TOP_K_DEFAULT),
+    ("Langues parlées et niveau de maîtrise", TOP_K_DEFAULT),
+    ("Compétences en management et niveau de maîtrise", TOP_K_DEFAULT),
+    ("Compétences en informatique et niveau de maîtrise", 20),
+    ("Compétences en gestion de projet et niveau de maîtrise", TOP_K_DEFAULT),
+    (
+        "Expériences professionnelles avec entreprises, postes, durées et réalisations",
+        15,
+    ),
+]
+
+PRESTATION_FINANCIERE_QUERIES: list[tuple[str, int]] = [
+    ("Nom et coût unitaire des prestations", TOP_K_DEFAULT),
+    ("Charge estimée en unités d'œuvre pour chaque prestation", TOP_K_DEFAULT),
+    ("Coût total de chaque prestation et coût total global", TOP_K_DEFAULT),
+]
+
+# ---------------------------------------------------------------------------
+# Extraction prompts
+# ---------------------------------------------------------------------------
+
+ENJEUX_BESOINS_EXTRACTION_PROMPT = """Extrais le contexte et les missions du projet depuis les extraits suivants.
+
+RÈGLES IMPORTANTES:
+- N'invente RIEN - utilise uniquement les informations présentes dans les extraits
+- Si une information n'est pas trouvée, utilise une chaîne vide
+- Le contexte doit décrire le projet de manière détaillée (2-3 phrases)
+- Les missions doivent résumer les objectifs clés (2-3 phrases)
+- Laisse refCahierCharges vide, il sera rempli automatiquement"""
+
+CV_EXTRACTION_PROMPT = """Extrais les informations du CV de l'intervenant depuis les extraits suivants.
+
+CONTEXTE PROJET (pour aligner les compétences et expériences):
+{project_context}
+
+RÈGLES IMPORTANTES:
+- N'invente RIEN - utilise uniquement les informations présentes dans les extraits
+- Les compétences et expériences doivent être pertinentes par rapport au contexte projet
+- Sélectionne les compétences les plus pertinentes par rapport au projet (max 3 par catégorie)
+- COMPÉTENCES INFORMATIQUES: trie par pertinence projet mais ne laisse pas de slots vides inutilement
+- Pour les expériences, garde les plus récentes et pertinentes (max 3)
+- Pour la maitrise (langues et compétences), utilise une échelle de 1 à 5 (en tant que string):
+  "1" = Débutant, "2" = Intermédiaire, "3" = Bon, "4" = Très bon, "5" = Expert
+- Si un emplacement de compétence n'est pas rempli (ex: competenceManagement3 est vide),
+  la maîtrise associée (maitriseManagement3) DOIT être une chaîne vide "", pas "0"
+- LANGUES: NE PAS inclure la langue maternelle du candidat (typiquement le français).
+  Inclure uniquement les langues étrangères (Anglais, Espagnol, Allemand, etc.).
+- Si une information n'est pas trouvée, utilise une chaîne vide
+- STYLE: Rédige TOUJOURS à la troisième personne (pas de "je", "j'ai", "mon").
+  Exemple: "A géré une équipe de 5 personnes" et non "J'ai géré une équipe de 5 personnes"."""
+
+PRESTATION_FINANCIERE_EXTRACTION_PROMPT = """Extrais les prestations financières depuis les extraits suivants.
+
+RÈGLES IMPORTANTES:
+- N'invente RIEN - utilise uniquement les informations présentes dans les extraits
+- Les prix doivent être en euros (nombres entiers)
+- La charge est exprimée en unités d'œuvre (jours/homme typiquement)
+- Le prixTotal d'une prestation = prix × charge
+- Le prixTotal global = somme de tous les prixTotal des prestations
+- NE PAS inventer de catégories de prestations. Si aucune information financière
+  n'est trouvée dans les extraits, laisse TOUS les champs vides (chaînes vides pour
+  les noms, 0 pour les montants). Ne crée pas de titres de catégories avec un coût de 0.
+- Remplis uniquement les prestations pour lesquelles tu as des données concrètes
+  (nom ET prix/charge). Un nom sans données financières n'est pas une prestation valide."""
+
+PPTX_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+DEFAULT_SYSTEM_PROMPT = prompt_md(
+    package="agentic_backend.agents.v2.production.ppt_filler_v2",
+    file_name="system_prompt.md",
+)
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+async def _enrich_with_skill_mastery(ctx: ToolContext, chunks_text: str) -> str:
+    """Fetch skill images referenced in chunks and inject mastery alt text."""
+    image_refs = parse_image_refs(chunks_text)
+    if not image_refs:
+        return chunks_text
+
+    mastery_map: dict[str, int] = {}
+    for doc_uid, filename in image_refs:
+        if not is_raster_image(filename) or filename in mastery_map:
+            continue
+        try:
+            image_bytes = await ctx.fetch_media(doc_uid, filename)
+            level = extract_mastery_from_image(image_bytes)
+            if level is not None:
+                mastery_map[filename] = level
+        except httpx.HTTPStatusError:
+            continue
+        except Exception:
+            logger.warning(
+                "[skill_mastery] Failed to fetch %s/%s",
+                doc_uid,
+                filename,
+                exc_info=True,
+            )
+
+    if mastery_map:
+        logger.info("[skill_mastery] Detected: %s", mastery_map)
+        chunks_text = inject_mastery_alt_text(chunks_text, mastery_map)
+
+    return chunks_text
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    tool_ref="ppt_filler.extract.enjeux_besoins",
+    description="Extrait le contexte et les missions du projet depuis les documents.",
+    success_message="Enjeux et besoins extraits.",
+)
+async def extract_enjeux_besoins(
+    ctx: ToolContext, context_hint: str = ""
+) -> ToolOutput:
+    bundle = await ctx.helpers.search_corpus_many(
+        ENJEUX_BESOINS_QUERIES, context_hint=context_hint
+    )
+    if not bundle.text:
+        return ctx.error("Aucun document trouvé.")
+
+    result = await ctx.extract_structured(
+        schema_without_max_length(EnjeuxBesoins),
+        prompt=ENJEUX_BESOINS_EXTRACTION_PROMPT,
+        text=bundle.text,
+    )
+
+    data = result.model_dump()
+    if bundle.ranked_filenames:
+        data["refCahierCharges"] = bundle.ranked_filenames[0]
+
+    return ctx.json(data, text="Enjeux et besoins extraits.")
+
+
+@tool(
+    tool_ref="ppt_filler.extract.cv",
+    description="Extrait les informations du CV de l'intervenant.",
+    success_message="CV extrait.",
+)
+async def extract_cv(
+    ctx: ToolContext, project_context: str = "", context_hint: str = ""
+) -> ToolOutput:
+    bundle = await ctx.helpers.search_corpus_many(CV_QUERIES, context_hint=context_hint)
+    if not bundle.text:
+        return ctx.error("Aucun document trouvé.")
+
+    enriched_text = await _enrich_with_skill_mastery(ctx, bundle.text)
+
+    result = await ctx.extract_structured(
+        schema_without_max_length(CV),
+        prompt=CV_EXTRACTION_PROMPT.format(
+            project_context=project_context or "Non fourni"
+        ),
+        text=enriched_text,
+    )
+
+    return ctx.json(result, text="CV extrait.")
+
+
+@tool(
+    tool_ref="ppt_filler.extract.prestation_financiere",
+    description="Extrait les informations de prestation financière depuis les documents.",
+    success_message="Prestations financières extraites.",
+)
+async def extract_prestation_financiere(
+    ctx: ToolContext, context_hint: str = ""
+) -> ToolOutput:
+    bundle = await ctx.helpers.search_corpus_many(
+        PRESTATION_FINANCIERE_QUERIES, context_hint=context_hint
+    )
+    if not bundle.text:
+        return ctx.error("Aucun document trouvé.")
+
+    result = await ctx.extract_structured(
+        schema_without_max_length(PrestationFinanciere),
+        prompt=PRESTATION_FINANCIERE_EXTRACTION_PROMPT,
+        text=bundle.text,
+    )
+
+    return ctx.json(result, text="Prestations financières extraites.")
+
+
+@tool(
+    tool_ref="ppt_filler.export.fill_template",
+    description=(
+        "Génère le fichier PowerPoint à partir des données extraites. "
+        "Les trois arguments sont les JSON issus des outils d'extraction."
+    ),
+    success_message="PowerPoint généré.",
+)
+async def fill_template(
+    ctx: ToolContext,
+    enjeuxBesoins: str,
+    cv: str,
+    prestationFinanciere: str,
+) -> ToolOutput:
+    # 1. Parse and validate the three JSON sections
+    try:
+        enjeux_data = (
+            json.loads(enjeuxBesoins)
+            if isinstance(enjeuxBesoins, str)
+            else enjeuxBesoins
+        )
+        cv_data = json.loads(cv) if isinstance(cv, str) else cv
+        prestation_data = (
+            json.loads(prestationFinanciere)
+            if isinstance(prestationFinanciere, str)
+            else prestationFinanciere
+        )
+    except json.JSONDecodeError as e:
+        return ctx.error(f"Erreur de parsing JSON: {e}")
+
+    validation_errors: list[str] = []
+    for section_name, model_cls, section_data in [
+        ("enjeuxBesoins", EnjeuxBesoins, enjeux_data),
+        ("cv", CV, cv_data),
+        ("prestationFinanciere", PrestationFinanciere, prestation_data),
+    ]:
+        try:
+            model_cls.model_validate(section_data)
+        except ValidationError as e:
+            for err in e.errors():
+                field = ".".join(str(loc) for loc in err["loc"])
+                validation_errors.append(f"{section_name}.{field}: {err['msg']}")
+
+    if validation_errors:
+        error_list = "\n".join(f"- {e}" for e in validation_errors)
+        return ctx.error(
+            f"Validation échouée. Raccourcis les champs trop longs "
+            f"puis rappelle fill_template:\n{error_list}"
+        )
+
+    enjeux = EnjeuxBesoins.model_validate(enjeux_data)
+    cv_model = CV.model_validate(cv_data)
+    prestation = PrestationFinanciere.model_validate(prestation_data)
+
+    # 2. Convert mastery levels to emojis
+    cv_dict = cv_model.model_dump()
+    for i in range(1, 4):
+        for category in ["Langue", "Management", "Informatique", "GestionProjet"]:
+            key = f"maitrise{category}{i}"
+            cv_dict[key] = convert_maitrise_to_emoji(cv_dict.get(key, ""))
+
+    # 3. Build template data
+    template_data = {
+        "enjeuxBesoins": enjeux.model_dump(),
+        "cv": cv_dict,
+        "prestationFinanciere": prestation.model_dump(),
+    }
+
+    # 4. Fetch PPTX template
+    template_key = ctx.helpers.setting_text(
+        "ppt.template_key", default="ppt_template.pptx"
+    )
+    resource = await ctx.read_resource(template_key)
+
+    # 5. Fill the template (python-pptx needs file paths)
+    template_path = None
+    output_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            delete=False, suffix=".pptx", prefix="ppt_template_"
+        ) as tmp_in:
+            tmp_in.write(resource.content_bytes)
+            template_path = Path(tmp_in.name)
+
+        with tempfile.NamedTemporaryFile(
+            delete=False, suffix=".pptx", prefix="reference_filled_"
+        ) as tmp_out:
+            output_path = Path(tmp_out.name)
+
+        fill_slide_from_structured_response(template_path, template_data, output_path)
+
+        output_bytes = output_path.read_bytes()
+    finally:
+        if template_path:
+            template_path.unlink(missing_ok=True)
+        if output_path:
+            output_path.unlink(missing_ok=True)
+
+    # 6. Publish the filled PPTX
+    timestamp = datetime.now().strftime("%m%d%H%M")
+    final_name = f"Prop_commerciale_{timestamp}.pptx"
+
+    artifact = await ctx.publish_bytes(
+        file_name=final_name,
+        content=output_bytes,
+        content_type=PPTX_CONTENT_TYPE,
+    )
+
+    return ToolOutput(
+        text="PowerPoint généré.",
+        ui_parts=(artifact.to_link_part(),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent definition
+# ---------------------------------------------------------------------------
+
+
+class PptFillerReActV2Definition(ReActAgent):
+    """V2 agent that extracts data from documents to fill PowerPoint templates."""
+
+    agent_id: str = "ppt_filler.react.v2"
+    role: str = "PowerPoint Template Filler"
+    description: str = (
+        "Extracts data from resumes and project documents to fill "
+        "PowerPoint templates with structured information."
+    )
+    tags: tuple[str, ...] = ("document", "powerpoint", "extraction", "react")
+    tools = (
+        extract_enjeux_besoins,
+        extract_cv,
+        extract_prestation_financiere,
+        fill_template,
+    )
+    system_prompt_template: str = Field(default=DEFAULT_SYSTEM_PROMPT, min_length=1)
+    fields: tuple[FieldSpec, ...] = (
+        FieldSpec(
+            key="system_prompt_template",
+            type="prompt",
+            title="System Prompt",
+            description="Instructions for the agent on how to extract and fill data.",
+            required=True,
+            default=DEFAULT_SYSTEM_PROMPT,
+            ui=UIHints(group="Prompts", multiline=True, markdown=True),
+        ),
+        FieldSpec(
+            key="ppt.template_key",
+            type="text",
+            title="PowerPoint Template Key",
+            description="Agent asset key for the .pptx template file.",
+            default="ppt_template.pptx",
+            ui=UIHints(group="PowerPoint"),
+        ),
+        FieldSpec(
+            key="chat_options.attach_files",
+            type="boolean",
+            title="Allow file attachments",
+            description="Show file upload/attachment controls for this agent.",
+            default=True,
+            ui=UIHints(group="Chat options"),
+        ),
+        FieldSpec(
+            key="chat_options.libraries_selection",
+            type="boolean",
+            title="Document libraries picker",
+            description="Let users select document libraries/knowledge sources for this agent.",
+            default=True,
+            ui=UIHints(group="Chat options"),
+        ),
+    )

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/export_utils.py
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/export_utils.py
@@ -1,0 +1,24 @@
+"""Utility functions for PPT export formatting."""
+
+
+def convert_maitrise_to_emoji(level: str | int) -> str:
+    """Convert maitrise level (1-5) to emoji pattern (●○○○○ to ●●●●●).
+
+    Args:
+        level: Integer or string from 1 to 5, or empty string for no skill
+
+    Returns:
+        String with filled (●) and empty (○) circles, or empty string if no level
+    """
+    if isinstance(level, str):
+        if not level.strip():
+            return ""
+        try:
+            level = int(level)
+        except ValueError:
+            return ""
+    if not 1 <= level <= 5:
+        return ""
+    filled = "●" * level
+    empty = "○" * (5 - level)
+    return filled + empty

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/powerpoint_template_util.py
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/powerpoint_template_util.py
@@ -1,0 +1,89 @@
+import logging
+import re
+
+from pptx import Presentation
+
+logger = logging.getLogger(__name__)
+
+
+def fill_slide_from_structured_response(ppt_path, structured_response, output_path):
+    prs = Presentation(ppt_path)
+    pattern = re.compile(r"\{([^}]+)\}")
+    slide_numbers = [3, 4, 5]
+    responses = structured_response.values()
+
+    for slide_number, response in zip(slide_numbers, responses):
+        slide = prs.slides[slide_number - 1]  # Convert to 0-based index
+
+        for shape in slide.shapes:
+            if not shape.has_text_frame:
+                continue
+
+            for paragraph in shape.text_frame.paragraphs:  # type: ignore
+                # Merge all runs to find complete placeholders (handles split placeholders)
+                full_text = "".join(run.text for run in paragraph.runs)
+
+                # Find all placeholders and their positions in the merged text
+                placeholder_replacements = {}
+                for match in pattern.finditer(full_text):
+                    key = match.group(1)
+                    if key in response:
+                        placeholder_replacements[match.start()] = {
+                            "end": match.end(),
+                            "placeholder": match.group(0),
+                            "value": str(response[key]),
+                        }
+
+                if not placeholder_replacements:
+                    continue
+
+                # Sort placeholders by position to handle multiple placeholders correctly
+                sorted_placeholders = sorted(
+                    placeholder_replacements.items(), key=lambda x: x[0]
+                )
+
+                # Process each run and replace placeholder text
+                char_position = 0
+                for run in paragraph.runs:
+                    run_start = char_position
+                    run_end = char_position + len(run.text)
+                    new_run_text = run.text
+                    offset = 0  # Track text length changes within this run
+
+                    for placeholder_start, replacement in sorted_placeholders:
+                        placeholder_end = replacement["end"]
+
+                        # Case 1: Placeholder starts in this run
+                        if run_start <= placeholder_start < run_end:
+                            local_start = placeholder_start - run_start + offset
+
+                            if placeholder_end <= run_end:
+                                # Placeholder is completely within this run
+                                placeholder_len = len(replacement["placeholder"])
+                                new_run_text = (
+                                    new_run_text[:local_start]
+                                    + replacement["value"]
+                                    + new_run_text[local_start + placeholder_len :]
+                                )
+                                offset += len(replacement["value"]) - placeholder_len
+                            else:
+                                # Placeholder spans multiple runs - replace the start
+                                new_run_text = (
+                                    new_run_text[:local_start] + replacement["value"]
+                                )
+
+                        # Case 2: This run is in the middle/end of a placeholder
+                        elif placeholder_start < run_start < placeholder_end:
+                            if placeholder_end >= run_end:
+                                # Entire run is part of the placeholder - empty it
+                                new_run_text = ""
+                            else:
+                                # Placeholder ends in this run - keep text after placeholder
+                                local_end = placeholder_end - run_start
+                                new_run_text = new_run_text[local_end:]
+
+                    run.text = new_run_text
+                    char_position = run_end
+
+    prs.save(output_path)
+    return output_path

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/prompts/system_prompt.md
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/prompts/system_prompt.md
@@ -1,0 +1,35 @@
+Tu es un expert en extraction de données professionnelles depuis des documents pour remplir des templates PowerPoint.
+
+## WORKFLOW
+
+Suis ces 4 étapes dans l'ordre. Ne passe jamais à l'étape suivante sans avoir terminé la précédente.
+
+**Étape 1 — Extraction des enjeux et besoins (OBLIGATOIRE EN PREMIER)**
+Appelle `extract_enjeux_besoins(context_hint=<nom du projet si connu>)`.
+Le contexte extrait sera réutilisé à l'étape 2 pour aligner le CV.
+
+**Étape 2 — Extraction du CV**
+Appelle `extract_cv(project_context=<contexte extrait étape 1>, context_hint=<nom du candidat si connu>)`.
+Le `project_context` permet de filtrer les compétences et expériences selon leur pertinence au projet.
+
+**Étape 3 — Extraction des prestations financières**
+Appelle `extract_prestation_financiere(context_hint=<indication si connue>)`.
+
+**Étape 4 — Génération du PowerPoint**
+Appelle `fill_template` avec les trois JSON extraits comme arguments séparés:
+```
+fill_template(enjeuxBesoins=<JSON étape 1>, cv=<JSON étape 2>, prestationFinanciere=<JSON étape 3>)
+```
+
+## RÈGLES
+
+- Les outils d'extraction utilisent UNIQUEMENT les informations présentes dans les documents. Ne JAMAIS inventer ou déduire des informations.
+- Les outils retournent des JSON à structure plate avec champs numérotés (formation1, formation2, etc.). Ces JSON sont prêts à être passés tels quels à `fill_template`.
+- Ne jamais appeler `fill_template` sans avoir les trois JSON.
+- Les niveaux de maîtrise (langues, compétences) sont sur une échelle de 1 à 5: 1=Débutant, 2=Intermédiaire, 3=Bon, 4=Très bon, 5=Expert.
+
+## COMMUNICATION
+
+- Sois concis entre les appels d'outils. Ne décris pas ce que tu vas faire avant chaque appel.
+- Ne montre pas les JSON bruts à l'utilisateur.
+- Si fill_template retourne un LinkPart, ne le réécris JAMAIS en texte ou en Markdown. N'affiche jamais d'URL brute ni de lien `[Download ...]`. Ne mentionne pas le bouton de téléchargement. Résume simplement ce qui a été extrait et les champs manquants.

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/pydantic_models.py
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/pydantic_models.py
@@ -1,0 +1,213 @@
+"""Pydantic models for PPT Filler agent structured outputs.
+
+Flattened structure to match PowerPoint template placeholders.
+max_length constraints define PPT card limits but are stripped for extraction
+(so the LLM doesn't self-truncate). Validation happens at fill_template time.
+"""
+
+from typing import Type
+
+from pydantic import BaseModel, Field, create_model
+
+
+def schema_without_max_length(model_class: Type[BaseModel]) -> Type[BaseModel]:
+    """Return a new Pydantic model with all max_length constraints removed.
+
+    Used with `with_structured_output(schema, method="json_schema")` so the LLM
+    extracts full content without truncating to fit PPT card limits.
+    """
+    fields = {}
+    for name, field_info in model_class.model_fields.items():
+        kwargs = {"default": field_info.default, "description": field_info.description}
+        fields[name] = (field_info.annotation, Field(**kwargs))
+    return create_model(model_class.__name__, **fields)
+
+
+# --- enjeuxBesoinsSchema ---
+
+
+class EnjeuxBesoins(BaseModel):
+    """Informations sur le contexte et les missions du projet."""
+
+    contexte: str = Field(
+        "",
+        max_length=270,
+        description="Contexte du projet. Une à deux phrases.",
+    )
+    missions: str = Field(
+        "",
+        max_length=270,
+        description="Ensemble des missions et objectifs. Une à deux phrases.",
+    )
+    refCahierCharges: str = Field(
+        "",
+        description="Nom du fichier duquel les données sont extraites.",
+    )
+
+
+# --- cvSchema ---
+
+
+class CV(BaseModel):
+    """Informations sur le CV de l'intervenant."""
+
+    trigramme: str = Field(
+        "",
+        max_length=3,
+        description="Trigramme servant à anonymiser le nom de l'intervenant (présent dans le CV).",
+    )
+    poste: str = Field(
+        "", max_length=60, description="L'intitulé du poste rempli par l'intervenant."
+    )
+
+    # Formations (max 3)
+    dateFormation1: str = Field("", description="Date de la formation 1.")
+    formation1: str = Field("", description="Nom de l'établissement ou formation 1.")
+    dateFormation2: str = Field("", description="Date de la formation 2.")
+    formation2: str = Field("", description="Nom de l'établissement ou formation 2.")
+    dateFormation3: str = Field("", description="Date de la formation 3.")
+    formation3: str = Field("", description="Nom de l'établissement ou formation 3.")
+
+    # Langues (max 1) - Exclude native language (e.g. French)
+    langue1: str = Field(
+        "", description="Langue parlée 1 (exclure la langue maternelle)."
+    )
+    maitriseLangue1: str = Field(
+        "", description="Maîtrise de la langue 1 (1-5). Chaîne vide si pas de langue."
+    )
+
+    # Compétences Management (max 3)
+    competenceManagement1: str = Field(
+        "", max_length=30, description="Compétence management 1."
+    )
+    maitriseManagement1: str = Field(
+        "", description="Maîtrise management 1 (1-5). Chaîne vide si pas de compétence."
+    )
+    competenceManagement2: str = Field(
+        "", max_length=30, description="Compétence management 2."
+    )
+    maitriseManagement2: str = Field(
+        "", description="Maîtrise management 2 (1-5). Chaîne vide si pas de compétence."
+    )
+    competenceManagement3: str = Field(
+        "", max_length=30, description="Compétence management 3."
+    )
+    maitriseManagement3: str = Field(
+        "", description="Maîtrise management 3 (1-5). Chaîne vide si pas de compétence."
+    )
+
+    # Compétences Informatique (max 3)
+    competenceInformatique1: str = Field(
+        "", max_length=30, description="Compétence informatique 1."
+    )
+    maitriseInformatique1: str = Field(
+        "",
+        description="Maîtrise informatique 1 (1-5). Chaîne vide si pas de compétence.",
+    )
+    competenceInformatique2: str = Field(
+        "", max_length=30, description="Compétence informatique 2."
+    )
+    maitriseInformatique2: str = Field(
+        "",
+        description="Maîtrise informatique 2 (1-5). Chaîne vide si pas de compétence.",
+    )
+    competenceInformatique3: str = Field(
+        "", max_length=30, description="Compétence informatique 3."
+    )
+    maitriseInformatique3: str = Field(
+        "",
+        description="Maîtrise informatique 3 (1-5). Chaîne vide si pas de compétence.",
+    )
+
+    # Compétences Gestion de Projet (max 3)
+    competenceGestionProjet1: str = Field(
+        "", max_length=30, description="Compétence gestion de projet 1."
+    )
+    maitriseGestionProjet1: str = Field(
+        "",
+        description="Maîtrise gestion projet 1 (1-5). Chaîne vide si pas de compétence.",
+    )
+    competenceGestionProjet2: str = Field(
+        "", max_length=30, description="Compétence gestion de projet 2."
+    )
+    maitriseGestionProjet2: str = Field(
+        "",
+        description="Maîtrise gestion projet 2 (1-5). Chaîne vide si pas de compétence.",
+    )
+    competenceGestionProjet3: str = Field(
+        "", max_length=30, description="Compétence gestion de projet 3."
+    )
+    maitriseGestionProjet3: str = Field(
+        "",
+        description="Maîtrise gestion projet 3 (1-5). Chaîne vide si pas de compétence.",
+    )
+
+    # Expériences (max 3)
+    entreprise1: str = Field("", description="Nom de l'entreprise 1.")
+    poste1: str = Field("", description="Nom du poste 1.")
+    duree1: str = Field("", description="Durée de l'expérience 1.")
+    realisations1: str = Field(
+        "", max_length=600, description="Description des tâches réalisées 1."
+    )
+    entreprise2: str = Field("", description="Nom de l'entreprise 2.")
+    poste2: str = Field("", description="Nom du poste 2.")
+    duree2: str = Field("", description="Durée de l'expérience 2.")
+    realisations2: str = Field(
+        "", max_length=600, description="Description des tâches réalisées 2."
+    )
+    entreprise3: str = Field("", description="Nom de l'entreprise 3.")
+    poste3: str = Field("", description="Nom du poste 3.")
+    duree3: str = Field("", description="Durée de l'expérience 3.")
+    realisations3: str = Field(
+        "", max_length=600, description="Description des tâches réalisées 3."
+    )
+
+
+# --- prestationFinanciereSchema ---
+
+
+class PrestationFinanciere(BaseModel):
+    """Informations sur les prestations financières facturées au client.
+
+    Ne remplir QUE les prestations pour lesquelles des données concrètes existent.
+    Ne pas inventer de catégories avec un coût de 0.
+    """
+
+    prestation1: str = Field(
+        "", description="Nom de la prestation 1. Vide si pas de données."
+    )
+    prix1: int = Field(0, description="Prix unitaire de la prestation 1.")
+    charge1: int = Field(
+        0, description="Charge estimée de la prestation 1 en unités d'oeuvre."
+    )
+    prixTotal1: int = Field(0, description="Coût total de la prestation 1.")
+
+    prestation2: str = Field("", description="Nom de la prestation 2.")
+    prix2: int = Field(0, description="Prix unitaire de la prestation 2.")
+    charge2: int = Field(
+        0, description="Charge estimée de la prestation 2 en unités d'oeuvre."
+    )
+    prixTotal2: int = Field(0, description="Coût total de la prestation 2.")
+
+    prestation3: str = Field("", description="Nom de la prestation 3.")
+    prix3: int = Field(0, description="Prix unitaire de la prestation 3.")
+    charge3: int = Field(
+        0, description="Charge estimée de la prestation 3 en unités d'oeuvre."
+    )
+    prixTotal3: int = Field(0, description="Coût total de la prestation 3.")
+
+    prixTotal: int = Field(0, description="Coût total de toutes les prestations.")
+
+
+# --- Utility model for schema-driven query generation ---
+
+
+class SearchQueries(BaseModel):
+    """Queries generated by the LLM to search for schema fields."""
+
+    queries: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=8,
+        description="Search queries to find information for all schema fields. Group related fields into fewer queries.",
+    )

--- a/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/skill_mastery.py
+++ b/agentic-backend/agentic_backend/agents/v2/production/ppt_filler_v2/skill_mastery.py
@@ -1,0 +1,213 @@
+"""Skill mastery detection for CV images.
+
+Supports two visual formats:
+- Blue-dot bars (214x33px, 0-5 filled dots)
+- Donut/ring charts (233x233px, 10 segments mapped to 1-5 scale)
+"""
+
+import io
+import logging
+import math
+import re
+from typing import Optional
+
+from PIL import Image, UnidentifiedImageError
+
+logger = logging.getLogger(__name__)
+
+
+def _is_blue(r: int, g: int, b: int) -> bool:
+    """Return True if the pixel is close enough to the target blue RGB(0, 174, 199)."""
+    dist = math.sqrt((r - 0) ** 2 + (g - 174) ** 2 + (b - 199) ** 2)
+    return dist < 60
+
+
+def count_filled_dots(img: Image.Image) -> int:
+    """Count the number of filled blue dots in a skill-bar image.
+
+    Args:
+        img: A PIL Image, expected to be 214x33 pixels.
+
+    Returns:
+        Number of filled dots (0-5).
+    """
+    rgb = img.convert("RGB")
+    width, height = rgb.size
+    data = rgb.tobytes()
+
+    cols_with_blue: list[int] = []
+    for x in range(width):
+        blue_count = 0
+        for y in range(height):
+            i = (y * width + x) * 3
+            if _is_blue(data[i], data[i + 1], data[i + 2]):
+                blue_count += 1
+        if blue_count > 5:
+            cols_with_blue.append(x)
+
+    if not cols_with_blue:
+        return 0
+
+    filled = 1
+    for i in range(1, len(cols_with_blue)):
+        if cols_with_blue[i] - cols_with_blue[i - 1] > 3:
+            filled += 1
+
+    return filled
+
+
+def _find_ring_radii(
+    data: bytes, width: int, height: int, cx: int, cy: int
+) -> Optional[tuple[int, int]]:
+    """Scan outward from center to find the ring's inner and outer radius.
+
+    Scans at 4 diagonal angles to avoid landing on segment gaps,
+    and returns the median inner/outer radius found.
+
+    Returns:
+        (inner_radius, outer_radius) or None if no ring detected.
+    """
+    max_r = min(cx, cy, width - cx, height - cy)
+    scan_angles = [math.pi / 4, 3 * math.pi / 4, 5 * math.pi / 4, 7 * math.pi / 4]
+    inner_hits: list[int] = []
+    outer_hits: list[int] = []
+
+    for angle in scan_angles:
+        cos_a, sin_a = math.cos(angle), math.sin(angle)
+        inner = None
+        last_r = 0
+        found_outer = False
+        for r in range(1, max_r):
+            x = int(cx + r * cos_a)
+            y = int(cy + r * sin_a)
+            if not (0 <= x < width and 0 <= y < height):
+                break
+            i = (y * width + x) * 3
+            pr, pg, pb = data[i], data[i + 1], data[i + 2]
+            is_white = pr > 230 and pg > 230 and pb > 230
+            last_r = r
+            if inner is None:
+                if not is_white:
+                    inner = r
+            else:
+                if is_white:
+                    outer_hits.append(r - 1)
+                    inner_hits.append(inner)
+                    found_outer = True
+                    break
+        if inner is not None and not found_outer:
+            outer_hits.append(last_r)
+            inner_hits.append(inner)
+
+    if not inner_hits:
+        return None
+    inner_hits.sort()
+    outer_hits.sort()
+    mid = len(inner_hits) // 2
+    inner_r = inner_hits[mid]
+    outer_r = outer_hits[mid]
+    if outer_r - inner_r < 3:
+        return None
+    return (inner_r, outer_r)
+
+
+def count_donut_segments(img: Image.Image) -> Optional[int]:
+    """Count filled (blue) segments in a 10-segment donut chart.
+
+    Samples at the center of each 36-degree arc along the mid-radius
+    of the ring. Maps the count to mastery 1-5 (filled // 2).
+
+    Returns:
+        Mastery level (1-5) or None if not a valid donut chart.
+    """
+    rgb = img.convert("RGB")
+    width, height = rgb.size
+    data = rgb.tobytes()
+    cx, cy = width // 2, height // 2
+
+    radii = _find_ring_radii(data, width, height, cx, cy)
+    if radii is None:
+        return None
+    inner_r, outer_r = radii
+    mid_r = (inner_r + outer_r) // 2
+
+    filled = 0
+    for seg in range(10):
+        angle = math.radians(seg * 36)
+        sx = int(cx + mid_r * math.cos(angle))
+        sy = int(cy + mid_r * math.sin(angle))
+        if not (0 <= sx < width and 0 <= sy < height):
+            continue
+        i = (sy * width + sx) * 3
+        if _is_blue(data[i], data[i + 1], data[i + 2]):
+            filled += 1
+
+    if filled <= 0 or filled > 10 or filled % 2 != 0:
+        return None
+    return filled // 2
+
+
+def extract_mastery_from_image(image_data: bytes) -> Optional[int]:
+    """Open raw image bytes and detect skill mastery from dots or donut chart.
+
+    Returns:
+        Mastery level (0-5) if the image is a skill indicator, None otherwise.
+    """
+    try:
+        with Image.open(io.BytesIO(image_data)) as img:
+            if img.size == (214, 33):
+                return count_filled_dots(img)
+            if img.size == (233, 233):
+                return count_donut_segments(img)
+            return None
+    except (UnidentifiedImageError, OSError) as exc:
+        logger.warning("[skill_mastery] Unreadable image: %s", exc)
+        return None
+
+
+def is_raster_image(filename: str) -> bool:
+    """Return True if the filename has a raster image extension."""
+    raster_suffixes = {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".bmp",
+        ".webp",
+        ".tif",
+        ".tiff",
+    }
+    dot = filename.rfind(".")
+    if dot == -1:
+        return False
+    return filename[dot:].lower() in raster_suffixes
+
+
+def parse_image_refs(chunks_text: str) -> list[tuple[str, str]]:
+    """Extract (document_uid, media_filename) pairs from <img> tags in markdown.
+
+    Matches src URLs like: knowledge-flow/v1/markdown/{uid}/media/{filename}
+    """
+    pattern = re.compile(
+        r'<img[^>]*\bsrc="[^"]*knowledge-flow/v1/markdown/([^"]+)/media/([^"]+)"[^>]*>'
+    )
+    return pattern.findall(chunks_text)
+
+
+def inject_mastery_alt_text(chunks_text: str, mastery_map: dict[str, int]) -> str:
+    """Replace alt text of <img> tags whose filename has a known mastery level."""
+    for filename, level in mastery_map.items():
+        alt_text = f"{level}/5 de maitrise"
+        pattern = re.compile(rf'(<img[^>]*\bsrc="[^"]*/{re.escape(filename)}"[^>]*)>')
+
+        def _repl(match: re.Match, alt=alt_text) -> str:
+            tag = match.group(1)
+            if "alt=" in tag:
+                tag = re.sub(r'alt="[^"]*"', f'alt="{alt}"', tag)
+            else:
+                tag = f'{tag} alt="{alt}"'
+            return tag + ">"
+
+        chunks_text = pattern.sub(_repl, chunks_text)
+
+    return chunks_text

--- a/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/agent_settings_bridge.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/agent_settings_bridge.py
@@ -331,6 +331,12 @@ def _apply_profile_to_definition(
     if not isinstance(profile_id, str) or not profile_id.strip():
         profile = _selected_react_profile(definition)
         if profile is None:
+            # Only apply a fallback profile to definitions that actually support
+            # profiles (i.e. have a react_profile_id field).  Custom agents like
+            # PptFillerReActV2Definition define their own system prompt and tools;
+            # overwriting them with a generic fallback profile is wrong.
+            if "react_profile_id" not in definition.__class__.model_fields:
+                return definition
             profile = _fallback_react_profile()
             if profile is None:
                 return definition

--- a/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/agent_settings_bridge.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/agent_settings_bridge.py
@@ -355,7 +355,9 @@ def _apply_profile_to_definition(
     # that have no class-level tools. If the definition already declares tool refs,
     # keep them; otherwise inherit from the profile.
     existing_tool_refs = getattr(definition, "declared_tool_refs", ())
-    effective_tool_refs = existing_tool_refs if existing_tool_refs else profile.declared_tool_refs
+    effective_tool_refs = (
+        existing_tool_refs if existing_tool_refs else profile.declared_tool_refs
+    )
     logger.debug(
         "[V2][PROFILE] applying profile=%s to class=%s profile_tool_refs=%r "
         "existing_tool_refs=%r effective_tool_refs=%r",

--- a/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/runtime_bootstrap.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/runtime_bootstrap.py
@@ -32,6 +32,8 @@ Example:
 
 from __future__ import annotations
 
+from langgraph.checkpoint.memory import MemorySaver
+
 from agentic_backend.application_context import get_kpi_writer
 from agentic_backend.common.structures import AgentSettings
 from agentic_backend.core.agents.v2.contracts.context import BoundRuntimeContext
@@ -57,8 +59,6 @@ from agentic_backend.core.agents.v2.support.authored_toolsets import (
     AuthoredToolRuntimePorts,
     build_authored_tool_handlers,
 )
-from langgraph.checkpoint.memory import MemorySaver
-
 from agentic_backend.integrations.v2_runtime.adapters import (
     CompositeToolInvoker,
     FredArtifactPublisher,

--- a/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/runtime_bootstrap.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/legacy_bridge/runtime_bootstrap.py
@@ -57,6 +57,8 @@ from agentic_backend.core.agents.v2.support.authored_toolsets import (
     AuthoredToolRuntimePorts,
     build_authored_tool_handlers,
 )
+from langgraph.checkpoint.memory import MemorySaver
+
 from agentic_backend.integrations.v2_runtime.adapters import (
     CompositeToolInvoker,
     FredArtifactPublisher,
@@ -130,7 +132,7 @@ def build_v2_session_agent(
         artifact_publisher=artifact_publisher,
         resource_reader=resource_reader,
         kpi=get_kpi_writer(),
-        checkpointer=checkpointer,
+        checkpointer=checkpointer if checkpointer is not None else MemorySaver(),
     )
     runtime = _build_runtime(definition=definition, services=services)
     runtime.bind(binding)

--- a/agentic-backend/agentic_backend/core/agents/v2/react/react_runtime.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/react/react_runtime.py
@@ -456,7 +456,9 @@ class ReActRuntime(AgentRuntime[ReActAgentDefinition, ReActInput, ReActOutput]):
         )
         logger.debug(
             "[V2][EXECUTOR] system_prompt_preview=%r",
-            (system_prompt[:200] + "...") if len(system_prompt) > 200 else system_prompt,
+            (system_prompt[:200] + "...")
+            if len(system_prompt) > 200
+            else system_prompt,
         )
         system_prompt = (
             f"{system_prompt}"

--- a/agentic-backend/config/agents_catalog.yaml
+++ b/agentic-backend/config/agents_catalog.yaml
@@ -55,6 +55,13 @@ agents:
     type: "agent"
     definition_ref: "v2.deep.corpus_investigator"
 
+  - id: "PPT Filler V2"
+    name: "PPT Filler"
+    type: "agent"
+    definition_ref: "v2.react.ppt_filler"
+    class_path: "agentic_backend.agents.v2.production.ppt_filler_v2.PptFillerReActV2Definition"
+    enabled: true
+
   - id: "BankTransferDemo"
     name: "BankTransferDemo"
     type: "agent"

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -684,16 +684,10 @@ export type ReActProfileSummary = {
   tags: string[];
 };
 export type ExecutionCategory = "graph" | "react" | "proxy";
-export type ToolCapabilityRequirement = {
-  required?: boolean;
-  description?: string | null;
-  kind?: "capability";
-  capability: string;
-};
 export type ToolRefRequirement = {
+  kind?: "tool_ref";
   required?: boolean;
   description?: string | null;
-  kind?: "tool_ref";
   tool_ref: string;
 };
 export type PreviewKind = "none" | "mermaid" | "dag" | "text";
@@ -709,14 +703,9 @@ export type AgentInspection = {
   tags?: string[];
   fields?: FieldSpec[];
   execution_category: ExecutionCategory;
-  declared_tool_refs?: (
-    | ({
-        kind: "capability";
-      } & ToolCapabilityRequirement)
-    | ({
-        kind: "tool_ref";
-      } & ToolRefRequirement)
-  )[];
+  /** Exact Fred runtime tools declared by the agent author. This exists so inspection and UIs can explain what the agent expects before runtime binding happens. */
+  declared_tool_refs?: ToolRefRequirement[];
+  /** Default MCP servers Fred should attach for this agent. These are runtime tool providers, not substitutes for first-class Fred declared tool refs. */
   default_mcp_servers?: McpServerRef[];
   preview?: AgentPreview;
 };


### PR DESCRIPTION
## Summary

- ported PPT filler to v2
- added a fallback to a classic MemorySaver if no checkpointer is given
- fixed agents without profiles getting their system prompt ignored

## Mandatory Checklist

- [ ] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [ ] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [ ] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

Paste the exact commands and short results.

## Risk / Rollback

State main risk and rollback approach.
