### PR TITLE
Update AGENTS.md AGENT.md file to be coherent with CLAUDE.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,51 +1,81 @@
-# AGENT.md
+# Fred Repository Orientation
 
-Quick orientation for AI coding assistants. Read this first, then follow the
-links to the relevant contracts.
+This file is a lightweight orientation guide for AI coding assistants and new contributors.
+
+It is not the primary instruction file.
+
+For mandatory development workflow, governance, and implementation rules, read these files first:
+
+1. `CLAUDE.md` — primary team development workflow and governance guide
+2. `AGENTS.md` — Codex / AI assistant entrypoint and instruction bridge
+3. Any nested `AGENTS.md`, `AGENTS.override.md`, or `CLAUDE.md` files in the target subdirectory
+
+If this file conflicts with `CLAUDE.md` or `AGENTS.md`, follow `CLAUDE.md` and `AGENTS.md`.
+
+---
 
 ## What Fred Is
 
-Fred is a production-ready platform for building and operating multi-agent AI
-applications. It has three planes:
+Fred is an agentic platform organized around several platform planes:
 
-- **Execution** — `libs/fred-runtime` + `apps/fred-agents` (FastAPI SSE pod)
-- **Product / tenancy** — `control-plane-backend` (team, sessions, enrollment)
-- **Knowledge** — `knowledge-flow-backend` (document ingestion + vector search)
-- **Frontend** — `frontend/` (React, rework design system)
+- Execution/runtime plane
+- Product and tenancy plane
+- Knowledge plane
+- Frontend/user-experience plane
 
-`agentic-backend` is being migrated out. Do not add execution logic there.
+The repository contains multiple applications, services, shared packages, and documentation areas. Before making changes, understand which plane and package own the behavior you are modifying.
 
-## Mandatory Context
+---
 
-Read in this order before making changes:
+## Repository Navigation
 
-1. [`docs/platform/DEVELOPER_CONTRACT.md`](./docs/swift/platform/DEVELOPER_CONTRACT.md) — build, test, PR rules
-2. [`docs/platform/PLATFORM_RUNTIME_MAP.md`](./docs/swift/platform/PLATFORM_RUNTIME_MAP.md) — canonical service map
-3. [`docs/backlog/BACKLOG.md`](./docs/swift/backlog/BACKLOG.md) — migration phase status (Phases 0–7)
-4. [`docs/WORKPLAN.md`](./docs/swift/WORKPLAN.md) — current sprint, who owns what
-5. [`docs/design/RUNTIME-EXECUTION-CONTRACT.md`](./docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md) — when touching fred-runtime, fred-sdk, SSE, CLI, KPI
-6. [`docs/design/CONTROL-PLANE-PRODUCT-CONTRACT.md`](./docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md) — when touching control-plane APIs or sessions
-7. [`docs/backlog/CHAT-UI-BACKLOG.md`](./docs/swift/backlog/CHAT-UI-BACKLOG.md) — when touching ManagedChatPage or chat UI components
+Start with:
 
-## Key Rules
+- `CLAUDE.md` for workflow, governance, and development process
+- `AGENTS.md` for Codex-compatible assistant instructions
+- `README.md` for repository-level overview
+- Relevant package-level `README.md` files
+- Relevant `Makefile` targets before inventing new commands
 
-- `agent_instance_id` is the only frontend execution identity — never raw `agent_id`
-- `session_id` is the only conversation identifier — never `thread_id`
-- Control-plane owns product/tenancy/authorization; runtime owns execution only
-- Frontend reads message history from runtime (`messages_url_template`), never from control-plane
-- Never hand-edit generated files (`runtimeOpenApi.ts`, `controlPlaneOpenApi.ts`) — regenerate from source
-- Run `make code-quality && make test` in every touched project
+Do not assume that similar-looking services have identical contracts or runtime behavior. Check the local package documentation and tests.
 
-## Common Make Targets
+---
 
-| Project | Run | Test | Quality |
-|---|---|---|---|
-| `libs/fred-sdk` | — | `make test` | `make code-quality` |
-| `libs/fred-runtime` | `make run` | `make test` | `make code-quality` |
-| `control-plane-backend` | `make run` | `make test` | `make code-quality` |
-| `knowledge-flow-backend` | `make run` | `make test` | `make code-quality` |
-| `frontend` | `make run` | — | `make code-quality` |
+## Development Principle
 
-## Doc Index
+Prefer small, targeted, reversible changes.
 
-Full documentation index: [`docs/README.md`](./docs/swift/README.md)
+Before modifying code:
+
+1. Identify the owning package or service.
+2. Read the relevant local documentation.
+3. Check existing patterns in nearby code.
+4. Reuse existing abstractions instead of creating parallel ones.
+5. Run the relevant quality and test commands defined by the package.
+
+---
+
+## Identity Concepts
+
+Fred commonly distinguishes between:
+
+- `agent_instance_id` — the configured/deployed agent instance
+- `session_id` — a user interaction or conversation session
+- request/message identifiers — individual runtime or transport-level events
+
+Do not conflate these concepts. If changing persistence, runtime execution, tracing, or knowledge integration, verify the expected identity model in the relevant code and contracts.
+
+---
+
+## Common Commands
+
+Prefer existing `make` targets over ad-hoc commands.
+
+Common targets may include:
+
+```bash
+make run
+make test
+make code-quality
+make lint
+make type-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,23 @@
-# AGENTS.md
+# Codex / AI Assistant Instructions
 
-All coding assistants working in this repository must follow:
+This repository uses `CLAUDE.md` as the primary development workflow and governance guide.
 
-- [`docs/platform/DEVELOPER_CONTRACT.md`](./docs/swift/platform/DEVELOPER_CONTRACT.md)
-- [`docs/platform/PLATFORM_RUNTIME_MAP.md`](./docs/swift/platform/PLATFORM_RUNTIME_MAP.md)
-- [`docs/design/RUNTIME-EXECUTION-CONTRACT.md`](./docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md) when touching `fred-sdk`, `fred-runtime`, runtime OpenAPI, frontend runtime typing, the CLI, or runtime observability/tracing/KPI/Langfuse metadata
-- [`docs/backlog/FRED-RUNTIME-QUALITY.md`](./docs/swift/backlog/FRED-RUNTIME-QUALITY.md) when touching `libs/fred-runtime` structure, typing, logging, coverage, or large refactors
-- [`docs/design/CONTROL-PLANE-PRODUCT-CONTRACT.md`](./docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md) when touching control-plane product/session/admin APIs or frontend migration away from `agentic-backend`
-- [`docs/backlog/BACKLOG.md`](./docs/swift/backlog/BACKLOG.md) for migration phase status and next-step sequencing
-- [`docs/WORKPLAN.md`](./docs/swift/WORKPLAN.md) for current sprint assignments — read before starting any task to avoid duplicating in-progress work
-- [`docs/backlog/FRONTEND-BACKLOG.md`](./docs/swift/backlog/FRONTEND-BACKLOG.md) when touching frontend bootstrap, session, or team identity
-- [`docs/backlog/CHAT-UI-BACKLOG.md`](./docs/swift/backlog/CHAT-UI-BACKLOG.md) when touching `ManagedChatPage`, chat UI components, or SSE event rendering
+Before making any code or documentation change, read and follow:
 
-Mandatory defaults:
+1. The root `CLAUDE.md`
+2. This root `AGENTS.md`
+3. Any nested `AGENTS.md`, `AGENTS.override.md`, or `CLAUDE.md` files in the target subdirectory
 
-- Keep changes minimal and avoid over-engineering.
-- Do not invent new architecture, new convergence layers, or undocumented product behavior.
-- Do not take initiative on architecture when the docs already define the split; follow the documented split.
-- Run `make code-quality` and `make test` in every touched project.
-- When a touched Python project uses a non-empty `basedpyright` baseline, also run raw `basedpyright` and report whether the baseline still masks errors.
-- Keep default tests offline (no external service dependency).
-- Mark external-service tests as `integration`.
-- For all default validation, assume zero third-party services are running (no MinIO, OpenSearch, Postgres, Keycloak, OpenFGA, Temporal, etc.).
-- Prefer strengthening existing typed contracts over adding ad hoc `dict[str, Any]` payloads.
-- Do not add new `Any`, `dict[str, Any]`, or similarly untyped payloads at contract, service, CLI, or persistence boundaries. If an external payload is genuinely opaque, keep it confined to the adapter and add a one-line `# opaque` or `# open bag` justification.
-- When extending `fred-sdk` or `fred-runtime`, first look for transitional bridges or duplicate request/state shapes and prefer collapsing them over threading new fields through every layer.
-- Do not add feature-specific side channels for `TeamAgent` or other one-off use cases when the real seam belongs in a shared runtime/SDK contract.
-- Do not introduce a second transport or execution request shape for a special case if the existing typed runtime contract can be extended instead.
-- Keep logging uniform. Reuse the existing logger channels and conventions, prefer deferred formatting (`logger.info("...", value)`), and do not introduce new `logger.*(f"...")` calls.
-- Do not keep growing monolithic modules. If a file is already very large (around `600+` lines), extract a focused module before adding another concern to it.
-- Never hand-edit generated files such as `frontend/src/slices/runtime/runtimeOpenApi.ts`; edit the source contract and regenerate.
-- If a needed type is missing, first strengthen the source contract or FastAPI schema and regenerate; do not add shadow DTOs in the frontend.
-- If the docs do not answer a migration decision, stop at the smallest safe change and update the docs/backlog instead of inventing a path.
-- Every new/modified function must document:
-  - why it exists
-  - how to use it
-  - and include a short usage example for shared helpers/public utility functions.
-- Keep functions intentional: business function or necessary shared helper that removes duplication.
-- For each new feature/improvement, prefer codebase shrink/reuse/refactor over net code growth.
-- When migration docs and implementation diverge, update the relevant docs in the same change.
+When `CLAUDE.md` refers to Claude or Claude Code, apply the same instruction to Codex unless the instruction is technically impossible in Codex.
+
+Conflict resolution order:
+
+1. Explicit user instruction
+2. Closest nested `AGENTS.override.md`, `AGENTS.md`, or `CLAUDE.md`
+3. Root `CLAUDE.md`
+4. Root `AGENTS.md`
+5. Root `AGENT.md`, if present
+
+If there is a conflict that cannot be resolved safely, stop and ask for clarification before changing files.
+
+Do not implement changes until the required workflow checks from `CLAUDE.md` have been completed.

--- a/old_AGENT.md
+++ b/old_AGENT.md
@@ -1,0 +1,51 @@
+# AGENT.md
+
+Quick orientation for AI coding assistants. Read this first, then follow the
+links to the relevant contracts.
+
+## What Fred Is
+
+Fred is a production-ready platform for building and operating multi-agent AI
+applications. It has three planes:
+
+- **Execution** — `libs/fred-runtime` + `apps/fred-agents` (FastAPI SSE pod)
+- **Product / tenancy** — `control-plane-backend` (team, sessions, enrollment)
+- **Knowledge** — `knowledge-flow-backend` (document ingestion + vector search)
+- **Frontend** — `frontend/` (React, rework design system)
+
+`agentic-backend` is being migrated out. Do not add execution logic there.
+
+## Mandatory Context
+
+Read in this order before making changes:
+
+1. [`docs/platform/DEVELOPER_CONTRACT.md`](./docs/swift/platform/DEVELOPER_CONTRACT.md) — build, test, PR rules
+2. [`docs/platform/PLATFORM_RUNTIME_MAP.md`](./docs/swift/platform/PLATFORM_RUNTIME_MAP.md) — canonical service map
+3. [`docs/backlog/BACKLOG.md`](./docs/swift/backlog/BACKLOG.md) — migration phase status (Phases 0–7)
+4. [`docs/WORKPLAN.md`](./docs/swift/WORKPLAN.md) — current sprint, who owns what
+5. [`docs/design/RUNTIME-EXECUTION-CONTRACT.md`](./docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md) — when touching fred-runtime, fred-sdk, SSE, CLI, KPI
+6. [`docs/design/CONTROL-PLANE-PRODUCT-CONTRACT.md`](./docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md) — when touching control-plane APIs or sessions
+7. [`docs/backlog/CHAT-UI-BACKLOG.md`](./docs/swift/backlog/CHAT-UI-BACKLOG.md) — when touching ManagedChatPage or chat UI components
+
+## Key Rules
+
+- `agent_instance_id` is the only frontend execution identity — never raw `agent_id`
+- `session_id` is the only conversation identifier — never `thread_id`
+- Control-plane owns product/tenancy/authorization; runtime owns execution only
+- Frontend reads message history from runtime (`messages_url_template`), never from control-plane
+- Never hand-edit generated files (`runtimeOpenApi.ts`, `controlPlaneOpenApi.ts`) — regenerate from source
+- Run `make code-quality && make test` in every touched project
+
+## Common Make Targets
+
+| Project | Run | Test | Quality |
+|---|---|---|---|
+| `libs/fred-sdk` | — | `make test` | `make code-quality` |
+| `libs/fred-runtime` | `make run` | `make test` | `make code-quality` |
+| `control-plane-backend` | `make run` | `make test` | `make code-quality` |
+| `knowledge-flow-backend` | `make run` | `make test` | `make code-quality` |
+| `frontend` | `make run` | — | `make code-quality` |
+
+## Doc Index
+
+Full documentation index: [`docs/README.md`](./docs/swift/README.md)

--- a/old_AGENTS.md
+++ b/old_AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+All coding assistants working in this repository must follow:
+
+- [`docs/platform/DEVELOPER_CONTRACT.md`](./docs/swift/platform/DEVELOPER_CONTRACT.md)
+- [`docs/platform/PLATFORM_RUNTIME_MAP.md`](./docs/swift/platform/PLATFORM_RUNTIME_MAP.md)
+- [`docs/design/RUNTIME-EXECUTION-CONTRACT.md`](./docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md) when touching `fred-sdk`, `fred-runtime`, runtime OpenAPI, frontend runtime typing, the CLI, or runtime observability/tracing/KPI/Langfuse metadata
+- [`docs/backlog/FRED-RUNTIME-QUALITY.md`](./docs/swift/backlog/FRED-RUNTIME-QUALITY.md) when touching `libs/fred-runtime` structure, typing, logging, coverage, or large refactors
+- [`docs/design/CONTROL-PLANE-PRODUCT-CONTRACT.md`](./docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md) when touching control-plane product/session/admin APIs or frontend migration away from `agentic-backend`
+- [`docs/backlog/BACKLOG.md`](./docs/swift/backlog/BACKLOG.md) for migration phase status and next-step sequencing
+- [`docs/WORKPLAN.md`](./docs/swift/WORKPLAN.md) for current sprint assignments — read before starting any task to avoid duplicating in-progress work
+- [`docs/backlog/FRONTEND-BACKLOG.md`](./docs/swift/backlog/FRONTEND-BACKLOG.md) when touching frontend bootstrap, session, or team identity
+- [`docs/backlog/CHAT-UI-BACKLOG.md`](./docs/swift/backlog/CHAT-UI-BACKLOG.md) when touching `ManagedChatPage`, chat UI components, or SSE event rendering
+
+Mandatory defaults:
+
+- Keep changes minimal and avoid over-engineering.
+- Do not invent new architecture, new convergence layers, or undocumented product behavior.
+- Do not take initiative on architecture when the docs already define the split; follow the documented split.
+- Run `make code-quality` and `make test` in every touched project.
+- When a touched Python project uses a non-empty `basedpyright` baseline, also run raw `basedpyright` and report whether the baseline still masks errors.
+- Keep default tests offline (no external service dependency).
+- Mark external-service tests as `integration`.
+- For all default validation, assume zero third-party services are running (no MinIO, OpenSearch, Postgres, Keycloak, OpenFGA, Temporal, etc.).
+- Prefer strengthening existing typed contracts over adding ad hoc `dict[str, Any]` payloads.
+- Do not add new `Any`, `dict[str, Any]`, or similarly untyped payloads at contract, service, CLI, or persistence boundaries. If an external payload is genuinely opaque, keep it confined to the adapter and add a one-line `# opaque` or `# open bag` justification.
+- When extending `fred-sdk` or `fred-runtime`, first look for transitional bridges or duplicate request/state shapes and prefer collapsing them over threading new fields through every layer.
+- Do not add feature-specific side channels for `TeamAgent` or other one-off use cases when the real seam belongs in a shared runtime/SDK contract.
+- Do not introduce a second transport or execution request shape for a special case if the existing typed runtime contract can be extended instead.
+- Keep logging uniform. Reuse the existing logger channels and conventions, prefer deferred formatting (`logger.info("...", value)`), and do not introduce new `logger.*(f"...")` calls.
+- Do not keep growing monolithic modules. If a file is already very large (around `600+` lines), extract a focused module before adding another concern to it.
+- Never hand-edit generated files such as `frontend/src/slices/runtime/runtimeOpenApi.ts`; edit the source contract and regenerate.
+- If a needed type is missing, first strengthen the source contract or FastAPI schema and regenerate; do not add shadow DTOs in the frontend.
+- If the docs do not answer a migration decision, stop at the smallest safe change and update the docs/backlog instead of inventing a path.
+- Every new/modified function must document:
+  - why it exists
+  - how to use it
+  - and include a short usage example for shared helpers/public utility functions.
+- Keep functions intentional: business function or necessary shared helper that removes duplication.
+- For each new feature/improvement, prefer codebase shrink/reuse/refactor over net code growth.
+- When migration docs and implementation diverge, update the relevant docs in the same change.


### PR DESCRIPTION
## Summary

Codex automatically discovers AGENTS.md files. It does not automatically treat CLAUDE.md as an instruction file unless configured as a fallback filename or explicitly told to read it. The bridge approach solves that by making AGENTS.md tell Codex to read CLAUDE.md. 

This will help keep the rules at one place "CLAUDE.md". i renamed the old version in order for Dimitri to delete it if he want to adopt this approch.

As for the AGENT.md, the file AGENT.md should be used as an orientation-only file, not as another rulebook. 
I also renamed the old version in order for Dimitri to delete it if he want to adopt this approch.

## Mandatory Checklist

- [X] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [X] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [X] I did not introduce unit/default tests that require external services.
- [X] Any test requiring external services is marked `@pytest.mark.integration`.
- [X] I updated documentation when behavior or conventions changed.

## Validation Notes

NA

## Risk / Rollback

NA
