### PR TITLE
fix(control-plane): sync OpenFGA public tuple when team is_private changes

### DIFF
--- a/control-plane-backend/control_plane_backend/team_metadata_store.py
+++ b/control-plane-backend/control_plane_backend/team_metadata_store.py
@@ -98,7 +98,6 @@ class TeamMetadataStore:
             if existing_row is None:
                 row = TeamMetadataRow(
                     id=str(team_id),
-                    is_private=True,
                     **update_values,
                 )
             else:

--- a/control-plane-backend/control_plane_backend/teams_service.py
+++ b/control-plane-backend/control_plane_backend/teams_service.py
@@ -151,6 +151,17 @@ async def update_team(
         patch = TeamMetadataPatch.model_validate(request.model_dump(exclude_unset=True))
         await app_context.get_team_metadata_store().upsert(team_id, patch)
 
+        if "is_private" in request.model_fields_set:
+            public_relation = Relation(
+                subject=RebacReference(Resource.USER, "*"),
+                relation=RelationType.PUBLIC,
+                resource=RebacReference(Resource.TEAM, team_id),
+            )
+            if request.is_private:
+                await rebac.delete_relations([public_relation])
+            else:
+                await rebac.add_relation(public_relation)
+
     group_summary = KeycloakGroupSummary(
         id=team_id,
         name=raw_group.get("name"),


### PR DESCRIPTION
## Summary

Two bugs in `update_team` / `TeamMetadataStore.upsert` related to the team public visibility feature:

1. **Missing OpenFGA sync**: `update_team` was persisting `is_private` in the metadata store but never writing or deleting the `user:* → public → team` tuple in OpenFGA. Setting a team public had no effect on authorization.

2. **Duplicate keyword argument crash**: `TeamMetadataStore.upsert` hardcoded `is_private=True` when constructing a new `TeamMetadataRow`, then also spread `**update_values` which could contain `is_private`. This caused a `TypeError` on the first PATCH for a team that had no existing metadata row.

## Mandatory Checklist

- [x] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

```
PATCH /control-plane/v1/teams/<id>  {"is_private": false}
→ Previously: 500 TypeError / 500 IntegrityError
→ Now: 200, OpenFGA public tuple created
```

## Risk / Rollback

Low risk — only affects the `update_team` code path. Rollback by reverting the two changed files. No migration needed (DB fix was a separate manual step to apply the correct schema defaults).