### PR TITLE
Fix when the session history for a newly created db in fred-agent

### DIFF
--- a/libs/fred-core/fred_core/history/postgres_history_store.py
+++ b/libs/fred-core/fred_core/history/postgres_history_store.py
@@ -44,7 +44,7 @@ from datetime import datetime, timezone
 from typing import Any, List
 
 from pydantic import TypeAdapter, ValidationError
-from sqlalchemy import delete, func, select
+from sqlalchemy import MetaData, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from fred_core.history.base_history_store import BaseHistoryStore
@@ -57,6 +57,7 @@ from fred_core.history.history_schema import (
     Role,
 )
 from fred_core.sql.async_session import make_session_factory, use_session
+from fred_core.sql.base_sql import advisory_lock_key, run_ddl_with_advisory_lock
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +140,9 @@ class PostgresHistoryStore(BaseHistoryStore):
     - upsert on ``(session_id, user_id, rank)`` — retried writes are idempotent
 
     DDL:
-    - the ``session_history`` table is managed by Alembic (fred-runtime migration
-      track); the pod must run ``alembic upgrade head`` before using this store
+    - the canonical schema is still tracked by fred-runtime Alembic migrations
+    - the store also self-initializes the runtime-owned table on first use so a
+      fresh local SQLite database does not fail before the first write
 
     Why upsert rather than insert:
     - a turn can be retried (HITL resume, network retry) and the same messages
@@ -150,6 +152,33 @@ class PostgresHistoryStore(BaseHistoryStore):
     def __init__(self, engine: AsyncEngine) -> None:
         self._engine = engine
         self._sessions = make_session_factory(engine)
+        self._metadata = MetaData()
+        SessionHistoryRow.__table__.to_metadata(self._metadata)
+        self._ddl_lock_id = advisory_lock_key(SessionHistoryRow.__tablename__)
+        self._tables_ready = False
+
+    async def _ensure_tables(self) -> None:
+        """
+        Ensure the runtime-owned history table exists before querying it.
+
+        Why this helper exists:
+        - fresh local SQLite runs create the database file before Alembic has
+          necessarily been applied
+        - the first history call is often ``next_rank()``, so table creation
+          must happen before both reads and writes
+
+        How to use it:
+        - call at the start of every public store operation
+        """
+        if self._tables_ready:
+            return
+        await run_ddl_with_advisory_lock(
+            engine=self._engine,
+            lock_key=self._ddl_lock_id,
+            ddl_sync_fn=self._metadata.create_all,
+            logger=logger,
+        )
+        self._tables_ready = True
 
     # ------------------------------------------------------------------
     # Write
@@ -182,6 +211,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         """
         if not messages:
             return
+        await self._ensure_tables()
         rows = [
             {
                 "session_id": session_id,
@@ -234,6 +264,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         Returns [] when no rows match — callers cannot distinguish "wrong owner"
         from "empty session" by design (avoids session-ID enumeration).
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             q = select(SessionHistoryRow).where(
                 SessionHistoryRow.session_id == session_id
@@ -294,6 +325,7 @@ class PostgresHistoryStore(BaseHistoryStore):
             sessions = await store.list_sessions(user_id="alice")
             # returns ["session-3", "session-1", ...]  most recent first
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
                 select(SessionHistoryRow.session_id)
@@ -315,6 +347,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         When user_id is provided, only rows belonging to that user are deleted.
         Returns the number of rows removed (0 when session not found or not owned).
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             where = [SessionHistoryRow.session_id == session_id]
             if user_id is not None:
@@ -332,6 +365,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         session: AsyncSession | None = None,
     ) -> bool:
         """Return True iff at least one history row exists for (session_id, user_id)."""
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
                 select(func.count()).where(
@@ -365,6 +399,7 @@ class PostgresHistoryStore(BaseHistoryStore):
             base = await store.next_rank(session_id="s1")
             # base = 0 for a new session, or MAX+1 for an existing one
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
                 select(func.max(SessionHistoryRow.rank)).where(

--- a/libs/fred-runtime/tests/test_history.py
+++ b/libs/fred-runtime/tests/test_history.py
@@ -32,6 +32,14 @@ from unittest.mock import AsyncMock
 
 from conftest import StaticChatModelFactory, ToolFriendlyFakeChatModel
 from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+
+from fred_core.history.history_schema import (
+    Channel,
+    ChatMessage,
+    Role,
+    TextPart,
+)
 from fred_sdk.authoring import ReActAgent, tool
 from fred_sdk.authoring.api import ToolContext
 from fred_sdk.contracts.models import ReActAgentDefinition
@@ -41,6 +49,7 @@ from langchain_core.messages import AIMessage
 from fred_runtime.app import AgentPodConfig, create_agent_app
 from fred_runtime.app import agent_app as agent_app_module
 from fred_runtime.app.agent_app import _write_turn_history
+from fred_runtime.app.dependencies import get_pod_container_from_app
 from fred_runtime.runtime_context import RuntimeConfig, RuntimeContext
 
 
@@ -553,3 +562,48 @@ def test_delete_session_passes_caller_uid_to_store(monkeypatch, tmp_path) -> Non
     mock_store.delete_session.assert_awaited_once_with(
         session_id="session-liam", user_id="alice-uid"
     )
+
+
+def test_fresh_sqlite_startup_initializes_history_table(monkeypatch, tmp_path) -> None:
+    """
+    A fresh SQLite-backed pod startup must initialize the history table before
+    the first history query or write.
+
+    Why this test exists:
+    - local runtime startup can create the SQLite file before any runtime
+      Alembic command has been run
+    - the first history operation is often ``next_rank()``, which previously
+      failed with ``no such table: session_history``
+    """
+    app = _make_app(monkeypatch, tmp_path)
+
+    with TestClient(app):
+        container = get_pod_container_from_app(app)
+        history_store = container.get_history_store()
+        assert history_store is not None
+
+        base_rank = asyncio.run(history_store.next_rank(session_id="fresh-session"))
+        assert base_rank == 0
+
+        asyncio.run(
+            history_store.save(
+                session_id="fresh-session",
+                user_id="alice",
+                messages=[
+                    ChatMessage(
+                        session_id="fresh-session",
+                        exchange_id="ex-1",
+                        rank=0,
+                        timestamp=datetime.now(timezone.utc),
+                        role=Role.user,
+                        channel=Channel.final,
+                        parts=[TextPart(text="hello")],
+                    )
+                ],
+            )
+        )
+
+        messages = asyncio.run(history_store.get("fresh-session", user_id="alice"))
+
+    assert len(messages) == 1
+    assert messages[0].parts[0].text == "hello"


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

<!-- ID from docs/swift/data/id-legend.yaml (e.g. S1, CP-2, M1-F.3).
     If there is no ID, explain why this work exists at all. -->

**ID:** <!-- S1 / CP-2 / … / "no ID — mechanical fix because …" -->

**Code: runtime history store now ensures session_history exists before use; added fresh-SQLite startup regression coverage**

**Backlog ref:** <!-- link to the [ ] checkbox in the relevant backlog file -->

---
## 3. What you built

Make sure that the session history table is created. otherwise, there will be an sql error in the prompt and the session history is lost upon refresh. 

<!-- Be concrete. Not "updated the service" — say which function, which model,
     which endpoint, which component, and what it now does differently.
     Two or three sentences is enough. Ten vague words is not. -->

---

## 4. Proof of quality

**Tests added or updated:**

<!-- List exact test function names and the file they live in.
     If you added none, explain why none were needed. -->

| Test | File | What it covers |
| ---- | ---- | -------------- |
|      |      |                |

**`make code-quality` output (paste the last line or "all checks passed"):**

```
Makefile:39: warning: overriding commands for target `docker-build'
Makefile:17: warning: ignoring old commands for target `docker-build'
Makefile:46: warning: overriding commands for target `run-docker'
Makefile:24: warning: ignoring old commands for target `run-docker'
✅ Dependencies installed using uv.
************ Executing Ruff linter ************
/Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.venv/bin/uv run ruff check
All checks passed!
************ Executing Ruff formatter ************
/Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.venv/bin/uv run ruff format --check
15 files already formatted
************ Executing Bandit with rules B101,B108 ingored (B101: assert_used, B108: hardcoded_tmp_directory) ************
/Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.venv/bin/uv run bandit \
		-r fred_agents \
		-s B101,B108 \
		--baseline /Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.baseline/bandit-baseline.json
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: B101,B108
[main]	INFO	running on Python 3.12.10
Run started:2026-06-08 13:17:38.308010+00:00

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 2028
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
cd .. && git ls-files -z /Users/marc/Documents/fred-workspace/fred/apps/fred-agents | xargs -0 /Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.venv/bin/detect-secrets-hook --baseline /Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.baseline/detect-secret-baseline.json
************ Executing Basedpyright type checker ************
/Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.venv/bin/uv run basedpyright --baseline-file /Users/marc/Documents/fred-workspace/fred/apps/fred-agents/.baseline/basedpyright-baseline.json
0 errors, 0 warnings, 0 notes
************ All code quality checks completed ************
```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```

```

**`make test` output (paste the summary line — pass count, 0 failures):**

```

```

If you touched multiple packages, paste one block per package.

---

## 5. Docs updated

Work through this line by line. If an item does not apply, write "n/a" and say why.

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    |              |
| New behaviour, API field, or contract change                      |              |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) |              |
| UX component implemented or visual status changed                 |              |
| Phase progress row exists for this area                           |              |
| WORKPLAN sprint item finished                                     |              |
| Code and a design doc now diverge                                 |              |

---

## 6. Close-out statement

<!--
Copy the exact block from the end of your implementation session.
If you don't have one, write it now — and wonder why you don't have it.
-->

```
## Task close-out
- Code:
- Tests:
- Docs updated:
- Backlog:
- Skipped steps:
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

**How do we roll back?**
