### PR TITLE
fix: tool calls no longer stream their output in v2 agents

### DIFF
--- a/agentic-backend/agentic_backend/core/agents/v2/react/react_stream_adapter.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/react/react_stream_adapter.py
@@ -192,7 +192,12 @@ def assistant_delta_from_stream_event(raw_event: object) -> str | None:
     - `delta = assistant_delta_from_stream_event(raw_event)`
     """
 
-    chunk = raw_event[0] if isinstance(raw_event, tuple) and raw_event else raw_event
+    if isinstance(raw_event, tuple) and len(raw_event) == 2:
+        chunk, chunk_meta = raw_event
+        if isinstance(chunk_meta, dict) and chunk_meta.get("langgraph_node") == "tools":
+            return None
+    else:
+        chunk = raw_event
     if not isinstance(chunk, AIMessageChunk):
         return None
     if chunk.tool_calls or chunk.tool_call_chunks:


### PR DESCRIPTION
## Summary

See issue

## Mandatory Checklist

- [ ] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [ ] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [ ] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

Paste the exact commands and short results.

## Risk / Rollback

State main risk and rollback approach.
