### PR TITLE
#1683 change database name to fred_kea

### DIFF
--- a/agentic-backend/config/configuration_prod.yaml
+++ b/agentic-backend/config/configuration_prod.yaml
@@ -115,7 +115,7 @@ storage:
   postgres:
     host: localhost
     port: 5432
-    database: fred
+    database: fred_kea
     username: fred
 
   opensearch:

--- a/control-plane-backend/config/configuration_prod.yaml
+++ b/control-plane-backend/config/configuration_prod.yaml
@@ -45,7 +45,7 @@ storage:
   postgres:
     host: localhost
     port: 5432
-    database: fred
+    database: fred_kea
     username: fred
   content_storage:
     type: minio

--- a/deploy/local/k3d/values-local.yaml
+++ b/deploy/local/k3d/values-local.yaml
@@ -135,7 +135,7 @@ x-kf-storage: &kf-storage
   postgres:
     host: postgres
     port: 5432
-    database: fred
+    database: fred_kea
     username: fred
     pool_size: 2
     max_overflow: 0
@@ -198,7 +198,7 @@ x-cp-storage: &cp-storage
   postgres:
     host: postgres
     port: 5432
-    database: fred
+    database: fred_kea
     username: fred
     pool_size: 2
     max_overflow: 0
@@ -288,7 +288,7 @@ applications:
         postgres:
           host: postgres
           port: 5432
-          database: fred
+          database: fred_kea
           username: fred
           pool_size: 2
           max_overflow: 0

--- a/knowledge-flow-backend/config/configuration_prod.yaml
+++ b/knowledge-flow-backend/config/configuration_prod.yaml
@@ -382,7 +382,7 @@ storage:
   postgres:
     host: localhost
     port: 5432
-    database: fred
+    database: fred_kea
     username: fred
     pool_size: 2
     max_overflow: 0


### PR DESCRIPTION
This only impact the developer experience. It also suggest when deploying a new kea (meaning only for a migration to swift) that fred_kea database name should be used to make it easier the migration process.