### PR TITLE
dva_risk_validator_v2.1

### DIFF
--- a/agentic-backend/agentic_backend/agents/v2/__init__.py
+++ b/agentic-backend/agentic_backend/agents/v2/__init__.py
@@ -9,6 +9,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .candidate.aegis_graph_skeleton import AegisGraphV2SkeletonDefinition
+    from .candidate.dva_risk_validator_assistant_v2_1 import (
+        DVARiskValidatorGraph,
+        DVARiskValidatorQA,
+    )
     from .demos.artifact_report import ArtifactReportDemoV2Definition
 
     # from .demos.postal_tracking import Definition as PostalTrackingDefinition
@@ -23,6 +27,8 @@ __all__ = [
     "ArtifactReportDemoV2Definition",
     "BasicDeepAgentDefinition",
     "CorpusInvestigatorDeepV2Definition",
+    "DVARiskValidatorGraph",
+    "DVARiskValidatorQA",
     "BasicReActDefinition",
 ]
 
@@ -45,6 +51,16 @@ def __getattr__(name: str) -> object:
         from .demos.artifact_report import ArtifactReportDemoV2Definition
 
         return ArtifactReportDemoV2Definition
+    if name == "DVARiskValidatorGraph":
+        from .candidate.dva_risk_validator_assistant_v2_1 import (
+            DVARiskValidatorGraph,
+        )
+
+        return DVARiskValidatorGraph
+    if name == "DVARiskValidatorQA":
+        from .candidate.dva_risk_validator_assistant_v2_1 import DVARiskValidatorQA
+
+        return DVARiskValidatorQA
     if name == "BasicDeepAgentDefinition":
         from .production.basic_deep import BasicDeepAgentDefinition
 

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/README.md
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/README.md
@@ -1,0 +1,63 @@
+# DVA Risk Validator Assistant v2.1
+
+This package provides two standalone candidate V2 agents:
+
+- `DVARiskValidatorGraph` (`candidate.dva_risk_validator.graph.v2_1`)
+- `DVARiskValidatorQA` (`candidate.dva_risk_validator.qa.v2_1`)
+
+Both definitions expose chat options with `default=True` for:
+
+- `chat_options.attach_files`
+- `chat_options.libraries_selection`
+- `chat_options.documents_selection`
+- `chat_options.search_rag_scoping`
+
+## Graph Agent
+
+`DVARiskValidatorGraph` validates DVA risk treatment evidence, enforces blocker
+rules, produces inferred recommendations, and publishes:
+
+- `result.md`
+- `risk_index.json`
+
+```mermaid
+flowchart TD
+  START([Start]) --> route_or_start
+  route_or_start --> ask_max_risk_count
+  ask_max_risk_count --> locate_risk_table
+  ask_max_risk_count --> ask_max_risk_count
+  locate_risk_table --> extract_source_risks
+  locate_risk_table --> maybe_ask_risk_section
+  maybe_ask_risk_section --> extract_source_risks
+  extract_source_risks --> enrich_to_requested_count
+  enrich_to_requested_count --> retrieve_coverage_evidence
+  retrieve_coverage_evidence --> validate_treatment
+  validate_treatment --> recommend_strategy
+  recommend_strategy --> recommend_actions_mitigations
+  recommend_actions_mitigations --> build_report
+  build_report --> publish_outputs
+  publish_outputs --> persist_session_scope
+  persist_session_scope --> finalize
+```
+
+## QA Agent
+
+`DVARiskValidatorQA` is a dedicated standalone ReAct definition for grounded
+follow-up questions over:
+
+- original DVA context
+- generated graph report
+- generated risk index
+
+```mermaid
+flowchart TD
+  user[User question] --> retrieve[knowledge.search]
+  retrieve --> grounded[Grounded answer drafting]
+  grounded --> sources[Append Sources section]
+```
+
+## Session Scope Merge
+
+Graph completion uses `merge_session_scope(...)` to preserve existing selected
+libraries/documents and append generated artifact `document_uid` values while
+setting `include_session_scope=True`.

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/__init__.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .graph_agent import DVARiskValidatorGraph
+from .qa_agent import DVARiskValidatorQA
+
+__all__ = [
+    "DVARiskValidatorGraph",
+    "DVARiskValidatorQA",
+]

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/graph_agent.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/graph_agent.py
@@ -1,0 +1,206 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph definition for DVA Risk Validator Assistant v2.1."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from agentic_backend.core.agents.agent_spec import FieldSpec, UIHints
+from agentic_backend.core.agents.v2 import GraphExecutionOutput, ToolRefRequirement
+from agentic_backend.core.agents.v2.graph.authoring import GraphAgent, GraphWorkflow
+from agentic_backend.core.agents.v2.support.builtins import TOOL_REF_KNOWLEDGE_SEARCH
+
+from .graph_state import DVARiskValidatorInput, DVARiskValidatorState
+from .graph_steps import (
+    ask_max_risk_count_step,
+    build_report_step,
+    enrich_to_requested_count_step,
+    extract_source_risks_step,
+    finalize_step,
+    locate_risk_table_step,
+    maybe_ask_risk_section_step,
+    persist_session_scope_step,
+    publish_outputs_step,
+    recommend_actions_mitigations_step,
+    recommend_strategy_step,
+    retrieve_coverage_evidence_step,
+    route_or_start_step,
+    validate_treatment_step,
+)
+
+
+def _chat_option_fields() -> tuple[FieldSpec, ...]:
+    """
+    Build explicit chat option field specs required by runtime scoping.
+
+    Why this exists:
+    - this graph is not profile-driven; it must expose chat options directly
+    - these keys drive attachment/library/document/RAG scope controls in runtime UI
+
+    How to use:
+    - keep these defaults at `True` unless the business workflow removes support
+
+    Example:
+    ```python
+    fields = _chat_option_fields()
+    ```
+    """
+
+    return (
+        FieldSpec(
+            key="chat_options.attach_files",
+            type="boolean",
+            title="Attachments",
+            description="Allow users to attach files used by DVA validation retrieval.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+        FieldSpec(
+            key="chat_options.libraries_selection",
+            type="boolean",
+            title="Library selection",
+            description="Allow users to select document libraries for this validation run.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+        FieldSpec(
+            key="chat_options.documents_selection",
+            type="boolean",
+            title="Document selection",
+            description="Allow users to scope validation to explicit document UIDs.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+        FieldSpec(
+            key="chat_options.search_rag_scoping",
+            type="boolean",
+            title="RAG scope",
+            description="Allow users to choose corpus/session/general retrieval scope.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+    )
+
+
+class DVARiskValidatorGraph(GraphAgent):
+    """
+    Workflow-shaped DVA Risk Validator assistant (v2.1).
+
+    This agent validates risk treatment evidence, generates recommendations,
+    publishes report artifacts, and prepares retrieval scope for follow-up QA.
+    """
+
+    agent_id: str = "candidate.dva_risk_validator.graph.v2_1"
+    role: str = "DVA Risk Validator Assistant v2.1 (Graph)"
+    description: str = (
+        "Graph workflow that validates DVA risks, treatment evidence, blockers, "
+        "and inferred mitigation recommendations with report/index artifacts."
+    )
+    tags: tuple[str, ...] = ("dva", "risk", "validator", "graph", "candidate", "v2")
+
+    fields: tuple[FieldSpec, ...] = _chat_option_fields()
+    declared_tool_refs: tuple[ToolRefRequirement, ...] = (
+        ToolRefRequirement(
+            tool_ref=TOOL_REF_KNOWLEDGE_SEARCH,
+            description=(
+                "Retrieve DVA evidence in current runtime scope. "
+                "Payload is limited to query/top_k; scope comes from RuntimeContext."
+            ),
+        ),
+    )
+
+    input_schema = DVARiskValidatorInput
+    state_schema = DVARiskValidatorState
+    input_to_state = {"message": "latest_user_text"}
+    output_state_field = "final_text"
+
+    workflow = GraphWorkflow(
+        entry="route_or_start",
+        nodes={
+            "route_or_start": route_or_start_step,
+            "ask_max_risk_count": ask_max_risk_count_step,
+            "locate_risk_table": locate_risk_table_step,
+            "maybe_ask_risk_section": maybe_ask_risk_section_step,
+            "extract_source_risks": extract_source_risks_step,
+            "enrich_to_requested_count": enrich_to_requested_count_step,
+            "retrieve_coverage_evidence": retrieve_coverage_evidence_step,
+            "validate_treatment": validate_treatment_step,
+            "recommend_strategy": recommend_strategy_step,
+            "recommend_actions_mitigations": recommend_actions_mitigations_step,
+            "build_report": build_report_step,
+            "publish_outputs": publish_outputs_step,
+            "persist_session_scope": persist_session_scope_step,
+            "finalize": finalize_step,
+        },
+        edges={
+            "extract_source_risks": "enrich_to_requested_count",
+            "enrich_to_requested_count": "retrieve_coverage_evidence",
+            "retrieve_coverage_evidence": "validate_treatment",
+            "validate_treatment": "recommend_strategy",
+            "recommend_strategy": "recommend_actions_mitigations",
+            "recommend_actions_mitigations": "build_report",
+            "build_report": "publish_outputs",
+            "publish_outputs": "persist_session_scope",
+            "persist_session_scope": "finalize",
+        },
+        routes={
+            "route_or_start": {
+                "start": "ask_max_risk_count",
+            },
+            "ask_max_risk_count": {
+                "valid": "locate_risk_table",
+                "retry": "ask_max_risk_count",
+            },
+            "locate_risk_table": {
+                "found": "extract_source_risks",
+                "missing": "maybe_ask_risk_section",
+            },
+            "maybe_ask_risk_section": {
+                "continue": "extract_source_risks",
+            },
+        },
+    )
+
+    def build_output(self, state: BaseModel) -> BaseModel:
+        """
+        Build final graph output including UI download links.
+
+        Why this exists:
+        - graph chat output must include report body and standard artifact link parts
+
+        How to use:
+        - runtime calls this automatically at graph completion
+
+        Example:
+        ```python
+        output = definition.build_output(state)
+        ```
+        """
+
+        typed_state = DVARiskValidatorState.model_validate(state)
+        ui_parts = []
+        if typed_state.result_artifact is not None:
+            ui_parts.append(typed_state.result_artifact.to_link_part())
+        if typed_state.risk_index_artifact is not None:
+            ui_parts.append(typed_state.risk_index_artifact.to_link_part())
+        return GraphExecutionOutput(
+            content=typed_state.final_text,
+            ui_parts=tuple(ui_parts),
+        )

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/graph_state.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/graph_state.py
@@ -1,0 +1,101 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""State models for the DVA Risk Validator graph workflow."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from agentic_backend.core.agents.runtime_context import RuntimeContext
+from agentic_backend.core.agents.v2 import PublishedArtifact
+
+
+class DVARiskValidatorInput(BaseModel):
+    """Input payload accepted by the graph agent."""
+
+    message: str = Field(..., min_length=1)
+
+
+class RiskEvidence(BaseModel):
+    """Evidence and treatment snapshot captured for one risk item."""
+
+    coverage_ref: str = "NO EVIDENCE FOUND"
+    coverage_citation: int | None = None
+    strategy_text: str = "NO EVIDENCE FOUND"
+    strategy_citation: int | None = None
+    actions: list[str] = Field(default_factory=list)
+    action_citations: list[int] = Field(default_factory=list)
+    owner_text: str = "NO EVIDENCE FOUND"
+    owner_citation: int | None = None
+    target_date_text: str = "NO EVIDENCE FOUND"
+    target_date_citation: int | None = None
+    mapping_text: str = "NO EVIDENCE FOUND"
+    mapping_citation: int | None = None
+    evidence_status: Literal["Sufficient", "Partial", "NO EVIDENCE FOUND"] = (
+        "NO EVIDENCE FOUND"
+    )
+    notes: str = "No direct treatment evidence was detected in retrieved passages."
+
+
+class RiskRecord(BaseModel):
+    """Normalized risk row used by report rendering and machine index export."""
+
+    risk_id: str
+    title: str
+    risk_type: Literal["Source", "Inferred"]
+    source_order: int
+    priority: Literal["P0", "P1", "P2", "P3"]
+    treatment_status: Literal["Adequate", "Partial", "Missing"] = "Missing"
+    blocker: bool = False
+    blocker_reason: str = ""
+    inferred_recommended_strategy: list[str] = Field(default_factory=list)
+    inferred_recommended_actions: list[str] = Field(default_factory=list)
+    evidence: RiskEvidence = Field(default_factory=RiskEvidence)
+
+
+class CitationSource(BaseModel):
+    """Single source row referenced by numeric in-report citations."""
+
+    index: int
+    title: str
+    file_name: str
+    section: str | None = None
+    page: int | None = None
+    document_uid: str | None = None
+
+
+class DVARiskValidatorState(BaseModel):
+    """Graph state tracked across all workflow steps."""
+
+    latest_user_text: str
+    requested_max_risks: int | None = None
+    risk_section_hint: str | None = None
+    risk_table_located: bool = False
+    source_risks: list[RiskRecord] = Field(default_factory=list)
+    all_risks: list[RiskRecord] = Field(default_factory=list)
+    sources: list[CitationSource] = Field(default_factory=list)
+    report_markdown: str = ""
+    risk_index_json: str = "{}"
+    result_artifact: PublishedArtifact | None = None
+    risk_index_artifact: PublishedArtifact | None = None
+    persisted_runtime_context: RuntimeContext | None = None
+    final_text: str = ""
+    done_reason: str | None = None
+    generated_at: str = Field(
+        default_factory=lambda: datetime.now(tz=UTC).isoformat(timespec="seconds")
+    )

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/graph_steps.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/graph_steps.py
@@ -1,0 +1,1171 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Business steps for DVA Risk Validator graph workflow."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, cast
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from agentic_backend.core.agents.v2 import (
+    GraphNodeContext,
+    HumanInputRequest,
+    ToolContentKind,
+)
+from agentic_backend.core.agents.v2.graph.authoring import (
+    StepResult,
+    typed_node,
+)
+from agentic_backend.core.agents.v2.support.builtins import TOOL_REF_KNOWLEDGE_SEARCH
+
+from .graph_state import CitationSource, DVARiskValidatorState, RiskEvidence, RiskRecord
+from .prompt_loader import load_dva_risk_validator_prompt
+from .reporting import (
+    blocker_status_for_risk,
+    render_risk_index_json,
+    render_validation_report,
+    treatment_status_for_risk,
+)
+from .session_scope import merge_session_scope
+
+_GRAPH_EXTRACT_PROMPT = load_dva_risk_validator_prompt(
+    "dva_risk_validator_graph_extract_system_prompt.md"
+)
+_GRAPH_RECOMMEND_PROMPT = load_dva_risk_validator_prompt(
+    "dva_risk_validator_graph_recommend_system_prompt.md"
+)
+
+_RISK_TABLE_QUERIES = (
+    "risk table DVA risk register mitigations owner target date",
+    "risks and mitigations risk assessment matrix",
+    "table des risques registre des risques mesures de mitigation",
+    "analyse des risques matrice des risques propriétaire date cible",
+)
+
+
+class ExtractedRisks(BaseModel):
+    """Structured extraction for ordered source risk rows."""
+
+    risks: list[str] = Field(default_factory=list)
+
+
+@typed_node(DVARiskValidatorState)
+async def route_or_start_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Route any user request into the DVA validation workflow.
+
+    Why this exists:
+    - keeps the graph entry explicit for model-operation routing and future branching
+
+    How to use:
+    - use as entry node in the workflow, then continue to max-risk collection
+    """
+
+    context.emit_status("route_or_start", "Starting DVA risk validation workflow.")
+    return StepResult(route_key="start")
+
+
+@typed_node(DVARiskValidatorState)
+async def ask_max_risk_count_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Collect and validate the maximum number of risks to produce.
+
+    Why this exists:
+    - the workflow must enforce an explicit user-chosen cap with a strict `<=30` rule
+
+    How to use:
+    - place this near the start of the graph before extraction and enrichment
+    """
+
+    if state.requested_max_risks is not None and 1 <= state.requested_max_risks <= 30:
+        return StepResult(route_key="valid")
+
+    response = await context.request_human_input(
+        HumanInputRequest(
+            stage="risk_count",
+            title="Maximum risk count",
+            question=(
+                "How many risks should I include in the report? "
+                "Please provide a number between 1 and 30."
+            ),
+            free_text=True,
+        )
+    )
+
+    requested = _extract_requested_risk_count(response)
+    if requested is None:
+        return StepResult(route_key="retry")
+
+    if requested > 30:
+        return StepResult(
+            state_update={
+                "final_text": (
+                    "Requested maximum risk count is too large. "
+                    "Please provide a number below 30."
+                )
+            },
+            route_key="retry",
+        )
+
+    return StepResult(
+        state_update={"requested_max_risks": requested},
+        route_key="valid",
+    )
+
+
+@typed_node(DVARiskValidatorState)
+async def locate_risk_table_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Locate whether the DVA contains a risk table using bilingual retrieval probes.
+
+    Why this exists:
+    - risk-table presence is mandatory before extracting ordered source risks
+
+    How to use:
+    - call early; route to HITL section hint when confidence is weak
+    """
+
+    del state
+    context.emit_status("locate_risk_table", "Searching DVA risk table evidence.")
+    for query in _RISK_TABLE_QUERIES:
+        result = await context.invoke_tool(
+            TOOL_REF_KNOWLEDGE_SEARCH,
+            {
+                "query": query,
+                "top_k": 6,
+            },
+        )
+        if _result_contains_risk_table_signal(result):
+            return StepResult(
+                route_key="found", state_update={"risk_table_located": True}
+            )
+    return StepResult(route_key="missing", state_update={"risk_table_located": False})
+
+
+@typed_node(DVARiskValidatorState)
+async def maybe_ask_risk_section_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Ask user for risk section hint when automatic risk-table location failed.
+
+    Why this exists:
+    - workflow must use HITL when it cannot confidently identify the risk table
+
+    How to use:
+    - place this immediately after locate step on the missing branch
+    """
+
+    if state.risk_table_located:
+        return StepResult(route_key="continue")
+
+    response = await context.request_human_input(
+        HumanInputRequest(
+            stage="risk_section",
+            title="Risk section hint",
+            question=(
+                "I could not confidently locate the DVA risk table. "
+                "Which section contains the listed risks?"
+            ),
+            free_text=True,
+        )
+    )
+    section_hint = _extract_text_answer(response)
+    if not section_hint:
+        return StepResult(route_key="continue")
+    return StepResult(
+        state_update={"risk_section_hint": section_hint}, route_key="continue"
+    )
+
+
+@typed_node(DVARiskValidatorState)
+async def extract_source_risks_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Extract source risks in source order using retrieval + structured parsing.
+
+    Why this exists:
+    - report order must start with DVA-native risks in original source order
+
+    How to use:
+    - run after locating the risk table and optional HITL section hint
+    """
+
+    query = _build_extraction_query(state.risk_section_hint)
+    result = await context.invoke_tool(
+        TOOL_REF_KNOWLEDGE_SEARCH,
+        {
+            "query": query,
+            "top_k": 12,
+        },
+    )
+    raw_text = _collect_result_text(result)
+
+    extracted = await _extract_risk_titles(raw_text, context)
+    if not extracted:
+        extracted = [
+            "Risk register entry could not be extracted automatically; infer from DVA context"
+        ]
+
+    source_risks = [
+        RiskRecord(
+            risk_id=f"R-{index:02d}",
+            title=title,
+            risk_type="Source",
+            source_order=index,
+            priority=_priority_for_position(index),
+            evidence=RiskEvidence(),
+        )
+        for index, title in enumerate(extracted, start=1)
+    ]
+
+    citations = _collect_citation_sources(result)
+    return StepResult(
+        state_update={
+            "source_risks": source_risks,
+            "all_risks": source_risks,
+            "sources": citations,
+        }
+    )
+
+
+@typed_node(DVARiskValidatorState)
+async def enrich_to_requested_count_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Append inferred risks when user-requested count exceeds extracted source risks.
+
+    Why this exists:
+    - workflow must complete to requested count while keeping source risks first
+
+    How to use:
+    - run after extraction and before per-risk coverage/treatment validation
+    """
+
+    del context
+    target = state.requested_max_risks or len(state.source_risks)
+    if target <= len(state.source_risks):
+        return StepResult(state_update={"all_risks": list(state.source_risks)})
+
+    all_risks = list(state.source_risks)
+    next_index = len(all_risks) + 1
+    while len(all_risks) < target:
+        all_risks.append(
+            RiskRecord(
+                risk_id=f"R-{next_index:02d}",
+                title=f"Inferred contextual risk {next_index}",
+                risk_type="Inferred",
+                source_order=next_index,
+                priority=_priority_for_position(next_index),
+                evidence=RiskEvidence(
+                    notes=(
+                        "This risk is inferred from domain context because the "
+                        "requested count exceeds extracted source rows."
+                    )
+                ),
+            )
+        )
+        next_index += 1
+
+    return StepResult(state_update={"all_risks": all_risks})
+
+
+@typed_node(DVARiskValidatorState)
+async def retrieve_coverage_evidence_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Retrieve per-risk coverage snippets from DVA scope and map numeric citations.
+
+    Why this exists:
+    - every material claim must map to evidence or explicit no-evidence marker
+
+    How to use:
+    - run after risk list finalization, before treatment validation
+    """
+
+    all_risks = list(state.all_risks)
+    sources = list(state.sources)
+    source_index = {source.index: source for source in sources}
+    max_index = max(source_index.keys(), default=0)
+
+    for idx, risk in enumerate(all_risks):
+        search_result = await context.invoke_tool(
+            TOOL_REF_KNOWLEDGE_SEARCH,
+            {
+                "query": f"{risk.title} treatment mitigation owner target date",
+                "top_k": 5,
+            },
+        )
+        risk_text = _collect_result_text(search_result)
+
+        new_sources = _collect_citation_sources(search_result)
+        for source in new_sources:
+            if source.index in source_index:
+                continue
+            max_index += 1
+            source_index[max_index] = source.model_copy(update={"index": max_index})
+
+        citation = max(source_index.keys(), default=1)
+        coverage_ref = _derive_coverage_reference(
+            risk_title=risk.title,
+            risk_text=risk_text,
+            search_result=search_result,
+        )
+        risk.evidence.coverage_ref = coverage_ref
+        risk.evidence.coverage_citation = (
+            citation if coverage_ref != "NO EVIDENCE FOUND" else None
+        )
+        all_risks[idx] = risk
+
+    ordered_sources = [source_index[key] for key in sorted(source_index.keys())]
+    return StepResult(state_update={"all_risks": all_risks, "sources": ordered_sources})
+
+
+@typed_node(DVARiskValidatorState)
+async def validate_treatment_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Validate treatment completeness and blocker rules from retrieved evidence.
+
+    Why this exists:
+    - missing strategy/owner/target-date must mark the risk as BLOCKER
+
+    How to use:
+    - run after coverage retrieval and before recommendation generation
+    """
+
+    del context
+    validated: list[RiskRecord] = []
+    for risk in state.all_risks:
+        enriched = _populate_treatment_fields_from_coverage(risk)
+        blocker, reason = blocker_status_for_risk(enriched)
+        enriched.blocker = blocker
+        enriched.blocker_reason = reason
+        enriched.treatment_status = treatment_status_for_risk(enriched)
+        validated.append(enriched)
+    return StepResult(state_update={"all_risks": validated})
+
+
+@typed_node(DVARiskValidatorState)
+async def recommend_strategy_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Generate inferred strategy recommendations for each risk.
+
+    Why this exists:
+    - recommendations are mandatory for source and inferred risks
+
+    How to use:
+    - run after treatment validation so recommendation prompt sees blocker context
+    """
+
+    recommended: list[RiskRecord] = []
+    for risk in state.all_risks:
+        strategy_lines = await _model_recommend_lines(
+            context,
+            operation="recommend_strategy",
+            system_prompt=_GRAPH_RECOMMEND_PROMPT,
+            user_prompt=(
+                f"Risk: {risk.title}\n"
+                f"Type: {risk.risk_type}\n"
+                f"Current status: {risk.treatment_status}\n"
+                f"Blocker: {risk.blocker_reason or 'none'}\n"
+                "Return 1-2 concise inferred strategy lines."
+            ),
+            fallback=[
+                "Align mitigation strategy with explicit accountable ownership.",
+                "Link each treatment commitment to verifiable DVA evidence.",
+            ],
+        )
+        risk.inferred_recommended_strategy = strategy_lines
+        recommended.append(risk)
+    return StepResult(state_update={"all_risks": recommended})
+
+
+@typed_node(DVARiskValidatorState)
+async def recommend_actions_mitigations_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Generate inferred action recommendations for each risk.
+
+    Why this exists:
+    - final risk cards require explicit recommended actions
+
+    How to use:
+    - run after strategy recommendation generation
+    """
+
+    final_risks: list[RiskRecord] = []
+    for risk in state.all_risks:
+        actions = await _model_recommend_lines(
+            context,
+            operation="recommend_actions",
+            system_prompt=_GRAPH_RECOMMEND_PROMPT,
+            user_prompt=(
+                f"Risk: {risk.title}\n"
+                f"Blocker: {risk.blocker_reason or 'none'}\n"
+                "Return exactly 3 inferred mitigation actions as short lines."
+            ),
+            fallback=[
+                "Define one concrete mitigation action with measurable outcome.",
+                "Assign one accountable owner for execution and reporting.",
+                "Set one target date and one follow-up checkpoint.",
+            ],
+        )
+        risk.inferred_recommended_actions = actions[:3]
+        final_risks.append(risk)
+    return StepResult(state_update={"all_risks": final_risks})
+
+
+@typed_node(DVARiskValidatorState)
+async def build_report_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Build markdown report and risk-index JSON payload.
+
+    Why this exists:
+    - report/index generation must remain explicit and testable before publication
+
+    How to use:
+    - run after all validation and recommendation steps
+    """
+
+    del context
+    report_markdown = render_validation_report(state.all_risks, state.sources)
+    source_document_uids = [
+        source.document_uid for source in state.sources if source.document_uid
+    ]
+    risk_index_json = render_risk_index_json(
+        state.all_risks,
+        state.sources,
+        source_document_uids=cast(list[str], source_document_uids),
+        result_document_uid=None,
+        risk_index_document_uid=None,
+    )
+    return StepResult(
+        state_update={
+            "report_markdown": report_markdown,
+            "risk_index_json": risk_index_json,
+        }
+    )
+
+
+@typed_node(DVARiskValidatorState)
+async def publish_outputs_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Publish `result.md` and `risk_index.json` artifacts.
+
+    Why this exists:
+    - graph output must provide downloadable artifacts for report and index
+
+    How to use:
+    - run once report and index payloads are finalized
+    """
+
+    report_artifact = await context.publish_text(
+        file_name="result.md",
+        text=state.report_markdown,
+        title="DVA Risk Validation Report",
+        content_type="text/markdown; charset=utf-8",
+    )
+    index_artifact = await context.publish_text(
+        file_name="risk_index.json",
+        text=state.risk_index_json,
+        title="DVA Risk Validation Index",
+        content_type="application/json",
+    )
+
+    updated_index = render_risk_index_json(
+        state.all_risks,
+        state.sources,
+        source_document_uids=[
+            source.document_uid for source in state.sources if source.document_uid
+        ],
+        result_document_uid=report_artifact.document_uid,
+        risk_index_document_uid=index_artifact.document_uid,
+    )
+
+    return StepResult(
+        state_update={
+            "result_artifact": report_artifact,
+            "risk_index_artifact": index_artifact,
+            "risk_index_json": updated_index,
+        }
+    )
+
+
+@typed_node(DVARiskValidatorState)
+async def persist_session_scope_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Merge generated artifact document UIDs into runtime session search scope.
+
+    Why this exists:
+    - QA follow-up turns must be able to search both original DVA and generated outputs
+
+    How to use:
+    - run after publication, then pass merged context through the normal session channel
+    """
+
+    generated_uids = [
+        uid
+        for uid in (
+            state.result_artifact.document_uid if state.result_artifact else None,
+            state.risk_index_artifact.document_uid
+            if state.risk_index_artifact
+            else None,
+        )
+        if uid
+    ]
+    merged = merge_session_scope(
+        context.binding.runtime_context,
+        generated_document_uids=cast(list[str], generated_uids),
+        fallback_search_policy="hybrid",
+    )
+    return StepResult(state_update={"persisted_runtime_context": merged})
+
+
+@typed_node(DVARiskValidatorState)
+async def finalize_step(
+    state: DVARiskValidatorState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Finalize user-facing text payload.
+
+    Why this exists:
+    - runtime output should show report body in chat while links are attached as UI parts
+
+    How to use:
+    - make this the terminal node of the graph
+    """
+
+    del context
+    return StepResult(
+        state_update={
+            "final_text": state.report_markdown,
+            "done_reason": "completed",
+        }
+    )
+
+
+def _extract_requested_risk_count(payload: object) -> int | None:
+    """Parse free-text HITL payload into an integer risk-count request."""
+
+    text = _extract_text_answer(payload)
+    if not text:
+        return None
+    match = re.search(r"\d+", text)
+    if not match:
+        return None
+    try:
+        return int(match.group(0))
+    except ValueError:
+        return None
+
+
+def _extract_text_answer(payload: object) -> str:
+    """Extract one human text answer from flexible HITL resume payload shapes."""
+
+    if isinstance(payload, str):
+        return payload.strip()
+    if not isinstance(payload, dict):
+        return ""
+    for key in ("text", "answer", "value", "choice_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _build_extraction_query(section_hint: str | None) -> str:
+    """Build bilingual retrieval query for source risk extraction."""
+
+    base = (
+        "Extract the ordered risk rows from DVA risk table / table des risques / "
+        "registre des risques, including risk title and mitigation context"
+    )
+    if not section_hint:
+        return base
+    return f"{base}. Prioritize section: {section_hint}"
+
+
+async def _extract_risk_titles(raw_text: str, context: GraphNodeContext) -> list[str]:
+    """Extract ordered risk titles from markdown-like retrieval text."""
+
+    if context.model is not None:
+        extracted = cast(
+            ExtractedRisks,
+            await context.invoke_structured_model(
+                ExtractedRisks,
+                messages=[
+                    SystemMessage(content=_GRAPH_EXTRACT_PROMPT),
+                    HumanMessage(content=raw_text[:5000]),
+                ],
+                operation="extract_source_risks",
+            ),
+        )
+        cleaned_model_rows = _clean_extracted_risk_titles(extracted.risks)
+        if cleaned_model_rows:
+            return cleaned_model_rows
+
+    heuristic = _heuristic_risk_rows(raw_text)
+    return _clean_extracted_risk_titles(heuristic)
+
+
+def _heuristic_risk_rows(raw_text: str) -> list[str]:
+    """Detect likely bilingual risk rows from plain text when no model is available."""
+
+    rows: list[str] = []
+    for line in raw_text.splitlines():
+        normalized = line.strip(" -\t")
+        lower = normalized.lower()
+        if not normalized:
+            continue
+        if "|" in normalized:
+            extracted_table_title = _risk_title_from_markdown_row(normalized)
+            if extracted_table_title:
+                rows.append(extracted_table_title)
+                continue
+        if any(
+            token in lower
+            for token in (
+                "risk",
+                "risque",
+                "mitigation",
+                "owner",
+                "propriétaire",
+                "matrice",
+            )
+        ):
+            rows.append(normalized[:180])
+    deduped: list[str] = []
+    for row in rows:
+        if row not in deduped:
+            deduped.append(row)
+    return deduped[:30]
+
+
+def _clean_extracted_risk_titles(raw_titles: list[str]) -> list[str]:
+    """Filter and normalize extracted rows so only meaningful risk titles remain."""
+
+    cleaned: list[str] = []
+    for title in raw_titles:
+        normalized = re.sub(r"\s+", " ", title).strip()
+        if not normalized:
+            continue
+        if "|" in normalized:
+            extracted = _risk_title_from_markdown_row(normalized)
+            if extracted:
+                normalized = extracted
+        normalized = normalized.strip(" -*`")
+        if _looks_like_non_risk_line(normalized):
+            continue
+        if normalized not in cleaned:
+            cleaned.append(normalized[:180])
+    return cleaned[:30]
+
+
+def _risk_title_from_markdown_row(line: str) -> str | None:
+    """Extract the probable 'Risk Title' cell from a markdown table row."""
+
+    parts = [part.strip() for part in line.split("|")]
+    parts = [part for part in parts if part]
+    if len(parts) < 3:
+        return None
+
+    lower_parts = [_strip_markup(part).lower().strip() for part in parts]
+    header_tokens = (
+        "id",
+        "risk",
+        "risk title",
+        "titre du risque",
+        "strategy",
+        "stratégie",
+        "impact",
+        "action",
+        "owner",
+        "propriétaire",
+        "target date",
+        "date cible",
+    )
+    header_hits = 0
+    for cell in lower_parts:
+        if any(token == cell or token in cell for token in header_tokens):
+            header_hits += 1
+    if header_hits >= max(3, (len(parts) + 1) // 2):
+        return None
+    if all(re.fullmatch(r"[-: ]+", part or "") for part in parts):
+        return None
+
+    # In common DVA markdown tables:
+    # category | id | risk title | strategy | impact | action
+    if len(parts) >= 3 and re.fullmatch(r"\d{1,3}", parts[1]):
+        return parts[2]
+
+    # Fallback: choose longest non-header segment.
+    candidates = [
+        part
+        for part in parts
+        if not re.fullmatch(r"\d{1,3}", part)
+        and not _looks_like_non_risk_line(part)
+        and len(part) > 8
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=len)
+
+
+def _looks_like_non_risk_line(text: str) -> bool:
+    """Return True for headings/metadata rows that are not concrete risk titles."""
+
+    lower = text.lower().strip()
+    if not lower:
+        return True
+    if lower.startswith("#") or lower.startswith("[") or lower.startswith(">"):
+        return True
+    if lower.startswith("<img") or "contents" in lower:
+        return True
+    if re.fullmatch(r"[-:| ]+", lower):
+        return True
+    if re.search(r"<[^>]+>", lower):
+        return True
+    if lower.count("[") >= 2 and lower.count("]") >= 2:
+        return True
+    if lower.startswith(("type:", "priority:", "coverage in", "source:", "status:")):
+        return True
+    if "|" in text:
+        parts = [_strip_markup(part).lower().strip() for part in text.split("|")]
+        parts = [part for part in parts if part]
+        if not parts:
+            return True
+        if all(re.fullmatch(r"[-: ]+", part) for part in parts):
+            return True
+        header_tokens = (
+            "id",
+            "risk",
+            "risk title",
+            "titre du risque",
+            "strategy",
+            "stratégie",
+            "impact",
+            "action",
+            "owner",
+            "propriétaire",
+            "target date",
+            "date cible",
+        )
+        header_hits = 0
+        for part in parts:
+            if any(token == part or token in part for token in header_tokens):
+                header_hits += 1
+        if header_hits >= max(3, (len(parts) + 1) // 2):
+            return True
+    return False
+
+
+def _result_contains_risk_table_signal(result: object) -> bool:
+    """Return True when retrieval output strongly suggests risk-table coverage."""
+
+    text = _collect_result_text(result)
+    lower = text.lower()
+    if any(
+        marker in lower
+        for marker in (
+            "risk table",
+            "risk register",
+            "table des risques",
+            "registre des risques",
+            "matrice des risques",
+        )
+    ):
+        return True
+
+    # Broader bilingual fallback:
+    # if retrieved text references risks plus treatment fields (owner/date/action),
+    # we treat this as sufficient confidence and avoid unnecessary HITL prompts.
+    has_risk_term = any(
+        token in lower
+        for token in (
+            "risk",
+            "risque",
+            "analyse des risques",
+            "risk assessment",
+        )
+    )
+    has_treatment_term = any(
+        token in lower
+        for token in (
+            "mitigation",
+            "owner",
+            "propriétaire",
+            "proprietaire",
+            "target date",
+            "date cible",
+            "action",
+            "mesure",
+            "traitement",
+        )
+    )
+    if has_risk_term and has_treatment_term:
+        return True
+
+    if re.search(r"\b(r[-\s]?\d{1,3}|risk\s+\d+|risque\s+\d+)\b", lower):
+        return True
+    return False
+
+
+def _collect_result_text(result: object) -> str:
+    """Normalize mixed tool-result blocks into one text blob."""
+
+    if result is None:
+        return ""
+
+    blocks = getattr(result, "blocks", ())
+    lines: list[str] = []
+    for block in blocks or ():
+        kind = getattr(block, "kind", None)
+        if kind == ToolContentKind.TEXT:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and text.strip():
+                lines.append(text.strip())
+        if kind == ToolContentKind.JSON:
+            data = getattr(block, "data", None)
+            lines.extend(_extract_text_from_json_payload(data))
+
+    if lines:
+        return "\n".join(lines)
+
+    sources = getattr(result, "sources", ())
+    for source in sources or ():
+        content = getattr(source, "content", None)
+        if isinstance(content, str) and content.strip():
+            lines.append(content.strip())
+    return "\n".join(lines)
+
+
+def _extract_text_from_json_payload(data: object) -> list[str]:
+    """Extract textual snippet lines from known knowledge.search JSON payloads."""
+
+    if not isinstance(data, dict):
+        return []
+
+    hits = data.get("hits")
+    if not isinstance(hits, list):
+        return []
+
+    lines: list[str] = []
+    for hit in hits:
+        if not isinstance(hit, dict):
+            continue
+        content = hit.get("content")
+        if isinstance(content, str) and content.strip():
+            lines.append(content.strip())
+    return lines
+
+
+def _collect_citation_sources(result: object) -> list[CitationSource]:
+    """Build citation metadata rows from retrieval sources."""
+
+    sources: list[CitationSource] = []
+    raw_sources = getattr(result, "sources", ())
+    for idx, source in enumerate(raw_sources or (), start=1):
+        title = str(getattr(source, "title", None) or "Retrieved source")
+        file_name = str(getattr(source, "file_name", None) or title)
+        section = cast(str | None, getattr(source, "section", None))
+        page = cast(int | None, getattr(source, "page", None))
+        document_uid = cast(str | None, getattr(source, "document_uid", None))
+        sources.append(
+            CitationSource(
+                index=idx,
+                title=title,
+                file_name=file_name,
+                section=section,
+                page=page,
+                document_uid=document_uid,
+            )
+        )
+    return sources
+
+
+def _priority_for_position(position: int) -> Literal["P0", "P1", "P2", "P3"]:
+    """Assign inferred P0-P3 priority from source-order position."""
+
+    if position % 4 == 1:
+        return "P0"
+    if position % 4 == 2:
+        return "P1"
+    if position % 4 == 3:
+        return "P2"
+    return "P3"
+
+
+def _populate_treatment_fields_from_coverage(risk: RiskRecord) -> RiskRecord:
+    """Populate mandatory treatment fields from compact coverage text heuristics."""
+
+    coverage = risk.evidence.coverage_ref.lower()
+    if coverage == "no evidence found":
+        risk.evidence.evidence_status = "NO EVIDENCE FOUND"
+        risk.evidence.strategy_text = "NO EVIDENCE FOUND"
+        risk.evidence.owner_text = "NO EVIDENCE FOUND"
+        risk.evidence.target_date_text = "NO EVIDENCE FOUND"
+        risk.evidence.actions = []
+        risk.evidence.notes = "No DVA paragraph was found for this risk."
+        return risk
+
+    citation = risk.evidence.coverage_citation
+    risk.evidence.mapping_text = "Mapped to nearest retrieved DVA section"
+    risk.evidence.mapping_citation = citation
+
+    has_strategy = any(token in coverage for token in ("strategy", "stratégie"))
+    has_owner = any(
+        token in coverage for token in ("owner", "propriétaire", "responsable")
+    )
+    has_target = any(token in coverage for token in ("target", "échéance", "date"))
+    has_action = any(token in coverage for token in ("action", "mitigation", "mesure"))
+
+    risk.evidence.strategy_text = (
+        "Strategy mentioned in DVA excerpt" if has_strategy else "NO EVIDENCE FOUND"
+    )
+    risk.evidence.strategy_citation = citation if has_strategy else None
+
+    risk.evidence.owner_text = (
+        "Owner mentioned in DVA excerpt" if has_owner else "NO EVIDENCE FOUND"
+    )
+    risk.evidence.owner_citation = citation if has_owner else None
+
+    risk.evidence.target_date_text = (
+        "Target date mentioned in DVA excerpt" if has_target else "NO EVIDENCE FOUND"
+    )
+    risk.evidence.target_date_citation = citation if has_target else None
+
+    if has_action:
+        risk.evidence.actions = ["Action or mitigation item detected in DVA excerpt"]
+        risk.evidence.action_citations = [citation] if citation is not None else []
+
+    present_fields = sum((has_strategy, has_owner, has_target, has_action))
+    if present_fields >= 3:
+        risk.evidence.evidence_status = "Sufficient"
+    else:
+        risk.evidence.evidence_status = "Partial"
+    risk.evidence.notes = "Treatment fields were inferred from retrieved DVA wording."
+    return risk
+
+
+async def _model_recommend_lines(
+    context: GraphNodeContext,
+    *,
+    operation: str,
+    system_prompt: str,
+    user_prompt: str,
+    fallback: list[str],
+) -> list[str]:
+    """Generate 1..N recommendation lines from model text with deterministic fallback."""
+
+    if context.model is None:
+        return fallback
+
+    message = await context.invoke_model(
+        [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=user_prompt),
+        ],
+        operation=operation,
+    )
+    raw = str(getattr(message, "content", "")).strip()
+    if not raw:
+        return fallback
+    lines = [line.strip(" -\t") for line in raw.splitlines() if line.strip()]
+    cleaned = [line for line in lines if len(line) > 2]
+    return cleaned[: max(1, len(fallback))] or fallback
+
+
+def _compact_line(raw_text: str) -> str:
+    """Normalize multiline snippet to one compact line for report tables."""
+
+    return re.sub(r"\s+", " ", raw_text).strip()[:240]
+
+
+def _derive_coverage_reference(
+    *,
+    risk_title: str,
+    risk_text: str,
+    search_result: object,
+) -> str:
+    """Build a human-readable coverage reference from retrieval output."""
+
+    if not risk_text.strip():
+        return "NO EVIDENCE FOUND"
+
+    source_section = _source_section_hint(search_result)
+    row_hint = _risk_table_row_reference(risk_text, risk_title)
+    if row_hint:
+        if source_section:
+            return f"{source_section} — {row_hint}"
+        return row_hint
+
+    heading = _markdown_heading_reference(risk_text)
+    if heading:
+        return heading
+
+    sentence = _sentence_for_risk_title(risk_text, risk_title)
+    if sentence:
+        return sentence
+
+    compact = _compact_line(_strip_markup(risk_text))
+    if compact:
+        return compact
+    return "NO EVIDENCE FOUND"
+
+
+def _source_section_hint(search_result: object) -> str | None:
+    """Return section/title hint from first retrieval source when available."""
+
+    for source in getattr(search_result, "sources", ()) or ():
+        section = getattr(source, "section", None)
+        if isinstance(section, str) and section.strip():
+            return section.strip()
+        title = getattr(source, "title", None)
+        if isinstance(title, str) and title.strip():
+            return title.strip()
+    return None
+
+
+def _risk_table_row_reference(risk_text: str, risk_title: str) -> str | None:
+    """Return concise row reference when risk appears inside markdown table rows."""
+
+    target = risk_title.lower().strip()
+    for line in risk_text.splitlines():
+        if "|" not in line:
+            continue
+        lower = line.lower()
+        if target and target not in lower:
+            continue
+        parts = [part.strip() for part in line.split("|") if part.strip()]
+        if len(parts) < 3:
+            continue
+        if re.fullmatch(r"\d{1,3}", parts[1]):
+            category = parts[0]
+            row_id = parts[1]
+            return f"Risk table row ({category}, ID {row_id})"
+        parsed_title = _risk_title_from_markdown_row(line)
+        if parsed_title:
+            return f"Risk table row ({parsed_title})"
+    return None
+
+
+def _markdown_heading_reference(risk_text: str) -> str | None:
+    """Extract the first markdown heading as coverage reference when present."""
+
+    for line in risk_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("### "):
+            return stripped[4:].strip()
+        if stripped.startswith("## "):
+            return stripped[3:].strip()
+    return None
+
+
+def _sentence_for_risk_title(risk_text: str, risk_title: str) -> str | None:
+    """Extract one sentence containing the risk title from free text chunks."""
+
+    cleaned = _strip_markup(risk_text)
+    if not cleaned:
+        return None
+    target = risk_title.lower().strip()
+    if not target:
+        return None
+    for sentence in re.split(r"(?<=[.!?])\s+", cleaned):
+        normalized = sentence.strip()
+        if target in normalized.lower():
+            return _compact_line(normalized)
+    return None
+
+
+def _strip_markup(text: str) -> str:
+    """Remove markdown/html noise from retrieved text before sentence extraction."""
+
+    without_images = re.sub(r"<img[^>]*>", " ", text, flags=re.IGNORECASE)
+    without_tags = re.sub(r"<[^>]+>", " ", without_images)
+    without_md_links = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", without_tags)
+    without_ref_links = re.sub(r"\[([^\]]+)\]\[[^\]]+\]", r"\1", without_md_links)
+    without_pipes = without_ref_links.replace("|", " ")
+    return re.sub(r"\s+", " ", without_pipes).strip()
+
+
+def preview_required_nodes() -> tuple[str, ...]:
+    """
+    Return the mandatory node ids expected in graph previews/tests.
+
+    Why this exists:
+    - keeps topology assertions stable and centralized for unit tests
+
+    How to use:
+    - use in tests to assert that workflow shape remains explicit
+
+    Example:
+    ```python
+    assert "locate_risk_table" in preview_required_nodes()
+    ```
+    """
+
+    return (
+        "route_or_start",
+        "ask_max_risk_count",
+        "locate_risk_table",
+        "maybe_ask_risk_section",
+        "extract_source_risks",
+        "enrich_to_requested_count",
+        "retrieve_coverage_evidence",
+        "validate_treatment",
+        "recommend_strategy",
+        "recommend_actions_mitigations",
+        "build_report",
+        "publish_outputs",
+        "persist_session_scope",
+        "finalize",
+    )

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompt_loader.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompt_loader.py
@@ -1,0 +1,47 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prompt loading helpers for DVA Risk Validator v2.1 agents."""
+
+from agentic_backend.core.agents.v2.resources import load_agent_prompt_markdown
+
+_DVA_RISK_VALIDATOR_PACKAGE = (
+    "agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1"
+)
+
+
+def load_dva_risk_validator_prompt(file_name: str) -> str:
+    """
+    Load one packaged markdown prompt from this agent package.
+
+    Why this exists:
+    - keeps prompt text in versioned markdown files instead of inline Python strings
+    - gives both graph and QA definitions one stable loading convention
+
+    How to use:
+    - place prompt files under `prompts/`
+    - call this helper with the file name
+
+    Example:
+    ```python
+    SYSTEM_PROMPT = load_dva_risk_validator_prompt(
+        "dva_risk_validator_qa_system_prompt.md"
+    )
+    ```
+    """
+
+    return load_agent_prompt_markdown(
+        package=_DVA_RISK_VALIDATOR_PACKAGE,
+        file_name=file_name,
+    )

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_graph_extract_system_prompt.md
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_graph_extract_system_prompt.md
@@ -1,0 +1,11 @@
+You extract source risks from DVA passages, especially markdown tables.
+
+Rules:
+- Keep source order from the DVA content when visible.
+- Support English and French vocabulary.
+- Return concise risk titles only.
+- If input contains markdown rows like:
+  `Category | ID | Risk Title | Strategy | Impact | Action`
+  then extract only the `Risk Title` cell for each data row.
+- Exclude table headers, section titles, links, TOC lines, image tags, and appendix text.
+- Do not invent DVA evidence.

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_graph_recommend_system_prompt.md
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_graph_recommend_system_prompt.md
@@ -1,0 +1,7 @@
+You provide inferred recommendations for DVA risk treatment.
+
+Rules:
+- Recommendations are inferred, not quoted DVA facts.
+- Provide actionable short lines.
+- Stay consistent with blocker status.
+- Support French or English user context.

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_graph_validate_system_prompt.md
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_graph_validate_system_prompt.md
@@ -1,0 +1,7 @@
+You validate DVA risk treatment evidence.
+
+Rules:
+- Check strategy, action owner, and action target date.
+- If any required field is missing, mark blocker.
+- If evidence is weak, prefer `NO EVIDENCE FOUND`.
+- Keep validation deterministic and concise.

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_qa_system_prompt.md
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/prompts/dva_risk_validator_qa_system_prompt.md
@@ -1,0 +1,13 @@
+You are DVARiskValidatorAssistant v2.1 QA.
+
+Behavior:
+- Always run `knowledge.search` before asserting factual claims.
+- Use current runtime scope (selected libraries/documents/session artifacts).
+- Search first in user language, then retry with FR/EN fallback when needed.
+- If evidence is missing or conflicting, state it explicitly.
+- Keep concise and grounded answers.
+
+Output:
+- Include a final `Sources` section for grounded answers.
+- Prefer user language when clear.
+- Keep citations explicit (section/page when available).

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/qa_agent.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/qa_agent.py
@@ -1,0 +1,133 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone ReAct QA definition for DVA Risk Validator Assistant v2.1."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from agentic_backend.core.agents.agent_spec import FieldSpec, UIHints
+from agentic_backend.core.agents.v2 import ToolRefRequirement
+from agentic_backend.core.agents.v2.authoring import ReActAgent
+from agentic_backend.core.agents.v2.support.builtins import TOOL_REF_KNOWLEDGE_SEARCH
+
+from .prompt_loader import load_dva_risk_validator_prompt
+
+
+QA_SYSTEM_PROMPT = load_dva_risk_validator_prompt(
+    "dva_risk_validator_qa_system_prompt.md"
+)
+
+
+def _qa_fields() -> tuple[FieldSpec, ...]:
+    """
+    Build author-facing QA configuration surface.
+
+    Why this exists:
+    - QA agent is standalone and must explicitly expose chat options for runtime scoping
+
+    How to use:
+    - keep the `chat_options.*` defaults enabled to preserve DVA/report/index retrieval
+
+    Example:
+    ```python
+    fields = _qa_fields()
+    ```
+    """
+
+    return (
+        FieldSpec(
+            key="system_prompt_template",
+            type="prompt",
+            title="System prompt",
+            description="Grounding instructions for DVA follow-up QA.",
+            required=True,
+            default=QA_SYSTEM_PROMPT,
+            ui=UIHints(group="Prompts", multiline=True, markdown=True),
+        ),
+        FieldSpec(
+            key="chat_options.attach_files",
+            type="boolean",
+            title="Attachments",
+            description="Allow QA turns to include additional attachment evidence.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+        FieldSpec(
+            key="chat_options.libraries_selection",
+            type="boolean",
+            title="Library selection",
+            description="Allow QA turns to restrict retrieval to selected libraries.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+        FieldSpec(
+            key="chat_options.documents_selection",
+            type="boolean",
+            title="Document selection",
+            description="Allow QA turns to restrict retrieval to selected documents.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+        FieldSpec(
+            key="chat_options.search_rag_scoping",
+            type="boolean",
+            title="RAG scope",
+            description="Allow QA turns to pick corpus/session/general retrieval scope.",
+            required=False,
+            default=True,
+            ui=UIHints(group="agentTuning.groups.chatOptions"),
+        ),
+    )
+
+
+class DVARiskValidatorQA(ReActAgent):
+    """
+    Follow-up QA agent grounded on DVA + generated validation artifacts.
+
+    This definition is dedicated to DVA risk follow-up questions and is not a
+    profile-only alias of the generic ReAct family.
+    """
+
+    agent_id: str = "candidate.dva_risk_validator.qa.v2_1"
+    role: str = "DVA Risk Validator Assistant v2.1 (QA)"
+    description: str = (
+        "Grounded follow-up QA over original DVA content and generated "
+        "validation report/index artifacts."
+    )
+    tags: tuple[str, ...] = (
+        "dva",
+        "risk",
+        "validator",
+        "qa",
+        "react",
+        "candidate",
+        "v2",
+    )
+
+    system_prompt_template: str = Field(default=QA_SYSTEM_PROMPT, min_length=1)
+    fields: tuple[FieldSpec, ...] = _qa_fields()
+    declared_tool_refs: tuple[ToolRefRequirement, ...] = (
+        ToolRefRequirement(
+            tool_ref=TOOL_REF_KNOWLEDGE_SEARCH,
+            description=(
+                "Search scoped DVA/report/index sources before answering factual "
+                "follow-up questions."
+            ),
+        ),
+    )

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/reporting.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/reporting.py
@@ -1,0 +1,310 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report and machine-index builders for DVA Risk Validator outputs."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Literal
+
+from .graph_state import CitationSource, RiskRecord
+
+
+def blocker_status_for_risk(risk: RiskRecord) -> tuple[bool, str]:
+    """
+    Decide blocker status from mandatory treatment fields.
+
+    Why this exists:
+    - blocker logic is a stable business rule reused by graph steps and tests
+
+    How to use:
+    - call after evidence extraction populated strategy/owner/target date fields
+
+    Example:
+    ```python
+    blocker, reason = blocker_status_for_risk(risk)
+    ```
+    """
+
+    missing: list[str] = []
+    if risk.evidence.strategy_text == "NO EVIDENCE FOUND":
+        missing.append("strategy")
+    if risk.evidence.owner_text == "NO EVIDENCE FOUND":
+        missing.append("action owner")
+    if risk.evidence.target_date_text == "NO EVIDENCE FOUND":
+        missing.append("action target date")
+    if not missing:
+        return False, ""
+    return True, f"Missing mandatory treatment field(s): {', '.join(missing)}."
+
+
+def treatment_status_for_risk(
+    risk: RiskRecord,
+) -> Literal["Adequate", "Partial", "Missing"]:
+    """
+    Classify treatment status from extracted evidence completeness.
+
+    Why this exists:
+    - report summary table needs one explicit status per risk
+
+    How to use:
+    - call after blocker evaluation
+
+    Example:
+    ```python
+    status = treatment_status_for_risk(risk)
+    ```
+    """
+
+    if risk.evidence.evidence_status == "NO EVIDENCE FOUND":
+        return "Missing"
+    if risk.blocker:
+        return "Partial"
+    return "Adequate"
+
+
+def render_validation_report(
+    risks: list[RiskRecord], sources: list[CitationSource]
+) -> str:
+    """
+    Render the mandatory markdown report with fixed section ordering.
+
+    Why this exists:
+    - enforces a stable report contract for users and downstream parsers
+
+    How to use:
+    - call after all risk enrichment/validation/recommendation steps complete
+
+    Example:
+    ```python
+    markdown = render_validation_report(risks, sources)
+    ```
+    """
+
+    lines: list[str] = []
+    lines.append("# DVA Risk Validation Report")
+    lines.append(
+        "Priority legend: priorities are **inferred** and ordered `P0` to `P3` "
+        "where `P3` is the least priority."
+    )
+    lines.append("")
+
+    lines.append("## DVA Risks (Full List, Source Order)")
+    for risk in risks:
+        lines.append(
+            f"- {risk.risk_id}: {risk.title} ({risk.risk_type}, priority {risk.priority} inferred)"
+        )
+    lines.append("")
+
+    lines.append(
+        "## Coverage List with reference to the paragraph that covers the risk"
+    )
+    for risk in risks:
+        coverage_ref = risk.evidence.coverage_ref
+        citation = (
+            f" [{risk.evidence.coverage_citation}]"
+            if risk.evidence.coverage_citation is not None
+            else ""
+        )
+        lines.append(f"- {risk.risk_id}: {coverage_ref}{citation}".rstrip())
+    lines.append("")
+
+    lines.append("## Treatment Validation Summary")
+    lines.append(
+        "| risk id | risk title | source or inferred | inferred priority | treatment status | blocker status | evidence status |"
+    )
+    lines.append("|---|---|---|---|---|---|---|")
+    for risk in risks:
+        lines.append(
+            "| "
+            f"{risk.risk_id} | {risk.title} | {risk.risk_type} | {risk.priority} | "
+            f"{risk.treatment_status} | {'Yes' if risk.blocker else 'No'} | "
+            f"{risk.evidence.evidence_status} |"
+        )
+    lines.append("")
+
+    lines.append("## Treatment Validation Details")
+    for risk in risks:
+        lines.extend(_render_risk_card(risk))
+        lines.append("")
+
+    lines.append("## Blockers & PDA Action Plan")
+    blockers = [risk for risk in risks if risk.blocker]
+    if not blockers:
+        lines.append("- No blockers were detected in current evidence scope.")
+    else:
+        for risk in blockers:
+            lines.append(f"- {risk.risk_id}: {risk.blocker_reason}")
+            lines.append(
+                f"- PDA action: update DVA section for {risk.risk_id} with strategy, owner, and target date evidence."
+            )
+    lines.append("")
+
+    lines.append("## Sources")
+    if not sources:
+        lines.append("- [1] No source metadata available from retrieval hits.")
+    else:
+        for source in sources:
+            details: list[str] = [source.title, source.file_name]
+            if source.page is not None:
+                details.append(f"page {source.page}")
+            if source.section:
+                details.append(f"section {source.section}")
+            if source.document_uid:
+                details.append(f"document_uid={source.document_uid}")
+            lines.append(f"- [{source.index}] " + " | ".join(details))
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def render_risk_index_json(
+    risks: list[RiskRecord],
+    sources: list[CitationSource],
+    *,
+    source_document_uids: list[str],
+    result_document_uid: str | None,
+    risk_index_document_uid: str | None,
+) -> str:
+    """
+    Build the machine-readable risk index artifact.
+
+    Why this exists:
+    - QA and downstream systems need a structured counterpart to the markdown report
+
+    How to use:
+    - call right before artifact publication once report content is final
+
+    Example:
+    ```python
+    payload = render_risk_index_json(risks, sources, source_document_uids=["doc-1"], ...)
+    ```
+    """
+
+    payload = {
+        "generated_at": datetime.now(tz=UTC).isoformat(timespec="seconds"),
+        "source_document_uids": sorted(set(source_document_uids)),
+        "risks": [
+            {
+                "risk_id": risk.risk_id,
+                "title": risk.title,
+                "source_or_inferred": risk.risk_type,
+                "source_order": risk.source_order,
+                "inferred_priority": risk.priority,
+                "coverage_reference": risk.evidence.coverage_ref,
+                "coverage_citation": risk.evidence.coverage_citation,
+                "treatment_status": risk.treatment_status,
+                "blocker": risk.blocker,
+                "blocker_reason": risk.blocker_reason,
+                "evidence_status": risk.evidence.evidence_status,
+                "inferred_recommended_strategy": risk.inferred_recommended_strategy,
+                "inferred_recommended_actions": risk.inferred_recommended_actions,
+            }
+            for risk in risks
+        ],
+        "citation_mapping": [
+            {
+                "index": source.index,
+                "title": source.title,
+                "file_name": source.file_name,
+                "section": source.section,
+                "page": source.page,
+                "document_uid": source.document_uid,
+            }
+            for source in sources
+        ],
+        "artifact_metadata": {
+            "result_document_uid": result_document_uid,
+            "risk_index_document_uid": risk_index_document_uid,
+        },
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _render_risk_card(risk: RiskRecord) -> list[str]:
+    """Render one risk detail card using the strict multiline format."""
+
+    lines: list[str] = []
+    lines.append(f"### {risk.risk_id} — {risk.title}")
+    lines.append(f"- **Type:** {risk.risk_type}")
+    lines.append(f"- **Priority:** {risk.priority} *(inferred)*")
+
+    coverage = risk.evidence.coverage_ref
+    if risk.evidence.coverage_citation is not None:
+        coverage = f"{coverage} [{risk.evidence.coverage_citation}]"
+    lines.append(f"- **Coverage in DVA:** {coverage}")
+    lines.append("")
+
+    lines.append("**DVA treatment**")
+    strategy = risk.evidence.strategy_text
+    if risk.evidence.strategy_citation is not None:
+        strategy = f"{strategy} [{risk.evidence.strategy_citation}]"
+    lines.append(f"- **Strategy (DVA):** {strategy}")
+
+    lines.append("- **Actions/Mitigations (DVA):**")
+    if risk.evidence.actions:
+        for idx, action in enumerate(risk.evidence.actions):
+            citation = (
+                f" [{risk.evidence.action_citations[idx]}]"
+                if idx < len(risk.evidence.action_citations)
+                else ""
+            )
+            lines.append(f"  - {action}{citation}")
+    else:
+        lines.append("  - NO EVIDENCE FOUND")
+
+    owner = risk.evidence.owner_text
+    if risk.evidence.owner_citation is not None:
+        owner = f"{owner} [{risk.evidence.owner_citation}]"
+    target_date = risk.evidence.target_date_text
+    if risk.evidence.target_date_citation is not None:
+        target_date = f"{target_date} [{risk.evidence.target_date_citation}]"
+    mapping = risk.evidence.mapping_text
+    if risk.evidence.mapping_citation is not None:
+        mapping = f"{mapping} [{risk.evidence.mapping_citation}]"
+
+    lines.append(f"- **Owner:** {owner}")
+    lines.append(f"- **Target date:** {target_date}")
+    lines.append(f"- **DVA mapping:** {mapping}")
+    lines.append("")
+
+    lines.append("**Evidence**")
+    lines.append(f"- **Evidence status:** {risk.evidence.evidence_status}")
+    lines.append(f"- **Notes:** {risk.evidence.notes}")
+    lines.append("")
+
+    lines.append("**Recommended strategy (inferred)**")
+    strategy_lines = risk.inferred_recommended_strategy or [
+        "Harmonize DVA wording with explicit accountable treatment owner."
+    ]
+    for strategy_line in strategy_lines:
+        lines.append(f"- {strategy_line}")
+    lines.append("")
+
+    lines.append("**Recommended actions (inferred)**")
+    action_lines = risk.inferred_recommended_actions or [
+        "Define one measurable mitigation action.",
+        "Assign one accountable owner.",
+        "Add one target date and review checkpoint.",
+    ]
+    for idx, action in enumerate(action_lines, start=1):
+        lines.append(f"{idx}. {action}")
+    lines.append("")
+
+    lines.append("**Blocker rationale**")
+    lines.append(
+        f"- **BLOCKER:** {'Yes' if risk.blocker else 'No'} — {risk.blocker_reason or 'No blocker condition detected.'}"
+    )
+    return lines

--- a/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/session_scope.py
+++ b/agentic-backend/agentic_backend/agents/v2/candidate/dva_risk_validator_assistant_v2_1/session_scope.py
@@ -1,0 +1,63 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable session-scope merge seam for graph-generated artifacts."""
+
+from __future__ import annotations
+
+from agentic_backend.core.agents.runtime_context import RuntimeContext
+
+
+def merge_session_scope(
+    runtime_context: RuntimeContext | None,
+    *,
+    generated_document_uids: list[str],
+    fallback_search_policy: str = "hybrid",
+) -> RuntimeContext:
+    """
+    Merge generated artifact document UIDs into runtime retrieval scope.
+
+    Why this exists:
+    - graph agents need a reusable way to keep original DVA scope and add newly
+      generated report/index artifacts so follow-up QA can search both
+
+    How to use:
+    - call this at graph finalization after artifact publication
+    - persist or return the resulting context through your normal session flow
+
+    Example:
+    ```python
+    merged = merge_session_scope(
+        runtime_context,
+        generated_document_uids=["doc-report", "doc-index"],
+        fallback_search_policy="hybrid",
+    )
+    ```
+    """
+
+    base = (
+        runtime_context.model_copy(deep=True) if runtime_context else RuntimeContext()
+    )
+
+    existing_uids = list(base.selected_document_uids or [])
+    for uid in generated_document_uids:
+        normalized = uid.strip()
+        if normalized and normalized not in existing_uids:
+            existing_uids.append(normalized)
+
+    base.selected_document_uids = existing_uids
+    base.include_session_scope = True
+    if not base.search_policy:
+        base.search_policy = fallback_search_policy
+    return base

--- a/agentic-backend/agentic_backend/agents/v2/definition_refs.py
+++ b/agentic-backend/agentic_backend/agents/v2/definition_refs.py
@@ -36,6 +36,8 @@ BID_MGR_DEFINITION_REF = "v2.proto.bid_mgr"
 PPT_FILLER_REACT_DEFINITION_REF = "v2.react.ppt_filler"
 ARTIFACT_REPORT_DEFINITION_REF = "v2.demo.artifact_report"
 AEGIS_GRAPH_SKELETON_DEFINITION_REF = "v2.graph.aegis_skeleton"
+DVA_RISK_VALIDATOR_GRAPH_DEFINITION_REF = "v2.candidate.dva_risk_validator.graph"
+DVA_RISK_VALIDATOR_QA_DEFINITION_REF = "v2.candidate.dva_risk_validator.qa"
 
 _CLASS_PATH_BY_DEFINITION_REF = MappingProxyType(
     {
@@ -58,6 +60,12 @@ _CLASS_PATH_BY_DEFINITION_REF = MappingProxyType(
         ),
         AEGIS_GRAPH_SKELETON_DEFINITION_REF: (
             "agentic_backend.agents.v2.candidate.aegis_graph_skeleton.AegisGraphV2SkeletonDefinition"
+        ),
+        DVA_RISK_VALIDATOR_GRAPH_DEFINITION_REF: (
+            "agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.DVARiskValidatorGraph"
+        ),
+        DVA_RISK_VALIDATOR_QA_DEFINITION_REF: (
+            "agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.DVARiskValidatorQA"
         ),
     }
 )

--- a/agentic-backend/tests/test_dva_risk_validator_authoring.py
+++ b/agentic-backend/tests/test_dva_risk_validator_authoring.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1 import (
+    DVARiskValidatorGraph,
+    DVARiskValidatorQA,
+)
+from agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.graph_state import (
+    CitationSource,
+    DVARiskValidatorState,
+    RiskEvidence,
+    RiskRecord,
+)
+from agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.graph_steps import (
+    _clean_extracted_risk_titles,
+    _derive_coverage_reference,
+    _result_contains_risk_table_signal,
+    ask_max_risk_count_step,
+    maybe_ask_risk_section_step,
+    preview_required_nodes,
+    publish_outputs_step,
+)
+from agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.reporting import (
+    blocker_status_for_risk,
+    render_validation_report,
+)
+from agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.session_scope import (
+    merge_session_scope,
+)
+from agentic_backend.agents.v2.definition_refs import (
+    class_path_for_definition_ref,
+)
+from agentic_backend.core.agents.runtime_context import RuntimeContext
+from agentic_backend.core.agents.v2 import (
+    ArtifactScope,
+    BoundRuntimeContext,
+    GraphNodeContext,
+    HumanInputRequest,
+    PortableContext,
+    PortableEnvironment,
+    PublishedArtifact,
+    RuntimeServices,
+    ToolContentBlock,
+    ToolContentKind,
+    ToolInvocationResult,
+)
+from agentic_backend.core.agents.v2.support.builtins import TOOL_REF_KNOWLEDGE_SEARCH
+
+
+class _FakeContext:
+    """Small graph context fake for offline unit tests."""
+
+    def __init__(
+        self,
+        *,
+        human_payload: object | None = None,
+    ) -> None:
+        self._human_payload = human_payload
+        self.requests: list[HumanInputRequest] = []
+        self.published: list[tuple[str, str]] = []
+
+    @property
+    def binding(self) -> BoundRuntimeContext:
+        return BoundRuntimeContext(
+            runtime_context=RuntimeContext(
+                session_id="session-1",
+                selected_document_libraries_ids=["lib-1"],
+                selected_document_uids=["doc-1"],
+                search_policy="semantic",
+            ),
+            portable_context=PortableContext(
+                request_id="req-1",
+                correlation_id="corr-1",
+                actor="user:test",
+                tenant="fred",
+                environment=PortableEnvironment.DEV,
+                session_id="session-1",
+                agent_id="candidate.dva_risk_validator.graph.v2_1",
+            ),
+        )
+
+    @property
+    def services(self) -> RuntimeServices:
+        return cast(RuntimeServices, object())
+
+    @property
+    def model(self) -> BaseChatModel | None:
+        return None
+
+    def emit_status(self, status: str, detail: str | None = None) -> None:
+        del status, detail
+
+    def emit_assistant_delta(self, delta: str) -> None:
+        del delta
+
+    async def invoke_model(self, messages, *, operation="default"):
+        del messages, operation
+        raise RuntimeError("Not expected in this test context.")
+
+    async def invoke_structured_model(
+        self, output_model, messages, *, operation="default"
+    ):
+        del output_model, messages, operation
+        raise RuntimeError("Not expected in this test context.")
+
+    async def invoke_tool(
+        self, tool_ref: str, payload: dict[str, object]
+    ) -> ToolInvocationResult:
+        assert tool_ref == TOOL_REF_KNOWLEDGE_SEARCH
+        query = str(payload.get("query") or "")
+        text = (
+            "table des risques - propriétaire - date cible"
+            if "risques" in query
+            else "risk table owner target date"
+        )
+        return ToolInvocationResult(
+            tool_ref=tool_ref,
+            blocks=(ToolContentBlock(kind=ToolContentKind.TEXT, text=text),),
+        )
+
+    async def invoke_runtime_tool(
+        self, tool_name: str, arguments: dict[str, object]
+    ) -> object:
+        del tool_name, arguments
+        return None
+
+    async def publish_text(self, **kwargs: object) -> PublishedArtifact:
+        file_name = str(kwargs["file_name"])
+        text = str(kwargs["text"])
+        self.published.append((file_name, text))
+        uid = "doc-result" if file_name == "result.md" else "doc-index"
+        return PublishedArtifact(
+            scope=ArtifactScope.USER,
+            key=f"v2/{file_name}",
+            file_name=file_name,
+            size=len(text.encode("utf-8")),
+            href=f"https://example.test/{file_name}",
+            document_uid=uid,
+            mime=str(kwargs.get("content_type") or "text/plain"),
+            title=str(kwargs.get("title") or file_name),
+        )
+
+    async def publish_bytes(self, **kwargs: object) -> PublishedArtifact:
+        del kwargs
+        raise RuntimeError("Not expected in this test context.")
+
+    async def fetch_resource(self, **kwargs: object) -> object:
+        del kwargs
+        raise RuntimeError("Not expected in this test context.")
+
+    async def fetch_text_resource(self, **kwargs: object) -> str:
+        del kwargs
+        raise RuntimeError("Not expected in this test context.")
+
+    async def request_human_input(self, request: HumanInputRequest) -> object:
+        self.requests.append(request)
+        return self._human_payload or {"text": "5"}
+
+
+def _state_for_steps() -> DVARiskValidatorState:
+    return DVARiskValidatorState(
+        latest_user_text="Analyze this DVA.",
+        all_risks=[
+            RiskRecord(
+                risk_id="R-01",
+                title="Missing governance traceability",
+                risk_type="Source",
+                source_order=1,
+                priority="P1",
+                evidence=RiskEvidence(),
+            )
+        ],
+        report_markdown="# report",
+        risk_index_json="{}",
+    )
+
+
+def test_definition_wiring_and_stable_ids() -> None:
+    graph = DVARiskValidatorGraph()
+    qa = DVARiskValidatorQA()
+
+    assert graph.agent_id == "candidate.dva_risk_validator.graph.v2_1"
+    assert qa.agent_id == "candidate.dva_risk_validator.qa.v2_1"
+
+    assert (
+        class_path_for_definition_ref("v2.candidate.dva_risk_validator.graph")
+        == "agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.DVARiskValidatorGraph"
+    )
+    assert (
+        class_path_for_definition_ref("v2.candidate.dva_risk_validator.qa")
+        == "agentic_backend.agents.v2.candidate.dva_risk_validator_assistant_v2_1.DVARiskValidatorQA"
+    )
+
+
+def test_chat_options_defaults_are_enabled_for_both_agents() -> None:
+    graph_fields = {field.key: field for field in DVARiskValidatorGraph().fields}
+    qa_fields = {field.key: field for field in DVARiskValidatorQA().fields}
+
+    for key in (
+        "chat_options.attach_files",
+        "chat_options.libraries_selection",
+        "chat_options.documents_selection",
+        "chat_options.search_rag_scoping",
+    ):
+        assert graph_fields[key].default is True
+        assert qa_fields[key].default is True
+
+
+def test_graph_preview_contains_expected_major_nodes() -> None:
+    preview = DVARiskValidatorGraph().preview().content
+    for node_id in preview_required_nodes():
+        assert node_id in preview
+
+
+@pytest.mark.asyncio
+async def test_risk_table_failure_path_emits_human_input_request() -> None:
+    context = _FakeContext(human_payload={"text": "Section 5 - Matrice des risques"})
+
+    result = await maybe_ask_risk_section_step(
+        DVARiskValidatorState(
+            latest_user_text="Validate",
+            risk_table_located=False,
+        ),
+        cast(GraphNodeContext, context),
+    )
+
+    assert context.requests
+    assert result.state_update["risk_section_hint"] == "Section 5 - Matrice des risques"
+
+
+@pytest.mark.asyncio
+async def test_max_risk_hitl_retries_when_above_30() -> None:
+    context = _FakeContext(human_payload={"text": "35"})
+
+    result = await ask_max_risk_count_step(
+        DVARiskValidatorState(latest_user_text="Validate"),
+        cast(GraphNodeContext, context),
+    )
+
+    assert result.route_key == "retry"
+
+
+def test_report_format_sections_in_order_and_sources_at_end() -> None:
+    risk = RiskRecord(
+        risk_id="R-01",
+        title="Supplier disruption",
+        risk_type="Source",
+        source_order=1,
+        priority="P2",
+        treatment_status="Partial",
+        blocker=True,
+        blocker_reason="Missing action owner.",
+        evidence=RiskEvidence(
+            coverage_ref="Risk section A",
+            coverage_citation=1,
+            strategy_text="Containment strategy",
+            strategy_citation=1,
+            actions=["Set fallback supplier"],
+            action_citations=[1],
+            owner_text="NO EVIDENCE FOUND",
+            target_date_text="2026-06-30",
+            target_date_citation=1,
+            mapping_text="Section A",
+            mapping_citation=1,
+            evidence_status="Partial",
+        ),
+    )
+    report = render_validation_report(
+        [risk],
+        [
+            CitationSource(
+                index=1, title="DVA", file_name="dva.pdf", document_uid="doc-1"
+            )
+        ],
+    )
+
+    s1 = report.index("## DVA Risks (Full List, Source Order)")
+    s2 = report.index(
+        "## Coverage List with reference to the paragraph that covers the risk"
+    )
+    s3 = report.index("## Treatment Validation Summary")
+    s4 = report.index("## Treatment Validation Details")
+    s5 = report.index("## Blockers & PDA Action Plan")
+    s6 = report.index("## Sources")
+    assert s1 < s2 < s3 < s4 < s5 < s6
+    assert report.strip().endswith("document_uid=doc-1")
+
+
+def test_blocker_rule_marks_missing_strategy_owner_or_target_date() -> None:
+    risk = RiskRecord(
+        risk_id="R-02",
+        title="Delayed remediation",
+        risk_type="Source",
+        source_order=2,
+        priority="P1",
+        evidence=RiskEvidence(
+            strategy_text="NO EVIDENCE FOUND",
+            owner_text="NO EVIDENCE FOUND",
+            target_date_text="NO EVIDENCE FOUND",
+        ),
+    )
+
+    blocker, reason = blocker_status_for_risk(risk)
+    assert blocker is True
+    assert "strategy" in reason
+    assert "action owner" in reason
+    assert "action target date" in reason
+
+
+@pytest.mark.asyncio
+async def test_artifact_publication_and_ui_link_parts() -> None:
+    context = _FakeContext()
+    state = _state_for_steps()
+
+    publish_result = await publish_outputs_step(state, cast(GraphNodeContext, context))
+    updated = state.model_copy(update=publish_result.state_update)
+
+    assert [name for name, _ in context.published] == ["result.md", "risk_index.json"]
+
+    output = DVARiskValidatorGraph().build_output(updated)
+    assert output.ui_parts
+    assert len(output.ui_parts) == 2
+
+
+def test_session_scope_persistence_merges_generated_document_uids() -> None:
+    runtime_context = RuntimeContext(
+        selected_document_libraries_ids=["lib-a"],
+        selected_document_uids=["doc-source"],
+        search_policy="semantic",
+    )
+
+    merged = merge_session_scope(
+        runtime_context,
+        generated_document_uids=["doc-result", "doc-index", "doc-result"],
+    )
+
+    assert merged.selected_document_libraries_ids == ["lib-a"]
+    assert merged.selected_document_uids == ["doc-source", "doc-result", "doc-index"]
+    assert merged.include_session_scope is True
+    assert merged.search_policy == "semantic"
+
+
+def test_qa_grounding_declares_knowledge_search_and_sources_contract() -> None:
+    qa = DVARiskValidatorQA()
+    refs = [item.tool_ref for item in qa.declared_tool_refs]
+
+    assert TOOL_REF_KNOWLEDGE_SEARCH in refs
+    assert "Sources" in qa.system_prompt_template
+
+
+def test_risk_table_detection_accepts_bilingual_treatment_signals() -> None:
+    result = ToolInvocationResult(
+        tool_ref=TOOL_REF_KNOWLEDGE_SEARCH,
+        blocks=(
+            ToolContentBlock(
+                kind=ToolContentKind.TEXT,
+                text=(
+                    "Analyse des risques: propriétaire, date cible, mesures de "
+                    "mitigation pour chaque risque."
+                ),
+            ),
+        ),
+    )
+    assert _result_contains_risk_table_signal(result) is True
+
+
+def test_clean_extracted_risk_titles_filters_markdown_noise() -> None:
+    cleaned = _clean_extracted_risk_titles(
+        [
+            "| **ID** | **Risk Title** | **Strategy** | **Impact** |",
+            "| Core delivery risks | 1 | Cross-team dependency drift | Reduce | Schedule impact |",
+            "[3. RISK REGISTER [10]][10]",
+            "> In any case, highlight major points such as major risks and mitigation actions",
+        ]
+    )
+    assert cleaned == ["Cross-team dependency drift"]
+
+
+def test_coverage_reference_uses_clean_risk_table_row_label() -> None:
+    risk_title = "Cross-team dependency drift"
+    risk_text = (
+        "| | **ID** | **Risk Title** | **Strategy** | **Impact** | **Action** |\n"
+        "|----------|-----|--------------|---------|----------------|--------------------|\n"
+        "| Core delivery risks | 1 | Cross-team dependency drift | Reduce | Schedule impact | Align interfaces |"
+    )
+    result = ToolInvocationResult(
+        tool_ref=TOOL_REF_KNOWLEDGE_SEARCH,
+        blocks=(ToolContentBlock(kind=ToolContentKind.TEXT, text=risk_text),),
+    )
+    coverage = _derive_coverage_reference(
+        risk_title=risk_title,
+        risk_text=risk_text,
+        search_result=result,
+    )
+    assert coverage == "Risk table row (Core delivery risks, ID 1)"

--- a/fred-core/fred_core/session/stores/postgres_json_session_store.py
+++ b/fred-core/fred_core/session/stores/postgres_json_session_store.py
@@ -75,11 +75,12 @@ class PostgresJsonSessionStore(BaseJsonSessionStore):
             insp = inspect(sync_conn)
             cols = {c["name"] for c in insp.get_columns(self.table_name)}
             if "team_id" not in cols:
+                # SQLite compatibility:
+                # some bundled SQLite versions reject `ADD COLUMN IF NOT EXISTS`.
+                # We already checked column presence via inspector, so plain ADD
+                # is safe and works across Postgres + SQLite.
                 sync_conn.execute(
-                    text(
-                        f'ALTER TABLE "{self.table_name}" '
-                        "ADD COLUMN IF NOT EXISTS team_id VARCHAR"
-                    )
+                    text(f'ALTER TABLE "{self.table_name}" ADD COLUMN team_id VARCHAR')
                 )
                 logger.info(
                     "[SESSION][PG] Added missing team_id column to %s",

--- a/fred-core/fred_core/tests/session/test_postgres_json_session_store_sqlite.py
+++ b/fred-core/fred_core/tests/session/test_postgres_json_session_store_sqlite.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import text
 
 from fred_core.common import PostgresStoreConfig
 from fred_core.session.stores import PostgresJsonSessionStore
@@ -42,5 +43,39 @@ async def test_sqlite_store_save_get_count_delete(tmp_path) -> None:
 
     await store.delete("s1")
     assert await store.count_for_user("u1") == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_backfills_missing_team_id_column(tmp_path) -> None:
+    db_path = tmp_path / "session_store_migration.sqlite3"
+    cfg = PostgresStoreConfig(sqlite_path=str(db_path))
+    engine = create_async_engine_from_config(cfg)
+
+    # Simulate a pre-migration table that does not yet have team_id.
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                """
+                CREATE TABLE "session" (
+                    session_id VARCHAR PRIMARY KEY,
+                    user_id VARCHAR,
+                    agent_id VARCHAR,
+                    session_data JSON,
+                    updated_at DATETIME
+                )
+                """
+            )
+        )
+
+    # Instantiating the store should add missing team_id without SQL errors.
+    store = PostgresJsonSessionStore(engine=engine, table_name="session", prefix="")
+    await store._ensure_schema_ready()
+
+    async with engine.begin() as conn:
+        rows = await conn.execute(text('PRAGMA table_info("session")'))
+        column_names = {row[1] for row in rows.fetchall()}
+    assert "team_id" in column_names
 
     await engine.dispose()


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Mandatory Checklist

- [X] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [X] The change is minimal and avoids over-engineering.
- [X] I ran `make code-quality` in every touched project.
- [X] I ran `make test` in every touched project.
- [X] I did not introduce unit/default tests that require external services.
- [X] Any test requiring external services is marked `@pytest.mark.integration`.
- [X] I updated documentation when behavior or conventions changed.

This is the config to put in the catlog to make the agents available in the frontend
  - id: "DVA Risk Validator Graph v2.1"
    name: "DVA Risk Validator Graph v2.1"
    type: "agent"
    definition_ref: "v2.candidate.dva_risk_validator.graph"
    enabled: true
    chat_options:
      attach_files: true
      libraries_selection: true
      documents_selection: true
      search_rag_scoping: true

  - id: "DVA Risk Validator QA v2.1"
    name: "DVA Risk Validator QA v2.1"
    type: "agent"
    definition_ref: "v2.candidate.dva_risk_validator.qa"
    enabled: true
    chat_options:
      attach_files: true
      libraries_selection: true
      documents_selection: true
      search_rag_scoping: true



## Risk / Rollback

NA
