### PR TITLE
fix: session_history missing on fresh SQLite db

### DIFF
--- a/libs/fred-core/fred_core/history/postgres_history_store.py
+++ b/libs/fred-core/fred_core/history/postgres_history_store.py
@@ -39,6 +39,7 @@ Example:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, List
@@ -153,32 +154,24 @@ class PostgresHistoryStore(BaseHistoryStore):
         self._engine = engine
         self._sessions = make_session_factory(engine)
         self._metadata = MetaData()
-        SessionHistoryRow.__table__.to_metadata(self._metadata)
+        SessionHistoryRow.__table__.to_metadata(self._metadata)  # type: ignore[attr-defined]
         self._ddl_lock_id = advisory_lock_key(SessionHistoryRow.__tablename__)
         self._tables_ready = False
+        self._ddl_asyncio_lock = asyncio.Lock()
 
     async def _ensure_tables(self) -> None:
-        """
-        Ensure the runtime-owned history table exists before querying it.
-
-        Why this helper exists:
-        - fresh local SQLite runs create the database file before Alembic has
-          necessarily been applied
-        - the first history call is often ``next_rank()``, so table creation
-          must happen before both reads and writes
-
-        How to use it:
-        - call at the start of every public store operation
-        """
         if self._tables_ready:
             return
-        await run_ddl_with_advisory_lock(
-            engine=self._engine,
-            lock_key=self._ddl_lock_id,
-            ddl_sync_fn=self._metadata.create_all,
-            logger=logger,
-        )
-        self._tables_ready = True
+        async with self._ddl_asyncio_lock:
+            if self._tables_ready:
+                return
+            await run_ddl_with_advisory_lock(
+                engine=self._engine,
+                lock_key=self._ddl_lock_id,
+                ddl_sync_fn=self._metadata.create_all,
+                logger=logger,
+            )
+            self._tables_ready = True
 
     # ------------------------------------------------------------------
     # Write

--- a/libs/fred-core/fred_core/history/postgres_history_store.py
+++ b/libs/fred-core/fred_core/history/postgres_history_store.py
@@ -44,7 +44,7 @@ from datetime import datetime, timezone
 from typing import Any, List
 
 from pydantic import TypeAdapter, ValidationError
-from sqlalchemy import delete, func, select
+from sqlalchemy import MetaData, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from fred_core.history.base_history_store import BaseHistoryStore
@@ -57,6 +57,7 @@ from fred_core.history.history_schema import (
     Role,
 )
 from fred_core.sql.async_session import make_session_factory, use_session
+from fred_core.sql.base_sql import advisory_lock_key, run_ddl_with_advisory_lock
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +140,9 @@ class PostgresHistoryStore(BaseHistoryStore):
     - upsert on ``(session_id, user_id, rank)`` — retried writes are idempotent
 
     DDL:
-    - the ``session_history`` table is managed by Alembic (fred-runtime migration
-      track); the pod must run ``alembic upgrade head`` before using this store
+    - the canonical schema is still tracked by fred-runtime Alembic migrations
+    - the store also self-initializes the runtime-owned table on first use so a
+      fresh local SQLite database does not fail before the first write
 
     Why upsert rather than insert:
     - a turn can be retried (HITL resume, network retry) and the same messages
@@ -150,6 +152,33 @@ class PostgresHistoryStore(BaseHistoryStore):
     def __init__(self, engine: AsyncEngine) -> None:
         self._engine = engine
         self._sessions = make_session_factory(engine)
+        self._metadata = MetaData()
+        SessionHistoryRow.__table__.to_metadata(self._metadata)
+        self._ddl_lock_id = advisory_lock_key(SessionHistoryRow.__tablename__)
+        self._tables_ready = False
+
+    async def _ensure_tables(self) -> None:
+        """
+        Ensure the runtime-owned history table exists before querying it.
+
+        Why this helper exists:
+        - fresh local SQLite runs create the database file before Alembic has
+          necessarily been applied
+        - the first history call is often ``next_rank()``, so table creation
+          must happen before both reads and writes
+
+        How to use it:
+        - call at the start of every public store operation
+        """
+        if self._tables_ready:
+            return
+        await run_ddl_with_advisory_lock(
+            engine=self._engine,
+            lock_key=self._ddl_lock_id,
+            ddl_sync_fn=self._metadata.create_all,
+            logger=logger,
+        )
+        self._tables_ready = True
 
     # ------------------------------------------------------------------
     # Write
@@ -182,6 +211,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         """
         if not messages:
             return
+        await self._ensure_tables()
         rows = [
             {
                 "session_id": session_id,
@@ -234,6 +264,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         Returns [] when no rows match — callers cannot distinguish "wrong owner"
         from "empty session" by design (avoids session-ID enumeration).
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             q = select(SessionHistoryRow).where(
                 SessionHistoryRow.session_id == session_id
@@ -294,6 +325,7 @@ class PostgresHistoryStore(BaseHistoryStore):
             sessions = await store.list_sessions(user_id="alice")
             # returns ["session-3", "session-1", ...]  most recent first
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
                 select(SessionHistoryRow.session_id)
@@ -315,6 +347,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         When user_id is provided, only rows belonging to that user are deleted.
         Returns the number of rows removed (0 when session not found or not owned).
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             where = [SessionHistoryRow.session_id == session_id]
             if user_id is not None:
@@ -332,6 +365,7 @@ class PostgresHistoryStore(BaseHistoryStore):
         session: AsyncSession | None = None,
     ) -> bool:
         """Return True iff at least one history row exists for (session_id, user_id)."""
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
                 select(func.count()).where(
@@ -365,6 +399,7 @@ class PostgresHistoryStore(BaseHistoryStore):
             base = await store.next_rank(session_id="s1")
             # base = 0 for a new session, or MAX+1 for an existing one
         """
+        await self._ensure_tables()
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
                 select(func.max(SessionHistoryRow.rank)).where(

--- a/libs/fred-runtime/tests/test_history.py
+++ b/libs/fred-runtime/tests/test_history.py
@@ -28,11 +28,11 @@ All tests are offline — no external services required.
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 from conftest import StaticChatModelFactory, ToolFriendlyFakeChatModel
 from fastapi.testclient import TestClient
-from datetime import datetime, timezone
 
 from fred_core.history.history_schema import (
     Channel,

--- a/libs/fred-runtime/tests/test_history.py
+++ b/libs/fred-runtime/tests/test_history.py
@@ -33,7 +33,6 @@ from unittest.mock import AsyncMock
 
 from conftest import StaticChatModelFactory, ToolFriendlyFakeChatModel
 from fastapi.testclient import TestClient
-
 from fred_core.history.history_schema import (
     Channel,
     ChatMessage,

--- a/libs/fred-runtime/tests/test_history.py
+++ b/libs/fred-runtime/tests/test_history.py
@@ -32,6 +32,14 @@ from unittest.mock import AsyncMock
 
 from conftest import StaticChatModelFactory, ToolFriendlyFakeChatModel
 from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+
+from fred_core.history.history_schema import (
+    Channel,
+    ChatMessage,
+    Role,
+    TextPart,
+)
 from fred_sdk.authoring import ReActAgent, tool
 from fred_sdk.authoring.api import ToolContext
 from fred_sdk.contracts.models import ReActAgentDefinition
@@ -41,6 +49,7 @@ from langchain_core.messages import AIMessage
 from fred_runtime.app import AgentPodConfig, create_agent_app
 from fred_runtime.app import agent_app as agent_app_module
 from fred_runtime.app.agent_app import _write_turn_history
+from fred_runtime.app.dependencies import get_pod_container_from_app
 from fred_runtime.runtime_context import RuntimeConfig, RuntimeContext
 
 
@@ -553,3 +562,48 @@ def test_delete_session_passes_caller_uid_to_store(monkeypatch, tmp_path) -> Non
     mock_store.delete_session.assert_awaited_once_with(
         session_id="session-liam", user_id="alice-uid"
     )
+
+
+def test_fresh_sqlite_startup_initializes_history_table(monkeypatch, tmp_path) -> None:
+    """
+    A fresh SQLite-backed pod startup must initialize the history table before
+    the first history query or write.
+
+    Why this test exists:
+    - local runtime startup can create the SQLite file before any runtime
+      Alembic command has been run
+    - the first history operation is often ``next_rank()``, which previously
+      failed with ``no such table: session_history``
+    """
+    app = _make_app(monkeypatch, tmp_path)
+
+    with TestClient(app):
+        container = get_pod_container_from_app(app)
+        history_store = container.get_history_store()
+        assert history_store is not None
+
+        base_rank = asyncio.run(history_store.next_rank(session_id="fresh-session"))
+        assert base_rank == 0
+
+        asyncio.run(
+            history_store.save(
+                session_id="fresh-session",
+                user_id="alice",
+                messages=[
+                    ChatMessage(
+                        session_id="fresh-session",
+                        exchange_id="ex-1",
+                        rank=0,
+                        timestamp=datetime.now(timezone.utc),
+                        role=Role.user,
+                        channel=Channel.final,
+                        parts=[TextPart(text="hello")],
+                    )
+                ],
+            )
+        )
+
+        messages = asyncio.run(history_store.get("fresh-session", user_id="alice"))
+
+    assert len(messages) == 1
+    assert messages[0].parts[0].text == "hello"


### PR DESCRIPTION
Picks up marcfawaz's fix from #1700 with review corrections applied (asyncio safety, import order, type annotation). Closes #1700.