### PR TITLE
chore: update wtf and launch.json for new project layout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,14 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Agentic Backend (configuration.yaml)",
+      "name": "Debug Fred Agents (configuration.yaml)",
       "type": "debugpy",
       "request": "launch",
-      "pythonPath": "${workspaceFolder}/agentic-backend/.venv/bin/python",
-      "cwd": "${workspaceFolder}/agentic-backend",
+      "pythonPath": "${workspaceFolder}/apps/fred-agents/.venv/bin/python",
+      "cwd": "${workspaceFolder}/apps/fred-agents",
       "module": "uvicorn",
       "args": [
-        "agentic_backend.main:create_app",
+        "fred_agents.main:create_app",
         "--factory",
         "--host",
         "0.0.0.0",
@@ -20,26 +20,26 @@
         "--loop",
         "asyncio",
         "--reload",
-        "--reload-dir", "${workspaceFolder}/agentic-backend/config",
+        "--reload-dir", "${workspaceFolder}/apps/fred-agents/config",
         "--reload-include", "*.py",
         "--reload-include", "*.yaml"
       ],
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/agentic-backend",
-        "CONFIG_FILE": "${workspaceFolder}/agentic-backend/config/configuration.yaml"
+        "PYTHONPATH": "${workspaceFolder}/apps/fred-agents",
+        "CONFIG_FILE": "${workspaceFolder}/apps/fred-agents/config/configuration.yaml"
       },
       "justMyCode": false,
       "console": "integratedTerminal"
     },
     {
-      "name": "Debug Agentic Backend (configuration_prod.yaml)",
+      "name": "Debug Fred Agents (configuration_prod.yaml)",
       "type": "debugpy",
       "request": "launch",
-      "python": "${workspaceFolder}/agentic-backend/.venv/bin/python",
-      "cwd": "${workspaceFolder}/agentic-backend",
+      "python": "${workspaceFolder}/apps/fred-agents/.venv/bin/python",
+      "cwd": "${workspaceFolder}/apps/fred-agents",
       "module": "uvicorn",
       "args": [
-        "agentic_backend.main:create_app",
+        "fred_agents.main:create_app",
         "--factory",
         "--host",
         "0.0.0.0",
@@ -50,14 +50,14 @@
         "--loop",
         "asyncio",
         "--reload",
-        "--reload-dir", "${workspaceFolder}/agentic-backend/config",
+        "--reload-dir", "${workspaceFolder}/apps/fred-agents/config",
         "--reload-include", "*.py",
         "--reload-include", "*.yaml",
 
       ],
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/agentic-backend",
-        "CONFIG_FILE": "${workspaceFolder}/agentic-backend/config/configuration_prod.yaml"
+        "PYTHONPATH": "${workspaceFolder}/apps/fred-agents",
+        "CONFIG_FILE": "${workspaceFolder}/apps/fred-agents/config/configuration_prod.yaml"
       },
       "justMyCode": false,
       "console": "integratedTerminal"
@@ -66,11 +66,11 @@
       "name": "Debug Agentic Academy",
       "type": "debugpy",
       "request": "launch",
-      "python": "${workspaceFolder}/agentic-backend/.venv/bin/python",
-      "cwd": "${workspaceFolder}/agentic-backend",
+      "python": "${workspaceFolder}/apps/fred-agents/.venv/bin/python",
+      "cwd": "${workspaceFolder}/apps/fred-agents",
       "module": "uvicorn",
       "args": [
-        "agentic_backend.main:create_app",
+        "fred_agents.main:create_app",
         "--factory",
         "--host",
         "0.0.0.0",
@@ -81,14 +81,14 @@
         "--loop",
         "asyncio",
         "--reload",
-        "--reload-dir", "${workspaceFolder}/agentic-backend/config",
+        "--reload-dir", "${workspaceFolder}/apps/fred-agents/config",
         "--reload-include", "*.py",
         "--reload-include", "*.yaml",
 
       ],
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/agentic-backend",
-        "CONFIG_FILE": "${workspaceFolder}/agentic-backend/config/configuration_academy.yaml"
+        "PYTHONPATH": "${workspaceFolder}/apps/fred-agents",
+        "CONFIG_FILE": "${workspaceFolder}/apps/fred-agents/config/configuration_academy.yaml"
       },
       "justMyCode": false,
       "console": "integratedTerminal"
@@ -157,8 +157,8 @@
       "name": "Debug Control Plane Backend (configuration_prod.yaml)",
       "type": "debugpy",
       "request": "launch",
-      "python": "${workspaceFolder}/control-plane-backend/.venv/bin/python",
-      "cwd": "${workspaceFolder}/control-plane-backend",
+      "python": "${workspaceFolder}/apps/control-plane-backend/.venv/bin/python",
+      "cwd": "${workspaceFolder}/apps/control-plane-backend",
       "module": "uvicorn",
       "args": [
         "control_plane_backend.main:create_app",
@@ -172,14 +172,14 @@
         "--loop",
         "asyncio",
         "--reload",
-        "--reload-dir", "${workspaceFolder}/control-plane-backend/config",
+        "--reload-dir", "${workspaceFolder}/apps/control-plane-backend/config",
         "--reload-include", "*.py",
         "--reload-include", "*.yaml",
 
       ],
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/control-plane-backend",
-        "CONFIG_FILE": "${workspaceFolder}/control-plane-backend/config/configuration_prod.yaml"
+        "PYTHONPATH": "${workspaceFolder}/apps/control-plane-backend",
+        "CONFIG_FILE": "${workspaceFolder}/apps/control-plane-backend/config/configuration_prod.yaml"
       },
       "justMyCode": false,
       "console": "integratedTerminal"
@@ -203,18 +203,18 @@
       "justMyCode": false
     },
     {
-      "name": "Debug all Agentic Backend tests",
+      "name": "Debug all Fred Agents tests",
       "type": "debugpy",
       "request": "launch",
       "module": "pytest",
-      "cwd": "${workspaceFolder}/agentic-backend",
+      "cwd": "${workspaceFolder}/apps/fred-agents",
       "args": [
         "-s",
         "-q"
       ],
       "envFile": "config/.env",
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/agentic-backend/knowledge_flow_backend",
+        "PYTHONPATH": "${workspaceFolder}/apps/fred-agents/fred_agents",
         "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}",
         "LOG_LEVEL": "DEBUG"
       },
@@ -260,11 +260,11 @@
       "justMyCode": false
     },
     {
-      "name": "Debug current Agentic Backend test file",
+      "name": "Debug current Fred Agents test file",
       "type": "debugpy",
       "request": "launch",
       "module": "pytest",
-      "cwd": "${workspaceFolder}/agentic-backend",
+      "cwd": "${workspaceFolder}/apps/fred-agents",
       "args": [
         "-s",
         "-vv",
@@ -272,7 +272,7 @@
       ],
       "envFile": "config/.env",
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/agentic-backend/agentic_backend",
+        "PYTHONPATH": "${workspaceFolder}/apps/fred-agents/fred_agents",
         "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}",
         "LOG_LEVEL": "DEBUG"
       },
@@ -283,7 +283,7 @@
       "type": "node-terminal",
       "request": "launch",
       "command": "npm run dev",
-      "cwd": "${workspaceFolder}/frontend"
+      "cwd": "${workspaceFolder}/apps/frontend"
     },
     {
       "name": "Debug Knowledge Flow Worker",

--- a/scripts/wtf/src/wtf/__init__.py
+++ b/scripts/wtf/src/wtf/__init__.py
@@ -133,6 +133,18 @@ def worktree_dir(branch: str) -> Path:
     return WORKTREE_BASE / f"fred-wt-{branch}"
 
 
+def current_worktree() -> tuple[Path, str]:
+    """Return (worktree_root, branch) for the worktree containing cwd, or raise."""
+    cwd = Path.cwd().resolve()
+    for wt in existing_worktree_dirs():
+        if cwd == wt or cwd.is_relative_to(wt):
+            branch = wt.name.removeprefix("fred-wt-")
+            return wt, branch
+    raise click.ClickException(
+        f"{cwd} is not inside a Fred worktree — run this command from within a worktree directory"
+    )
+
+
 def existing_worktree_dirs() -> list[Path]:
     return sorted(p for p in WORKTREE_BASE.iterdir() if p.is_dir() and p.name.startswith("fred-wt-"))
 
@@ -351,6 +363,93 @@ def patch_vscode_tasks(wt: Path, ports: dict[str, int], autorun_task: str | None
     tasks_file.write_text(json.dumps(tasks, indent=2) + "\n")
 
 
+def worktree_skip_paths(wt: Path) -> list[str]:
+    """Return the list of worktree-local config paths that should be hidden from git status."""
+    paths = [
+        *[
+            f"{service_dir(svc)}/config/configuration_prod.yaml"
+            for svc in PYTHON_SERVICES
+        ],
+        f"{service_dir('fred-agents')}/config/mcp_catalog.yaml",
+        f"{service_dir('fred-agents')}/config/models_catalog.yaml",
+        "knowledge-flow-backend/config/configuration_worker.yaml",
+        "deploy/local/k3d/values-local.yaml",
+        ".vscode/tasks.json",
+        ".vscode/launch.json",
+        ".vscode/fred.code-workspace",
+    ]
+    return [p for p in paths if (wt / p).exists()]
+
+
+def hide_config_files(wt: Path) -> None:
+    """Mark worktree-local config files as skip-worktree so they don't show in git status."""
+    existing = worktree_skip_paths(wt)
+    if existing:
+        run_quiet(["git", "update-index", "--skip-worktree", *existing], cwd=wt)
+
+
+def read_ports_md(wt: Path) -> dict[str, int]:
+    """Parse PORTS.md and return a {service: port} dict."""
+    ports_file = wt / "PORTS.md"
+    if not ports_file.exists():
+        raise click.ClickException(f"PORTS.md not found in {wt} — cannot read port allocation")
+    content = ports_file.read_text()
+    service_patterns = {
+        "fred-agents": r"Fred Agents\s*\|\s*(\d+)",
+        "knowledge-flow-backend": r"Knowledge Flow Backend\s*\|\s*(\d+)",
+        "control-plane-backend": r"Control Plane Backend\s*\|\s*(\d+)",
+        "frontend": r"Frontend\s*\|\s*(\d+)",
+    }
+    ports: dict[str, int] = {}
+    for svc, pattern in service_patterns.items():
+        m = re.search(pattern, content)
+        if not m:
+            raise click.ClickException(f"Could not find port for '{svc}' in PORTS.md")
+        ports[svc] = int(m.group(1))
+    return ports
+
+
+def apply_patch_pipeline(wt: Path, branch: str, ports: dict[str, int], autorun_task: str | None = None) -> None:
+    """Apply the full worktree patch pipeline: prod configs, .vscode, and skip-worktree hiding."""
+    # Disable prometheus metrics in prod configs
+    for svc in PYTHON_SERVICES:
+        prod_cfg = wt / service_dir(svc) / "config" / "configuration_prod.yaml"
+        if prod_cfg.exists():
+            content = prod_cfg.read_text()
+            patched = content.replace("metrics_enabled: true", "metrics_enabled: false")
+            if patched != content:
+                prod_cfg.write_text(patched)
+
+    # Patch inter-service URLs that reference knowledge-flow-backend by its default port
+    kf_port = str(DEFAULT_PORTS["knowledge-flow-backend"])
+    kf_new_port = str(ports["knowledge-flow-backend"])
+    for cfg_path in [
+        wt / service_dir("fred-agents") / "config" / "configuration_prod.yaml",
+        wt / service_dir("fred-agents") / "config" / "mcp_catalog.yaml",
+    ]:
+        if cfg_path.exists():
+            content = cfg_path.read_text()
+            patched = content.replace(f"localhost:{kf_port}", f"localhost:{kf_new_port}")
+            if patched != content:
+                cfg_path.write_text(patched)
+                info(f"Patched {cfg_path.relative_to(wt)}")
+
+    # Copy .vscode from main repo (ensures latest tasks.json) then patch
+    vscode_dir = wt / ".vscode"
+    vscode_dir.mkdir(exist_ok=True)
+    for f in (FRED_ROOT / ".vscode").iterdir():
+        shutil.copy2(f, vscode_dir / f.name)
+
+    color = pick_color()
+    patch_workspace_file(wt, color, branch)
+    patch_vscode_tasks(wt, ports, autorun_task)
+    patch_launch_json(wt, ports)
+    ok("VSCode config patched")
+
+    hide_config_files(wt)
+    ok("Patched files hidden from git status (skip-worktree)")
+
+
 def generate_ports_md(branch: str, ports: dict[str, int]) -> str:
     return textwrap.dedent(f"""\
         # Worktree: {branch}
@@ -476,14 +575,6 @@ def create(branch: str | None, from_issue: str | None, provider: str | None, aut
         make_cmd = ["make", make_target] if target_in_wt else ["make", "-f", str(FRED_ROOT / "Makefile"), make_target]
         run(make_cmd, cwd=wt)
 
-    # Disable prometheus metrics in prod configs (avoids port collisions between worktrees)
-    for svc in PYTHON_SERVICES:
-        prod_cfg = wt / service_dir(svc) / "config" / "configuration_prod.yaml"
-        if prod_cfg.exists():
-            content = prod_cfg.read_text()
-            content = content.replace("metrics_enabled: true", "metrics_enabled: false")
-            prod_cfg.write_text(content)
-
     # Allocate ports
     step("Allocating ports...")
     used_ports: set[int] = set()
@@ -495,50 +586,7 @@ def create(branch: str | None, from_issue: str | None, provider: str | None, aut
     # Write PORTS.md
     (wt / "PORTS.md").write_text(generate_ports_md(branch, ports))
 
-    # Patch inter-service URLs that reference knowledge-flow-backend by its default port
-    kf_port = str(DEFAULT_PORTS["knowledge-flow-backend"])
-    kf_new_port = str(ports["knowledge-flow-backend"])
-    for cfg_path in [
-        wt / service_dir("fred-agents") / "config" / "configuration_prod.yaml",
-        wt / service_dir("fred-agents") / "config" / "mcp_catalog.yaml",
-    ]:
-        if cfg_path.exists():
-            content = cfg_path.read_text()
-            patched = content.replace(f"localhost:{kf_port}", f"localhost:{kf_new_port}")
-            if patched != content:
-                cfg_path.write_text(patched)
-                info(f"Patched {cfg_path.relative_to(wt)}")
-
-    # Copy .vscode from main repo (ensures latest tasks.json) then patch
-    vscode_dir = wt / ".vscode"
-    vscode_dir.mkdir(exist_ok=True)
-    for f in (FRED_ROOT / ".vscode").iterdir():
-        shutil.copy2(f, vscode_dir / f.name)
-
-    color = pick_color()
-    patch_workspace_file(wt, color, branch)
-    patch_vscode_tasks(wt, ports, autorun_task)
-    patch_launch_json(wt, ports)
-    ok("VSCode config patched")
-
-    # Hide worktree-local patches from git status (skip-worktree per worktree)
-    skip_paths = [
-        *[
-            f"{service_dir(svc)}/config/configuration_prod.yaml"
-            for svc in PYTHON_SERVICES
-        ],
-        f"{service_dir('fred-agents')}/config/mcp_catalog.yaml",
-        f"{service_dir('fred-agents')}/config/models_catalog.yaml",
-        "knowledge-flow-backend/config/configuration_worker.yaml",
-        "deploy/local/k3d/values-local.yaml",
-        ".vscode/tasks.json",
-        ".vscode/launch.json",
-        ".vscode/fred.code-workspace",
-    ]
-    existing_skip = [p for p in skip_paths if (wt / p).exists()]
-    if existing_skip:
-        run_quiet(["git", "update-index", "--skip-worktree", *existing_skip], cwd=wt)
-        ok("Patched files hidden from git status (skip-worktree)")
+    apply_patch_pipeline(wt, branch, ports, autorun_task)
 
     # Open VSCode
     step("Opening VSCode...")
@@ -637,3 +685,51 @@ def open_worktree(branch: str):
         stderr=subprocess.DEVNULL,
     )
     ok(f"VSCode opened: {workspace_file}")
+
+
+@cli.command(name="show-hidden-files")
+def show_hidden_files():
+    """Remove skip-worktree so patched config files appear in git status."""
+    wt, branch = current_worktree()
+
+    existing = worktree_skip_paths(wt)
+    if not existing:
+        ok("No skip-worktree files found — nothing to unhide")
+        return
+
+    run_quiet(["git", "update-index", "--no-skip-worktree", *existing], cwd=wt)
+    ok(f"Unhidden {len(existing)} file(s) from git status ({branch})")
+    for p in existing:
+        info(p)
+
+
+@cli.command(name="hide-config-files")
+def hide_config_files_cmd():
+    """Re-apply skip-worktree on patched config files so they are hidden from git status."""
+    wt, branch = current_worktree()
+
+    existing = worktree_skip_paths(wt)
+    if not existing:
+        ok("No config files to hide")
+        return
+
+    hide_config_files(wt)
+    ok(f"Hidden {len(existing)} file(s) from git status ({branch})")
+    for p in existing:
+        info(p)
+
+
+@cli.command(name="patch-wt")
+@click.option("-t", "--autorun-task", type=str, default=None, shell_complete=complete_vscode_task,
+              help="VSCode task to mark as run-on-folder-open")
+def patch_wt(autorun_task: str | None):
+    """Re-apply the full patch pipeline (ports, workspace, tasks, launch) for the current worktree.
+
+    Useful after a stash pop or manual reset of config files.
+    """
+    wt, branch = current_worktree()
+
+    step(f"Re-patching worktree {click.style(branch, fg='yellow')}...")
+    ports = read_ports_md(wt)
+    apply_patch_pipeline(wt, branch, ports, autorun_task)
+    ok("Done")

--- a/scripts/wtf/src/wtf/__init__.py
+++ b/scripts/wtf/src/wtf/__init__.py
@@ -23,17 +23,17 @@ FRED_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 WORKTREE_BASE = FRED_ROOT.parent
 PORT_RANGE = (9300, 9999)
 
-PYTHON_SERVICES = ["agentic-backend", "knowledge-flow-backend", "control-plane-backend"]
+PYTHON_SERVICES = ["fred-agents", "knowledge-flow-backend", "control-plane-backend"]
 ALL_SERVICES = [*PYTHON_SERVICES, "frontend"]
 SERVICE_DIRS = {
-    "agentic-backend": Path("agentic-backend"),
+    "fred-agents": Path("apps/fred-agents"),
     "knowledge-flow-backend": Path("knowledge-flow-backend"),
     "control-plane-backend": Path("apps/control-plane-backend"),
     "frontend": Path("apps/frontend"),
 }
 
 DEFAULT_PORTS = {
-    "agentic-backend": 8000,
+    "fred-agents": 8000,
     "knowledge-flow-backend": 8111,
     "control-plane-backend": 8222,
     "frontend": 5173,
@@ -330,7 +330,7 @@ def patch_vscode_tasks(wt: Path, ports: dict[str, int], autorun_task: str | None
                     if "VITE_PORT" not in arg:
                         frontend_env = (
                             f"VITE_PORT={ports['frontend']} "
-                            f"VITE_BACKEND_URL=http://localhost:{ports['agentic-backend']} "
+                            f"VITE_BACKEND_URL=http://localhost:{ports['fred-agents']} "
                             f"VITE_BACKEND_URL_KNOWLEDGE=http://localhost:{ports['knowledge-flow-backend']} "
                             f"VITE_BACKEND_URL_CONTROL_PLANE=http://localhost:{ports['control-plane-backend']}"
                         )
@@ -357,7 +357,7 @@ def generate_ports_md(branch: str, ports: dict[str, int]) -> str:
 
         | Service                 | Port  | URL                                                          |
         |-------------------------|-------|--------------------------------------------------------------|
-        | Agentic Backend         | {ports["agentic-backend"]} | http://localhost:{ports["agentic-backend"]}/agentic/v1/docs             |
+        | Fred Agents             | {ports["fred-agents"]} | http://localhost:{ports["fred-agents"]}/agentic/v1/docs                 |
         | Knowledge Flow Backend  | {ports["knowledge-flow-backend"]} | http://localhost:{ports["knowledge-flow-backend"]}/knowledge-flow/v1/docs       |
         | Control Plane Backend   | {ports["control-plane-backend"]} | http://localhost:{ports["control-plane-backend"]}/control-plane/v1/docs         |
         | Frontend                | {ports["frontend"]} | http://localhost:{ports["frontend"]}                                     |
@@ -440,15 +440,18 @@ def create(branch: str | None, from_issue: str | None, provider: str | None, aut
         ok(f"Fetched {remote}/{remote_branch}")
         from_ref = f"{remote}/{remote_branch}"
 
-    if branch_exists_local:
-        run(["git", "worktree", "add", str(wt), branch], env=git_env)
-    elif branch_exists_remote:
-        run(["git", "worktree", "add", str(wt), f"origin/{branch}"], env=git_env)
-    else:
-        cmd = ["git", "worktree", "add", "-b", branch, str(wt)]
-        if from_ref:
-            cmd.append(from_ref)
-        run(cmd, env=git_env)
+    try:
+        if branch_exists_local:
+            run(["git", "worktree", "add", str(wt), branch], env=git_env)
+        elif branch_exists_remote:
+            run(["git", "worktree", "add", str(wt), f"origin/{branch}"], env=git_env)
+        else:
+            cmd = ["git", "worktree", "add", "-b", branch, str(wt)]
+            if from_ref:
+                cmd.append(from_ref)
+            run(cmd, env=git_env)
+    except subprocess.CalledProcessError:
+        raise click.ClickException(f"git failed to create worktree for branch '{branch}' — see error above")
 
     # Copy .env files
     step("Copying .env files...")
@@ -496,8 +499,8 @@ def create(branch: str | None, from_issue: str | None, provider: str | None, aut
     kf_port = str(DEFAULT_PORTS["knowledge-flow-backend"])
     kf_new_port = str(ports["knowledge-flow-backend"])
     for cfg_path in [
-        wt / "agentic-backend" / "config" / "configuration_prod.yaml",
-        wt / "agentic-backend" / "config" / "mcp_catalog.yaml",
+        wt / service_dir("fred-agents") / "config" / "configuration_prod.yaml",
+        wt / service_dir("fred-agents") / "config" / "mcp_catalog.yaml",
     ]:
         if cfg_path.exists():
             content = cfg_path.read_text()
@@ -524,8 +527,8 @@ def create(branch: str | None, from_issue: str | None, provider: str | None, aut
             f"{service_dir(svc)}/config/configuration_prod.yaml"
             for svc in PYTHON_SERVICES
         ],
-        "agentic-backend/config/mcp_catalog.yaml",
-        "agentic-backend/config/models_catalog.yaml",
+        f"{service_dir('fred-agents')}/config/mcp_catalog.yaml",
+        f"{service_dir('fred-agents')}/config/models_catalog.yaml",
         "knowledge-flow-backend/config/configuration_worker.yaml",
         "deploy/local/k3d/values-local.yaml",
         ".vscode/tasks.json",
@@ -550,7 +553,7 @@ def create(branch: str | None, from_issue: str | None, provider: str | None, aut
     click.echo(click.style(f"  🌿 Worktree ready: {branch}", fg="green", bold=True))
     click.echo(bar)
     click.echo(f"  {click.style('Dir:', bold=True)}      {wt}")
-    click.echo(f"  {click.style('Agentic:', bold=True)}  " + click.style(f"http://localhost:{ports['agentic-backend']}/agentic/v1/docs", fg="cyan"))
+    click.echo(f"  {click.style('Agents:', bold=True)}   " + click.style(f"http://localhost:{ports['fred-agents']}/agentic/v1/docs", fg="cyan"))
     click.echo(f"  {click.style('KF:', bold=True)}        " + click.style(f"http://localhost:{ports['knowledge-flow-backend']}/knowledge-flow/v1/docs", fg="cyan"))
     click.echo(f"  {click.style('CP:', bold=True)}        " + click.style(f"http://localhost:{ports['control-plane-backend']}/control-plane/v1/docs", fg="cyan"))
     click.echo(f"  {click.style('Frontend:', bold=True)} " + click.style(f"http://localhost:{ports['frontend']}", fg="cyan"))

--- a/scripts/wtf/src/wtf/__init__.py
+++ b/scripts/wtf/src/wtf/__init__.py
@@ -465,8 +465,32 @@ def generate_ports_md(branch: str, ports: dict[str, int]) -> str:
 
 # ── Commands ─────────────────────────────────────────────────────────────────
 
+_WORKTREE_COMMANDS = {"show-hidden-files", "hide-config-files", "patch-wt"}
 
-@click.group()
+
+class _GroupedGroup(click.Group):
+    """click.Group that renders commands in two labelled sections in --help."""
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        global_cmds: list[tuple[str, str]] = []
+        worktree_cmds: list[tuple[str, str]] = []
+
+        for name in self.list_commands(ctx):
+            cmd = self.commands.get(name)
+            if cmd is None or cmd.hidden:
+                continue
+            help_text = cmd.get_short_help_str(limit=formatter.width or 80)
+            (worktree_cmds if name in _WORKTREE_COMMANDS else global_cmds).append((name, help_text))
+
+        if global_cmds:
+            with formatter.section("Global commands"):
+                formatter.write_dl(global_cmds)
+        if worktree_cmds:
+            with formatter.section("Worktree commands (run from inside a worktree)"):
+                formatter.write_dl(worktree_cmds)
+
+
+@click.group(cls=_GroupedGroup)
 def cli():
     """Manage git worktrees for parallel Fred development."""
 

--- a/scripts/wtf/uv.lock
+++ b/scripts/wtf/uv.lock
@@ -1,0 +1,35 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "wtf"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "click" }]


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**ID:** no ID — mechanical fix because the project layout changed post-creation of wtf

**Problem in one sentence:** `wtf` and `.vscode/launch.json` still referenced the old paths (`agentic-backend` at root, `control-plane-backend` at root) after services were moved to `apps/` and `agentic-backend` was renamed to `fred-agents`.

**Backlog ref:** n/a — mechanical path update

---

## 2. Before you wrote a single line of code

**RFC written?** not required — mechanical fix, no design change, purely updating paths to match existing layout

**Plan presented to the team before implementation?** n/a — mechanical fix

**Confirmation received?** n/a — mechanical fix

---

## 3. What you built

Updated `scripts/wtf/src/wtf/__init__.py`:
- `PYTHON_SERVICES`, `SERVICE_DIRS`, `DEFAULT_PORTS`: `agentic-backend` → `fred-agents` with path `apps/fred-agents`
- All hardcoded `agentic-backend` path references updated to use `service_dir('fred-agents')`
- Frontend VITE env injection and `generate_ports_md` updated to use `fred-agents` key
- Added clean `ClickException` catch on `git worktree add` failure instead of raw traceback

Updated `.vscode/launch.json`:
- All `agentic-backend` filesystem paths → `apps/fred-agents`
- `agentic_backend.main:create_app` → `fred_agents.main:create_app`
- All `control-plane-backend` paths → `apps/control-plane-backend`
- `${workspaceFolder}/frontend` cwd → `apps/frontend`
- Debug config display names updated

**New wtf maintenance commands** (all operate on the worktree containing cwd — no branch argument needed):
- `wtf patch-wt`: re-apply the full patch pipeline (metrics, KF URLs, `.vscode`, ports) after a stash pop or config reset
- `wtf show-hidden-files`: remove `skip-worktree` so patched config files appear in `git status`
- `wtf hide-config-files`: re-apply `skip-worktree` to suppress them again

**Refactoring:** extracted shared logic into reusable helpers (`apply_patch_pipeline`, `worktree_skip_paths`, `hide_config_files`, `read_ports_md`, `current_worktree`) so `create` and the new commands share a single code path.

---

## 4. Proof of quality

**Tests added or updated:** none needed — path constant changes with manual end-to-end validation

**Validated:** `wtf create` and `wtf remove` run end-to-end successfully with the local source (`uv run wtf`), confirmed correct `.env` copying, port patching, tasks.json patching, and PORTS.md generation. New commands verified via `wtf --help`.

---

## 5. Docs updated

| What changed | File updated |
| ------------ | ------------ |
| Backlog `[ ]` item is now done | n/a |
| New behaviour, API field, or contract change | n/a — path fix + internal commands only |
| Frozen contract touched | n/a |
| UX component implemented | n/a |
| Phase progress row | n/a |
| WORKPLAN sprint item | n/a |
| Code and design doc diverge | n/a |

---

## 6. Close-out statement

```
## Task close-out
- Code: updated wtf service registry, hardcoded paths, launch.json debug configs; added patch-wt/show-hidden-files/hide-config-files commands and extracted shared helpers
- Tests: none added — manually validated full create/remove cycle with uv run wtf
- Docs updated: none — mechanical fix + internal tooling
- Backlog: none — not tracked
- Skipped steps: RFC (mechanical fix), backlog entry (mechanical fix)
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** `wtf create` copies .env to wrong paths or fails to patch config files — worktree would start but services would use wrong ports.

**How do we roll back?** Revert this commit; reinstall wtf from previous version.