### PR TITLE
feat: JSON schema generation and CI validation for backend configs

### DIFF
--- a/.github/workflows/Check-config-schema.yml
+++ b/.github/workflows/Check-config-schema.yml
@@ -10,6 +10,9 @@ on:
       - main
       - swift
 
+permissions:
+  contents: read
+
 jobs:
   check-config:
     name: "${{ matrix.app }}"

--- a/.github/workflows/Check-config-schema.yml
+++ b/.github/workflows/Check-config-schema.yml
@@ -1,0 +1,84 @@
+name: Check Config JSON Schemas
+
+on:
+  push:
+    branches:
+      - main
+      - swift
+  pull_request:
+    branches:
+      - main
+      - swift
+
+jobs:
+  check-schema-drift:
+    name: Schema drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies (control-plane-backend)
+        run: uv sync --extra dev
+        working-directory: apps/control-plane-backend
+
+      - name: Install dependencies (knowledge-flow-backend)
+        run: uv sync --extra dev
+        working-directory: apps/knowledge-flow-backend
+
+      - name: Install dependencies (fred-agents)
+        run: uv sync
+        working-directory: apps/fred-agents
+
+      - name: Schema drift check — control-plane-backend
+        run: make check-config-schema-drift
+        working-directory: apps/control-plane-backend
+
+      - name: Schema drift check — knowledge-flow-backend
+        run: make check-config-schema-drift
+        working-directory: apps/knowledge-flow-backend
+
+      - name: Schema drift check — fred-agents
+        run: make check-config-schema-drift
+        working-directory: apps/fred-agents
+
+  check-config-files:
+    name: Config file validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies (control-plane-backend)
+        run: uv sync --extra dev
+        working-directory: apps/control-plane-backend
+
+      - name: Install dependencies (knowledge-flow-backend)
+        run: uv sync --extra dev
+        working-directory: apps/knowledge-flow-backend
+
+      - name: Install dependencies (fred-agents)
+        run: uv sync
+        working-directory: apps/fred-agents
+
+      - name: Config file validation — control-plane-backend
+        run: make check-config-files
+        working-directory: apps/control-plane-backend
+
+      - name: Config file validation — knowledge-flow-backend
+        run: make check-config-files
+        working-directory: apps/knowledge-flow-backend
+
+      - name: Config file validation — fred-agents
+        run: make check-config-files
+        working-directory: apps/fred-agents

--- a/.github/workflows/Check-config-schema.yml
+++ b/.github/workflows/Check-config-schema.yml
@@ -11,9 +11,18 @@ on:
       - swift
 
 jobs:
-  check-schema-drift:
-    name: Schema drift check
+  check-config:
+    name: "${{ matrix.app }}"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - app: control-plane-backend
+            uv_args: --extra dev
+          - app: knowledge-flow-backend
+            uv_args: --extra dev
+          - app: fred-agents
+            uv_args: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -23,62 +32,14 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies (control-plane-backend)
-        run: uv sync --extra dev
-        working-directory: apps/control-plane-backend
+      - name: Install dependencies
+        run: uv sync ${{ matrix.uv_args }}
+        working-directory: apps/${{ matrix.app }}
 
-      - name: Install dependencies (knowledge-flow-backend)
-        run: uv sync --extra dev
-        working-directory: apps/knowledge-flow-backend
-
-      - name: Install dependencies (fred-agents)
-        run: uv sync
-        working-directory: apps/fred-agents
-
-      - name: Schema drift check — control-plane-backend
+      - name: Schema drift check
         run: make check-config-schema-drift
-        working-directory: apps/control-plane-backend
+        working-directory: apps/${{ matrix.app }}
 
-      - name: Schema drift check — knowledge-flow-backend
-        run: make check-config-schema-drift
-        working-directory: apps/knowledge-flow-backend
-
-      - name: Schema drift check — fred-agents
-        run: make check-config-schema-drift
-        working-directory: apps/fred-agents
-
-  check-config-files:
-    name: Config file validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies (control-plane-backend)
-        run: uv sync --extra dev
-        working-directory: apps/control-plane-backend
-
-      - name: Install dependencies (knowledge-flow-backend)
-        run: uv sync --extra dev
-        working-directory: apps/knowledge-flow-backend
-
-      - name: Install dependencies (fred-agents)
-        run: uv sync
-        working-directory: apps/fred-agents
-
-      - name: Config file validation — control-plane-backend
+      - name: Config file validation
         run: make check-config-files
-        working-directory: apps/control-plane-backend
-
-      - name: Config file validation — knowledge-flow-backend
-        run: make check-config-files
-        working-directory: apps/knowledge-flow-backend
-
-      - name: Config file validation — fred-agents
-        run: make check-config-files
-        working-directory: apps/fred-agents
+        working-directory: apps/${{ matrix.app }}

--- a/.vscode/fred.code-workspace
+++ b/.vscode/fred.code-workspace
@@ -52,7 +52,8 @@
 			"esbenp.prettier-vscode",
 			"vivaxy.vscode-conventional-commits",
 			"lokalise.i18n-ally",
-			"openfga.openfga-vscode"
+			"openfga.openfga-vscode",
+			"redhat.vscode-yaml"
 		]
 	}
 }

--- a/apps/control-plane-backend/Makefile
+++ b/apps/control-plane-backend/Makefile
@@ -5,6 +5,7 @@ include ../../scripts/makefiles/python-vars.mk
 include ../../scripts/makefiles/python-deps.mk
 include ../../scripts/makefiles/python-run.mk
 include ../../scripts/makefiles/python-openapi.mk
+include ../../scripts/makefiles/python-config-schema.mk
 include ../../scripts/makefiles/python-code-quality.mk
 include ../../scripts/makefiles/python-security.mk
 include ../../scripts/makefiles/python-test.mk

--- a/apps/control-plane-backend/config/configuration.yaml
+++ b/apps/control-plane-backend/config/configuration.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 app:
   name: Control Plane Backend
   base_url: /control-plane/v1
@@ -5,10 +6,6 @@ app:
   port: 8222
   log_level: info
   gcu_version: "v1"
-  # Production defaults: scrape via Prometheus/Grafana and avoid KPI log noise.
-  kpi_process_metrics_interval_sec: 0
-  kpi_log_summary_interval_sec: 0.0
-  kpi_log_summary_top_n: 0
   default_team_max_resources_storage_size: 5368709120
   personal_max_resources_storage_size: 5368709120
 

--- a/apps/control-plane-backend/config/configuration_prod.yaml
+++ b/apps/control-plane-backend/config/configuration_prod.yaml
@@ -1,13 +1,10 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 app:
   name: Control Plane Backend
   base_url: /control-plane/v1
   address: 0.0.0.0
   port: 8222
   log_level: debug
-  # Production defaults: scrape via Prometheus/Grafana and avoid KPI log noise.
-  kpi_process_metrics_interval_sec: 0
-  kpi_log_summary_interval_sec: 0.0
-  kpi_log_summary_top_n: 0
   default_team_max_resources_storage_size: 5368709120
   personal_max_resources_storage_size: 5368709120
 

--- a/apps/control-plane-backend/config/configuration_test.yaml
+++ b/apps/control-plane-backend/config/configuration_test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 app:
   name: Control Plane Backend
   base_url: /control-plane/v1

--- a/apps/control-plane-backend/config/configuration_worker.yaml
+++ b/apps/control-plane-backend/config/configuration_worker.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 app:
   name: Control Plane Backend
   base_url: /control-plane/v1

--- a/apps/control-plane-backend/config/schema/configuration.schema.json
+++ b/apps/control-plane-backend/config/schema/configuration.schema.json
@@ -1,0 +1,818 @@
+{
+  "$defs": {
+    "AppConfig": {
+      "properties": {
+        "name": {
+          "default": "Control Plane Backend",
+          "title": "Name",
+          "type": "string"
+        },
+        "base_url": {
+          "default": "/control-plane/v1",
+          "title": "Base Url",
+          "type": "string"
+        },
+        "address": {
+          "default": "127.0.0.1",
+          "title": "Address",
+          "type": "string"
+        },
+        "port": {
+          "default": 8222,
+          "title": "Port",
+          "type": "integer"
+        },
+        "log_level": {
+          "default": "info",
+          "title": "Log Level",
+          "type": "string"
+        },
+        "gcu_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Gcu Version"
+        },
+        "default_team_max_resources_storage_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Default maximum resources storage size in bytes for a team",
+          "title": "Default Team Max Resources Storage Size"
+        },
+        "personal_max_resources_storage_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum resources storage size in bytes for a personal space",
+          "title": "Personal Max Resources Storage Size"
+        }
+      },
+      "title": "AppConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "FrontendBootstrapConfig": {
+      "description": "Static frontend bootstrap configuration served by control-plane.",
+      "properties": {
+        "feature_flags": {
+          "$ref": "#/$defs/FrontendFeatureFlags"
+        },
+        "ui_settings": {
+          "$ref": "#/$defs/FrontendUiSettings"
+        }
+      },
+      "title": "FrontendBootstrapConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "FrontendFeatureFlags": {
+      "description": "Typed feature flags exposed to the frontend bootstrap.",
+      "properties": {
+        "enableK8Features": {
+          "default": false,
+          "title": "Enablek8Features",
+          "type": "boolean"
+        },
+        "enableElecWarfare": {
+          "default": false,
+          "title": "Enableelecwarfare",
+          "type": "boolean"
+        }
+      },
+      "title": "FrontendFeatureFlags",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "FrontendUiSettings": {
+      "description": "Small typed UI settings surface owned by control-plane.",
+      "properties": {
+        "siteDisplayName": {
+          "default": "Fred",
+          "title": "Sitedisplayname",
+          "type": "string"
+        },
+        "agentsNicknameSingular": {
+          "default": "agent",
+          "title": "Agentsnicknamesingular",
+          "type": "string"
+        },
+        "agentsNicknamePlural": {
+          "default": "agents",
+          "title": "Agentsnicknameplural",
+          "type": "string"
+        }
+      },
+      "title": "FrontendUiSettings",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "LocalContentStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "local",
+          "default": "local",
+          "title": "Type",
+          "type": "string"
+        },
+        "root_path": {
+          "default": "~/.fred/control-plane/content-storage",
+          "description": "Local storage directory",
+          "title": "Root Path",
+          "type": "string"
+        }
+      },
+      "title": "LocalContentStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "M2MSecurity": {
+      "description": "Configuration for machine-to-machine authentication.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "realm_url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Realm Url",
+          "type": "string"
+        },
+        "client_id": {
+          "title": "Client Id",
+          "type": "string"
+        },
+        "audience": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Audience"
+        },
+        "secret_env_var": {
+          "default": "M2M_CLIENT_SECRET",
+          "title": "Secret Env Var",
+          "type": "string"
+        }
+      },
+      "required": [
+        "realm_url",
+        "client_id"
+      ],
+      "title": "M2MSecurity",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "MinioContentStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "minio",
+          "title": "Type",
+          "type": "string"
+        },
+        "endpoint": {
+          "default": "http://localhost:9000",
+          "description": "MinIO API URL",
+          "title": "Endpoint",
+          "type": "string"
+        },
+        "access_key": {
+          "description": "MinIO access key",
+          "title": "Access Key",
+          "type": "string"
+        },
+        "secret_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "MinIO secret key (from MINIO_SECRET_KEY env by default)",
+          "title": "Secret Key"
+        },
+        "bucket_name": {
+          "default": "control-plane-content",
+          "description": "Content store bucket name (suffix '-objects' is used for banner objects)",
+          "title": "Bucket Name",
+          "type": "string"
+        },
+        "secure": {
+          "default": false,
+          "description": "Use TLS (https)",
+          "title": "Secure",
+          "type": "boolean"
+        },
+        "public_endpoint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional public endpoint used to generate browser-facing presigned URLs",
+          "title": "Public Endpoint"
+        },
+        "public_secure": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional TLS override for public endpoint (auto-inferred when omitted)",
+          "title": "Public Secure"
+        }
+      },
+      "required": [
+        "type",
+        "access_key"
+      ],
+      "title": "MinioContentStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenFgaRebacConfig": {
+      "description": "Configuration for an OpenFGA-backed relationship engine.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "To disable ReBAC checks (do not disable in production). If OIDC (UserSecurity and M2MSecurity) ReBAC check will be disabled even if this is true.",
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "openfga",
+          "default": "openfga",
+          "title": "Type",
+          "type": "string"
+        },
+        "api_url": {
+          "description": "Base URL for the OpenFGA HTTP API (e.g. https://fga.example.com)",
+          "format": "uri",
+          "minLength": 1,
+          "title": "Api Url",
+          "type": "string"
+        },
+        "store_name": {
+          "default": "fred",
+          "description": "Name of the OpenFGA store to use",
+          "title": "Store Name",
+          "type": "string"
+        },
+        "authorization_model_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional authorization model ID to use for read operations. Will be overridden if sync_schema_on_init is True.",
+          "title": "Authorization Model Id"
+        },
+        "create_store_if_needed": {
+          "default": true,
+          "description": "Create the OpenFGA store if it does not already exist",
+          "title": "Create Store If Needed",
+          "type": "boolean"
+        },
+        "sync_schema_on_init": {
+          "default": true,
+          "description": "Synchronize the authorization model when creating the engine",
+          "title": "Sync Schema On Init",
+          "type": "boolean"
+        },
+        "token_env_var": {
+          "default": "OPENFGA_API_TOKEN",
+          "description": "Environment variable that stores the OpenFGA API token",
+          "title": "Token Env Var",
+          "type": "string"
+        },
+        "timeout_millisec": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional timeout in milliseconds for OpenFGA API requests",
+          "title": "Timeout Millisec"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Static HTTP headers to send with each OpenFGA API request",
+          "title": "Headers"
+        }
+      },
+      "required": [
+        "api_url"
+      ],
+      "title": "OpenFgaRebacConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PlatformConfig": {
+      "description": "Control-plane deployment configuration for product/runtime coordination.\n\nContains ONLY infrastructure references (which runtime pods exist).\nManaged agent instance enrollment (which team has which agents) is\nDB-backed and never stored in this deployment config.",
+      "properties": {
+        "frontend": {
+          "$ref": "#/$defs/FrontendBootstrapConfig"
+        },
+        "runtime_catalog_sources": {
+          "items": {
+            "$ref": "#/$defs/RuntimeCatalogSourceConfig"
+          },
+          "title": "Runtime Catalog Sources",
+          "type": "array"
+        }
+      },
+      "title": "PlatformConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PolicyConfig": {
+      "properties": {
+        "purge_catalog_path": {
+          "default": "./conversation_policy_catalog.yaml",
+          "title": "Purge Catalog Path",
+          "type": "string"
+        }
+      },
+      "title": "PolicyConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PostgresStoreConfig": {
+      "properties": {
+        "type": {
+          "const": "postgres",
+          "default": "postgres",
+          "title": "Type",
+          "type": "string"
+        },
+        "host": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PostgreSQL host",
+          "title": "Host"
+        },
+        "port": {
+          "default": 5432,
+          "title": "Port",
+          "type": "integer"
+        },
+        "sqlite_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the SQLite database file (for local dev/testing).",
+          "title": "Sqlite Path"
+        },
+        "database": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Database"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Username"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Password"
+        },
+        "echo": {
+          "default": false,
+          "description": "SQLAlchemy echo flag.",
+          "title": "Echo",
+          "type": "boolean"
+        },
+        "pool_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional pool size for the engine.",
+          "title": "Pool Size"
+        },
+        "max_overflow": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional max_overflow for SQLAlchemy pool (defaults to SQLAlchemy's 10 if unset).",
+          "title": "Max Overflow"
+        },
+        "pool_timeout": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Seconds to wait for a connection from the pool before timing out.",
+          "title": "Pool Timeout"
+        },
+        "pool_recycle": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recycle connections after this many seconds (prevents stale TCP / server timeouts).",
+          "title": "Pool Recycle"
+        },
+        "pool_pre_ping": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Enable SQLAlchemy pool_pre_ping to evict stale connections.",
+          "title": "Pool Pre Ping"
+        },
+        "connect_args": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional connect_args passed to SQLAlchemy.",
+          "title": "Connect Args"
+        }
+      },
+      "title": "PostgresStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "RuntimeCatalogSourceConfig": {
+      "description": "Configured runtime endpoint used for read-only template aggregation.",
+      "properties": {
+        "runtime_id": {
+          "minLength": 1,
+          "title": "Runtime Id",
+          "type": "string"
+        },
+        "base_url": {
+          "minLength": 1,
+          "title": "Base Url",
+          "type": "string"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "ingress_prefix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ingress-relative URL prefix for browser-facing runtime access, e.g. /runtime/agents-v2. Required for execution preparation. MUST NOT be a cluster-internal hostname or pod IP.",
+          "title": "Ingress Prefix"
+        }
+      },
+      "required": [
+        "runtime_id",
+        "base_url"
+      ],
+      "title": "RuntimeCatalogSourceConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "SchedulerBackend": {
+      "description": "Allowed scheduler backend values across Fred backends.\n\nWhy this exists:\n- Avoid raw string literals (`\"temporal\"`, `\"memory\"`) spread in business code.\n- Keep one typed source of truth used by configuration parsing and runtime checks.\n\nHow to use:\n```python\nfrom fred_core.scheduler import SchedulerBackend\n\nif backend == SchedulerBackend.MEMORY:\n    ...\n```",
+      "enum": [
+        "temporal",
+        "memory"
+      ],
+      "title": "SchedulerBackend",
+      "type": "string"
+    },
+    "SchedulerConfig": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "backend": {
+          "$ref": "#/$defs/SchedulerBackend",
+          "default": "temporal"
+        },
+        "temporal": {
+          "$ref": "#/$defs/TemporalSchedulerConfig"
+        }
+      },
+      "title": "SchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "SecurityConfiguration": {
+      "properties": {
+        "m2m": {
+          "$ref": "#/$defs/M2MSecurity"
+        },
+        "user": {
+          "$ref": "#/$defs/UserSecurity"
+        },
+        "authorized_origins": {
+          "default": [],
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Authorized Origins",
+          "type": "array"
+        },
+        "rebac": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "openfga": "#/$defs/OpenFgaRebacConfig"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OpenFgaRebacConfig"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rebac"
+        }
+      },
+      "required": [
+        "m2m",
+        "user"
+      ],
+      "title": "SecurityConfiguration",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "StorageConfig": {
+      "properties": {
+        "postgres": {
+          "$ref": "#/$defs/PostgresStoreConfig"
+        },
+        "content_storage": {
+          "discriminator": {
+            "mapping": {
+              "local": "#/$defs/LocalContentStorageConfig",
+              "minio": "#/$defs/MinioContentStorageConfig"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/LocalContentStorageConfig"
+            },
+            {
+              "$ref": "#/$defs/MinioContentStorageConfig"
+            }
+          ],
+          "title": "Content Storage"
+        }
+      },
+      "title": "StorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TemporalSchedulerConfig": {
+      "properties": {
+        "host": {
+          "default": "localhost:7233",
+          "title": "Host",
+          "type": "string"
+        },
+        "namespace": {
+          "default": "default",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "task_queue": {
+          "default": "default",
+          "title": "Task Queue",
+          "type": "string"
+        },
+        "workflow_id_prefix": {
+          "default": "task",
+          "title": "Workflow Id Prefix",
+          "type": "string"
+        },
+        "connect_timeout_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 5,
+          "title": "Connect Timeout Seconds"
+        },
+        "ingestion_workflow_parallelism": {
+          "default": 3,
+          "description": "Max number of files launched in parallel per parent ingestion workflow.",
+          "minimum": 1,
+          "title": "Ingestion Workflow Parallelism",
+          "type": "integer"
+        },
+        "ingestion_max_concurrent_workflow_tasks": {
+          "default": 3,
+          "description": "Max concurrent Temporal workflow tasks processed by a worker process.",
+          "minimum": 1,
+          "title": "Ingestion Max Concurrent Workflow Tasks",
+          "type": "integer"
+        },
+        "ingestion_max_concurrent_activities": {
+          "default": 3,
+          "description": "Max concurrent Temporal activities processed by a worker process.",
+          "minimum": 1,
+          "title": "Ingestion Max Concurrent Activities",
+          "type": "integer"
+        }
+      },
+      "title": "TemporalSchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "UserSecurity": {
+      "description": "Configuration for user authentication.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "realm_url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Realm Url",
+          "type": "string"
+        },
+        "client_id": {
+          "title": "Client Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "realm_url",
+        "client_id"
+      ],
+      "title": "UserSecurity",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "app": {
+      "$ref": "#/$defs/AppConfig"
+    },
+    "platform": {
+      "$ref": "#/$defs/PlatformConfig"
+    },
+    "scheduler": {
+      "$ref": "#/$defs/SchedulerConfig"
+    },
+    "security": {
+      "$ref": "#/$defs/SecurityConfiguration"
+    },
+    "storage": {
+      "$ref": "#/$defs/StorageConfig"
+    },
+    "policies": {
+      "$ref": "#/$defs/PolicyConfig"
+    }
+  },
+  "required": [
+    "app",
+    "scheduler"
+  ],
+  "title": "Configuration",
+  "type": "object",
+  "additionalProperties": false
+}

--- a/apps/fred-agents/Makefile
+++ b/apps/fred-agents/Makefile
@@ -6,6 +6,7 @@ include ../../scripts/makefiles/python-deps.mk
 include ../../scripts/makefiles/python-run.mk
 include ../../scripts/makefiles/python-code-quality.mk
 include ../../scripts/makefiles/python-openapi.mk
+include ../../scripts/makefiles/python-config-schema.mk
 include ../../scripts/makefiles/python-test.mk
 include ../../scripts/makefiles/python-clean.mk
 include ../../scripts/makefiles/help.mk

--- a/apps/fred-agents/config/configuration.yaml
+++ b/apps/fred-agents/config/configuration.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 app:
   name: "Fred default agents"
   base_url: "/fred/agents/v2"

--- a/apps/fred-agents/config/configuration_prod.yaml
+++ b/apps/fred-agents/config/configuration_prod.yaml
@@ -28,7 +28,7 @@ security:
     api_url: "http://localhost:9080"
 
 ai:
-  knowledge_flow_url: "http://localhost:9528/knowledge-flow/v1"
+  knowledge_flow_url: "http://localhost:8111/knowledge-flow/v1"
   timeout:
     connect: 20
     read: 60

--- a/apps/fred-agents/config/configuration_prod.yaml
+++ b/apps/fred-agents/config/configuration_prod.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 app:
   name: "Fred default agents"
   base_url: "/fred/agents/v2"
@@ -27,7 +28,7 @@ security:
     api_url: "http://localhost:9080"
 
 ai:
-  knowledge_flow_url: "http://localhost:8111/knowledge-flow/v1"
+  knowledge_flow_url: "http://localhost:9528/knowledge-flow/v1"
   timeout:
     connect: 20
     read: 60

--- a/apps/fred-agents/config/schema/configuration.schema.json
+++ b/apps/fred-agents/config/schema/configuration.schema.json
@@ -1,0 +1,874 @@
+{
+  "$defs": {
+    "InMemoryLogStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "in_memory",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "InMemoryLogStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "LangfuseObservabilityConfig": {
+      "description": "Langfuse connection settings.\n\nOnly non-secret settings live here.\nCredentials go in the .env file as LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY.",
+      "properties": {
+        "host": {
+          "default": "http://localhost:3001",
+          "title": "Host",
+          "type": "string"
+        }
+      },
+      "title": "LangfuseObservabilityConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "M2MSecurity": {
+      "description": "Configuration for machine-to-machine authentication.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "realm_url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Realm Url",
+          "type": "string"
+        },
+        "client_id": {
+          "title": "Client Id",
+          "type": "string"
+        },
+        "audience": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Audience"
+        },
+        "secret_env_var": {
+          "default": "M2M_CLIENT_SECRET",
+          "title": "Secret Env Var",
+          "type": "string"
+        }
+      },
+      "required": [
+        "realm_url",
+        "client_id"
+      ],
+      "title": "M2MSecurity",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "MetricsBackend": {
+      "description": "Metrics emission backend for the agent pod.\n\n- null       \u2014 no metrics, all timer events are dropped\n- logging    \u2014 each timer is emitted as a structured log entry (default)\n- prometheus \u2014 KPI/process metrics are exported in Prometheus format on the\n               dedicated metrics port configured under `app`",
+      "enum": [
+        "null",
+        "logging",
+        "prometheus"
+      ],
+      "title": "MetricsBackend",
+      "type": "string"
+    },
+    "OpenFgaRebacConfig": {
+      "description": "Configuration for an OpenFGA-backed relationship engine.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "To disable ReBAC checks (do not disable in production). If OIDC (UserSecurity and M2MSecurity) ReBAC check will be disabled even if this is true.",
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "openfga",
+          "default": "openfga",
+          "title": "Type",
+          "type": "string"
+        },
+        "api_url": {
+          "description": "Base URL for the OpenFGA HTTP API (e.g. https://fga.example.com)",
+          "format": "uri",
+          "minLength": 1,
+          "title": "Api Url",
+          "type": "string"
+        },
+        "store_name": {
+          "default": "fred",
+          "description": "Name of the OpenFGA store to use",
+          "title": "Store Name",
+          "type": "string"
+        },
+        "authorization_model_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional authorization model ID to use for read operations. Will be overridden if sync_schema_on_init is True.",
+          "title": "Authorization Model Id"
+        },
+        "create_store_if_needed": {
+          "default": true,
+          "description": "Create the OpenFGA store if it does not already exist",
+          "title": "Create Store If Needed",
+          "type": "boolean"
+        },
+        "sync_schema_on_init": {
+          "default": true,
+          "description": "Synchronize the authorization model when creating the engine",
+          "title": "Sync Schema On Init",
+          "type": "boolean"
+        },
+        "token_env_var": {
+          "default": "OPENFGA_API_TOKEN",
+          "description": "Environment variable that stores the OpenFGA API token",
+          "title": "Token Env Var",
+          "type": "string"
+        },
+        "timeout_millisec": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional timeout in milliseconds for OpenFGA API requests",
+          "title": "Timeout Millisec"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Static HTTP headers to send with each OpenFGA API request",
+          "title": "Headers"
+        }
+      },
+      "required": [
+        "api_url"
+      ],
+      "title": "OpenFgaRebacConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenSearchIndexConfig": {
+      "properties": {
+        "type": {
+          "const": "opensearch",
+          "title": "Type",
+          "type": "string"
+        },
+        "index": {
+          "description": "OpenSearch index name",
+          "title": "Index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "index"
+      ],
+      "title": "OpenSearchIndexConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenSearchStoreConfig": {
+      "properties": {
+        "host": {
+          "description": "OpenSearch host URL",
+          "title": "Host",
+          "type": "string"
+        },
+        "username": {
+          "description": "Username from env",
+          "title": "Username",
+          "type": "string"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Password from env",
+          "title": "Password"
+        },
+        "secure": {
+          "default": false,
+          "description": "Use TLS (https)",
+          "title": "Secure",
+          "type": "boolean"
+        },
+        "verify_certs": {
+          "default": false,
+          "description": "Verify TLS certs",
+          "title": "Verify Certs",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "host",
+        "username"
+      ],
+      "title": "OpenSearchStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PodAIConfig": {
+      "description": "AI model and knowledge-flow settings for an agent pod.\n\nWhy this section exists separately from AgentAppSettings:\n- pods only need the outbound Knowledge Flow base URL plus runtime HTTP\n  timeout tuning shared by KF and MCP adapters\n- gateway-only concerns such as attachment/session limits should not leak\n  into the pod config contract\n\nExample:\n- `PodAIConfig(knowledge_flow_url=\"http://localhost:8111/knowledge-flow/v1\", timeout=RuntimeTimeouts(connect=20, read=60))`",
+      "properties": {
+        "knowledge_flow_url": {
+          "default": "http://localhost:8111/knowledge-flow/v1",
+          "title": "Knowledge Flow Url",
+          "type": "string"
+        },
+        "timeout": {
+          "$ref": "#/$defs/RuntimeTimeouts",
+          "description": "Timeout settings for pod outbound HTTP calls to Knowledge Flow and other runtime adapters."
+        }
+      },
+      "title": "PodAIConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PodAppConfig": {
+      "description": "Basic HTTP server and local observability settings for an agent pod.\n\nWhy this exists:\n- every pod needs the same HTTP binding knobs plus the small Prometheus/KPI\n  settings already used by the other Fred backends\n- keeping these fields in `app` preserves the familiar startup contract for\n  local benches and scrape-based debugging\n\nHow to use it:\n- keep the defaults for simple local development\n- set `metrics_port` / `metrics_address` when `observability.metrics` is\n  `prometheus`\n\nExample:\n- `PodAppConfig(base_url=\"/pod/v1\", port=8000, metrics_port=9115)`",
+      "properties": {
+        "name": {
+          "default": "Fred Agent Pod",
+          "title": "Name",
+          "type": "string"
+        },
+        "base_url": {
+          "default": "/api/v1",
+          "title": "Base Url",
+          "type": "string"
+        },
+        "host": {
+          "default": "127.0.0.1",
+          "title": "Host",
+          "type": "string"
+        },
+        "port": {
+          "default": 8000,
+          "title": "Port",
+          "type": "integer"
+        },
+        "log_level": {
+          "default": "info",
+          "title": "Log Level",
+          "type": "string"
+        },
+        "limit_concurrency": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional maximum number of concurrent HTTP or WebSocket connections accepted by Uvicorn. Leave unset to disable the limit.",
+          "title": "Limit Concurrency"
+        },
+        "gcu_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Gcu Version"
+        },
+        "metrics_address": {
+          "default": "127.0.0.1",
+          "title": "Metrics Address",
+          "type": "string"
+        },
+        "metrics_port": {
+          "default": 9000,
+          "title": "Metrics Port",
+          "type": "integer"
+        },
+        "kpi_process_metrics_interval_sec": {
+          "default": 0,
+          "description": "Emit process and SQL pool KPIs every N seconds. Set 0 to disable the background emitters.",
+          "title": "Kpi Process Metrics Interval Sec",
+          "type": "integer"
+        },
+        "kpi_log_summary_interval_sec": {
+          "default": 0.0,
+          "description": "Emit periodic KPI summary logs every N seconds for local benches. Set 0 to disable.",
+          "title": "Kpi Log Summary Interval Sec",
+          "type": "number"
+        },
+        "kpi_log_summary_top_n": {
+          "default": 0,
+          "description": "Top-N KPI summary rows to log. 0 means all / disabled.",
+          "title": "Kpi Log Summary Top N",
+          "type": "integer"
+        },
+        "openai_compat": {
+          "default": true,
+          "title": "Openai Compat",
+          "type": "boolean"
+        }
+      },
+      "title": "PodAppConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PodObservabilityConfig": {
+      "description": "Observability provider selection for a Fred agent pod.\n\nNon-secret settings (backend choice, endpoints) live in configuration.yaml.\nCredentials (API keys, tokens) stay in the .env file.\n\nExample:\n    observability:\n      tracer: logging       # null | logging | langfuse\n      metrics: logging      # null | logging | prometheus\n      langfuse:\n        host: \"http://localhost:3001\"\n        # LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY in .env",
+      "properties": {
+        "tracer": {
+          "$ref": "#/$defs/TracerBackend",
+          "default": "logging"
+        },
+        "metrics": {
+          "$ref": "#/$defs/MetricsBackend",
+          "default": "logging"
+        },
+        "langfuse": {
+          "$ref": "#/$defs/LangfuseObservabilityConfig"
+        }
+      },
+      "title": "PodObservabilityConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PodPlatformConfig": {
+      "description": "Small set of Fred platform service URLs needed by the pod runtime.\n\nWhy this exists:\n- agent pods stay execution-focused, but some execution paths still need a\n  central Fred service such as control-plane for managed agent-instance\n  resolution\n\nHow to use it:\n- set `control_plane_url` when the pod should accept `agent_instance_id`\n  execution requests\n\nExample:\n- `PodPlatformConfig(control_plane_url=\"http://localhost:8222/control-plane/v1\")`",
+      "properties": {
+        "control_plane_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Control Plane Url"
+        }
+      },
+      "title": "PodPlatformConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PodSchedulerConfig": {
+      "description": "Temporal scheduler settings for an agent pod.\n\nDisabled by default \u2014 only needed for Story B (deep/durable agents).\nReuses TemporalSchedulerConfig from fred-core.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "backend": {
+          "$ref": "#/$defs/SchedulerBackend",
+          "default": "temporal"
+        },
+        "temporal": {
+          "$ref": "#/$defs/TemporalSchedulerConfig"
+        }
+      },
+      "title": "PodSchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PodStorageConfig": {
+      "description": "Persistence backend settings for an agent pod.\n\nAll conversation state (sessions, multi-turn history, checkpoints) is\nmanaged exclusively by the LangGraph SQL checkpointer, which uses the\n`postgres` connection. There are no separate session or history tables.\n\nFields:\n- `postgres`: SQL engine used by the LangGraph checkpointer (SQLite in\n  local dev via sqlite_path, PostgreSQL in production via host/port/database)\n- `opensearch`: optional, for log forwarding in production\n- `log_store`: optional, for structured log persistence",
+      "properties": {
+        "postgres": {
+          "$ref": "#/$defs/PostgresStoreConfig"
+        },
+        "opensearch": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OpenSearchStoreConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "log_store": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "in_memory": "#/$defs/InMemoryLogStorageConfig",
+                  "opensearch": "#/$defs/OpenSearchIndexConfig",
+                  "stdout": "#/$defs/StdoutLogStorageConfig"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/InMemoryLogStorageConfig"
+                },
+                {
+                  "$ref": "#/$defs/StdoutLogStorageConfig"
+                },
+                {
+                  "$ref": "#/$defs/OpenSearchIndexConfig"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Store"
+        }
+      },
+      "title": "PodStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PostgresStoreConfig": {
+      "properties": {
+        "type": {
+          "const": "postgres",
+          "default": "postgres",
+          "title": "Type",
+          "type": "string"
+        },
+        "host": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PostgreSQL host",
+          "title": "Host"
+        },
+        "port": {
+          "default": 5432,
+          "title": "Port",
+          "type": "integer"
+        },
+        "sqlite_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the SQLite database file (for local dev/testing).",
+          "title": "Sqlite Path"
+        },
+        "database": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Database"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Username"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Password"
+        },
+        "echo": {
+          "default": false,
+          "description": "SQLAlchemy echo flag.",
+          "title": "Echo",
+          "type": "boolean"
+        },
+        "pool_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional pool size for the engine.",
+          "title": "Pool Size"
+        },
+        "max_overflow": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional max_overflow for SQLAlchemy pool (defaults to SQLAlchemy's 10 if unset).",
+          "title": "Max Overflow"
+        },
+        "pool_timeout": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Seconds to wait for a connection from the pool before timing out.",
+          "title": "Pool Timeout"
+        },
+        "pool_recycle": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recycle connections after this many seconds (prevents stale TCP / server timeouts).",
+          "title": "Pool Recycle"
+        },
+        "pool_pre_ping": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Enable SQLAlchemy pool_pre_ping to evict stale connections.",
+          "title": "Pool Pre Ping"
+        },
+        "connect_args": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional connect_args passed to SQLAlchemy.",
+          "title": "Connect Args"
+        }
+      },
+      "title": "PostgresStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "RuntimeTimeouts": {
+      "description": "Minimal timeout settings for outbound runtime HTTP clients.\n\nWhy this exists:\n- KF/MCP clients need consistent timeout settings across runtimes\n\nHow to use it:\n- construct with explicit connect/read values\n- call `as_httpx_timeout_config()` to feed httpx",
+      "properties": {
+        "connect": {
+          "default": 5.0,
+          "title": "Connect",
+          "type": "number"
+        },
+        "read": {
+          "default": 30.0,
+          "title": "Read",
+          "type": "number"
+        },
+        "write": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Write"
+        },
+        "pool": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pool"
+        }
+      },
+      "title": "RuntimeTimeouts",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "SchedulerBackend": {
+      "description": "Allowed scheduler backend values across Fred backends.\n\nWhy this exists:\n- Avoid raw string literals (`\"temporal\"`, `\"memory\"`) spread in business code.\n- Keep one typed source of truth used by configuration parsing and runtime checks.\n\nHow to use:\n```python\nfrom fred_core.scheduler import SchedulerBackend\n\nif backend == SchedulerBackend.MEMORY:\n    ...\n```",
+      "enum": [
+        "temporal",
+        "memory"
+      ],
+      "title": "SchedulerBackend",
+      "type": "string"
+    },
+    "SecurityConfiguration": {
+      "properties": {
+        "m2m": {
+          "$ref": "#/$defs/M2MSecurity"
+        },
+        "user": {
+          "$ref": "#/$defs/UserSecurity"
+        },
+        "authorized_origins": {
+          "default": [],
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Authorized Origins",
+          "type": "array"
+        },
+        "rebac": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "openfga": "#/$defs/OpenFgaRebacConfig"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OpenFgaRebacConfig"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rebac"
+        }
+      },
+      "required": [
+        "m2m",
+        "user"
+      ],
+      "title": "SecurityConfiguration",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "StdoutLogStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "stdout",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "StdoutLogStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TemporalSchedulerConfig": {
+      "properties": {
+        "host": {
+          "default": "localhost:7233",
+          "title": "Host",
+          "type": "string"
+        },
+        "namespace": {
+          "default": "default",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "task_queue": {
+          "default": "default",
+          "title": "Task Queue",
+          "type": "string"
+        },
+        "workflow_id_prefix": {
+          "default": "task",
+          "title": "Workflow Id Prefix",
+          "type": "string"
+        },
+        "connect_timeout_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 5,
+          "title": "Connect Timeout Seconds"
+        },
+        "ingestion_workflow_parallelism": {
+          "default": 3,
+          "description": "Max number of files launched in parallel per parent ingestion workflow.",
+          "minimum": 1,
+          "title": "Ingestion Workflow Parallelism",
+          "type": "integer"
+        },
+        "ingestion_max_concurrent_workflow_tasks": {
+          "default": 3,
+          "description": "Max concurrent Temporal workflow tasks processed by a worker process.",
+          "minimum": 1,
+          "title": "Ingestion Max Concurrent Workflow Tasks",
+          "type": "integer"
+        },
+        "ingestion_max_concurrent_activities": {
+          "default": 3,
+          "description": "Max concurrent Temporal activities processed by a worker process.",
+          "minimum": 1,
+          "title": "Ingestion Max Concurrent Activities",
+          "type": "integer"
+        }
+      },
+      "title": "TemporalSchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TracerBackend": {
+      "description": "Distributed tracing backend for the agent pod.\n\n- null     \u2014 no tracing, all spans are dropped\n- logging  \u2014 each span is emitted as a structured log entry (default)\n- langfuse \u2014 spans are sent to a Langfuse server;\n             credentials (LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY) must be\n             set in the .env file; host is configured in the langfuse section",
+      "enum": [
+        "null",
+        "logging",
+        "langfuse"
+      ],
+      "title": "TracerBackend",
+      "type": "string"
+    },
+    "UserSecurity": {
+      "description": "Configuration for user authentication.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "realm_url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Realm Url",
+          "type": "string"
+        },
+        "client_id": {
+          "title": "Client Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "realm_url",
+        "client_id"
+      ],
+      "title": "UserSecurity",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "description": "Complete structured configuration for a Fred agent pod.\n\nMirrors agentic-backend's `Configuration` model, scoped to what an agent\npod actually needs. All field types are reused from fred-core and fred-sdk\n\u2014 no new types invented here.\n\nHow to use it:\n- write a `config/configuration.yaml` alongside `config/models_catalog.yaml`\n  and `config/mcp_catalog.yaml`\n- call `load_agent_pod_config()` at startup\n- pass the result to `create_agent_app(config=...)`\n\nThe `security` field is a `SecurityConfiguration` from fred-core, the same\ntype used in agentic-backend. When `security.user.enabled` is True,\n`create_agent_app` enforces Keycloak JWT validation on every endpoint.",
+  "properties": {
+    "app": {
+      "$ref": "#/$defs/PodAppConfig"
+    },
+    "security": {
+      "$ref": "#/$defs/SecurityConfiguration"
+    },
+    "ai": {
+      "$ref": "#/$defs/PodAIConfig"
+    },
+    "observability": {
+      "$ref": "#/$defs/PodObservabilityConfig"
+    },
+    "storage": {
+      "$ref": "#/$defs/PodStorageConfig"
+    },
+    "scheduler": {
+      "$ref": "#/$defs/PodSchedulerConfig"
+    },
+    "platform": {
+      "$ref": "#/$defs/PodPlatformConfig"
+    }
+  },
+  "required": [
+    "security"
+  ],
+  "title": "AgentPodConfig",
+  "type": "object",
+  "additionalProperties": false
+}

--- a/apps/knowledge-flow-backend/Makefile
+++ b/apps/knowledge-flow-backend/Makefile
@@ -5,6 +5,7 @@ include ../../scripts/makefiles/python-vars.mk
 include ../../scripts/makefiles/python-deps.mk
 include ../../scripts/makefiles/python-run.mk
 include ../../scripts/makefiles/python-openapi.mk
+include ../../scripts/makefiles/python-config-schema.mk
 include ../../scripts/makefiles/python-code-quality.mk
 include ../../scripts/makefiles/python-security.mk
 include ../../scripts/makefiles/python-test.mk

--- a/apps/knowledge-flow-backend/config/configuration.yaml
+++ b/apps/knowledge-flow-backend/config/configuration.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -347,18 +348,6 @@ vision_model:
       keepalive_expiry_seconds: 10
     temperature: 0 # optional
 
-audio_model:
-  whisper_model_size: base
-  device: cpu
-  language: null
-# ocr_model:
-#   provider: openai
-#   name: mistral-ocr-latest
-#   settings:
-#     base_url: https://api.mistral.ai/v1
-#     request_timeout: 300
-#     signed_url_expiry_hours: 1
-
 crossencoder_model:
   name: cross-encoder/ms-marco-MiniLM-L-12-v2
   settings:
@@ -383,8 +372,6 @@ storage:
   tag_store:
     type: "postgres"
   metadata_store:
-    type: "postgres"
-  task_store:
     type: "postgres"
   tabular_store:
     artifacts_prefix: "tabular/datasets"

--- a/apps/knowledge-flow-backend/config/configuration_bench.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_bench.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -353,8 +354,6 @@ storage:
     type: "postgres"
 
   metadata_store:
-    type: "postgres"
-  task_store:
     type: "postgres"
   tabular_store:
     artifacts_prefix: "tabular/datasets"

--- a/apps/knowledge-flow-backend/config/configuration_gcp.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_gcp.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -317,8 +318,6 @@ storage:
   tag_store:
     type: "postgres"
   metadata_store:
-    type: "postgres"
-  task_store:
     type: "postgres"
   tabular_store:
     artifacts_prefix: "tabular/datasets"

--- a/apps/knowledge-flow-backend/config/configuration_prod.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_prod.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -407,8 +408,6 @@ storage:
   tag_store:
     type: "postgres"
   metadata_store:
-    type: "postgres"
-  task_store:
     type: "postgres"
   tabular_store:
     artifacts_prefix: "tabular/datasets"

--- a/apps/knowledge-flow-backend/config/configuration_test.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -289,8 +290,6 @@ storage:
   tag_store:
     type: "postgres"
   metadata_store:
-    type: "postgres"
-  task_store:
     type: "postgres"
   tabular_store:
     artifacts_prefix: "tabular/datasets"

--- a/apps/knowledge-flow-backend/config/configuration_worker.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_worker.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./schema/configuration.schema.json
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -314,8 +315,6 @@ storage:
   tag_store:
     type: "postgres"
   metadata_store:
-    type: "postgres"
-  task_store:
     type: "postgres"
   tabular_store:
     artifacts_prefix: "tabular/datasets"

--- a/apps/knowledge-flow-backend/config/schema/configuration.schema.json
+++ b/apps/knowledge-flow-backend/config/schema/configuration.schema.json
@@ -837,17 +837,10 @@
           "type": "string"
         },
         "secret_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "MinIO secret key (from MINIO_SECRET_KEY env).",
-          "title": "Secret Key"
+          "title": "Secret Key",
+          "type": "string"
         },
         "bucket_name": {
           "anyOf": [
@@ -939,17 +932,10 @@
           "type": "string"
         },
         "secret_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "MinIO secret key (from MINIO_SECRET_KEY env variable)",
-          "title": "Secret Key"
+          "title": "Secret Key",
+          "type": "string"
         },
         "region": {
           "anyOf": [
@@ -1000,17 +986,10 @@
           "type": "string"
         },
         "secret_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
           "default": null,
           "description": "MinIO secret key (from MINIO_SECRET_KEY env)",
-          "title": "Secret Key"
+          "title": "Secret Key",
+          "type": "string"
         },
         "bucket_name": {
           "default": "app-bucket",

--- a/apps/knowledge-flow-backend/config/schema/configuration.schema.json
+++ b/apps/knowledge-flow-backend/config/schema/configuration.schema.json
@@ -1,0 +1,2830 @@
+{
+  "$defs": {
+    "AppConfig": {
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Knowledge Flow Backend",
+          "title": "Name"
+        },
+        "base_url": {
+          "default": "/knowledge-flow/v1",
+          "title": "Base Url",
+          "type": "string"
+        },
+        "address": {
+          "default": "127.0.0.1",
+          "title": "Address",
+          "type": "string"
+        },
+        "port": {
+          "default": 8000,
+          "title": "Port",
+          "type": "integer"
+        },
+        "log_level": {
+          "default": "info",
+          "title": "Log Level",
+          "type": "string"
+        },
+        "reload": {
+          "default": false,
+          "title": "Reload",
+          "type": "boolean"
+        },
+        "reload_dir": {
+          "default": ".",
+          "title": "Reload Dir",
+          "type": "string"
+        },
+        "metrics_enabled": {
+          "default": true,
+          "title": "Metrics Enabled",
+          "type": "boolean"
+        },
+        "metrics_address": {
+          "default": "127.0.0.1",
+          "title": "Metrics Address",
+          "type": "string"
+        },
+        "metrics_port": {
+          "default": 9111,
+          "title": "Metrics Port",
+          "type": "integer"
+        },
+        "kpi_process_metrics_interval_sec": {
+          "default": 10,
+          "description": "Interval in seconds for processing and logging KPI metrics.",
+          "title": "Kpi Process Metrics Interval Sec",
+          "type": "integer"
+        },
+        "kpi_log_summary_interval_sec": {
+          "default": 0.0,
+          "description": "Emit KPI summary logs every N seconds (bench/debug). Set 0 to disable.",
+          "title": "Kpi Log Summary Interval Sec",
+          "type": "number"
+        },
+        "kpi_log_summary_top_n": {
+          "default": 0,
+          "description": "Top-N metrics to show in KPI summary logs. 0 means all / disabled.",
+          "title": "Kpi Log Summary Top N",
+          "type": "integer"
+        },
+        "gcu_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Gcu Version"
+        },
+        "default_team_max_resources_storage_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Default storage limit in bytes for a team when not explicitly set.",
+          "title": "Default Team Max Resources Storage Size"
+        },
+        "personal_max_resources_storage_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum resources storage size in bytes for a personal space",
+          "title": "Personal Max Resources Storage Size"
+        }
+      },
+      "title": "AppConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ChromaVectorStorageConfig": {
+      "description": "Local, embedded Chroma. No server needed.\n- persist_path: folder where Chroma (DuckDB/Parquet) stores data\n- collection_name: logical collection for your chunks\n- distance: ANN space; 'cosine' matches our UI-friendly similarity",
+      "properties": {
+        "type": {
+          "const": "chroma",
+          "title": "Type",
+          "type": "string"
+        },
+        "local_path": {
+          "default": "~/.fred/knowledge-flow/chromadb-vector-store",
+          "description": "Local vector storage path",
+          "title": "Local Path",
+          "type": "string"
+        },
+        "collection_name": {
+          "default": "fred_chunks",
+          "description": "Chroma collection name",
+          "title": "Collection Name",
+          "type": "string"
+        },
+        "distance": {
+          "default": "cosine",
+          "description": "Vector space (affects HNSW metric)",
+          "enum": [
+            "cosine",
+            "l2",
+            "ip"
+          ],
+          "title": "Distance",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "ChromaVectorStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ClickHouseStoreConfig": {
+      "properties": {
+        "host": {
+          "default": "localhost",
+          "description": "ClickHouse host",
+          "title": "Host",
+          "type": "string"
+        },
+        "port": {
+          "default": 8123,
+          "description": "ClickHouse HTTP port",
+          "title": "Port",
+          "type": "integer"
+        },
+        "database": {
+          "default": "default",
+          "description": "ClickHouse database",
+          "title": "Database",
+          "type": "string"
+        },
+        "username": {
+          "default": "default",
+          "description": "ClickHouse username",
+          "title": "Username",
+          "type": "string"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "ClickHouse password (from CLICKHOUSE_PASSWORD env)",
+          "title": "Password"
+        },
+        "secure": {
+          "default": false,
+          "description": "Use HTTPS for ClickHouse client",
+          "title": "Secure",
+          "type": "boolean"
+        },
+        "verify": {
+          "default": true,
+          "description": "Verify TLS certificates for ClickHouse",
+          "title": "Verify",
+          "type": "boolean"
+        }
+      },
+      "title": "ClickHouseStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ClickHouseVectorStorageConfig": {
+      "description": "ClickHouse backend.\n- Uses shared `storage.clickhouse` connection settings.\n- Stores vectors in the configured table.",
+      "properties": {
+        "type": {
+          "const": "clickhouse",
+          "title": "Type",
+          "type": "string"
+        },
+        "table": {
+          "default": "fred_vectors",
+          "description": "ClickHouse table name for chunks",
+          "title": "Table",
+          "type": "string"
+        },
+        "bulk_size": {
+          "default": 1000,
+          "description": "Number of rows per insert batch",
+          "title": "Bulk Size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "ClickHouseVectorStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "DocumentGuardrailConfig": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable ingestion-time document marking guardrails.",
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "source_tags": {
+          "description": "Optional source tags this guardrail applies to. Empty means all sources.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Source Tags",
+          "type": "array"
+        },
+        "allowed_labels": {
+          "description": "Optional allow-list of labels accepted by the guardrail. Empty means detection-only.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowed Labels",
+          "type": "array"
+        },
+        "on_no_label": {
+          "default": "allow",
+          "description": "Behavior when no explicit document marking is detected.",
+          "enum": [
+            "allow",
+            "warn",
+            "reject"
+          ],
+          "title": "On No Label",
+          "type": "string"
+        },
+        "patterns": {
+          "description": "Regex patterns used to recognize explicit document markings.",
+          "items": {
+            "$ref": "#/$defs/DocumentMarkingPatternConfig"
+          },
+          "title": "Patterns",
+          "type": "array"
+        }
+      },
+      "title": "DocumentGuardrailConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "DocumentMarkingPatternConfig": {
+      "properties": {
+        "label": {
+          "description": "Normalized label returned when the regex matches.",
+          "minLength": 1,
+          "title": "Label",
+          "type": "string"
+        },
+        "pattern": {
+          "description": "Regex used to detect the marking in extracted guardrail text.",
+          "minLength": 1,
+          "title": "Pattern",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "pattern"
+      ],
+      "title": "DocumentMarkingPatternConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "DuckdbStoreConfig": {
+      "properties": {
+        "type": {
+          "const": "duckdb",
+          "title": "Type",
+          "type": "string"
+        },
+        "duckdb_path": {
+          "description": "Path to the DuckDB database file.",
+          "title": "Duckdb Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "duckdb_path"
+      ],
+      "title": "DuckdbStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "FileSystemPullSource": {
+      "properties": {
+        "type": {
+          "const": "pull",
+          "default": "pull",
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of this source",
+          "title": "Description"
+        },
+        "provider": {
+          "const": "local_path",
+          "title": "Provider",
+          "type": "string"
+        },
+        "base_path": {
+          "title": "Base Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "base_path"
+      ],
+      "title": "FileSystemPullSource",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "GitPullSource": {
+      "properties": {
+        "type": {
+          "const": "pull",
+          "default": "pull",
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of this source",
+          "title": "Description"
+        },
+        "provider": {
+          "const": "github",
+          "title": "Provider",
+          "type": "string"
+        },
+        "repo": {
+          "description": "GitHub repository in the format 'owner/repo'",
+          "title": "Repo",
+          "type": "string"
+        },
+        "branch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "main",
+          "description": "Git branch to pull from",
+          "title": "Branch"
+        },
+        "subdir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "",
+          "description": "Subdirectory to extract files from",
+          "title": "Subdir"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional GitHub username (for logs)",
+          "title": "Username"
+        },
+        "token": {
+          "description": "GitHub token (from GITHUB_TOKEN env variable)",
+          "title": "Token",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repo",
+        "token"
+      ],
+      "title": "GitPullSource",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "GitlabPullSource": {
+      "properties": {
+        "type": {
+          "const": "pull",
+          "default": "pull",
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of this source",
+          "title": "Description"
+        },
+        "provider": {
+          "const": "gitlab",
+          "title": "Provider",
+          "type": "string"
+        },
+        "repo": {
+          "description": "GitLab repository in the format 'namespace/project'",
+          "title": "Repo",
+          "type": "string"
+        },
+        "branch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "main",
+          "description": "Branch to pull from",
+          "title": "Branch"
+        },
+        "subdir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "",
+          "description": "Optional subdirectory to scan files from",
+          "title": "Subdir"
+        },
+        "token": {
+          "description": "GitLab private token (from GITLAB_TOKEN env variable)",
+          "title": "Token",
+          "type": "string"
+        },
+        "base_url": {
+          "default": "https://gitlab.com/api/v4",
+          "description": "GitLab API base URL",
+          "title": "Base Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "repo",
+        "token"
+      ],
+      "title": "GitlabPullSource",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "InMemoryLogStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "in_memory",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "InMemoryLogStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "InMemoryStoreConfig": {
+      "description": "Minimal config for in-memory stores (dev/test only).",
+      "properties": {
+        "type": {
+          "const": "memory",
+          "default": "memory",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "title": "InMemoryStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "InMemoryVectorStorage": {
+      "properties": {
+        "type": {
+          "const": "in_memory",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "InMemoryVectorStorage",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "IngestionProcessingProfile": {
+      "enum": [
+        "fast",
+        "medium",
+        "rich"
+      ],
+      "title": "IngestionProcessingProfile",
+      "type": "string"
+    },
+    "IntegrationsConfig": {
+      "description": "Optional upstream service integrations consumed by Knowledge Flow.",
+      "properties": {
+        "prometheus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PrometheusConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional Prometheus API configuration for cluster-wide metrics queries."
+        }
+      },
+      "title": "IntegrationsConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "LibraryProcessorConfig": {
+      "description": "Configuration structure for a library-level output processor.\n\nAttributes:\n    class_path (str): Dotted import path of the processor class.\n    description (str): Human readable explanation of what the processor does.",
+      "properties": {
+        "class_path": {
+          "description": "Dotted import path of the library output processor class",
+          "title": "Class Path",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of the library output processor purpose shown in the UI.",
+          "title": "Description"
+        }
+      },
+      "required": [
+        "class_path"
+      ],
+      "title": "LibraryProcessorConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "LocalContentStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "local",
+          "title": "Type",
+          "type": "string"
+        },
+        "root_path": {
+          "default": "~/.fred/knowledge-flow/content-store",
+          "description": "Local storage directory",
+          "title": "Root Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "LocalContentStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "LocalFilesystemConfig": {
+      "properties": {
+        "type": {
+          "const": "local",
+          "default": "local",
+          "title": "Type",
+          "type": "string"
+        },
+        "root": {
+          "default": "~/.fred/knowledge-flow/filesystem/",
+          "description": "Local filesystem root directory.",
+          "title": "Root",
+          "type": "string"
+        }
+      },
+      "title": "LocalFilesystemConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "LogStoreConfig": {
+      "properties": {
+        "type": {
+          "const": "log",
+          "title": "Type",
+          "type": "string"
+        },
+        "level": {
+          "description": "Logging level",
+          "title": "Level",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "level"
+      ],
+      "title": "LogStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "M2MSecurity": {
+      "description": "Configuration for machine-to-machine authentication.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "realm_url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Realm Url",
+          "type": "string"
+        },
+        "client_id": {
+          "title": "Client Id",
+          "type": "string"
+        },
+        "audience": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Audience"
+        },
+        "secret_env_var": {
+          "default": "M2M_CLIENT_SECRET",
+          "title": "Secret Env Var",
+          "type": "string"
+        }
+      },
+      "required": [
+        "realm_url",
+        "client_id"
+      ],
+      "title": "M2MSecurity",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "MCPConfig": {
+      "description": "Feature toggles for MCP-only HTTP/MCP surfaces.\n\nThese do NOT affect core storage backends (e.g., using OpenSearch\nas vector store or metadata store). They only control whether\noptional monitoring/exploration controllers and their MCP servers\nare exposed.",
+      "properties": {
+        "reports_enabled": {
+          "default": true,
+          "description": "Expose the Reports MCP server (Markdown-first report generation).",
+          "title": "Reports Enabled",
+          "type": "boolean"
+        },
+        "kpi_enabled": {
+          "default": true,
+          "description": "Expose the KPI MCP server for querying application KPIs.",
+          "title": "Kpi Enabled",
+          "type": "boolean"
+        },
+        "tabular_enabled": {
+          "default": true,
+          "description": "Expose the Tabular MCP server for SQL/table exploration.",
+          "title": "Tabular Enabled",
+          "type": "boolean"
+        },
+        "statistic_enabled": {
+          "default": true,
+          "description": "Expose the Statistical MCP server for data analysis helpers.",
+          "title": "Statistic Enabled",
+          "type": "boolean"
+        },
+        "text_enabled": {
+          "default": true,
+          "description": "Expose the Text MCP server for semantic vector search.",
+          "title": "Text Enabled",
+          "type": "boolean"
+        },
+        "templates_enabled": {
+          "default": true,
+          "description": "Expose the Template MCP server for prompts/templates.",
+          "title": "Templates Enabled",
+          "type": "boolean"
+        },
+        "resources_enabled": {
+          "default": true,
+          "description": "Expose the Resources MCP server for resource/tag management.",
+          "title": "Resources Enabled",
+          "type": "boolean"
+        },
+        "opensearch_ops_enabled": {
+          "default": false,
+          "description": "Expose OpenSearch operational endpoints and the corresponding MCP server.",
+          "title": "Opensearch Ops Enabled",
+          "type": "boolean"
+        },
+        "prometheus_ops_enabled": {
+          "default": false,
+          "description": "Expose Prometheus operational endpoints and the corresponding MCP server.",
+          "title": "Prometheus Ops Enabled",
+          "type": "boolean"
+        },
+        "neo4j_enabled": {
+          "default": false,
+          "description": "Expose Neo4j graph exploration endpoints and the corresponding MCP server.",
+          "title": "Neo4J Enabled",
+          "type": "boolean"
+        },
+        "filesystem_enabled": {
+          "default": false,
+          "description": "Expose agent filesystem utils endpoints and the corresponding MCP server.",
+          "title": "Filesystem Enabled",
+          "type": "boolean"
+        }
+      },
+      "title": "MCPConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "MinioFilesystemConfig": {
+      "properties": {
+        "type": {
+          "const": "minio",
+          "default": "minio",
+          "title": "Type",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "MinIO or S3 compatible endpoint.",
+          "title": "Endpoint",
+          "type": "string"
+        },
+        "access_key": {
+          "description": "MinIO access key.",
+          "title": "Access Key",
+          "type": "string"
+        },
+        "secret_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "MinIO secret key (from MINIO_SECRET_KEY env).",
+          "title": "Secret Key"
+        },
+        "bucket_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "filesystem",
+          "description": "MinIO bucket name.",
+          "title": "Bucket Name"
+        },
+        "secure": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Use TLS for the MinIO client.",
+          "title": "Secure"
+        }
+      },
+      "required": [
+        "endpoint",
+        "access_key"
+      ],
+      "title": "MinioFilesystemConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "MinioPullSource": {
+      "properties": {
+        "type": {
+          "const": "pull",
+          "default": "pull",
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of this source",
+          "title": "Description"
+        },
+        "provider": {
+          "const": "minio",
+          "title": "Provider",
+          "type": "string"
+        },
+        "endpoint_url": {
+          "description": "S3-compatible endpoint (e.g., https://s3.amazonaws.com)",
+          "title": "Endpoint Url",
+          "type": "string"
+        },
+        "bucket_name": {
+          "description": "Name of the S3 bucket to scan",
+          "title": "Bucket Name",
+          "type": "string"
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "",
+          "description": "Optional prefix (folder path) to scan inside the bucket",
+          "title": "Prefix"
+        },
+        "access_key": {
+          "description": "MinIO access key (from MINIO_ACCESS_KEY env variable)",
+          "title": "Access Key",
+          "type": "string"
+        },
+        "secret_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "MinIO secret key (from MINIO_SECRET_KEY env variable)",
+          "title": "Secret Key"
+        },
+        "region": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "us-east-1",
+          "description": "AWS region (used by some clients)",
+          "title": "Region"
+        },
+        "secure": {
+          "default": true,
+          "description": "Use HTTPS (secure=True) or HTTP (secure=False)",
+          "title": "Secure",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "provider",
+        "endpoint_url",
+        "bucket_name",
+        "access_key"
+      ],
+      "title": "MinioPullSource",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "MinioStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "minio",
+          "title": "Type",
+          "type": "string"
+        },
+        "endpoint": {
+          "default": "localhost:9000",
+          "description": "MinIO API URL",
+          "title": "Endpoint",
+          "type": "string"
+        },
+        "access_key": {
+          "description": "MinIO access key (from MINIO_ACCESS_KEY env)",
+          "title": "Access Key",
+          "type": "string"
+        },
+        "secret_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "MinIO secret key (from MINIO_SECRET_KEY env)",
+          "title": "Secret Key"
+        },
+        "bucket_name": {
+          "default": "app-bucket",
+          "description": "Content store bucket name",
+          "title": "Bucket Name",
+          "type": "string"
+        },
+        "secure": {
+          "default": false,
+          "description": "Use TLS (https)",
+          "title": "Secure",
+          "type": "boolean"
+        },
+        "public_endpoint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Public MinIO endpoint for browser-facing presigned URLs (e.g. 'https://my.minio.ingress'). If not set, uses endpoint.",
+          "title": "Public Endpoint"
+        },
+        "public_secure": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Use TLS for public endpoint. If not set, inferred from public_endpoint scheme.",
+          "title": "Public Secure"
+        }
+      },
+      "required": [
+        "type",
+        "access_key"
+      ],
+      "title": "MinioStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ModelConfiguration": {
+      "properties": {
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Provider of the AI model, e.g., openai, ollama, azure.",
+          "title": "Provider"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Model name, e.g., gpt-4o, llama2.",
+          "title": "Name"
+        },
+        "settings": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Additional provider-specific settings, e.g. Azure endpoint/API version or Vertex AI project/location.",
+          "title": "Settings"
+        }
+      },
+      "title": "ModelConfiguration",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenFgaRebacConfig": {
+      "description": "Configuration for an OpenFGA-backed relationship engine.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "To disable ReBAC checks (do not disable in production). If OIDC (UserSecurity and M2MSecurity) ReBAC check will be disabled even if this is true.",
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "openfga",
+          "default": "openfga",
+          "title": "Type",
+          "type": "string"
+        },
+        "api_url": {
+          "description": "Base URL for the OpenFGA HTTP API (e.g. https://fga.example.com)",
+          "format": "uri",
+          "minLength": 1,
+          "title": "Api Url",
+          "type": "string"
+        },
+        "store_name": {
+          "default": "fred",
+          "description": "Name of the OpenFGA store to use",
+          "title": "Store Name",
+          "type": "string"
+        },
+        "authorization_model_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional authorization model ID to use for read operations. Will be overridden if sync_schema_on_init is True.",
+          "title": "Authorization Model Id"
+        },
+        "create_store_if_needed": {
+          "default": true,
+          "description": "Create the OpenFGA store if it does not already exist",
+          "title": "Create Store If Needed",
+          "type": "boolean"
+        },
+        "sync_schema_on_init": {
+          "default": true,
+          "description": "Synchronize the authorization model when creating the engine",
+          "title": "Sync Schema On Init",
+          "type": "boolean"
+        },
+        "token_env_var": {
+          "default": "OPENFGA_API_TOKEN",
+          "description": "Environment variable that stores the OpenFGA API token",
+          "title": "Token Env Var",
+          "type": "string"
+        },
+        "timeout_millisec": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional timeout in milliseconds for OpenFGA API requests",
+          "title": "Timeout Millisec"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Static HTTP headers to send with each OpenFGA API request",
+          "title": "Headers"
+        }
+      },
+      "required": [
+        "api_url"
+      ],
+      "title": "OpenFgaRebacConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenSearchIndexConfig": {
+      "properties": {
+        "type": {
+          "const": "opensearch",
+          "title": "Type",
+          "type": "string"
+        },
+        "index": {
+          "description": "OpenSearch index name",
+          "title": "Index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "index"
+      ],
+      "title": "OpenSearchIndexConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenSearchStoreConfig": {
+      "properties": {
+        "host": {
+          "description": "OpenSearch host URL",
+          "title": "Host",
+          "type": "string"
+        },
+        "username": {
+          "description": "Username from env",
+          "title": "Username",
+          "type": "string"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Password from env",
+          "title": "Password"
+        },
+        "secure": {
+          "default": false,
+          "description": "Use TLS (https)",
+          "title": "Secure",
+          "type": "boolean"
+        },
+        "verify_certs": {
+          "default": false,
+          "description": "Verify TLS certs",
+          "title": "Verify Certs",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "host",
+        "username"
+      ],
+      "title": "OpenSearchStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "OpenSearchVectorIndexConfig": {
+      "properties": {
+        "type": {
+          "const": "opensearch",
+          "title": "Type",
+          "type": "string"
+        },
+        "index": {
+          "description": "OpenSearch index name",
+          "title": "Index",
+          "type": "string"
+        },
+        "bulk_size": {
+          "default": 1000,
+          "description": "Number of documents to send in each bulk insert request",
+          "title": "Bulk Size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type",
+        "index"
+      ],
+      "title": "OpenSearchVectorIndexConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PdfPipelineConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "backend": {
+          "default": "docling_parse",
+          "description": "PDF backend for Docling conversion.",
+          "enum": [
+            "dlparse_v4",
+            "pypdfium2",
+            "docling_parse"
+          ],
+          "title": "Backend",
+          "type": "string"
+        },
+        "images_scale": {
+          "default": 2.0,
+          "description": "Docling PDF image scaling factor.",
+          "exclusiveMinimum": 0.0,
+          "title": "Images Scale",
+          "type": "number"
+        },
+        "generate_picture_images": {
+          "default": false,
+          "description": "Generate extracted picture image assets during PDF conversion. Independent from profile.process_images (image description).",
+          "title": "Generate Picture Images",
+          "type": "boolean"
+        },
+        "generate_page_images": {
+          "default": false,
+          "description": "Generate full-page images for PDFs.",
+          "title": "Generate Page Images",
+          "type": "boolean"
+        },
+        "generate_table_images": {
+          "default": false,
+          "description": "Generate table images for PDFs.",
+          "title": "Generate Table Images",
+          "type": "boolean"
+        },
+        "do_table_structure": {
+          "default": false,
+          "description": "Enable table structure extraction in the standard Docling PDF pipeline.",
+          "title": "Do Table Structure",
+          "type": "boolean"
+        },
+        "do_ocr": {
+          "default": false,
+          "description": "Enable OCR in the standard Docling PDF pipeline.",
+          "title": "Do Ocr",
+          "type": "boolean"
+        },
+        "ocr_backend": {
+          "anyOf": [
+            {
+              "enum": [
+                "onnxruntime",
+                "openvino",
+                "paddle",
+                "torch"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "openvino",
+          "description": "Override RapidOCR inference backend when OCR is enabled.",
+          "title": "Ocr Backend"
+        },
+        "force_full_page_ocr": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Override RapidOCR full-page OCR. Set to true to OCR every page even when backend text exists.",
+          "title": "Force Full Page Ocr"
+        },
+        "ocr_batch_size": {
+          "default": 4,
+          "description": "OCR batch size used by Docling's threaded StandardPdfPipeline. Larger batches improve throughput but increase memory usage.",
+          "minimum": 1,
+          "title": "Ocr Batch Size",
+          "type": "integer"
+        },
+        "layout_batch_size": {
+          "default": 4,
+          "description": "Layout batch size used by Docling's threaded StandardPdfPipeline. Larger batches improve throughput but increase memory usage.",
+          "minimum": 1,
+          "title": "Layout Batch Size",
+          "type": "integer"
+        },
+        "table_batch_size": {
+          "default": 4,
+          "description": "Table-structure batch size used by Docling's threaded StandardPdfPipeline. Larger batches improve throughput but increase memory usage.",
+          "minimum": 1,
+          "title": "Table Batch Size",
+          "type": "integer"
+        },
+        "batch_polling_interval_seconds": {
+          "default": 0.5,
+          "description": "Polling interval in seconds used by Docling's threaded StandardPdfPipeline to accumulate batches before processing.",
+          "exclusiveMinimum": 0.0,
+          "title": "Batch Polling Interval Seconds",
+          "type": "number"
+        },
+        "queue_max_size": {
+          "default": 100,
+          "description": "Maximum inter-stage queue size used by Docling's threaded StandardPdfPipeline. Smaller queues reduce buffering and can lower memory usage.",
+          "minimum": 1,
+          "title": "Queue Max Size",
+          "type": "integer"
+        }
+      },
+      "title": "PdfPipelineConfig",
+      "type": "object"
+    },
+    "PgVectorStorageConfig": {
+      "description": "PostgreSQL + pgvector backend.\n- Uses shared `storage.postgres` connection settings.\n- Stores vectors in the default pgvector table under a collection name.",
+      "properties": {
+        "type": {
+          "const": "pgvector",
+          "title": "Type",
+          "type": "string"
+        },
+        "collection_name": {
+          "default": "fred_chunks",
+          "description": "Logical collection name",
+          "title": "Collection Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "PgVectorStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PostgresStoreConfig": {
+      "properties": {
+        "type": {
+          "const": "postgres",
+          "default": "postgres",
+          "title": "Type",
+          "type": "string"
+        },
+        "host": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PostgreSQL host",
+          "title": "Host"
+        },
+        "port": {
+          "default": 5432,
+          "title": "Port",
+          "type": "integer"
+        },
+        "sqlite_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the SQLite database file (for local dev/testing).",
+          "title": "Sqlite Path"
+        },
+        "database": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Database"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Username"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Password"
+        },
+        "echo": {
+          "default": false,
+          "description": "SQLAlchemy echo flag.",
+          "title": "Echo",
+          "type": "boolean"
+        },
+        "pool_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional pool size for the engine.",
+          "title": "Pool Size"
+        },
+        "max_overflow": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional max_overflow for SQLAlchemy pool (defaults to SQLAlchemy's 10 if unset).",
+          "title": "Max Overflow"
+        },
+        "pool_timeout": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Seconds to wait for a connection from the pool before timing out.",
+          "title": "Pool Timeout"
+        },
+        "pool_recycle": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recycle connections after this many seconds (prevents stale TCP / server timeouts).",
+          "title": "Pool Recycle"
+        },
+        "pool_pre_ping": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Enable SQLAlchemy pool_pre_ping to evict stale connections.",
+          "title": "Pool Pre Ping"
+        },
+        "connect_args": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional connect_args passed to SQLAlchemy.",
+          "title": "Connect Args"
+        }
+      },
+      "title": "PostgresStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PostgresTableConfig": {
+      "properties": {
+        "type": {
+          "const": "postgres",
+          "title": "Type",
+          "type": "string"
+        },
+        "table": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Table name used by the store. Deprecated: stores now use fixed table names.",
+          "title": "Table"
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional prefix applied to the table name. Deprecated: stores now use fixed table names.",
+          "title": "Prefix"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "PostgresTableConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ProcessingConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "default_profile": {
+          "$ref": "#/$defs/IngestionProcessingProfile",
+          "default": "medium",
+          "description": "Default ingestion processing profile when no request-level profile is provided."
+        },
+        "profiles": {
+          "$ref": "#/$defs/ProfilesConfig",
+          "description": "Named ingestion profiles for request-level pipeline/option selection."
+        }
+      },
+      "title": "ProcessingConfig",
+      "type": "object"
+    },
+    "ProcessorConfig": {
+      "description": "Configuration structure for a file processor.\nAttributes:\n    suffix (str): The file extension this processor handles (e.g., '.pdf').\n    class_path (str): Dotted import path of the processor class.\n    description (str): Human readable explanation of what the processor does.",
+      "properties": {
+        "suffix": {
+          "description": "The file extension this processor handles (e.g., '.pdf')",
+          "title": "Suffix",
+          "type": "string"
+        },
+        "class_path": {
+          "description": "Dotted import path of the processor class",
+          "title": "Class Path",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of the processor purpose shown in the UI.",
+          "title": "Description"
+        }
+      },
+      "required": [
+        "suffix",
+        "class_path"
+      ],
+      "title": "ProcessorConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ProfileConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "use_gpu": {
+          "default": true,
+          "description": "Enable/disable GPU usage for this profile (if supported by the selected processors).",
+          "title": "Use Gpu",
+          "type": "boolean"
+        },
+        "process_images": {
+          "default": false,
+          "description": "Enable/disable semantic image description in markdown for this profile.",
+          "title": "Process Images",
+          "type": "boolean"
+        },
+        "generate_summary": {
+          "default": false,
+          "description": "Enable/disable human-centric abstract and keyword generation for this profile.",
+          "title": "Generate Summary",
+          "type": "boolean"
+        },
+        "input_activity_timeout": {
+          "default": "1h",
+          "description": "Temporal start-to-close timeout for input processing activities (e.g., '1h', '45m').",
+          "title": "Input Activity Timeout",
+          "type": "string"
+        },
+        "activity_heartbeat_timeout": {
+          "default": "5m",
+          "description": "Temporal heartbeat timeout for input processing activities (e.g., '5m', '10m'). Must be larger than the worker's heartbeat interval (~20s).",
+          "title": "Activity Heartbeat Timeout",
+          "type": "string"
+        },
+        "pdf": {
+          "$ref": "#/$defs/PdfPipelineConfig",
+          "description": "PDF processing options for this profile."
+        },
+        "text_splitter": {
+          "$ref": "#/$defs/TextSplitterConfig",
+          "description": "Text splitter configuration for vectorization and summarization."
+        },
+        "input_processors": {
+          "description": "Input processors selected for this profile (suffix-specific).",
+          "items": {
+            "$ref": "#/$defs/ProfileInputProcessorConfig"
+          },
+          "title": "Input Processors",
+          "type": "array"
+        },
+        "retry_initial_interval": {
+          "default": "30s",
+          "description": "Temporal retry delay before the first retry for this profile's ingestion activities.",
+          "title": "Retry Initial Interval",
+          "type": "string"
+        },
+        "retry_backoff_coefficient": {
+          "default": 2.0,
+          "description": "Temporal retry backoff coefficient for this profile's ingestion activities.",
+          "minimum": 1.0,
+          "title": "Retry Backoff Coefficient",
+          "type": "number"
+        },
+        "retry_maximum_interval": {
+          "default": "10m",
+          "description": "Maximum Temporal retry delay for this profile's ingestion activities.",
+          "title": "Retry Maximum Interval",
+          "type": "string"
+        },
+        "retry_maximum_attempts": {
+          "default": 6,
+          "description": "Maximum Temporal activity attempts for this profile, including the first attempt.",
+          "minimum": 1,
+          "title": "Retry Maximum Attempts",
+          "type": "integer"
+        },
+        "retry_non_retryable_error_types": {
+          "description": "Temporal application error types that should fail fast for this profile without retry.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Retry Non Retryable Error Types",
+          "type": "array"
+        }
+      },
+      "title": "ProfileConfig",
+      "type": "object"
+    },
+    "ProfileInputProcessorConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "suffix": {
+          "description": "The file suffix this processor handles (e.g., '.pdf').",
+          "title": "Suffix",
+          "type": "string"
+        },
+        "class_path": {
+          "description": "Dotted import path of the processor class.",
+          "title": "Class Path",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of the processor purpose shown in the UI.",
+          "title": "Description"
+        }
+      },
+      "required": [
+        "suffix",
+        "class_path"
+      ],
+      "title": "ProfileInputProcessorConfig",
+      "type": "object"
+    },
+    "ProfilesConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "fast": {
+          "$ref": "#/$defs/ProfileConfig"
+        },
+        "medium": {
+          "$ref": "#/$defs/ProfileConfig"
+        },
+        "rich": {
+          "$ref": "#/$defs/ProfileConfig"
+        }
+      },
+      "title": "ProfilesConfig",
+      "type": "object"
+    },
+    "PrometheusConfig": {
+      "properties": {
+        "base_url": {
+          "description": "Base URL of a Prometheus-compatible HTTP API.",
+          "title": "Base Url",
+          "type": "string"
+        },
+        "verify_ssl": {
+          "default": true,
+          "description": "Verify upstream TLS certificates when querying Prometheus.",
+          "title": "Verify Ssl",
+          "type": "boolean"
+        },
+        "timeout_seconds": {
+          "default": 15.0,
+          "description": "HTTP timeout applied to Prometheus API calls.",
+          "exclusiveMinimum": 0,
+          "title": "Timeout Seconds",
+          "type": "number"
+        },
+        "bearer_token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional bearer token loaded from PROMETHEUS_BEARER_TOKEN.",
+          "title": "Bearer Token"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "admin",
+          "description": "Basic-auth username configured directly in prometheus.username. Defaults to 'admin'.",
+          "title": "Username"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional basic-auth password loaded from PROMETHEUS_PASSWORD.",
+          "title": "Password"
+        }
+      },
+      "required": [
+        "base_url"
+      ],
+      "title": "PrometheusConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "PushSourceConfig": {
+      "properties": {
+        "type": {
+          "const": "push",
+          "default": "push",
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of this source",
+          "title": "Description"
+        }
+      },
+      "title": "PushSourceConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "SchedulerBackend": {
+      "description": "Allowed scheduler backend values across Fred backends.\n\nWhy this exists:\n- Avoid raw string literals (`\"temporal\"`, `\"memory\"`) spread in business code.\n- Keep one typed source of truth used by configuration parsing and runtime checks.\n\nHow to use:\n```python\nfrom fred_core.scheduler import SchedulerBackend\n\nif backend == SchedulerBackend.MEMORY:\n    ...\n```",
+      "enum": [
+        "temporal",
+        "memory"
+      ],
+      "title": "SchedulerBackend",
+      "type": "string"
+    },
+    "SchedulerConfig": {
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "backend": {
+          "$ref": "#/$defs/SchedulerBackend",
+          "default": "temporal"
+        },
+        "temporal": {
+          "$ref": "#/$defs/TemporalSchedulerConfig"
+        }
+      },
+      "required": [
+        "temporal"
+      ],
+      "title": "SchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "SecurityConfiguration": {
+      "properties": {
+        "m2m": {
+          "$ref": "#/$defs/M2MSecurity"
+        },
+        "user": {
+          "$ref": "#/$defs/UserSecurity"
+        },
+        "authorized_origins": {
+          "default": [],
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Authorized Origins",
+          "type": "array"
+        },
+        "rebac": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "openfga": "#/$defs/OpenFgaRebacConfig"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OpenFgaRebacConfig"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rebac"
+        }
+      },
+      "required": [
+        "m2m",
+        "user"
+      ],
+      "title": "SecurityConfiguration",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "SpherePullSource": {
+      "properties": {
+        "type": {
+          "const": "pull",
+          "default": "pull",
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable description of this source",
+          "title": "Description"
+        },
+        "provider": {
+          "const": "sphere",
+          "title": "Provider",
+          "type": "string"
+        },
+        "base_url": {
+          "description": "Base URL for the Sphere API",
+          "title": "Base Url",
+          "type": "string"
+        },
+        "parent_node_id": {
+          "description": "ID of the parent folder or node to list/download",
+          "title": "Parent Node Id",
+          "type": "string"
+        },
+        "username": {
+          "description": "Username for Sphere Basic Auth",
+          "title": "Username",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password (loaded from SPHERE_PASSWORD)",
+          "title": "Password",
+          "type": "string"
+        },
+        "apikey": {
+          "description": "API key (loaded from SPHERE_API_KEY)",
+          "title": "Apikey",
+          "type": "string"
+        },
+        "verify_ssl": {
+          "default": false,
+          "description": "Set to True to verify SSL certs",
+          "title": "Verify Ssl",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "provider",
+        "base_url",
+        "parent_node_id",
+        "username",
+        "password",
+        "apikey"
+      ],
+      "title": "SpherePullSource",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "StdoutLogStorageConfig": {
+      "properties": {
+        "type": {
+          "const": "stdout",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "StdoutLogStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "StorageConfig": {
+      "properties": {
+        "postgres": {
+          "$ref": "#/$defs/PostgresStoreConfig"
+        },
+        "opensearch": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OpenSearchStoreConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional OpenSearch store"
+        },
+        "clickhouse": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ClickHouseStoreConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional ClickHouse store"
+        },
+        "resource_store": {
+          "discriminator": {
+            "mapping": {
+              "duckdb": "#/$defs/DuckdbStoreConfig",
+              "log": "#/$defs/LogStoreConfig",
+              "memory": "#/$defs/InMemoryStoreConfig",
+              "opensearch": "#/$defs/OpenSearchIndexConfig",
+              "postgres": "#/$defs/PostgresTableConfig"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/DuckdbStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/OpenSearchIndexConfig"
+            },
+            {
+              "$ref": "#/$defs/LogStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/PostgresTableConfig"
+            },
+            {
+              "$ref": "#/$defs/InMemoryStoreConfig"
+            }
+          ],
+          "title": "Resource Store"
+        },
+        "tag_store": {
+          "discriminator": {
+            "mapping": {
+              "duckdb": "#/$defs/DuckdbStoreConfig",
+              "log": "#/$defs/LogStoreConfig",
+              "memory": "#/$defs/InMemoryStoreConfig",
+              "opensearch": "#/$defs/OpenSearchIndexConfig",
+              "postgres": "#/$defs/PostgresTableConfig"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/DuckdbStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/OpenSearchIndexConfig"
+            },
+            {
+              "$ref": "#/$defs/LogStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/PostgresTableConfig"
+            },
+            {
+              "$ref": "#/$defs/InMemoryStoreConfig"
+            }
+          ],
+          "title": "Tag Store"
+        },
+        "kpi_store": {
+          "discriminator": {
+            "mapping": {
+              "duckdb": "#/$defs/DuckdbStoreConfig",
+              "log": "#/$defs/LogStoreConfig",
+              "memory": "#/$defs/InMemoryStoreConfig",
+              "opensearch": "#/$defs/OpenSearchIndexConfig",
+              "postgres": "#/$defs/PostgresTableConfig"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/DuckdbStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/OpenSearchIndexConfig"
+            },
+            {
+              "$ref": "#/$defs/LogStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/PostgresTableConfig"
+            },
+            {
+              "$ref": "#/$defs/InMemoryStoreConfig"
+            }
+          ],
+          "title": "Kpi Store"
+        },
+        "metadata_store": {
+          "discriminator": {
+            "mapping": {
+              "duckdb": "#/$defs/DuckdbStoreConfig",
+              "log": "#/$defs/LogStoreConfig",
+              "memory": "#/$defs/InMemoryStoreConfig",
+              "opensearch": "#/$defs/OpenSearchIndexConfig",
+              "postgres": "#/$defs/PostgresTableConfig"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/DuckdbStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/OpenSearchIndexConfig"
+            },
+            {
+              "$ref": "#/$defs/LogStoreConfig"
+            },
+            {
+              "$ref": "#/$defs/PostgresTableConfig"
+            },
+            {
+              "$ref": "#/$defs/InMemoryStoreConfig"
+            }
+          ],
+          "title": "Metadata Store"
+        },
+        "tabular_store": {
+          "$ref": "#/$defs/TabularStoreConfig",
+          "description": "Dataset-centric tabular runtime configuration backed by Parquet artifacts in content storage."
+        },
+        "vector_store": {
+          "discriminator": {
+            "mapping": {
+              "chroma": "#/$defs/ChromaVectorStorageConfig",
+              "clickhouse": "#/$defs/ClickHouseVectorStorageConfig",
+              "in_memory": "#/$defs/InMemoryVectorStorage",
+              "opensearch": "#/$defs/OpenSearchVectorIndexConfig",
+              "pgvector": "#/$defs/PgVectorStorageConfig",
+              "weaviate": "#/$defs/WeaviateVectorStorage"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/InMemoryVectorStorage"
+            },
+            {
+              "$ref": "#/$defs/OpenSearchVectorIndexConfig"
+            },
+            {
+              "$ref": "#/$defs/ChromaVectorStorageConfig"
+            },
+            {
+              "$ref": "#/$defs/WeaviateVectorStorage"
+            },
+            {
+              "$ref": "#/$defs/PgVectorStorageConfig"
+            },
+            {
+              "$ref": "#/$defs/ClickHouseVectorStorageConfig"
+            }
+          ],
+          "title": "Vector Store"
+        },
+        "log_store": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "in_memory": "#/$defs/InMemoryLogStorageConfig",
+                  "opensearch": "#/$defs/OpenSearchIndexConfig",
+                  "stdout": "#/$defs/StdoutLogStorageConfig"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/InMemoryLogStorageConfig"
+                },
+                {
+                  "$ref": "#/$defs/StdoutLogStorageConfig"
+                },
+                {
+                  "$ref": "#/$defs/OpenSearchIndexConfig"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional log store",
+          "title": "Log Store"
+        }
+      },
+      "required": [
+        "postgres",
+        "resource_store",
+        "tag_store",
+        "kpi_store",
+        "metadata_store",
+        "vector_store"
+      ],
+      "title": "StorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TabularQueryConfig": {
+      "description": "Runtime settings for dataset-centric SQL queries.\n\nWhy this exists:\n- Tabular querying now runs on transient Parquet datasets rather than\n  long-lived SQL tables.\n- These values keep query execution bounded and configurable from YAML.\n\nHow to use:\n- Keep the default `duckdb` engine.\n- Tune result limits and backend-internal presigned URL TTL per deployment.",
+      "properties": {
+        "engine": {
+          "const": "duckdb",
+          "default": "duckdb",
+          "description": "Embedded query engine used to read Parquet datasets.",
+          "title": "Engine",
+          "type": "string"
+        },
+        "access_mode": {
+          "const": "presigned_url",
+          "default": "presigned_url",
+          "description": "Primary object-access method for remote tabular artifacts.",
+          "title": "Access Mode",
+          "type": "string"
+        },
+        "internal_presigned_ttl_seconds": {
+          "default": 3600,
+          "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads.",
+          "minimum": 1,
+          "title": "Internal Presigned Ttl Seconds",
+          "type": "integer"
+        },
+        "default_max_rows": {
+          "default": 200,
+          "description": "Default preview row limit applied when callers omit max_rows.",
+          "minimum": 1,
+          "title": "Default Max Rows",
+          "type": "integer"
+        },
+        "max_rows": {
+          "default": 1000,
+          "description": "Hard cap applied to query result previews.",
+          "minimum": 1,
+          "title": "Max Rows",
+          "type": "integer"
+        }
+      },
+      "title": "TabularQueryConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TabularStoreConfig": {
+      "description": "Dataset-centric tabular storage settings for the supported tabular runtime.\n\nWhy this exists:\n- CSV ingestion persists one Parquet artifact per document in the shared\n  content store.\n- One dedicated config block keeps object keys and query limits explicit.\n\nHow to use:\n- Configure the block directly under `storage.tabular_store`.\n- `artifacts_prefix` namespaces Parquet datasets under the shared\n  content-store object area.\n- `format` is intentionally fixed to `parquet`.",
+      "properties": {
+        "artifacts_prefix": {
+          "default": "tabular/datasets",
+          "description": "Prefix under content_storage objects where Parquet datasets are stored.",
+          "title": "Artifacts Prefix",
+          "type": "string"
+        },
+        "format": {
+          "const": "parquet",
+          "default": "parquet",
+          "description": "Physical storage format used for tabular artifacts.",
+          "title": "Format",
+          "type": "string"
+        },
+        "compression": {
+          "default": "snappy",
+          "description": "Parquet compression codec used when persisting tabular artifacts.",
+          "title": "Compression",
+          "type": "string"
+        },
+        "query": {
+          "$ref": "#/$defs/TabularQueryConfig",
+          "description": "Runtime limits and access settings for tabular SQL queries."
+        }
+      },
+      "title": "TabularStoreConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TemporalSchedulerConfig": {
+      "properties": {
+        "host": {
+          "default": "localhost:7233",
+          "title": "Host",
+          "type": "string"
+        },
+        "namespace": {
+          "default": "default",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "task_queue": {
+          "default": "default",
+          "title": "Task Queue",
+          "type": "string"
+        },
+        "workflow_id_prefix": {
+          "default": "task",
+          "title": "Workflow Id Prefix",
+          "type": "string"
+        },
+        "connect_timeout_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 5,
+          "title": "Connect Timeout Seconds"
+        },
+        "ingestion_workflow_parallelism": {
+          "default": 3,
+          "description": "Max number of files launched in parallel per parent ingestion workflow.",
+          "minimum": 1,
+          "title": "Ingestion Workflow Parallelism",
+          "type": "integer"
+        },
+        "ingestion_max_concurrent_workflow_tasks": {
+          "default": 3,
+          "description": "Max concurrent Temporal workflow tasks processed by a worker process.",
+          "minimum": 1,
+          "title": "Ingestion Max Concurrent Workflow Tasks",
+          "type": "integer"
+        },
+        "ingestion_max_concurrent_activities": {
+          "default": 3,
+          "description": "Max concurrent Temporal activities processed by a worker process.",
+          "minimum": 1,
+          "title": "Ingestion Max Concurrent Activities",
+          "type": "integer"
+        }
+      },
+      "title": "TemporalSchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "TextSplitterConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "chunk_size": {
+          "default": 1500,
+          "description": "Maximum number of characters per chunk for text splitting.",
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        },
+        "chunk_overlap": {
+          "default": 150,
+          "description": "Number of overlapping characters between consecutive chunks.",
+          "minimum": 0,
+          "title": "Chunk Overlap",
+          "type": "integer"
+        },
+        "preserve_tables": {
+          "default": true,
+          "description": "If true, keep annotated markdown tables intact (do not split by size).",
+          "title": "Preserve Tables",
+          "type": "boolean"
+        }
+      },
+      "title": "TextSplitterConfig",
+      "type": "object"
+    },
+    "UserSecurity": {
+      "description": "Configuration for user authentication.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "realm_url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Realm Url",
+          "type": "string"
+        },
+        "client_id": {
+          "title": "Client Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "realm_url",
+        "client_id"
+      ],
+      "title": "UserSecurity",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "WeaviateVectorStorage": {
+      "properties": {
+        "type": {
+          "const": "weaviate",
+          "title": "Type",
+          "type": "string"
+        },
+        "host": {
+          "default": "https://localhost:8080",
+          "description": "Weaviate host",
+          "title": "Host",
+          "type": "string"
+        },
+        "index_name": {
+          "default": "CodeDocuments",
+          "description": "Weaviate class (collection) name",
+          "title": "Index Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "WeaviateVectorStorage",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "WorkspaceLayoutConfig": {
+      "description": "Configurable storage path layout for workspace storage.\n\nAllowed placeholders:\n  {user_id}, {agent_id}, {key}",
+      "properties": {
+        "user_pattern": {
+          "default": "users/{user_id}/{key}",
+          "description": "Path template for user exchange storage",
+          "title": "User Pattern",
+          "type": "string"
+        },
+        "agent_config_pattern": {
+          "default": "agents/{agent_id}/config/{key}",
+          "description": "Path template for agent config storage",
+          "title": "Agent Config Pattern",
+          "type": "string"
+        },
+        "agent_user_pattern": {
+          "default": "agents/{agent_id}/users/{user_id}/{key}",
+          "description": "Path template for per-user agent storage",
+          "title": "Agent User Pattern",
+          "type": "string"
+        }
+      },
+      "title": "WorkspaceLayoutConfig",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "app": {
+      "$ref": "#/$defs/AppConfig"
+    },
+    "integrations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/IntegrationsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional third-party service integrations used by the backend."
+    },
+    "chat_model": {
+      "$ref": "#/$defs/ModelConfiguration"
+    },
+    "embedding_model": {
+      "$ref": "#/$defs/ModelConfiguration"
+    },
+    "vision_model": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModelConfiguration"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "ocr_model": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModelConfiguration"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional remote OCR model configuration. When set, PDF OCR can be delegated to an external API instead of local Docling OCR."
+    },
+    "crossencoder_model": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModelConfiguration"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "security": {
+      "$ref": "#/$defs/SecurityConfiguration"
+    },
+    "attachment_processors": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ProcessorConfig"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional fast-text processors for attachments. Uses the same ProcessorConfig structure, but classes must subclass BaseFastTextProcessor. If omitted, the default fast processor is used.",
+      "title": "Attachment Processors"
+    },
+    "document_guardrail": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DocumentGuardrailConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional ingestion-time guardrail for explicit document markings."
+    },
+    "output_processors": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ProcessorConfig"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Output Processors"
+    },
+    "library_output_processors": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/LibraryProcessorConfig"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Library Output Processors"
+    },
+    "content_storage": {
+      "description": "Content Storage configuration",
+      "discriminator": {
+        "mapping": {
+          "local": "#/$defs/LocalContentStorageConfig",
+          "minio": "#/$defs/MinioStorageConfig"
+        },
+        "propertyName": "type"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LocalContentStorageConfig"
+        },
+        {
+          "$ref": "#/$defs/MinioStorageConfig"
+        }
+      ],
+      "title": "Content Storage"
+    },
+    "scheduler": {
+      "$ref": "#/$defs/SchedulerConfig"
+    },
+    "processing": {
+      "$ref": "#/$defs/ProcessingConfig",
+      "description": "A collection of feature flags to enable or disable optional functionality."
+    },
+    "document_sources": {
+      "additionalProperties": {
+        "discriminator": {
+          "mapping": {
+            "pull": {
+              "discriminator": {
+                "mapping": {
+                  "github": "#/$defs/GitPullSource",
+                  "gitlab": "#/$defs/GitlabPullSource",
+                  "local_path": "#/$defs/FileSystemPullSource",
+                  "minio": "#/$defs/MinioPullSource",
+                  "sphere": "#/$defs/SpherePullSource"
+                },
+                "propertyName": "provider"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/FileSystemPullSource"
+                },
+                {
+                  "$ref": "#/$defs/GitPullSource"
+                },
+                {
+                  "$ref": "#/$defs/SpherePullSource"
+                },
+                {
+                  "$ref": "#/$defs/GitlabPullSource"
+                },
+                {
+                  "$ref": "#/$defs/MinioPullSource"
+                }
+              ]
+            },
+            "push": "#/$defs/PushSourceConfig"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/PushSourceConfig"
+          },
+          {
+            "discriminator": {
+              "mapping": {
+                "github": "#/$defs/GitPullSource",
+                "gitlab": "#/$defs/GitlabPullSource",
+                "local_path": "#/$defs/FileSystemPullSource",
+                "minio": "#/$defs/MinioPullSource",
+                "sphere": "#/$defs/SpherePullSource"
+              },
+              "propertyName": "provider"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/FileSystemPullSource"
+              },
+              {
+                "$ref": "#/$defs/GitPullSource"
+              },
+              {
+                "$ref": "#/$defs/SpherePullSource"
+              },
+              {
+                "$ref": "#/$defs/GitlabPullSource"
+              },
+              {
+                "$ref": "#/$defs/MinioPullSource"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Mapping of source_tag identifiers to push/pull source configurations",
+      "title": "Document Sources",
+      "type": "object"
+    },
+    "storage": {
+      "$ref": "#/$defs/StorageConfig"
+    },
+    "mcp": {
+      "$ref": "#/$defs/MCPConfig",
+      "description": "Feature toggles for MCP-only endpoints and servers."
+    },
+    "filesystem": {
+      "description": "Filesystem backend configuration.",
+      "discriminator": {
+        "mapping": {
+          "local": "#/$defs/LocalFilesystemConfig",
+          "minio": "#/$defs/MinioFilesystemConfig"
+        },
+        "propertyName": "type"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LocalFilesystemConfig"
+        },
+        {
+          "$ref": "#/$defs/MinioFilesystemConfig"
+        }
+      ],
+      "title": "Filesystem"
+    },
+    "workspace_layout": {
+      "$ref": "#/$defs/WorkspaceLayoutConfig",
+      "description": "Patterns used to build workspace storage paths."
+    }
+  },
+  "required": [
+    "app",
+    "chat_model",
+    "embedding_model",
+    "security",
+    "content_storage",
+    "scheduler",
+    "storage",
+    "filesystem"
+  ],
+  "title": "Configuration",
+  "type": "object",
+  "additionalProperties": false
+}

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -32,6 +32,7 @@ from fred_core.common import (
 )
 from fred_core.scheduler import SchedulerBackend
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic.json_schema import WithJsonSchema
 
 """
 This module defines the top level data structures used by controllers, processors
@@ -156,7 +157,7 @@ class MinioStorageConfig(BaseModel):
     type: Literal["minio"]
     endpoint: str = Field(default="localhost:9000", description="MinIO API URL")
     access_key: str = Field(..., description="MinIO access key (from MINIO_ACCESS_KEY env)")
-    secret_key: str = Field(description="MinIO secret key (from MINIO_SECRET_KEY env)")
+    secret_key: Annotated[str, WithJsonSchema({"type": "string"})] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env)")  # type: ignore[assignment]
     bucket_name: str = Field(default="app-bucket", description="Content store bucket name")
     secure: bool = Field(default=False, description="Use TLS (https)")
     public_endpoint: Optional[str] = Field(default=None, description="Public MinIO endpoint for browser-facing presigned URLs (e.g. 'https://my.minio.ingress'). If not set, uses endpoint.")
@@ -809,7 +810,7 @@ class MinioPullSource(BasePullSourceConfig):
     bucket_name: str = Field(..., description="Name of the S3 bucket to scan")
     prefix: Optional[str] = Field(default="", description="Optional prefix (folder path) to scan inside the bucket")
     access_key: str = Field(..., description="MinIO access key (from MINIO_ACCESS_KEY env variable)")
-    secret_key: str = Field(description="MinIO secret key (from MINIO_SECRET_KEY env variable)")
+    secret_key: Annotated[str, WithJsonSchema({"type": "string"})] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env variable)")  # type: ignore[assignment]
     region: Optional[str] = Field(default="us-east-1", description="AWS region (used by some clients)")
     secure: bool = Field(default=True, description="Use HTTPS (secure=True) or HTTP (secure=False)")
 
@@ -938,7 +939,7 @@ class MinioFilesystemConfig(BaseModel):
     type: Literal["minio"] = "minio"
     endpoint: str = Field(..., description="MinIO or S3 compatible endpoint.")
     access_key: str = Field(..., description="MinIO access key.")
-    secret_key: str = Field(description="MinIO secret key (from MINIO_SECRET_KEY env).")
+    secret_key: Annotated[str, WithJsonSchema({"type": "string"})] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env).")  # type: ignore[assignment]
     bucket_name: Optional[str] = Field("filesystem", description="MinIO bucket name.")
     secure: Optional[bool] = Field(False, description="Use TLS for the MinIO client.")
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -156,7 +156,7 @@ class MinioStorageConfig(BaseModel):
     type: Literal["minio"]
     endpoint: str = Field(default="localhost:9000", description="MinIO API URL")
     access_key: str = Field(..., description="MinIO access key (from MINIO_ACCESS_KEY env)")
-    secret_key: str = Field(..., description="MinIO secret key (from MINIO_SECRET_KEY env)")
+    secret_key: Optional[str] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env)")
     bucket_name: str = Field(default="app-bucket", description="Content store bucket name")
     secure: bool = Field(default=False, description="Use TLS (https)")
     public_endpoint: Optional[str] = Field(default=None, description="Public MinIO endpoint for browser-facing presigned URLs (e.g. 'https://my.minio.ingress'). If not set, uses endpoint.")
@@ -809,7 +809,7 @@ class MinioPullSource(BasePullSourceConfig):
     bucket_name: str = Field(..., description="Name of the S3 bucket to scan")
     prefix: Optional[str] = Field(default="", description="Optional prefix (folder path) to scan inside the bucket")
     access_key: str = Field(..., description="MinIO access key (from MINIO_ACCESS_KEY env variable)")
-    secret_key: str = Field(..., description="MinIO secret key (from MINIO_SECRET_KEY env variable)")
+    secret_key: Optional[str] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env variable)")
     region: Optional[str] = Field(default="us-east-1", description="AWS region (used by some clients)")
     secure: bool = Field(default=True, description="Use HTTPS (secure=True) or HTTP (secure=False)")
 
@@ -938,7 +938,7 @@ class MinioFilesystemConfig(BaseModel):
     type: Literal["minio"] = "minio"
     endpoint: str = Field(..., description="MinIO or S3 compatible endpoint.")
     access_key: str = Field(..., description="MinIO access key.")
-    secret_key: str = Field(..., description="MinIO secret key.")
+    secret_key: Optional[str] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env).")
     bucket_name: Optional[str] = Field("filesystem", description="MinIO bucket name.")
     secure: Optional[bool] = Field(False, description="Use TLS for the MinIO client.")
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -156,7 +156,7 @@ class MinioStorageConfig(BaseModel):
     type: Literal["minio"]
     endpoint: str = Field(default="localhost:9000", description="MinIO API URL")
     access_key: str = Field(..., description="MinIO access key (from MINIO_ACCESS_KEY env)")
-    secret_key: Optional[str] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env)")
+    secret_key: str = Field(description="MinIO secret key (from MINIO_SECRET_KEY env)")
     bucket_name: str = Field(default="app-bucket", description="Content store bucket name")
     secure: bool = Field(default=False, description="Use TLS (https)")
     public_endpoint: Optional[str] = Field(default=None, description="Public MinIO endpoint for browser-facing presigned URLs (e.g. 'https://my.minio.ingress'). If not set, uses endpoint.")
@@ -809,7 +809,7 @@ class MinioPullSource(BasePullSourceConfig):
     bucket_name: str = Field(..., description="Name of the S3 bucket to scan")
     prefix: Optional[str] = Field(default="", description="Optional prefix (folder path) to scan inside the bucket")
     access_key: str = Field(..., description="MinIO access key (from MINIO_ACCESS_KEY env variable)")
-    secret_key: Optional[str] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env variable)")
+    secret_key: str = Field(description="MinIO secret key (from MINIO_SECRET_KEY env variable)")
     region: Optional[str] = Field(default="us-east-1", description="AWS region (used by some clients)")
     secure: bool = Field(default=True, description="Use HTTPS (secure=True) or HTTP (secure=False)")
 
@@ -938,7 +938,7 @@ class MinioFilesystemConfig(BaseModel):
     type: Literal["minio"] = "minio"
     endpoint: str = Field(..., description="MinIO or S3 compatible endpoint.")
     access_key: str = Field(..., description="MinIO access key.")
-    secret_key: Optional[str] = Field(default=None, description="MinIO secret key (from MINIO_SECRET_KEY env).")
+    secret_key: str = Field(description="MinIO secret key (from MINIO_SECRET_KEY env).")
     bucket_name: Optional[str] = Field("filesystem", description="MinIO bucket name.")
     secure: Optional[bool] = Field(False, description="Use TLS for the MinIO client.")
 

--- a/scripts/check_config_files.py
+++ b/scripts/check_config_files.py
@@ -1,0 +1,84 @@
+# /// script
+# dependencies = [
+#   "jsonschema>=4.0,<5",
+#   "pyyaml>=6.0",
+# ]
+# ///
+"""Validate backend configuration YAML files against their JSON schemas.
+
+Usage:
+    python check_config_files.py <schema.json> <config_dir>
+
+All files matching *configuration*.yaml in <config_dir> are validated against
+the same schema, including configuration_worker.yaml.
+Validation is strict: extra keys not present in the schema are rejected.
+
+Exit code: 0 if all files pass, 1 if any file fails or is missing.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _load_json(path: Path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _load_yaml(path: Path) -> object:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _validate(instance: object, schema: dict) -> list[str]:
+    """Return a list of human-readable error strings, empty if valid."""
+    from jsonschema import Draft7Validator
+
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.absolute_path))
+    return [
+        f"  [{'.'.join(str(p) for p in e.absolute_path) or '<root>'}] {e.message}"
+        for e in errors
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate config YAML files against JSON schemas")
+    parser.add_argument("schema", help="Path to the JSON schema file")
+    parser.add_argument("config_dir", help="Directory containing configuration*.yaml files")
+    args = parser.parse_args()
+
+    config_dir = Path(args.config_dir)
+    schema = _load_json(Path(args.schema))
+
+    yaml_files = sorted(config_dir.glob("*configuration*.yaml"))
+    if not yaml_files:
+        print(f"WARNING: No configuration*.yaml files found in {config_dir}")
+        sys.exit(0)
+
+    all_passed = True
+    for yaml_file in yaml_files:
+        instance = _load_yaml(yaml_file)
+        errors = _validate(instance, schema)
+
+        if errors:
+            print(f"FAIL  {yaml_file.relative_to(config_dir.parent)}")
+            for err in errors:
+                print(err)
+            all_passed = False
+        else:
+            print(f"OK    {yaml_file.relative_to(config_dir.parent)}")
+
+    if not all_passed:
+        print("\nValidation failed. Fix the errors above or update the schema with 'make generate-config-schema'.")
+        sys.exit(1)
+
+    print("\nAll configuration files are valid.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_config_schema.py
+++ b/scripts/generate_config_schema.py
@@ -1,0 +1,51 @@
+"""Generate a JSON schema from a Pydantic BaseModel config class.
+
+Usage:
+    python generate_config_schema.py <module.ClassName> <output.json>
+
+Example:
+    python generate_config_schema.py control_plane_backend.config.models.Configuration \
+        apps/control-plane-backend/config/schema/configuration.schema.json
+"""
+
+import importlib
+import json
+import sys
+
+
+def _set_no_additional_properties(node: object) -> None:
+    """Recursively add additionalProperties: false to every object schema node."""
+    if isinstance(node, dict):
+        if node.get("type") == "object" or "properties" in node:
+            node.setdefault("additionalProperties", False)
+        for value in node.values():
+            _set_no_additional_properties(value)
+    elif isinstance(node, list):
+        for item in node:
+            _set_no_additional_properties(item)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <module.ClassName> <output.json>", file=sys.stderr)
+        sys.exit(1)
+
+    qualified_name = sys.argv[1]
+    output_path = sys.argv[2]
+
+    module_path, class_name = qualified_name.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+
+    schema = cls.model_json_schema()
+    _set_no_additional_properties(schema)
+
+    with open(output_path, "w") as f:
+        json.dump(schema, f, indent=2)
+        f.write("\n")
+
+    print(f"Schema written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/makefiles/config/INFO-control-plane.mk
+++ b/scripts/makefiles/config/INFO-control-plane.mk
@@ -19,3 +19,7 @@ ENV_FILE            ?= .venv
 LOG_LEVEL           ?= info
 PROJECT_ID          ?= 12345
 HELM_ARCHIVE        ?= ./$(PROJECT_SLUG)-$(VERSION).tgz
+
+# Config JSON schema
+CONFIG_SCHEMA_MODULE ?= control_plane_backend.config.models
+CONFIG_SCHEMA_CLASS  ?= Configuration

--- a/scripts/makefiles/config/INFO-fred-agents.mk
+++ b/scripts/makefiles/config/INFO-fred-agents.mk
@@ -19,3 +19,7 @@ ENV_FILE            ?= ./config/.env
 LOG_LEVEL           ?= info
 PROJECT_ID          ?= 12345  # Optional if using Helm
 HELM_ARCHIVE        ?= ./$(PROJECT_SLUG)-$(VERSION).tgz
+
+# Config JSON schema
+CONFIG_SCHEMA_MODULE ?= fred_runtime.app.config
+CONFIG_SCHEMA_CLASS  ?= AgentPodConfig

--- a/scripts/makefiles/config/INFO-knowledge-flow.mk
+++ b/scripts/makefiles/config/INFO-knowledge-flow.mk
@@ -19,3 +19,7 @@ ENV_FILE            ?= .venv
 LOG_LEVEL           ?= info
 PROJECT_ID          ?= 74648
 HELM_ARCHIVE        ?= ./$(PROJECT_SLUG)-$(VERSION).tgz
+
+# Config JSON schema
+CONFIG_SCHEMA_MODULE ?= knowledge_flow_backend.common.structures
+CONFIG_SCHEMA_CLASS  ?= Configuration

--- a/scripts/makefiles/python-config-schema.mk
+++ b/scripts/makefiles/python-config-schema.mk
@@ -25,5 +25,5 @@ check-config-schema-drift: dev ## Fail if committed schemas differ from freshly 
 	@echo "Schema drift check passed for $(notdir $(SCHEMA_FILE))"
 
 .PHONY: check-config-files
-check-config-files: dev ## Validate all config/*.yaml files against their JSON schemas (strict: no extra keys)
+check-config-files: generate-config-schema ## Validate all config/*.yaml files against their JSON schemas (strict: no extra keys)
 	$(UV) run $(_CHECK_CONFIG_SCRIPT) $(SCHEMA_FILE) $(ROOT_DIR)/config

--- a/scripts/makefiles/python-config-schema.mk
+++ b/scripts/makefiles/python-config-schema.mk
@@ -1,0 +1,29 @@
+##@ Config JSON Schema
+
+_SCHEMA_MK_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+_GEN_SCHEMA_SCRIPT  := $(_SCHEMA_MK_DIR)/../generate_config_schema.py
+_CHECK_CONFIG_SCRIPT := $(_SCHEMA_MK_DIR)/../check_config_files.py
+
+SCHEMA_DIR  := $(ROOT_DIR)/config/schema
+SCHEMA_FILE := $(SCHEMA_DIR)/configuration.schema.json
+
+_SCHEMA_QUALIFIED := $(CONFIG_SCHEMA_MODULE).$(CONFIG_SCHEMA_CLASS)
+
+.PHONY: generate-config-schema
+generate-config-schema: dev ## Generate JSON schemas from Pydantic config models
+	@mkdir -p $(SCHEMA_DIR)
+	$(PYTHON) $(_GEN_SCHEMA_SCRIPT) $(_SCHEMA_QUALIFIED) $(SCHEMA_FILE)
+
+_DRIFT_TMP := /tmp/schema-drift-check/$(PROJECT_NAME)
+
+.PHONY: check-config-schema-drift
+check-config-schema-drift: dev ## Fail if committed schemas differ from freshly generated ones
+	@mkdir -p $(_DRIFT_TMP)
+	@$(PYTHON) $(_GEN_SCHEMA_SCRIPT) $(_SCHEMA_QUALIFIED) $(_DRIFT_TMP)/configuration.schema.json
+	@diff $(SCHEMA_FILE) $(_DRIFT_TMP)/configuration.schema.json \
+		|| (echo "ERROR: $(SCHEMA_FILE) is out of date. Run 'make generate-config-schema' and commit the result." && exit 1)
+	@echo "Schema drift check passed for $(notdir $(SCHEMA_FILE))"
+
+.PHONY: check-config-files
+check-config-files: dev ## Validate all config/*.yaml files against their JSON schemas (strict: no extra keys)
+	$(UV) run $(_CHECK_CONFIG_SCRIPT) $(SCHEMA_FILE) $(ROOT_DIR)/config


### PR DESCRIPTION
## Summary
- Add JSON schema generation and CI validation for backend configs
- Fix type errors: `secret_key` in `MinioStorageConfig`, `MinioPullSource`, and `MinioFilesystemConfig` was typed as `Optional[str]` but the `model_validator` always injects `MINIO_SECRET_KEY` and raises if absent — so `None` is never a valid post-construction value; corrected to `str`

## Test plan
- [ ] CI passes (`make type-check` in `knowledge-flow-backend`)
- [ ] JSON schema generation workflow passes
- [ ] MinIO-based storage, pull source, and filesystem config still load correctly from env