### PR TITLE
fix: guard against undefined before calling toLowerCase

### DIFF
--- a/frontend/src/common/agent.ts
+++ b/frontend/src/common/agent.ts
@@ -43,7 +43,7 @@ interface AgentVisuals {
  * @returns An object containing the icon component and a functional color hint.
  */
 export const getAgentVisuals = (agent: AnyAgent): AgentVisuals => {
-  const roleText = agent.tuning.role.toLowerCase();
+  const roleText = (agent.tuning?.role ?? "").toLowerCase();
 
   // 1. Data/Knowledge/Information
   if (

--- a/frontend/src/rework/components/shared/organisms/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/frontend/src/rework/components/shared/organisms/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -32,7 +32,7 @@ export default function TeamContentNavbar() {
   const navigationItems: NavigationMenuItemProps[] = [
     {
       type: "link",
-      label: agentsNicknamePlural.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase()),
+      label: (agentsNicknamePlural ?? "").toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase()),
       icon: { category: "outlined", type: agentIconName as IconType, filled: true },
       linkProps: { to: `/team/${teamId}/agents` },
     },


### PR DESCRIPTION
Closes #1609

## Summary

- Guard `agentsNicknamePlural` in `TeamContentNavbar` with `?? ""` before calling `.toLowerCase()` — this property is optional and undefined before the frontend config loads, crashing the sidebar and triggering the router error boundary.
- Guard `agent.tuning?.role` in `getAgentVisuals` with optional chaining and `?? ""` — `tuning` is nullable.