### PR TITLE
docs(MIGR-00): add Kea→Swift migration epic and backlog

### DIFF
--- a/docs/swift/PMO-BOARD.md
+++ b/docs/swift/PMO-BOARD.md
@@ -24,7 +24,7 @@ Do not add new scope or statuses here that are absent from the source docs.
 - `Execution` column priority: GitHub issue -> PR -> working branch -> `TBD`.
 - When an execution ref is known, mirror it under the backlog item as `Execution: ...`.
 
-Last updated: 2026-06-04
+Last updated: 2026-06-05
 
 ## Active And Next Up
 
@@ -48,6 +48,7 @@ Last updated: 2026-06-04
 | `PROMPT-06` | `PROMPT-MARKETPLACE` | Dimitri | En attente de `PROMPT-04` | [BACKLOG §3d.10](backlog/BACKLOG.md) | [PROMPT-LIBRARY-RFC](rfc/PROMPT-LIBRARY-RFC.md) | `TBD` |
 | `UX-01` | `UX-AUDIT` | Felix | A lancer | [BACKLOG §UX-1](backlog/BACKLOG.md) | [COMPONENT-UX](ux/COMPONENT-UX.md) | `TBD` |
 | `FRONT-05` | `FRONTEND-CLEANUP` | Felix | En attente de `CHAT-03` | [FRONTEND-BACKLOG §7](backlog/FRONTEND-BACKLOG.md) | — | `TBD` |
+| `MIGR-00` | `KEA-SWIFT-CUTOVER` | Florian | A définir — 3 workstreams: cherry-picks, DB migration, feature parity | [KEA-MIGRATION-BACKLOG](backlog/KEA-MIGRATION-BACKLOG.md) | — | `TBD` |
 | `DEVOPS-FREDLAB` | `DEVOPS-FREDLAB` | Sébastien | **⚠️ CRITIQUE — reste le Helm chart pour GCP / GKE Autopilot interne** | [BACKLOG §3b](backlog/BACKLOG.md) | — | `TBD` |
 | `OPS-01` | `DEVOPS-HELM-CHART` | Simon | A lancer — prerequis CI + Docker clos | [BACKLOG §3b.11](backlog/BACKLOG.md) | [FRED-CHART-MODERNIZATION-RFC](rfc/FRED-CHART-MODERNIZATION-RFC.md) | GitHub issue `#1685` |
 

--- a/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
+++ b/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
@@ -27,7 +27,7 @@ Legend: **[needed]** = blocking for production cutover · **[good-to-have]** = q
   — *GCU acceptance was broken on some screen sizes, reported in production*
   — source: [`4fc90cc`](https://github.com/ThalesGroup/fred/commit/4fc90cc8d)
 
-- [ ] **MIGR-01.03** — Dockerfile base image bumps: Node + nginx + Python 3.12.13-slim
+- [ ] **MIGR-01.03** — Dockerfile base image bumps: Node + nginx
   — *CVE fixes requested by SSI on frontend image*
   — source:
     - [ ] [#1635](https://github.com/ThalesGroup/fred/commit/a41540422) `a414404`

--- a/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
+++ b/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
@@ -1,0 +1,135 @@
+# Kea→Swift Migration Backlog
+
+Epic: **MIGR-00** — Kea→Swift production cutover
+
+This backlog tracks the three workstreams needed to cut over from Kea (production) to
+Swift (new architecture). Owner of each sub-item = the person doing the work.
+Set `owner:` in `id-legend.yaml` when a ticket is picked up.
+
+---
+
+## §1 Cherry-picks and code adaptations (MIGR-01)
+
+Commits or features from the Kea codebase that need to be cherry-picked or
+re-implemented for Swift. For each item, note the source commit/PR and what
+adaptation is needed (e.g. API contract change, dependency replacement).
+
+Legend: **[needed]** = blocking for production cutover · **[good-to-have]** = quality / dev-experience
+
+### Needed
+
+- [ ] **MIGR-01.01** — Upload warning banner on document upload drawer and chat attachments
+  — *SSI requirement: prevent accidental upload of sensitive files*
+  — source: [#1597](https://github.com/ThalesGroup/fred/commit/34ea331a3) `34ea331` · [#1634](https://github.com/ThalesGroup/fred/commit/7b6320bc3) `7b6320b`
+  — adaptation: check if chat attachment component exists in Swift; both commits may need to be applied
+
+- [ ] **MIGR-01.02** — Fix GCU acceptation button on specific resolutions + placement fixes (delete agent button, add-member popover, select popover)
+  — *GCU acceptance was broken on some screen sizes, reported in production*
+  — source: [`4fc90cc`](https://github.com/ThalesGroup/fred/commit/4fc90cc8d)
+
+- [ ] **MIGR-01.03** — Dockerfile base image bumps: Node + nginx + Python 3.12.13-slim
+  — *CVE fixes requested by SSI on frontend image*
+  — source:
+    - [ ] [#1635](https://github.com/ThalesGroup/fred/commit/a41540422) `a414404`
+    - [X] [#1647](https://github.com/ThalesGroup/fred/commit/38d4880ce) `38d4880`
+
+- [ ] **MIGR-01.04** — Add `created_at` / `updated_at` timestamps to all ORM tables
+  — *Required to verify production KPIs*
+  — source: [#1612](https://github.com/ThalesGroup/fred/commit/e2be3fb7c) `e2be3fb`
+
+- [ ] **MIGR-01.05** — Migrate to trunk-based development with unified release tag
+  — *Rename main branch to `main`; single tag triggers a release*
+  — source: [#1622](https://github.com/ThalesGroup/fred/commit/67916e113) `67916e1`
+
+- [X] **MIGR-01.06** — Garbage-collect uploaded files after processing to prevent `/tmp` clogging
+  — *Prevents disk exhaustion in the Temporal worker in production*
+  — source: [#1605](https://github.com/ThalesGroup/fred/commit/ea048fe06) `ea048fe`
+
+- [X] **MIGR-01.07** — Guard against `undefined` before calling `.toLowerCase()` in frontend
+  — *Fixes a frontend crash reported by a user*
+  — source: [#1611](https://github.com/ThalesGroup/fred/commit/026f21a6a) `026f21a`
+
+- [X] **MIGR-01.08** — Fix broken link in team join-request email
+  — *Wrong URL in the invite email*
+  — source: [#1589](https://github.com/ThalesGroup/fred/commit/5dd8a8f4d) `5dd8a8f`
+
+- [X] **MIGR-01.11** — Inherit `extraVolumes` and `extraVolumeMounts` in Helm hook Job
+  — *Migration hook Jobs were missing volume mounts defined at chart level*
+  — source: [#1659](https://github.com/ThalesGroup/fred/commit/7dce0561c) `7dce056`
+
+- [X] **MIGR-01.12** — Add fast PDF processor
+  — *New processor significantly reduces PDF ingestion time*
+  — source: [#1626](https://github.com/ThalesGroup/fred/commit/3ab0af7a3) `3ab0af7`
+
+- [X] **MIGR-01.13** — Mitigate knowledge-flow worker memory pressure during PDF medium-rich ingestion
+  — *Prevents OOM crashes on large/rich PDFs in production*
+  — source: [#1624](https://github.com/ThalesGroup/fred/commit/45db88821) `45db888`
+
+- [X] **MIGR-01.14** — Cap concurrent uvicorn connections, configurable via Helm values and Makefiles
+  — *Prevents connection overload; tunable per environment*
+  — source: [#1627](https://github.com/ThalesGroup/fred/commit/688c4fa91) `688c4fa`
+
+- [X] **MIGR-01.15** — Add custom `RetryPolicy` support for Temporal activities
+  — *Allows per-activity retry tuning to avoid cascading failures*
+  — source: [#1576](https://github.com/ThalesGroup/fred/commit/6550bb73d) `6550bb7`
+
+### Good to have
+
+- [ ] **MIGR-01.09** — Remove SCSS, migrate to pure CSS className syntax
+  — *Removes old SCSS layer; project is now pure CSS*
+  — source: [#1636](https://github.com/ThalesGroup/fred/commit/419b79554) `419b795`
+
+- [X] **MIGR-01.10** — Fix company-managed CA certificate handling in local dev environment
+  — *Required for developers working on Leap*
+  — source: [#1620](https://github.com/ThalesGroup/fred/commit/403bf3aff) `403bf3a`
+
+---
+
+## §2 Postgres data/schema migration and backfill scripts for Fred tables(MIGR-02)
+
+Schema diffs and backfill scripts for existing production data.
+Each row represents one backfill script or migration step.
+
+### Required
+
+- [ ] **MIGR-02.01** — Cherry-pick `created_at` / `updated_at` timestamps on all ORM tables
+  — *Prerequisite for KPI queries on production data*
+  — depends on: MIGR-01.04 (same commit, must land first)
+
+- [ ] **MIGR-02.02** — Backfill script: migrate data from `agent` → `agent_instance`, then drop `agent`
+  — *`agent` table is the Kea model; Swift uses `agent_instance` — production data must be migrated before cutover*
+
+### Optional
+
+- [ ] **MIGR-02.03** — Backfill script: migrate conversations from `session` → `session_metadata`
+  — *Table rename between Kea and Swift; existing sessions would be lost without this*
+
+- [ ] **MIGR-02.04** — Handle `session_history` schema change
+  — *Schema differs between Kea and Swift; assess: migrate in place, transform, or accept history loss*
+
+---
+
+## §3 Feature parity — Kea features missing in Swift (MIGR-03)
+
+Features present in Kea production that are not yet in Swift.
+For each item: assess whether to port as-is, adapt to Swift architecture, or drop
+with a written rationale.
+
+- [ ] **MIGR-03.01** — Session attachments — add document to a conversation directly
+  — *Users could attach documents inline in a chat session in Kea*
+
+- [ ] **MIGR-03.02** — Message feedback — leave a rating with 5 stars and a comment on a chat message
+  — *Feedback feature was available in Kea; used for quality monitoring*
+
+- [ ] **MIGR-03.03** — Source citation in chat — display source references alongside agent responses
+  — *Kea showed which documents/sources were used in the response*
+
+---
+
+## Progress
+
+| Workstream | Total | Done | Remaining |
+| ---------- | ----- | ---- | --------- |
+| MIGR-01 Cherry-picks | 15 (13 needed + 2 good-to-have) | 9 | 6 |
+| MIGR-02 DB migration | 4 (2 required + 2 optional) | 0 | 4 |
+| MIGR-03 Feature parity | 3 | 0 | 3 |

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -8,7 +8,7 @@
 # are listed in meta.domains. See CLAUDE.md § Task IDs for the full rule.
 
 meta:
-  last_updated: "2026-06-04"
+  last_updated: "2026-06-05"
   id_format: "DOMAIN-NN where DOMAIN is a 4-7 letter code, NN is two-digit sequential"
   status_values: [open, in_progress, done, deferred, not_started]
   domains:
@@ -18,6 +18,7 @@ meta:
     FILES:   "Agent filesystem — virtual FS, file exchange, upload/download, LinkPart rendering"
     FRONT:   "Frontend migration and refactor (excluding chat UI)"
     MEMORY:  "Multi-agent conversational memory"
+    MIGR:    "Kea→Swift production cutover — cherry-picks, DB migrations, feature parity"
     OBSERV:  "Observability, metrics, Prometheus, KPIs"
     OPS:     "CLI, deployment, environment ops"
     PROMPT:  "Prompt safety, library, context picker, marketplace"
@@ -715,6 +716,43 @@ items:
       session. Known first issue: search policy and RAG scope select options show
       long description strings as single truncated tooltip lines — needs a proper
       multi-line tooltip or description placement (McpServerCard + TuningFieldRenderer).
+
+  # ── MIGR ──────────────────────────────────────────────────────────────
+  # Epic: Kea→Swift production cutover.
+  # MIGR-00 is the parent epic; child tickets use parent: MIGR-00.
+
+  - id: MIGR-00
+    title: "Kea→Swift production cutover — top-level epic"
+    status: open
+    owner: Florian
+    refs:
+      backlog: "docs/swift/backlog/KEA-MIGRATION-BACKLOG.md"
+    notes: >
+      Umbrella for the full Kea→Swift production migration. Three workstreams:
+      (1) cherry-picks / code adaptations from Kea (MIGR-01),
+      (2) Postgres data migration and backfill scripts (MIGR-02),
+      (3) feature parity — Kea features missing in Swift (MIGR-03).
+
+  - id: MIGR-01
+    title: "Cherry-picks and code adaptations from Kea to Swift"
+    status: open
+    parent: MIGR-00
+    refs:
+      backlog: "docs/swift/backlog/KEA-MIGRATION-BACKLOG.md §1"
+
+  - id: MIGR-02
+    title: "Postgres data migration and backfill scripts"
+    status: open
+    parent: MIGR-00
+    refs:
+      backlog: "docs/swift/backlog/KEA-MIGRATION-BACKLOG.md §2"
+
+  - id: MIGR-03
+    title: "Feature parity — Kea features missing in Swift"
+    status: open
+    parent: MIGR-00
+    refs:
+      backlog: "docs/swift/backlog/KEA-MIGRATION-BACKLOG.md §3"
 
   # ── VALID ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**ID:** MIGR-00 (epic), MIGR-01, MIGR-02, MIGR-03

**Problem in one sentence:** There was no structured place to track the Kea→Swift production cutover work — cherry-picks, DB migrations, and feature parity gaps were untracked.

**Backlog ref:** [docs/swift/backlog/KEA-MIGRATION-BACKLOG.md](docs/swift/backlog/KEA-MIGRATION-BACKLOG.md)

---

## 2. Before you wrote a single line of code

**RFC written?** Not required — this is a documentation/tracking change only, no code or API changes.

**Plan presented to the team before implementation?** Yes — structured and confirmed during the backlog authoring session.

**Confirmation received?** Yes.

---

## 3. What you built

- Added `MIGR` domain to `docs/swift/data/id-legend.yaml`
- Registered 4 tickets: `MIGR-00` (epic), `MIGR-01` (cherry-picks), `MIGR-02` (DB migration), `MIGR-03` (feature parity)
- Created `docs/swift/backlog/KEA-MIGRATION-BACKLOG.md` with:
  - §1: 15 cherry-pick items (8 needed / 2 good-to-have / 5 from second batch), 9 already marked done
  - §2: 4 DB migration items (2 required, 2 optional)
  - §3: 3 feature parity items (session attachments, message feedback, source citation)
- Updated `docs/swift/PMO-BOARD.md` with the MIGR-00 epic row

---

## 4. Proof of quality

**Tests added or updated:** n/a — documentation only

**`make code-quality`:** n/a — no code changed

**`make test`:** n/a — no code changed

---

## 5. Docs updated

| What changed | File updated |
| ------------ | ------------ |
| New MIGR domain and 4 ticket IDs registered | `docs/swift/data/id-legend.yaml` |
| New backlog file for Kea→Swift migration | `docs/swift/backlog/KEA-MIGRATION-BACKLOG.md` |
| PMO board updated with MIGR-00 epic row | `docs/swift/PMO-BOARD.md` |

---

## 6. Close-out statement

```
## Task close-out
- Code: none — documentation only
- Tests: none needed
- Docs updated: id-legend.yaml, KEA-MIGRATION-BACKLOG.md, PMO-BOARD.md
- Backlog: MIGR-00 created and open
- Skipped steps: RFC (not required — tracking/doc change, no design decision)
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** Nothing functional — these are tracking documents only.

**How do we roll back?** Revert this commit.