### PR TITLE
fix: set back old tool name and params for retrocompatibilty on kf vector search tool

### DIFF
--- a/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
+++ b/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
@@ -5,11 +5,12 @@ import logging
 from typing import Optional, Sequence
 
 from langchain_core.tools import BaseTool, tool
-from langgraph.prebuilt import ToolRuntime
 
+# from langgraph.prebuilt import ToolRuntime
 from agentic_backend.common.kf_base_client import KnowledgeFlowAgentContext
 from agentic_backend.common.kf_vectorsearch_client import VectorSearchClient
-from agentic_backend.core.agents.runtime_context import RuntimeContext
+
+# from agentic_backend.core.agents.runtime_context import RuntimeContext
 
 logger = logging.getLogger(__name__)
 
@@ -17,15 +18,18 @@ logger = logging.getLogger(__name__)
 def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
     """Return in-process LangChain tools for Knowledge Flow vector search."""
 
-    @tool("semantic_search")
+    @tool("search_documents_using_vectorization")
     async def kf_vector_search(
-        runtime: ToolRuntime[RuntimeContext],
-        query: str,
+        # todo: set back when gitlab agents do not call this tool directly with ainvoke (and use VectorSearchClient directly instead)
+        # runtime: ToolRuntime[RuntimeContext],
+        question: str,
         top_k: int = 5,
         document_library_tags_ids: Optional[Sequence[str]] = None,
         document_uids: Optional[Sequence[str]] = None,
     ) -> str:
         """Search the user's document library using semantic similarity (RAG).
+
+        By default, keep a top_k of 5.
 
         Returns ranked hits with title, content, and rank. For each answer:
         - Cite sources with bracketed numbers matching hit rank: [1], [2], etc.
@@ -34,10 +38,10 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
         """
         client = VectorSearchClient(agent=agent)
         hits = await client.agent_search(
-            # todo: retrieve agent settings from `runtime.context`
+            # todo: retrieve agent settings and runtime_context from `runtime.context.context` (lanchain)
             agent_settings=agent.agent_settings,
-            runtime_context=runtime.context,
-            question=query,
+            runtime_context=agent.runtime_context,
+            question=question,
             top_k=top_k,
             document_library_tags_ids=document_library_tags_ids,
             document_uids=document_uids,
@@ -45,6 +49,6 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
 
         # todo: return a string to agent and json metadata for the UI ?
         serialized = [h.model_dump() if hasattr(h, "model_dump") else h for h in hits]
-        return json.dumps({"hits": serialized}, ensure_ascii=False)
+        return json.dumps(serialized, ensure_ascii=False)
 
     return [kf_vector_search]

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -648,7 +648,7 @@
       "placeholder": "Write your message…  Enter to send • Shift+Enter for newline"
     },
     "attachFiles": "Attach files",
-    "addLibraries": "Add libraries",
+    "addLibraries": "Select folders",
     "addDocuments": "Add documents",
     "attachments": {
       "betaNotice": "File attachments are in beta. Supported formats: PDF, DOC, DOCX, PPT, PPTX, TXT, MD, CSV, TSV, RTF, HTML, JSON, JSONL, XLS, XLSX. Please provide feedback to help us improve this feature.",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -649,7 +649,7 @@
       "placeholder": "Écrivez votre message…  Entrée pour envoyer • Maj+Entrée pour un saut de ligne"
     },
     "attachFiles": "Joindre des fichiers",
-    "addLibraries": "Ajouter des bibliothèques",
+    "addLibraries": "Sélectionner des dossiers",
     "addDocuments": "Ajouter des documents",
     "attachments": {
       "betaNotice": "Les pièces jointes sont en version bêta. Formats pris en charge : PDF, DOC, DOCX, PPT, PPTX, TXT, MD, CSV, TSV, RTF, HTML, JSON, JSONL, XLS, XLSX. Veuillez donner votre avis pour nous aider à améliorer cette fonctionnalité.",


### PR DESCRIPTION
+ improve translation key
+ improve kf vector search tool description

## Summary

Describe what changed and why.

## Mandatory Checklist

- [ ] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [ ] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [ ] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

Paste the exact commands and short results.

## Risk / Rollback

State main risk and rollback approach.
