### PR TITLE
fix(sql): enable pool_pre_ping by default to prevent stale connection errors

### DIFF
--- a/libs/fred-core/fred_core/sql/base_sql.py
+++ b/libs/fred-core/fred_core/sql/base_sql.py
@@ -86,7 +86,7 @@ def create_engine_from_config(config: PostgresStoreConfig) -> Engine:
         config.pool_recycle if config.pool_recycle is not None else -1
     )
     effective_pool_pre_ping = (
-        config.pool_pre_ping if config.pool_pre_ping is not None else False
+        config.pool_pre_ping if config.pool_pre_ping is not None else True
     )
     logger.warning(
         "[SQL][Engine] Creating engine (single PG config assumed): "
@@ -236,7 +236,7 @@ def create_async_engine_from_config(config: PostgresStoreConfig):
         config.pool_recycle if config.pool_recycle is not None else -1
     )
     effective_pool_pre_ping = (
-        config.pool_pre_ping if config.pool_pre_ping is not None else False
+        config.pool_pre_ping if config.pool_pre_ping is not None else True
     )
 
     logger.warning(


### PR DESCRIPTION
## Summary

Enable `pool_pre_ping=True` by default in both `create_engine_from_config` and `create_async_engine_from_config`.

Without this, connections sitting idle in the asyncpg pool can be silently closed by the PostgreSQL server or a network proxy. SQLAlchemy would then hand out a dead connection at checkout, causing `InterfaceError: connection is closed` to surface as a 500 on the next request (observed in production on the GCU check path in `get_current_user`).

With `pool_pre_ping=True`, SQLAlchemy issues a cheap `SELECT 1` health-check before handing each connection to the caller. Dead connections are transparently replaced. The `pool_pre_ping` config field is preserved so callers can still opt out explicitly by setting it to `False`.

## Mandatory Checklist

- [ ] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

Reproduced by the production traceback:
```
asyncpg.exceptions._base.InterfaceError: connection is closed
sqlalchemy.exc.InterfaceError: ... SELECT users.id ... WHERE users.id = $1::UUID
  File "/fred-core/fred_core/security/oidc.py", line 395, in get_current_user
```

Fix: two one-line changes in `libs/fred-core/fred_core/sql/base_sql.py` (lines 89 and 239), changing the fallback default from `False` to `True`.

## Risk / Rollback

**Risk:** Minor latency increase (~0.1–1 ms per connection checkout) due to the extra `SELECT 1` ping. Only noticeable at very high throughput with a saturated pool.

**Rollback:** Set `pool_pre_ping: false` in the `PostgresStoreConfig` for the affected service, or revert this commit. No schema or data changes involved.