### PR TITLE
feature/frontend-adds-display-documents-scrlling-arrows

### DIFF
--- a/frontend/src/rework/components/shared/molecules/HorizontalScrollRow/HorizontalScrollRow.module.css
+++ b/frontend/src/rework/components/shared/molecules/HorizontalScrollRow/HorizontalScrollRow.module.css
@@ -16,6 +16,50 @@
   display: none;
 }
 
+/* Arrow controls (discoverability for mouse users) */
+.arrowBtn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 32px;
+  width: 32px;
+  border-radius: 999px;
+  border: 1px solid var(--outline-variant, rgba(255, 255, 255, 0.18));
+  background: color-mix(in srgb, var(--surface-container, #1f1f1f) 75%, transparent);
+  color: var(--on-surface, #fff);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 2;
+  transition:
+    opacity 150ms ease,
+    background 150ms ease,
+    border-color 150ms ease;
+  opacity: 0;
+  pointer-events: none;
+  user-select: none;
+  line-height: 1;
+  font-size: 20px;
+}
+
+.arrowBtn:hover {
+  background: color-mix(in srgb, var(--surface-container, #1f1f1f) 88%, transparent);
+  border-color: var(--outline, rgba(255, 255, 255, 0.28));
+}
+
+.arrowBtn:focus-visible {
+  outline: 2px solid var(--primary, #5dcaa5);
+  outline-offset: 2px;
+}
+
+.arrowLeft {
+  left: 6px;
+}
+
+.arrowRight {
+  right: 6px;
+}
+
 /* Gradient fade overlays — controlled by data attributes set by JS */
 .wrapper::before,
 .wrapper::after {
@@ -46,4 +90,15 @@
 
 .wrapper[data-fade-right="true"]::after {
   opacity: 1;
+}
+
+/* When there is more content to scroll, show the arrow on that side. */
+.wrapper[data-fade-left="true"] .arrowLeft {
+  opacity: 0.9;
+  pointer-events: auto;
+}
+
+.wrapper[data-fade-right="true"] .arrowRight {
+  opacity: 0.9;
+  pointer-events: auto;
 }

--- a/frontend/src/rework/components/shared/molecules/HorizontalScrollRow/HorizontalScrollRow.tsx
+++ b/frontend/src/rework/components/shared/molecules/HorizontalScrollRow/HorizontalScrollRow.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PropsWithChildren, useEffect, useRef, useState } from "react";
+import { PropsWithChildren, useCallback, useEffect, useRef, useState } from "react";
 import styles from "./HorizontalScrollRow.module.css";
 
 interface HorizontalScrollRowProps {
@@ -28,6 +28,14 @@ export function HorizontalScrollRow({
   const rowRef = useRef<HTMLDivElement>(null);
   const [fadeLeft, setFadeLeft] = useState(false);
   const [fadeRight, setFadeRight] = useState(false);
+
+  const scrollByPage = useCallback((direction: "left" | "right") => {
+    const el = rowRef.current;
+    if (!el) return;
+    const delta = Math.max(180, Math.round(el.clientWidth * 0.85));
+    const left = direction === "left" ? -delta : delta;
+    el.scrollBy({ left, behavior: "smooth" });
+  }, []);
 
   useEffect(() => {
     const el = rowRef.current;
@@ -55,6 +63,16 @@ export function HorizontalScrollRow({
       data-fade-left={fadeLeft}
       data-fade-right={fadeRight}
     >
+      {fadeLeft && (
+        <button
+          type="button"
+          className={`${styles.arrowBtn} ${styles.arrowLeft}`}
+          onClick={() => scrollByPage("left")}
+          aria-label="Scroll left"
+        >
+          ‹
+        </button>
+      )}
       <div
         ref={rowRef}
         className={styles.row}
@@ -62,6 +80,16 @@ export function HorizontalScrollRow({
       >
         {children}
       </div>
+      {fadeRight && (
+        <button
+          type="button"
+          className={`${styles.arrowBtn} ${styles.arrowRight}`}
+          onClick={() => scrollByPage("right")}
+          aria-label="Scroll right"
+        >
+          ›
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/rework/components/shared/organisms/AssistantTurn/AssistantTurn.tsx
+++ b/frontend/src/rework/components/shared/organisms/AssistantTurn/AssistantTurn.tsx
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ChatMessage, VectorSearchHit } from "../../../../../slices/agentic/agenticOpenApi";
 import { ThoughtTrace } from "@shared/molecules/ThoughtTrace/ThoughtTrace";
 import { AssistantMessage } from "@shared/molecules/AssistantMessage/AssistantMessage";
 import { HorizontalScrollRow } from "@shared/molecules/HorizontalScrollRow/HorizontalScrollRow";
 import { SourceCard } from "@shared/molecules/SourceCard/SourceCard";
+import { SourceDetailModal } from "@shared/molecules/SourcesPanel/SourceDetailModal/SourceDetailModal";
 import { ActionBar } from "@shared/molecules/ActionBar/ActionBar";
 import { hitToSource } from "../../../../utils/conversationUtils";
 import type { Action } from "@shared/molecules/ActionBar/ActionBar";
@@ -32,9 +33,18 @@ interface AssistantTurnProps {
 
 export function AssistantTurn({ text, traceMessages, sources, isStreaming }: AssistantTurnProps) {
   const [activeSourceIndex, setActiveSourceIndex] = useState<number | null>(null);
+  const [selected, setSelected] = useState<{ source: VectorSearchHit; index: number } | null>(null);
 
   // All hooks before any conditional returns.
   const uiSources = useMemo(() => sources.map((h, i) => hitToSource(h, i)), [sources]);
+
+  useEffect(() => {
+    if (activeSourceIndex == null) return;
+    const i = activeSourceIndex - 1;
+    const source = sources[i];
+    if (!source) return;
+    setSelected({ source, index: activeSourceIndex });
+  }, [activeSourceIndex, sources]);
 
   const copyAction = useCallback(() => {
     navigator.clipboard.writeText(text).catch(() => {});
@@ -68,7 +78,10 @@ export function AssistantTurn({ text, traceMessages, sources, isStreaming }: Ass
               key={src.id}
               source={src}
               index={i + 1}
-              onClick={activeSourceIndex === i + 1 ? undefined : () => setActiveSourceIndex(i + 1)}
+              onClick={() => {
+                setActiveSourceIndex(i + 1);
+                setSelected({ source: sources[i], index: i + 1 });
+              }}
             />
           ))}
         </HorizontalScrollRow>
@@ -76,6 +89,17 @@ export function AssistantTurn({ text, traceMessages, sources, isStreaming }: Ass
 
       {!isStreaming && text && (
         <ActionBar actions={actions} className={styles.actions} />
+      )}
+
+      {selected && (
+        <SourceDetailModal
+          source={selected.source}
+          index={selected.index}
+          onClose={() => {
+            setSelected(null);
+            setActiveSourceIndex(null);
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

In a RAG agent, the retreived documents are displayed in horizental list. if i click on a doc, i need to see its content. i added the necessary to display its content.

Another ergonomic prob, i can scroll the document right and left with the trachpad but i can not with a mouse. i added right and left arrows accordingly. and above all, if there is no arrow a new, will not be able to infer that he can scroll without the arrows.