### PR TITLE
knowledge flow local policy

### DIFF
--- a/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
@@ -386,11 +386,23 @@ class VectorSearchService:
         Returns:
             List[VectorSearchHit]: A list of VectorSearchHit objects containing the search results.
 
-        Raises:
-            TypeError: If the vector_store does not expose full_text_search.
+        Notes:
+            When the current vector store backend does not expose `full_text_search`, this
+            method falls back to semantic ANN search. This keeps local dev backends
+            (e.g. Chroma) usable even when the request policy defaults to `strict`.
         """
         if not isinstance(self.vector_store, SupportsFullTextSearch):
-            raise TypeError(f"Strict search requires a backend exposing full_text_search, but vector_store is {type(self.vector_store).__name__}")
+            logger.warning(
+                "[VECTOR][SEARCH][STRICT] backend=%s lacks full_text_search; falling back to semantic search",
+                type(self.vector_store).__name__,
+            )
+            return await self._semantic(
+                question=question,
+                user=user,
+                k=k,
+                library_tags_ids=library_tags_ids,
+                metadata_terms_extra=metadata_terms_extra,
+            )
         full_text_store = cast(SupportsFullTextSearch, self.vector_store)
 
         metadata_terms: dict[str, Any] = {"retrievable": [True]}
@@ -453,11 +465,23 @@ class VectorSearchService:
         Returns:
             List[VectorSearchHit]: A list of search hits with relevant metadata.
 
-        Raises:
-            TypeError: If the vector store does not expose hybrid_search.
+        Notes:
+            When the current vector store backend does not expose `hybrid_search`, this
+            method falls back to semantic ANN search. This keeps local dev backends
+            (e.g. Chroma) usable even when the request policy defaults to `hybrid`.
         """
         if not isinstance(self.vector_store, SupportsHybridSearch):
-            raise TypeError(f"Hybrid search requires a backend exposing hybrid_search, but vector_store is {type(self.vector_store).__name__}")
+            logger.warning(
+                "[VECTOR][SEARCH][HYBRID] backend=%s lacks hybrid_search; falling back to semantic search",
+                type(self.vector_store).__name__,
+            )
+            return await self._semantic(
+                question=question,
+                user=user,
+                k=k,
+                library_tags_ids=library_tags_ids,
+                metadata_terms_extra=metadata_terms_extra,
+            )
         hybrid_store = cast(SupportsHybridSearch, self.vector_store)
 
         metadata_terms: dict[str, Any] = {"retrievable": [True]}
@@ -533,7 +557,6 @@ class VectorSearchService:
             List[VectorSearchHit]: A list of VectorSearchHit objects containing the search results.
 
         Raises:
-            TypeError: If the vector store does not support the selected search policy.
             Exception: For any other unexpected errors during the search process.
         """
         corpus_hits: List[VectorSearchHit] = []

--- a/knowledge-flow-backend/tests/services/test_vector_search_service.py
+++ b/knowledge-flow-backend/tests/services/test_vector_search_service.py
@@ -199,3 +199,37 @@ async def test_similarity_search_zero_k(monkeypatch, test_user):
     )
     assert isinstance(results, list)
     assert results == []
+
+
+async def test_hybrid_policy_falls_back_to_semantic_when_backend_unsupported(monkeypatch, test_user):
+    """Test: hybrid policy should not crash when backend lacks hybrid_search; falls back to semantic."""
+    monkeypatch.setattr(vector_search_service.ApplicationContext, "get_instance", DummyContext)
+    monkeypatch.setattr(vector_search_service, "TagService", DummyTagService)
+    monkeypatch.setattr(vector_search_service, "MetadataService", DummyMetadataService)
+    vector_svc = VectorSearchService()
+    results = await vector_svc.search(
+        question="What is AI?",
+        user=test_user,
+        top_k=2,
+        document_library_tags_ids=None,
+        policy_name=SearchPolicyName.hybrid,
+    )
+    assert isinstance(results, list)
+    assert len(results) == 2
+
+
+async def test_strict_policy_falls_back_to_semantic_when_backend_unsupported(monkeypatch, test_user):
+    """Test: strict policy should not crash when backend lacks full_text_search; falls back to semantic."""
+    monkeypatch.setattr(vector_search_service.ApplicationContext, "get_instance", DummyContext)
+    monkeypatch.setattr(vector_search_service, "TagService", DummyTagService)
+    monkeypatch.setattr(vector_search_service, "MetadataService", DummyMetadataService)
+    vector_svc = VectorSearchService()
+    results = await vector_svc.search(
+        question="What is AI?",
+        user=test_user,
+        top_k=2,
+        document_library_tags_ids=None,
+        policy_name=SearchPolicyName.strict,
+    )
+    assert isinstance(results, list)
+    assert len(results) == 2


### PR DESCRIPTION
A search error is coming from the policy/backend mismatch: the request defaults to search_policy=hybrid, but the configured vector store(local dev) backend doesn’t expose hybrid_search, so VectorSearchService._hybrid() raises an error 

I fixed it by gracefully falling back to semantic when hybrid (or strict) isn’t supported by the current backend.
