### PR TITLE
Fix Kaniko symlink error for alembic.ini in prod Dockerfiles

### DIFF
--- a/agentic-backend/dockerfiles/Dockerfile-prod
+++ b/agentic-backend/dockerfiles/Dockerfile-prod
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # -----------------------------------------------------------------------------
 # BUILD STAGE
 # -----------------------------------------------------------------------------
@@ -41,8 +40,10 @@ COPY fred-core /fred-core
 # Install dependencies using make with both VENV and TARGET properly set
 RUN make dev
 
-# Copy projets (exclude alembic.ini symlink; the real file is copied next)
-COPY --exclude=alembic.ini agentic-backend/. /app/
+# Copy projets; remove the broken alembic.ini symlink before copying the real
+# file — Kaniko preserves symlinks as-is and would fail resolving the target.
+COPY agentic-backend/. /app/
+RUN rm -f /app/alembic.ini
 COPY alembic.ini /app/alembic.ini
 
 # -----------------------------------------------------------------------------
@@ -87,8 +88,10 @@ ENV PRODUCTION_FASTAPI_DOCS_ENABLED=${PRODUCTION_FASTAPI_DOCS_ENABLED}
 # Set working directory
 WORKDIR /app
 
-# Copy app source (exclude alembic.ini symlink; the real file is copied next)
-COPY --exclude=alembic.ini --chown=${USER_ID}:${GROUP_ID} agentic-backend/. /app
+# Copy app source; remove the broken alembic.ini symlink before copying the
+# real file — Kaniko preserves symlinks as-is and would fail resolving the target.
+COPY --chown=${USER_ID}:${GROUP_ID} agentic-backend/. /app
+RUN rm -f /app/alembic.ini
 COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /app/alembic.ini
 COPY --chown=${USER_ID}:${GROUP_ID} fred-core /fred-core
 COPY --chown=${USER_ID}:${GROUP_ID} scripts /scripts

--- a/control-plane-backend/dockerfiles/Dockerfile-prod
+++ b/control-plane-backend/dockerfiles/Dockerfile-prod
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # -----------------------------------------------------------------------------
 # BUILD STAGE
 # -----------------------------------------------------------------------------
@@ -28,8 +27,10 @@ COPY fred-core /fred-core
 
 RUN make dev
 
-# Exclude alembic.ini symlink; the real file is copied next
-COPY --exclude=alembic.ini control-plane-backend/. /app/
+# Remove the broken alembic.ini symlink before copying the real file —
+# Kaniko preserves symlinks as-is and would fail resolving the target.
+COPY control-plane-backend/. /app/
+RUN rm -f /app/alembic.ini
 COPY alembic.ini /app/alembic.ini
 
 # -----------------------------------------------------------------------------
@@ -55,8 +56,10 @@ ENV PRODUCTION_FASTAPI_DOCS_ENABLED=${PRODUCTION_FASTAPI_DOCS_ENABLED}
 
 WORKDIR /app
 
-# Exclude alembic.ini symlink; the real file is copied next
-COPY --exclude=alembic.ini --chown=${USER_ID}:${GROUP_ID} control-plane-backend/. /app
+# Remove the broken alembic.ini symlink before copying the real file —
+# Kaniko preserves symlinks as-is and would fail resolving the target.
+COPY --chown=${USER_ID}:${GROUP_ID} control-plane-backend/. /app
+RUN rm -f /app/alembic.ini
 COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /app/alembic.ini
 COPY --chown=${USER_ID}:${GROUP_ID} fred-core /fred-core
 COPY --chown=${USER_ID}:${GROUP_ID} scripts /scripts

--- a/knowledge-flow-backend/dockerfiles/Dockerfile-prod
+++ b/knowledge-flow-backend/dockerfiles/Dockerfile-prod
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # -----------------------------------------------------------------------------
 # BUILD STAGE
 # -----------------------------------------------------------------------------
@@ -45,8 +44,10 @@ RUN mkdir -p $TIKTOKEN_CACHE_DIR
 # Download encodings for offline usage
 RUN python /scripts/download_encodings.py https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken
 
-# Copy projets (exclude alembic.ini symlink; the real file is copied next)
-COPY --exclude=alembic.ini knowledge-flow-backend/. /app/
+# Remove the broken alembic.ini symlink before copying the real file —
+# Kaniko preserves symlinks as-is and would fail resolving the target.
+COPY knowledge-flow-backend/. /app/
+RUN rm -f /app/alembic.ini
 COPY alembic.ini /app/alembic.ini
 
 # -----------------------------------------------------------------------------
@@ -132,8 +133,10 @@ ENV HF_HUB_DISABLE_TELEMETRY=1
 # Set working directory
 WORKDIR /app
 
-# Copy app source (exclude alembic.ini symlink; the real file is copied next)
-COPY --exclude=alembic.ini --chown=${USER_ID}:${GROUP_ID} knowledge-flow-backend/. /app
+# Remove the broken alembic.ini symlink before copying the real file —
+# Kaniko preserves symlinks as-is and would fail resolving the target.
+COPY --chown=${USER_ID}:${GROUP_ID} knowledge-flow-backend/. /app
+RUN rm -f /app/alembic.ini
 COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /app/alembic.ini
 COPY --chown=${USER_ID}:${GROUP_ID} fred-core /fred-core
 COPY --chown=${USER_ID}:${GROUP_ID} scripts /scripts


### PR DESCRIPTION
## Summary

- Kaniko (used in GitLab CI) preserves symlinks as-is during `COPY`, unlike Docker BuildKit which resolves them
- Copying the backend directory drops `alembic.ini` as a broken symlink (`→ ../alembic.ini`) inside the container; the subsequent `COPY alembic.ini /app/alembic.ini` fails trying to write through a dangling symlink
- `COPY --exclude` is not supported by Kaniko's Dockerfile parser (it ignores `# syntax=` directives too), so the fix is `RUN rm -f /app/alembic.ini` between the backend `COPY` and the real-file `COPY`

## Mandatory Checklist

- [ ] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

GitHub Actions (BuildKit): unaffected — `RUN rm -f` on a symlink works fine.
GitLab CI (Kaniko): the broken symlink is removed before Kaniko tries to write through it.

## Risk / Rollback

Low — Dockerfile-only change, no logic affected. Rollback: revert this commit.