### PR TITLE
1492 translation typos and fix starlette encodes file headers with latin-1 codec

### DIFF
--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1336,8 +1336,8 @@
       "marketplace": {
         "title": "Marketplace",
         "menu": {
-          "teams": "Equipe",
-          "tools": "Tools",
+          "teams": "Équipe",
+          "tools": "Outils",
           "apps": "Apps"
         }
       },
@@ -1394,7 +1394,7 @@
           "label": "Description de l'équipe",
           "placeholder": "Aidez les autres utilisateurs à comprendre le rôle de votre équipe."
         },
-        "privateTeam": "Equipe privé",
+        "privateTeam": "Équipe privée",
         "teamPrompt": {
           "label": "Contexte de l'équipe (prompt)",
           "placeholder": "Décrivez ici les enjeux et les objectifs de votre équipe. Ces éléments seront pris en compte par vos {{agentsNicknamePlural}} d’équipe."
@@ -1411,7 +1411,7 @@
     },
     "marketplace": {
       "teams": {
-        "title": "Equipes de la communauté",
+        "title": "Équipes de la communauté",
         "yourTeams": "Vos équipes",
         "otherTeams": "Découvrez d'autres équipes"
       }

--- a/knowledge-flow-backend/knowledge_flow_backend/features/content/asset_controller.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/content/asset_controller.py
@@ -9,7 +9,10 @@ from fred_core import KeycloakUser, get_current_user
 from starlette.background import BackgroundTask
 
 from knowledge_flow_backend.features.content.asset_service import AssetListResponse, AssetMeta, AssetService, ScopeType
-from knowledge_flow_backend.features.content.content_controller import parse_range_header  # reuse helper
+from knowledge_flow_backend.features.content.content_controller import (
+    build_content_disposition_header,
+    parse_range_header,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -250,7 +253,7 @@ class AssetController:
         content_type = meta.content_type or "application/octet-stream"
         headers = {
             "Accept-Ranges": "bytes",
-            "Content-Disposition": f'inline; filename="{meta.file_name}"',
+            "Content-Disposition": build_content_disposition_header("inline", meta.file_name),
         }
 
         rng = parse_range_header(range_header)

--- a/knowledge-flow-backend/knowledge_flow_backend/features/content/content_controller.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/content/content_controller.py
@@ -16,6 +16,7 @@ import logging
 import re
 from datetime import timedelta
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from fastapi.responses import StreamingResponse
@@ -68,6 +69,32 @@ def parse_range_header(range_str: Optional[str]) -> Optional[tuple[int | None, i
     start = int(start_s) if start_s else None
     end = int(end_s) if end_s else None
     return start, end
+
+
+def build_content_disposition_header(disposition_type: str, file_name: str) -> str:
+    """
+    Build an ASCII-safe Content-Disposition header for downloads and inline previews.
+
+    Why this exists:
+    Starlette encodes response headers as latin-1. User-provided file names can
+    include typographic punctuation or other Unicode characters that would crash
+    response creation when inserted directly into `filename="..."`.
+
+    How to use it:
+    Pass the desired disposition (`"inline"` or `"attachment"`) and the original
+    file name. The helper returns a header value with:
+    - an ASCII fallback in `filename=...`
+    - the original UTF-8 name in RFC 5987 `filename*=...`
+
+    Example:
+    `build_content_disposition_header("inline", "l’avis.pdf")`
+    returns a safe header such as
+    `inline; filename="l'avis.pdf"; filename*=UTF-8''l%E2%80%99avis.pdf`
+    """
+    fallback_name = file_name.encode("latin-1", errors="replace").decode("latin-1")
+    fallback_name = fallback_name.replace("\\", "_").replace('"', "'")
+    encoded_name = quote(file_name, safe="")
+    return f"{disposition_type}; filename=\"{fallback_name}\"; filename*=UTF-8''{encoded_name}"
 
 
 _MEDIA_RE = re.compile(r"knowledge-flow/v1/markdown/([^/]+)/media/([^/?#\s\"']+)")
@@ -209,7 +236,11 @@ class ContentController:
             try:
                 stream, file_name, content_type = await self.service.get_document_media(user, document_uid, media_id)
 
-                return StreamingResponse(content=stream, media_type=content_type, headers={"Content-Disposition": f'attachment; filename="{file_name}"'})
+                return StreamingResponse(
+                    content=stream,
+                    media_type=content_type,
+                    headers={"Content-Disposition": build_content_disposition_header("attachment", file_name)},
+                )
             except FileNotFoundError as e:
                 raise HTTPException(status_code=404, detail=str(e))
 
@@ -240,7 +271,7 @@ class ContentController:
             return StreamingResponse(
                 content=stream,
                 media_type=media_type,
-                headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+                headers={"Content-Disposition": build_content_disposition_header("attachment", file_name)},
             )
 
         @router.get(
@@ -268,7 +299,7 @@ class ContentController:
 
                 headers = {
                     "Accept-Ranges": "bytes",
-                    "Content-Disposition": f'inline; filename="{file_name}"',
+                    "Content-Disposition": build_content_disposition_header("inline", file_name),
                 }
 
                 rng = parse_range_header(range_header)

--- a/knowledge-flow-backend/tests/features/content/test_content_disposition_headers.py
+++ b/knowledge-flow-backend/tests/features/content/test_content_disposition_headers.py
@@ -1,0 +1,11 @@
+from knowledge_flow_backend.features.content.content_controller import (
+    build_content_disposition_header,
+)
+
+
+def test_build_content_disposition_header_keeps_unicode_filename_via_filename_star() -> None:
+    header = build_content_disposition_header("inline", "Rapport d’avril 2026.pdf")
+
+    assert header.startswith('inline; filename="Rapport d?avril 2026.pdf"; ')
+    assert "filename*=UTF-8''Rapport%20d%E2%80%99avril%202026.pdf" in header
+    header.encode("latin-1")


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Mandatory Checklist

- [ ] I followed [`docs/DEVELOPER_CONTRACT.md`](../docs/DEVELOPER_CONTRACT.md).
- [ ] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [ ] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

Paste the exact commands and short results.

## Risk / Rollback

State main risk and rollback approach.
