### PR TITLE
feat: add configurable upload warning alert to document upload drawer

### DIFF
--- a/agentic-backend/agentic_backend/common/structures.py
+++ b/agentic-backend/agentic_backend/common/structures.py
@@ -325,6 +325,17 @@ class AIConfig(BaseModel):
         return cleaned
 
 
+class UploadWarning(BaseModel):
+    severity: Literal["info", "warning", "error", "success"] = Field(
+        default="info",
+        description="MUI Alert severity level.",
+    )
+    messages: Dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → message map (e.g. {"en": "...", "fr": "..."}).',
+    )
+
+
 class FrontendFlags(BaseModel):
     enableK8Features: bool = False
     enableElecWarfare: bool = False
@@ -357,6 +368,10 @@ class Properties(BaseModel):
     defaultTeamAvatarFile: str = "default-team-avatar.png"
     defaultPersonalAvatarFile: str = "default-team-avatar.png"
     gcuVersion: str | None = None
+    uploadWarning: Optional[UploadWarning] = Field(
+        default=None,
+        description="Optional alert shown in the document upload drawer. Omit to show nothing.",
+    )
 
 
 class FrontendSettings(BaseModel):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fred-ui",
-  "version": "1.5.0-post",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fred-ui",
-      "version": "1.5.0-post",
+      "version": "1.5.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/frontend/public/release.md
+++ b/frontend/public/release.md
@@ -1,3 +1,17 @@
+**Unreleased** — XXXX-XX-XX
+
+- **Features**
+
+  - add capacity to specify custom RetryPolicy for Temporal activities (#1576)
+  - feat: added fast lite md processor (#1593)
+  - expose metrics for prometheus scraping on control plane (#1592)
+  - add configurable upload warning alert to document upload drawer (#1597)
+
+- **Bug Fixes**
+
+  - typo in link in mail to request to join a team (#1589)
+  - spurious langfuse error log (#1594)
+
 **v1.5.3** — 2026-05-03
 
 - **Improvements**

--- a/frontend/src/components/documents/libraries/DocumentUploadDrawer.tsx
+++ b/frontend/src/components/documents/libraries/DocumentUploadDrawer.tsx
@@ -15,6 +15,7 @@
 import SaveIcon from "@mui/icons-material/Save";
 import UploadIcon from "@mui/icons-material/Upload";
 import {
+  Alert,
   Box,
   Button,
   Drawer,
@@ -30,6 +31,7 @@ import React, { useMemo, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { useTranslation } from "react-i18next";
 import { usePermissions } from "../../../security/usePermissions";
+import { useFrontendProperties } from "../../../hooks/useFrontendProperties";
 import { SimpleTooltip } from "../../../shared/ui/tooltips/Tooltips";
 import { UploadProcessProgressSummary, streamUploadOrProcessDocument } from "../../../slices/streamDocumentUpload";
 import {
@@ -60,12 +62,19 @@ export const DocumentUploadDrawer: React.FC<DocumentUploadDrawerProps> = ({
   onUploadComplete,
   metadata,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { showError, showInfo } = useToast();
   const theme = useTheme();
   const { can } = usePermissions();
   // TODO(security): replace this temporary gate with a dedicated permission for profile selection.
   const canSelectProcessingProfile = can("document", "update");
+
+  const { uploadWarning } = useFrontendProperties();
+  const uploadWarningMessage = uploadWarning?.messages
+    ? (uploadWarning.messages[i18n.language?.split("-")[0] ?? "en"] ??
+        uploadWarning.messages["en"] ??
+        null)
+    : null;
 
   const [uploadMode, setUploadMode] = useState<"upload" | "process">("process");
   const [processingProfile, setProcessingProfile] = useState<IngestionProcessingProfile>("fast");
@@ -313,6 +322,12 @@ export const DocumentUploadDrawer: React.FC<DocumentUploadDrawerProps> = ({
       <Typography variant="h5" fontWeight="bold" gutterBottom>
         {t("documentLibrary.uploadDrawerTitle")}
       </Typography>
+
+      {uploadWarning && uploadWarningMessage && (
+        <Alert severity={uploadWarning.severity ?? "info"} sx={{ mt: 1.5 }}>
+          {uploadWarningMessage}
+        </Alert>
+      )}
 
       <FormControl fullWidth sx={{ mt: 2 }}>
         <Typography variant="subtitle2" gutterBottom>

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -1149,6 +1149,14 @@ export type FrontendFlags = {
   enableK8Features?: boolean;
   enableElecWarfare?: boolean;
 };
+export type UploadWarning = {
+  /** MUI Alert severity level. */
+  severity?: "info" | "warning" | "error" | "success";
+  /** Locale → message map (e.g. {"en": "...", "fr": "..."}). */
+  messages?: {
+    [key: string]: string;
+  };
+};
 export type Properties = {
   logoName?: string;
   logoNameDark?: string;
@@ -1174,6 +1182,8 @@ export type Properties = {
   defaultTeamAvatarFile?: string;
   defaultPersonalAvatarFile?: string;
   gcuVersion?: string | null;
+  /** Optional alert shown in the document upload drawer. Omit to show nothing. */
+  uploadWarning?: UploadWarning | null;
 };
 export type FrontendSettings = {
   feature_flags: FrontendFlags;


### PR DESCRIPTION
## Summary

- Add `UploadWarning` Pydantic model to `Properties` in `structures.py` — holds a severity level and a locale-keyed message map
- Regenerate `agenticOpenApi.ts` to expose `UploadWarning` and the new `uploadWarning` field on `Properties`
- Render a conditional MUI `Alert` in `DocumentUploadDrawer` between the title and mode selector; resolves locale via `i18n.language` with `"en"` fallback
- Document `uploadWarning` with a commented example block in `values.yaml`

Deployers configure the warning via Helm overrides or config YAML — no frontend code change needed to activate or update the message.

Example of configuration to put in agentic config file:

```yaml
frontend_settings:
  properties:
    uploadWarning:
      severity: "warning"
      messages:
        en: "Only PDF and Word files are supported. Max size: 50 MB."
        fr: "Seuls les fichiers PDF et Word sont acceptés. Taille max : 50 Mo."
```

## Mandatory Checklist

- [ ] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [ ] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [ ] I did not introduce unit/default tests that require external services.
- [ ] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

1. Add `uploadWarning` block to `agentic-backend/config/configuration_prod.yaml` and restart the backend
2. Confirm `/agentic/v1/config/frontend_settings` returns `uploadWarning` with severity and messages
3. Open the document upload drawer — alert appears with the correct message and severity
4. Switch browser language between `en` and `fr` — message switches accordingly
5. Remove `uploadWarning` from config — no alert is shown

## Risk / Rollback

No risk: `uploadWarning` defaults to `null`, so existing deployments that omit the field are unaffected. Rollback by removing the `uploadWarning` key from the config YAML.