### PR TITLE
fix: correct ENV_FILE default in INFO-fred-agents.mk

### DIFF
--- a/scripts/makefiles/config/INFO-fred-agents.mk
+++ b/scripts/makefiles/config/INFO-fred-agents.mk
@@ -15,7 +15,7 @@ IMAGE_FULL          ?= $(REGISTRY_URL)/$(REGISTRY_NAMESPACE)/$(IMAGE_NAME):$(IMA
 
 # Runtime
 PORT                ?= 8000
-ENV_FILE            ?= .venv
+ENV_FILE            ?= ./config/.env
 LOG_LEVEL           ?= info
 PROJECT_ID          ?= 12345  # Optional if using Helm
 HELM_ARCHIVE        ?= ./$(PROJECT_SLUG)-$(VERSION).tgz


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**ID:** no ID — mechanical fix

**Problem in one sentence:** `ENV_FILE` was defaulting to `.venv` (a typo) in `scripts/makefiles/config/INFO-fred-agents.mk`, which is included before `python-vars.mk` sets the correct `./config/.env` default, causing `make rrun-prod` (and all run targets) to fail loading the `.env` file and miss API keys like `OPENAI_API_KEY`.

**Backlog ref:** n/a — single-line typo fix

---

## 2. Before you wrote a single line of code

**RFC written?** not required — mechanical fix (one-line typo: `.venv` → `./config/.env`)

**Plan presented to the team before implementation?** not required — mechanical fix

**Confirmation received?** not required — mechanical fix

---

## 3. What you built

Changed `ENV_FILE ?= .venv` to `ENV_FILE ?= ./config/.env` in `scripts/makefiles/config/INFO-fred-agents.mk`. Since this INFO file is included before `python-vars.mk`, its `?=` assignment wins, so the wrong value was always used.

---

## 4. Proof of quality

**Tests added or updated:** none needed — single-line config typo fix

**`make code-quality` output:** n/a — Makefile only

**`make test` output:** n/a — Makefile only

---

## 5. Docs updated

| What changed | File updated |
| --- | --- |
| Backlog `[ ]` item is now done | n/a |
| New behaviour, API field, or contract change | n/a |
| Frozen contract touched | n/a |
| UX component implemented or visual status changed | n/a |
| Phase progress row exists for this area | n/a |
| WORKPLAN sprint item finished | n/a |
| Code and a design doc now diverge | n/a |

---

## 6. Close-out statement

```
## Task close-out
- Code: fixed ENV_FILE default from `.venv` to `./config/.env` in INFO-fred-agents.mk
- Tests: none needed — Makefile variable typo fix
- Docs updated: none — mechanical fix
- Backlog: none — not tracked
- Skipped steps: Steps 1–3 skipped — single-line typo, no design decision involved
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** `make run*` targets for fred-agents would continue using the wrong `.env` path; rollback by reverting this one-line change.

**How do we roll back?** `git revert` this commit.