### PR TITLE
Bugfix/knowledge flow search policy

### DIFF
--- a/frontend/src/rework/components/pages/GcuPage/GcuPage.tsx
+++ b/frontend/src/rework/components/pages/GcuPage/GcuPage.tsx
@@ -33,7 +33,8 @@ export default function GcuPage() {
 
   const [gcuMarkdown, setGcuMarkdown] = useState<string>("");
   const [hasReachedBottom, setHasReachedBottom] = useState(false);
-  const bottomRef = useRef(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const base = (import.meta.env?.BASE_URL as string | undefined)?.replace(/\/$/, "") ?? "";
@@ -54,27 +55,28 @@ export default function GcuPage() {
   }, [i18n.language]);
 
   useEffect(() => {
+    if (hasReachedBottom) return;
+    const root = contentRef.current;
+    const target = bottomRef.current;
+    if (!root || !target) return;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
           setHasReachedBottom(true);
-          observer.unobserve(entry.target);
-        } else {
-          setHasReachedBottom(false);
+          observer.disconnect();
         }
       },
       {
-        root: null,
-        threshold: 1.0,
+        root,
+        threshold: 0.01,
       },
     );
 
-    if (bottomRef.current) {
-      observer.observe(bottomRef.current);
-    }
+    observer.observe(target);
 
     return () => observer.disconnect();
-  }, [gcuMarkdown]);
+  }, [gcuMarkdown, hasReachedBottom]);
 
   const handleAcceptGcu = async () => {
     await trigger().unwrap();
@@ -82,9 +84,9 @@ export default function GcuPage() {
   };
 
   return (
-    <div className={styles.gcuContainer}>
+      <div className={styles.gcuContainer}>
       <div className={styles.gcuTitle}>{t("rework.gcu.title")}</div>
-      <div className={styles.gcuContent}>
+      <div className={styles.gcuContent} ref={contentRef}>
         <MarkdownRenderer content={gcuMarkdown} />
         <div ref={bottomRef} />
       </div>

--- a/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
@@ -171,6 +171,37 @@ class VectorSearchService:
                 actor=self._kpi_actor(user=user),
             )
 
+    def _resolve_policy_for_backend(self, policy: SearchPolicyName) -> SearchPolicyName:
+        """
+        Ensure the requested policy is compatible with the configured vector-store backend.
+
+        Why this exists:
+        - Some deployments use a vector store backend that only supports ANN (semantic) search.
+        - The UI/agents default to `hybrid`, which requires `hybrid_search` support.
+        - In dev/offline environments this mismatch should degrade gracefully instead of 500'ing.
+
+        How to use:
+        - Call this before selecting the search strategy function.
+
+        Example:
+            policy = self._resolve_policy_for_backend(SearchPolicyName.hybrid)
+        """
+        if policy == SearchPolicyName.hybrid and not isinstance(self.vector_store, SupportsHybridSearch):
+            logger.warning(
+                "[SEARCH_POLICY] requested=%s but backend=%s has no hybrid_search; falling back to semantic",
+                policy.value,
+                type(self.vector_store).__name__,
+            )
+            return SearchPolicyName.semantic
+        if policy == SearchPolicyName.strict and not isinstance(self.vector_store, SupportsFullTextSearch):
+            logger.warning(
+                "[SEARCH_POLICY] requested=%s but backend=%s has no full_text_search; falling back to semantic",
+                policy.value,
+                type(self.vector_store).__name__,
+            )
+            return SearchPolicyName.semantic
+        return policy
+
     # ---------- helpers -------------------------------------------------------
 
     async def _collect_document_ids_from_tags(self, tags_ids: Optional[List[str]], user: KeycloakUser) -> Set[str]:
@@ -563,7 +594,7 @@ class VectorSearchService:
                     authorized_document_uids = await self.metadata_service.filter_readable_document_uids(user, document_uids)
 
             # Search function dispatch
-            policy_key = policy_name or SearchPolicyName.hybrid
+            policy_key = self._resolve_policy_for_backend(policy_name or SearchPolicyName.hybrid)
             logger.debug(
                 "[SEARCH_POLICY] received=%r resolved=%r question_preview=%r",
                 policy_name,

--- a/knowledge-flow-backend/tests/services/test_vector_search_service.py
+++ b/knowledge-flow-backend/tests/services/test_vector_search_service.py
@@ -199,3 +199,25 @@ async def test_similarity_search_zero_k(monkeypatch, test_user):
     )
     assert isinstance(results, list)
     assert results == []
+
+
+async def test_default_policy_falls_back_to_semantic_when_hybrid_unsupported(monkeypatch, test_user):
+    """
+    Default policy is `hybrid`, but the DummyVectorStore only implements ANN.
+    Expectation: service should gracefully fall back to semantic instead of raising TypeError.
+    """
+    monkeypatch.setattr(vector_search_service.ApplicationContext, "get_instance", DummyContext)
+    monkeypatch.setattr(vector_search_service, "TagService", DummyTagService)
+    monkeypatch.setattr(vector_search_service, "MetadataService", DummyMetadataService)
+    vector_svc = VectorSearchService()
+
+    results = await vector_svc.search(
+        question="What is RAG?",
+        user=test_user,
+        top_k=2,
+        document_library_tags_ids=None,
+        policy_name=None,
+    )
+
+    assert len(results) == 2
+    assert all(getattr(hit, "content", None) for hit in results)

--- a/libs/fred-core/pyproject.toml
+++ b/libs/fred-core/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pydantic>=2.5.2,<3.0.0",
     "python-dotenv>=1.0.1,<2.0.0",
     "sqlalchemy>=2.0.42",
+    "greenlet>=3.0.3",
     "sqlparse>=0.5.3",
     "httpx>=0.28.1",
     "langchain-core>=1.3.0",


### PR DESCRIPTION
## Summary

The search error is coming from the policy/backend mismatch: the request defaults to search_policy=hybrid, but the configured vector store(local dev) backend doesn’t expose hybrid_search, so VectorSearchService._hybrid() used to raise a TypeError which bubbles up as a 500.

I fixed it by gracefully falling back to semantic when hybrid (or strict) isn’t supported by the current backend.