### PR TITLE
fix: reduce lag in agent form by memoizing heavy sub-components

### DIFF
--- a/frontend/src/components/agentHub/AgentToolsSelection.tsx
+++ b/frontend/src/components/agentHub/AgentToolsSelection.tsx
@@ -1,4 +1,5 @@
 import { Stack, Typography } from "@mui/material";
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { McpServerRef, useListMcpServersAgenticV1AgentsMcpServersGetQuery } from "../../slices/agentic/agenticOpenApi";
 import { AgentOptionSelectionCard } from "./AgentOptionSelectionCard";
@@ -8,7 +9,7 @@ export interface AgentToolsSelectionProps {
   onMcpServerRefsChange: (newMcpServerRefs: McpServerRef[]) => void;
 }
 
-export function AgentToolsSelection({ mcpServerRefs, onMcpServerRefsChange }: AgentToolsSelectionProps) {
+export const AgentToolsSelection = memo(function AgentToolsSelection({ mcpServerRefs, onMcpServerRefsChange }: AgentToolsSelectionProps) {
   const { t } = useTranslation();
   const { data: mcpServersData, isLoading: isLoadingMcpServers } = useListMcpServersAgenticV1AgentsMcpServersGetQuery();
   const refIds = new Set(mcpServerRefs.map((ref) => ref.id));
@@ -55,4 +56,4 @@ export function AgentToolsSelection({ mcpServerRefs, onMcpServerRefsChange }: Ag
       </Stack>
     </Stack>
   );
-}
+});

--- a/frontend/src/components/agentHub/TuningForm.tsx
+++ b/frontend/src/components/agentHub/TuningForm.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Box, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { FieldSpec } from "../../slices/agentic/agenticOpenApi";
 import { AgentOptionSelectionCard } from "./AgentOptionSelectionCard";
@@ -22,7 +23,7 @@ type Props = {
   onChange: (index: number, next: any) => void;
 };
 
-export function TuningForm({ fields, onChange }: Props) {
+export const TuningForm = memo(function TuningForm({ fields, onChange }: Props) {
   const { t } = useTranslation();
   // optional grouping by ui.group
   const filedsToShow = fields.filter((f) => !f.ui?.hide);
@@ -114,7 +115,7 @@ export function TuningForm({ fields, onChange }: Props) {
       ))}
     </Stack>
   );
-}
+});
 
 function groupBy<T>(arr: T[], key: (t: T) => string) {
   return arr.reduce<Record<string, T[]>>((acc, v) => {


### PR DESCRIPTION
## Summary

Wrap `AgentToolsSelection` and `TuningForm` with `React.memo` to prevent unnecessary re-renders when the parent form state changes (e.g. typing in the agent name field), which was causing noticeable input lag.

We should maybe add react-compiler to the project, so it does it automatically on all component ?

## Mandatory Checklist

- [ ] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [ ] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

Manually tested: typing in the agent name field no longer causes lag; MCP server selection and tuning fields continue to work correctly.

## Risk / Rollback

Low risk — `memo` is a pure rendering optimization with no behavioral change. Rollback by removing the `memo` wrapper from both components.