### PR TITLE
feat(AGENT-FILESYSTEM): add bounded paginated filesystem reads

### DIFF
--- a/apps/frontend/public/config.json
+++ b/apps/frontend/public/config.json
@@ -1,7 +1,7 @@
 {
   "frontend_basename": "/",
   "user_auth": {
-    "enabled": true,
+    "enabled": false,
     "realm_url": "http://app-keycloak:8080/realms/app",
     "client_id": "app"
   }

--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -630,6 +630,17 @@ const injectedRtkApi = api.injectEndpoints({
         params: {
           offset: queryArg.offset,
           limit: queryArg.limit,
+          max_chars: queryArg.maxChars,
+        },
+      }),
+    }),
+    readFilePage: build.query<ReadFilePageApiResponse, ReadFilePageApiArg>({
+      query: (queryArg) => ({
+        url: `/knowledge-flow/v1/fs/page/${queryArg.path}`,
+        params: {
+          offset: queryArg.offset,
+          limit: queryArg.limit,
+          max_chars: queryArg.maxChars,
         },
       }),
     }),
@@ -1564,7 +1575,15 @@ export type ReadFileApiResponse = /** status 200 Successful Response */ any;
 export type ReadFileApiArg = {
   path: string;
   offset?: number;
-  limit?: number;
+  limit?: number | null;
+  maxChars?: number | null;
+};
+export type ReadFilePageApiResponse = /** status 200 Successful Response */ FileReadPage;
+export type ReadFilePageApiArg = {
+  path: string;
+  offset?: number;
+  limit?: number | null;
+  maxChars?: number | null;
 };
 export type WriteFileApiResponse = /** status 200 Successful Response */ any;
 export type WriteFileApiArg = {
@@ -2579,6 +2598,17 @@ export type ResourceUpdate = {
   description?: string | null;
   labels?: string[] | null;
 };
+export type FileReadPage = {
+  path: string;
+  content: string;
+  start_line: number;
+  end_line: number | null;
+  returned_lines: number;
+  total_lines: number;
+  has_more: boolean;
+  next_offset: number | null;
+  truncated: boolean;
+};
 export type BodyWriteFile = {
   data: string;
 };
@@ -3019,6 +3049,8 @@ export const {
   useLazyStatFileOrDirectoryQuery,
   useReadFileQuery,
   useLazyReadFileQuery,
+  useReadFilePageQuery,
+  useLazyReadFilePageQuery,
   useWriteFileMutation,
   useDeleteFileMutation,
   useEditFileMutation,

--- a/apps/knowledge-flow-backend/config/configuration.yaml
+++ b/apps/knowledge-flow-backend/config/configuration.yaml
@@ -418,6 +418,10 @@ mcp:
   prometheus_ops_enabled: true
   neo4j_enabled: false
   filesystem_enabled: true
+  filesystem_read_default_limit: 100
+  filesystem_read_max_limit: 500
+  filesystem_read_default_max_chars: 20000
+  filesystem_read_absolute_max_chars: 50000
 
 filesystem:
   type: local

--- a/apps/knowledge-flow-backend/config/configuration_bench.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_bench.yaml
@@ -399,6 +399,10 @@ mcp:
   prometheus_ops_enabled: false
   neo4j_enabled: false
   filesystem_enabled: true
+  filesystem_read_default_limit: 100
+  filesystem_read_max_limit: 500
+  filesystem_read_default_max_chars: 20000
+  filesystem_read_absolute_max_chars: 50000
 
 filesystem:
   type: minio

--- a/apps/knowledge-flow-backend/config/configuration_gcp.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_gcp.yaml
@@ -352,6 +352,10 @@ mcp:
   prometheus_ops_enabled: false
   neo4j_enabled: false
   filesystem_enabled: true
+  filesystem_read_default_limit: 100
+  filesystem_read_max_limit: 500
+  filesystem_read_default_max_chars: 20000
+  filesystem_read_absolute_max_chars: 50000
 
 filesystem:
   type: local

--- a/apps/knowledge-flow-backend/config/configuration_prod.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_prod.yaml
@@ -451,6 +451,10 @@ mcp:
   prometheus_ops_enabled: false
   neo4j_enabled: false
   filesystem_enabled: true
+  filesystem_read_default_limit: 100
+  filesystem_read_max_limit: 500
+  filesystem_read_default_max_chars: 20000
+  filesystem_read_absolute_max_chars: 50000
 filesystem:
   type: minio
   endpoint: http://localhost:8333

--- a/apps/knowledge-flow-backend/config/configuration_test.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_test.yaml
@@ -324,6 +324,10 @@ mcp:
   prometheus_ops_enabled: false
   neo4j_enabled: false
   filesystem_enabled: true
+  filesystem_read_default_limit: 100
+  filesystem_read_max_limit: 500
+  filesystem_read_default_max_chars: 20000
+  filesystem_read_absolute_max_chars: 50000
 
 filesystem:
   type: local

--- a/apps/knowledge-flow-backend/config/configuration_worker.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_worker.yaml
@@ -360,6 +360,10 @@ mcp:
   prometheus_ops_enabled: false
   neo4j_enabled: false
   filesystem_enabled: true
+  filesystem_read_default_limit: 100
+  filesystem_read_max_limit: 500
+  filesystem_read_default_max_chars: 20000
+  filesystem_read_absolute_max_chars: 50000
 filesystem:
   type: minio
   endpoint: http://localhost:8333

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -617,6 +617,34 @@ class MCPConfig(BaseModel):
         default=False,
         description="Expose agent filesystem utils endpoints and the corresponding MCP server.",
     )
+    filesystem_read_default_limit: int = Field(
+        default=100,
+        ge=1,
+        description="Default line count returned by filesystem read_file when callers omit limit.",
+    )
+    filesystem_read_max_limit: int = Field(
+        default=500,
+        ge=1,
+        description="Absolute maximum line count accepted by filesystem read_file.",
+    )
+    filesystem_read_default_max_chars: int = Field(
+        default=20_000,
+        ge=1,
+        description="Default maximum character count returned by filesystem read_file when callers omit max_chars.",
+    )
+    filesystem_read_absolute_max_chars: int = Field(
+        default=50_000,
+        ge=1,
+        description="Absolute maximum character count accepted by filesystem read_file.",
+    )
+
+    @model_validator(mode="after")
+    def validate_filesystem_read_limits(self) -> "MCPConfig":
+        if self.filesystem_read_default_limit > self.filesystem_read_max_limit:
+            raise ValueError("mcp.filesystem_read_default_limit must be <= mcp.filesystem_read_max_limit")
+        if self.filesystem_read_default_max_chars > self.filesystem_read_absolute_max_chars:
+            raise ValueError("mcp.filesystem_read_default_max_chars must be <= mcp.filesystem_read_absolute_max_chars")
+        return self
 
 
 class SchedulerConfig(BaseModel):

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/mcp_fs_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/mcp_fs_controller.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import logging
+from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from fred_core import Action, KeycloakUser, Resource, authorize_or_raise, get_current_user
 from pydantic import BaseModel
 
 from knowledge_flow_backend.features.filesystem.mcp_fs_service import McpFilesystemService
+from knowledge_flow_backend.features.filesystem.virtual_fs_contract import FileReadPage
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +60,11 @@ class McpFilesystemController:
 
     def _handle_exception(self, e: Exception, context: str):
         if isinstance(e, PermissionError):
-            raise HTTPException(400, str(e))
+            raise HTTPException(403, str(e))
         if isinstance(e, FileNotFoundError):
-            raise HTTPException(404, "Path not found")
+            raise HTTPException(404, str(e) or "Path not found")
+        if isinstance(e, ValueError):
+            raise HTTPException(400, str(e))
         logger.exception("%s failed", context)
         raise HTTPException(500, "Internal server error")
 
@@ -92,15 +96,48 @@ class McpFilesystemController:
         @router.get("/fs/cat/{path:path}", tags=["Filesystem"], summary="Read a file", operation_id="read_file")
         async def cat(
             path: str,
-            offset: int = 0,
-            limit: int = 100,
+            offset: Annotated[int, Query(ge=0)] = 0,
+            limit: Annotated[int | None, Query(ge=1)] = None,
+            max_chars: Annotated[int | None, Query(ge=1)] = None,
             user: KeycloakUser = Depends(get_current_user),
         ):
             authorize_or_raise(user, Action.READ, Resource.FILES)
             try:
-                return await self.service.read_file(user, path, offset=offset, limit=limit)
+                return await self.service.read_file(
+                    user,
+                    path,
+                    offset=offset,
+                    limit=limit,
+                    max_chars=max_chars,
+                )
             except Exception as e:
                 self._handle_exception(e, "Cat")
+
+        @router.get(
+            "/fs/page/{path:path}",
+            tags=["Filesystem"],
+            summary="Read a paginated file page",
+            operation_id="read_file_page",
+            response_model=FileReadPage,
+        )
+        async def read_file_page(
+            path: str,
+            offset: Annotated[int, Query(ge=0)] = 0,
+            limit: Annotated[int | None, Query(ge=1)] = None,
+            max_chars: Annotated[int | None, Query(ge=1)] = None,
+            user: KeycloakUser = Depends(get_current_user),
+        ):
+            authorize_or_raise(user, Action.READ, Resource.FILES)
+            try:
+                return await self.service.read_file_page(
+                    user,
+                    path,
+                    offset=offset,
+                    limit=limit,
+                    max_chars=max_chars,
+                )
+            except Exception as e:
+                self._handle_exception(e, "ReadFilePage")
 
         @router.post("/fs/write/{path:path}", tags=["Filesystem"], summary="Write a file", operation_id="write_file")
         async def write(path: str, data: str = Body(..., embed=True), user: KeycloakUser = Depends(get_current_user)):

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/mcp_fs_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/mcp_fs_service.py
@@ -39,10 +39,11 @@ from knowledge_flow_backend.features.filesystem.virtual_fs_contract import (
     AREA_CORPUS,
     AREA_TEAM,
     AREA_WORKSPACE,
+    FileReadPage,
     VirtualArea,
     absolute_virtual_path,
     dir_entry,
-    format_numbered_file_excerpt,
+    format_numbered_file_page,
     join_virtual_child,
     normalize_virtual_path,
     resolve_virtual_path,
@@ -54,6 +55,63 @@ from knowledge_flow_backend.features.metadata.service import MetadataService
 from knowledge_flow_backend.features.tag.tag_service import TagService
 
 logger = logging.getLogger(__name__)
+
+
+class FilesystemReadBounds:
+    """
+    Effective server-side bounds for paginated filesystem reads.
+
+    Why this exists:
+    - bounded reads must be enforced consistently for HTTP and MCP callers
+    - keeping the resolved defaults together avoids sprinkling config lookups
+
+    How to use:
+    - build once from configuration during service initialization
+    - pass optional caller values to `resolve(...)` before formatting output
+    """
+
+    def __init__(
+        self,
+        *,
+        default_limit: int,
+        max_limit: int,
+        default_max_chars: int,
+        absolute_max_chars: int,
+    ) -> None:
+        self.default_limit = default_limit
+        self.max_limit = max_limit
+        self.default_max_chars = default_max_chars
+        self.absolute_max_chars = absolute_max_chars
+
+    def resolve(
+        self,
+        *,
+        limit: int | None,
+        max_chars: int | None,
+    ) -> tuple[int, int]:
+        """
+        Resolve caller inputs to validated effective read bounds.
+
+        Why this exists:
+        - callers may omit optional bounds but the backend must still enforce defaults
+        - upper-limit checks belong close to the canonical config values
+
+        How to use:
+        - pass the optional caller-provided `limit` and `max_chars`
+        - receive the effective `(limit, max_chars)` pair or a ValueError
+        """
+
+        effective_limit = self.default_limit if limit is None else limit
+        effective_max_chars = self.default_max_chars if max_chars is None else max_chars
+        if effective_limit <= 0:
+            raise ValueError("limit must be > 0")
+        if effective_limit > self.max_limit:
+            raise ValueError(f"limit must be <= {self.max_limit}")
+        if effective_max_chars <= 0:
+            raise ValueError("max_chars must be > 0")
+        if effective_max_chars > self.absolute_max_chars:
+            raise ValueError(f"max_chars must be <= {self.absolute_max_chars}")
+        return effective_limit, effective_max_chars
 
 
 class McpFilesystemService:
@@ -88,10 +146,17 @@ class McpFilesystemService:
         """
 
         context = ApplicationContext.get_instance()
+        mcp_config = context.get_config().mcp
         filesystem = context.get_filesystem()
         self.scoped_areas = ScopedAreaFilesystem(
             scoped_storage=WorkspaceFilesystem(filesystem),
             rebac=context.get_rebac_engine(),
+        )
+        self.read_bounds = FilesystemReadBounds(
+            default_limit=mcp_config.filesystem_read_default_limit,
+            max_limit=mcp_config.filesystem_read_max_limit,
+            default_max_chars=mcp_config.filesystem_read_default_max_chars,
+            absolute_max_chars=mcp_config.filesystem_read_absolute_max_chars,
         )
         self.corpus_area = CorpusVirtualFilesystem(
             metadata_service=MetadataService(),
@@ -190,7 +255,8 @@ class McpFilesystemService:
         path: str,
         *,
         offset: int = 0,
-        limit: int = 100,
+        limit: int | None = None,
+        max_chars: int | None = None,
     ) -> str:
         """
         Read one text file using paginated numbered lines.
@@ -200,14 +266,61 @@ class McpFilesystemService:
         - pagination avoids forcing callers to load an entire large file at once
 
         How to use:
-        - pass a visible file path plus optional zero-based `offset` and `limit`
+        - pass a visible file path plus optional zero-based `offset`, `limit`, and `max_chars`
 
         Example:
-        - `await read_file(user, "/workspace/report.md", offset=0, limit=50)`
+        - `await read_file(user, "/workspace/report.md", offset=0, limit=50, max_chars=5000)`
         """
 
+        return (
+            await self.read_file_page(
+                user,
+                path,
+                offset=offset,
+                limit=limit,
+                max_chars=max_chars,
+            )
+        ).content
+
+    @authorize(action=Action.READ, resource=Resource.FILES)
+    async def read_file_page(
+        self,
+        user: KeycloakUser,
+        path: str,
+        *,
+        offset: int = 0,
+        limit: int | None = None,
+        max_chars: int | None = None,
+    ) -> FileReadPage:
+        """
+        Read one text file as a structured numbered page with continuation metadata.
+
+        Why this exists:
+        - long-document agents need a reliable `next_offset` instead of guessing after truncation
+        - the filesystem layer should expose this safely without adding a parallel document API
+
+        How to use:
+        - pass the same path inputs as `read_file(...)`
+        - continue with `next_offset` while `has_more` is true
+
+        Example:
+        - `await read_file_page(user, "/corpus/documents/doc-1/preview.md", offset=0, limit=40, max_chars=20000)`
+        """
+
+        effective_limit, effective_max_chars = self.read_bounds.resolve(
+            limit=limit,
+            max_chars=max_chars,
+        )
         content = await self.cat(user, path)
-        return format_numbered_file_excerpt(content, offset=offset, limit=limit)
+        return format_numbered_file_page(
+            path=absolute_virtual_path(path),
+            content=content,
+            offset=offset,
+            limit=effective_limit,
+            max_chars=effective_max_chars,
+            max_read_lines=self.read_bounds.max_limit,
+            max_read_chars=self.read_bounds.absolute_max_chars,
+        )
 
     @authorize(action=Action.READ, resource=Resource.FILES)
     async def glob(

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/virtual_fs_contract.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/virtual_fs_contract.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from fred_core import FilesystemResourceInfo, FilesystemResourceInfoResult
+from pydantic import BaseModel
 
 AREA_WORKSPACE = "workspace"
 AREA_USER_LEGACY = "user"
@@ -50,6 +51,33 @@ class ResolvedVirtualPath:
 
     area: VirtualArea
     segments: tuple[str, ...]
+
+
+class FileReadPage(BaseModel):
+    """
+    Structured paginated filesystem read response.
+
+    Why this exists:
+    - agents need a deterministic continuation contract when `max_chars` stops a page early
+    - keeping the response typed makes the HTTP and MCP surface explicit
+
+    How to use:
+    - call `format_numbered_file_page(...)` to build one page from raw file text
+    - continue with `next_offset` until `has_more` becomes false
+
+    Example:
+    - `page = format_numbered_file_page(path="/corpus/documents/doc-1/preview.md", content="a\\nb", limit=1, max_chars=20)`
+    """
+
+    path: str
+    content: str
+    start_line: int
+    end_line: int | None
+    returned_lines: int
+    total_lines: int
+    has_more: bool
+    next_offset: int | None
+    truncated: bool
 
 
 def current_time_utc() -> datetime:
@@ -211,6 +239,7 @@ def format_numbered_file_excerpt(
     *,
     offset: int = 0,
     limit: int = 100,
+    max_chars: int | None = None,
 ) -> str:
     """
     Format one text excerpt with one-based numbered lines.
@@ -221,24 +250,114 @@ def format_numbered_file_excerpt(
 
     How to use:
     - pass raw file text plus a zero-based offset and positive limit
+    - optionally pass `max_chars` to cap the rendered excerpt length server-side
     - the result contains only the requested slice with line numbers
 
     Example:
     - `format_numbered_file_excerpt("a\\nb", offset=0, limit=1)` returns `"1 | a"`
     """
 
+    return format_numbered_file_page(
+        path="",
+        content=content,
+        offset=offset,
+        limit=limit,
+        max_chars=max_chars,
+    ).content
+
+
+def format_numbered_file_page(
+    *,
+    path: str,
+    content: str,
+    offset: int = 0,
+    limit: int = 100,
+    max_chars: int | None = None,
+    max_read_lines: int | None = None,
+    max_read_chars: int | None = None,
+) -> FileReadPage:
+    """
+    Build one paginated numbered filesystem read page with safe continuation metadata.
+
+    Why this exists:
+    - agents must be able to continue reading long files without guessing the next offset
+    - `read_file` and `read_file_page` should share one deterministic pagination algorithm
+
+    How to use:
+    - pass the raw file text plus the requested offset/limit/max_chars
+    - optionally pass server-side ceiling values to enforce hard bounds
+
+    Example:
+    - `format_numbered_file_page(path="/workspace/report.md", content="a\\nb", offset=0, limit=1, max_chars=20)`
+    """
+
     if offset < 0:
         raise ValueError("offset must be >= 0")
     if limit <= 0:
         raise ValueError("limit must be > 0")
+    if max_read_lines is not None and limit > max_read_lines:
+        raise ValueError(f"limit must be <= {max_read_lines}")
+    if max_chars is not None and max_chars <= 0:
+        raise ValueError("max_chars must be > 0")
+    if max_chars is not None and max_read_chars is not None and max_chars > max_read_chars:
+        raise ValueError(f"max_chars must be <= {max_read_chars}")
 
     lines = content.splitlines()
-    excerpt = lines[offset : offset + limit]
-    if not excerpt:
-        return ""
+    total_lines = len(lines)
+    if offset >= total_lines:
+        return FileReadPage(
+            path=path,
+            content="",
+            start_line=offset,
+            end_line=None,
+            returned_lines=0,
+            total_lines=total_lines,
+            has_more=False,
+            next_offset=None,
+            truncated=False,
+        )
 
-    width = len(str(offset + len(excerpt)))
-    return "\n".join(f"{offset + index + 1:>{width}} | {line}" for index, line in enumerate(excerpt))
+    requested_end = min(offset + limit, total_lines)
+    width = len(str(requested_end))
+    rendered_lines: list[str] = []
+    truncated = False
+
+    for line_index in range(offset, requested_end):
+        rendered_line = f"{line_index + 1:>{width}} | {lines[line_index]}"
+        candidate_lines = [*rendered_lines, rendered_line]
+        candidate = "\n".join(candidate_lines)
+        if max_chars is None or len(candidate) <= max_chars:
+            rendered_lines.append(rendered_line)
+            continue
+
+        truncated = True
+        if not rendered_lines:
+            if max_chars == 1:
+                rendered_lines.append("…")
+            else:
+                trimmed = rendered_line[: max_chars - 1].rstrip()
+                rendered_lines.append(f"{trimmed}…" if trimmed else "…")
+            break
+        break
+
+    returned_lines = len(rendered_lines)
+    end_line = offset + returned_lines - 1 if returned_lines > 0 else None
+    next_offset = offset + returned_lines
+    has_more = next_offset < total_lines
+    if not has_more:
+        next_offset = None
+
+    return FileReadPage(
+        path=path,
+        content="\n".join(rendered_lines),
+        start_line=offset,
+        end_line=end_line,
+        returned_lines=returned_lines,
+        total_lines=total_lines,
+        has_more=has_more,
+        next_offset=next_offset,
+        truncated=truncated,
+    )
 
 
 def resolve_virtual_path(

--- a/apps/knowledge-flow-backend/tests/services/test_corpus_virtual_filesystem.py
+++ b/apps/knowledge-flow-backend/tests/services/test_corpus_virtual_filesystem.py
@@ -289,3 +289,13 @@ async def test_unknown_natural_folder_raises_file_not_found(app_context):
 
     with pytest.raises(FileNotFoundError):
         await corpus_fs.cat_area(_user(), ("missing", "preview.md"))
+
+
+@pytest.mark.asyncio
+async def test_legacy_document_uid_preview_path_reads_preview(app_context):
+    document = _document(uid="doc-1", name="Quarterly Report.pdf", tag_ids=[])
+    corpus_fs = _corpus_filesystem(tags=[], docs=[document])
+
+    preview = await corpus_fs.cat_area(_user(), ("documents", "doc-1", "preview.md"))
+
+    assert preview == "# Preview for doc-1"

--- a/apps/knowledge-flow-backend/tests/services/test_mcp_fs_controller.py
+++ b/apps/knowledge-flow-backend/tests/services/test_mcp_fs_controller.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from fred_core import KeycloakUser
+
+from knowledge_flow_backend.features.filesystem import mcp_fs_controller as controller_module
+from knowledge_flow_backend.features.filesystem.mcp_fs_controller import McpFilesystemController
+from knowledge_flow_backend.features.filesystem.virtual_fs_contract import FileReadPage
+
+
+def _user() -> KeycloakUser:
+    return KeycloakUser(
+        uid="u-1",
+        username="tester",
+        email="tester@example.com",
+        roles=["admin"],
+        groups=["admins"],
+    )
+
+
+class _ServiceStub:
+    async def read_file(self, user, path, *, offset=0, limit=None, max_chars=None):
+        del user, path, offset, limit, max_chars
+        raise FileNotFoundError("Path not found")
+
+    async def read_file_page(self, user, path, *, offset=0, limit=None, max_chars=None):
+        del user, path, offset, limit, max_chars
+        raise FileNotFoundError("Path not found")
+
+    async def ls(self, user, path="/"):
+        del user, path
+        return []
+
+    async def stat(self, user, path):
+        del user, path
+        raise FileNotFoundError("Path not found")
+
+    async def write(self, user, path, data):
+        del user, path, data
+        return None
+
+    async def delete(self, user, path):
+        del user, path
+        return None
+
+    async def edit_file(self, user, path, *, old_string, new_string, replace_all=False):
+        del user, path, old_string, new_string, replace_all
+        return {"path": "/workspace/report.md", "occurrences": 1}
+
+    async def glob(self, user, pattern, path="/"):
+        del user, pattern, path
+        return []
+
+    async def grep(self, user, pattern, path="/"):
+        del user, pattern, path
+        return []
+
+    async def mkdir(self, user, path):
+        del user, path
+        return None
+
+
+def _build_filesystem_app(monkeypatch, service: object | None = None) -> TestClient:
+    router = APIRouter(prefix="/knowledge-flow/v1")
+    monkeypatch.setattr(controller_module.McpFilesystemController, "__init__", _controller_init(service or _ServiceStub()))
+    McpFilesystemController(router)
+    app = FastAPI()
+    app.dependency_overrides[controller_module.get_current_user] = _user
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _controller_init(service: object):
+    def _init(self, router: APIRouter):
+        self.service = service
+        self._register_routes(router)
+
+    return _init
+
+
+def test_fs_cat_returns_400_for_limit_above_max(app_context, monkeypatch) -> None:
+    service = _ServiceStub()
+
+    async def fake_read_file(user, path, *, offset=0, limit=None, max_chars=None):
+        del user, path, offset, max_chars
+        if limit == 501:
+            raise ValueError("limit must be <= 500")
+        return ""
+
+    service.read_file = fake_read_file
+
+    with _build_filesystem_app(monkeypatch, service) as client:
+        response = client.get("/knowledge-flow/v1/fs/cat/workspace/report.md", params={"limit": 501})
+
+    assert response.status_code == 400
+    assert "limit must be <= 500" in response.text
+
+
+def test_fs_cat_returns_400_for_max_chars_above_max(app_context, monkeypatch) -> None:
+    service = _ServiceStub()
+
+    async def fake_read_file(user, path, *, offset=0, limit=None, max_chars=None):
+        del user, path, offset, limit
+        if max_chars == 50001:
+            raise ValueError("max_chars must be <= 50000")
+        return ""
+
+    service.read_file = fake_read_file
+
+    with _build_filesystem_app(monkeypatch, service) as client:
+        response = client.get("/knowledge-flow/v1/fs/cat/workspace/report.md", params={"max_chars": 50001})
+
+    assert response.status_code == 400
+    assert "max_chars must be <= 50000" in response.text
+
+
+def test_fs_cat_returns_422_for_negative_offset(app_context, monkeypatch) -> None:
+    with _build_filesystem_app(monkeypatch) as client:
+        response = client.get("/knowledge-flow/v1/fs/cat/workspace/report.md", params={"offset": -1})
+
+    assert response.status_code == 422
+
+
+def test_fs_cat_returns_404_for_unknown_path(app_context, monkeypatch) -> None:
+    with _build_filesystem_app(monkeypatch) as client:
+        response = client.get("/knowledge-flow/v1/fs/cat/workspace/missing.txt")
+
+    assert response.status_code == 404
+
+
+def test_fs_page_returns_403_for_permission_error(app_context, monkeypatch) -> None:
+    service = _ServiceStub()
+
+    async def fake_read_file_page(user, path, *, offset=0, limit=None, max_chars=None):
+        del user, path, offset, limit, max_chars
+        raise PermissionError("Forbidden")
+
+    service.read_file_page = fake_read_file_page
+
+    with _build_filesystem_app(monkeypatch, service) as client:
+        response = client.get("/knowledge-flow/v1/fs/page/workspace/report.md")
+
+    assert response.status_code == 403
+    assert "Forbidden" in response.text
+
+
+def test_fs_page_returns_structured_payload(app_context, monkeypatch) -> None:
+    service = _ServiceStub()
+
+    async def fake_read_file_page(user, path, *, offset=0, limit=None, max_chars=None):
+        del user, limit, max_chars
+        return FileReadPage(
+            path=f"/{path}",
+            content="1 | alpha",
+            start_line=offset,
+            end_line=offset,
+            returned_lines=1,
+            total_lines=3,
+            has_more=True,
+            next_offset=offset + 1,
+            truncated=True,
+        )
+
+    service.read_file_page = fake_read_file_page
+
+    with _build_filesystem_app(monkeypatch, service) as client:
+        response = client.get(
+            "/knowledge-flow/v1/fs/page/corpus/documents/doc-1/preview.md",
+            params={"offset": 0, "limit": 40, "max_chars": 20000},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["next_offset"] == 1
+    assert response.json()["truncated"] is True
+
+
+def test_openapi_exposes_read_file_and_read_file_page(app_context, monkeypatch) -> None:
+    with _build_filesystem_app(monkeypatch) as client:
+        schema = client.get("/openapi.json").json()
+
+    read_file_operation = schema["paths"]["/knowledge-flow/v1/fs/cat/{path}"]["get"]
+    read_file_page_operation = schema["paths"]["/knowledge-flow/v1/fs/page/{path}"]["get"]
+
+    assert read_file_operation["operationId"] == "read_file"
+    assert read_file_page_operation["operationId"] == "read_file_page"
+    assert {parameter["name"] for parameter in read_file_page_operation["parameters"]} == {"path", "offset", "limit", "max_chars"}
+    assert read_file_page_operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"].endswith("/FileReadPage")

--- a/apps/knowledge-flow-backend/tests/services/test_mcp_fs_service.py
+++ b/apps/knowledge-flow-backend/tests/services/test_mcp_fs_service.py
@@ -6,9 +6,10 @@ from fred_core import (
 )
 
 from knowledge_flow_backend.features.filesystem.mcp_fs_service import (
+    FilesystemReadBounds,
     McpFilesystemService,
 )
-from knowledge_flow_backend.features.filesystem.virtual_fs_contract import VirtualArea
+from knowledge_flow_backend.features.filesystem.virtual_fs_contract import FileReadPage, VirtualArea
 
 
 def _user() -> KeycloakUser:
@@ -128,6 +129,12 @@ def _service() -> tuple[McpFilesystemService, _ScopedAreaStub, _CorpusAreaStub]:
     corpus_area = _CorpusAreaStub()
     service.scoped_areas = scoped_areas
     service.corpus_area = corpus_area
+    service.read_bounds = FilesystemReadBounds(
+        default_limit=100,
+        max_limit=500,
+        default_max_chars=20_000,
+        absolute_max_chars=50_000,
+    )
     return service, scoped_areas, corpus_area
 
 
@@ -182,6 +189,116 @@ async def test_read_file_formats_numbered_excerpt(app_context):
 
     assert excerpt == "2 | line2\n3 | line3"
     assert corpus_area.calls[-1] == ("cat_area", (_user(), ("CIR", "report.md")), {})
+
+
+@pytest.mark.asyncio
+async def test_read_file_page_returns_structured_page(app_context):
+    service, _scoped_areas, _corpus_area = _service()
+
+    async def _cat(user, path):
+        del user, path
+        return "alpha\nbeta\ngamma"
+
+    service.cat = _cat
+
+    page = await service.read_file_page(_user(), "/workspace/report.md", offset=0, limit=3, max_chars=12)
+
+    assert page == FileReadPage(
+        path="/workspace/report.md",
+        content="1 | alpha",
+        start_line=0,
+        end_line=0,
+        returned_lines=1,
+        total_lines=3,
+        has_more=True,
+        next_offset=1,
+        truncated=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_file_page_reads_corpus_document_uid_path(app_context):
+    service, _scoped_areas, corpus_area = _service()
+
+    page = await service.read_file_page(
+        _user(),
+        "/corpus/documents/doc-1/preview.md",
+        offset=0,
+        limit=2,
+        max_chars=100,
+    )
+
+    assert page.content == "1 | line1\n2 | line2"
+    assert page.next_offset == 2
+    assert corpus_area.calls[-1] == ("cat_area", (_user(), ("documents", "doc-1", "preview.md")), {})
+
+
+@pytest.mark.asyncio
+async def test_read_file_applies_default_bounds_when_caller_omits_them(app_context):
+    service, _scoped_areas, _corpus_area = _service()
+
+    async def _cat(user, path):
+        del user, path
+        return "\n".join(f"line {index}" for index in range(1, 200))
+
+    service.cat = _cat
+    service.read_bounds = FilesystemReadBounds(
+        default_limit=2,
+        max_limit=500,
+        default_max_chars=100,
+        absolute_max_chars=50_000,
+    )
+
+    excerpt = await service.read_file(_user(), "/workspace/report.md")
+
+    assert excerpt == "1 | line 1\n2 | line 2"
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_limit_above_configured_max(app_context):
+    service, _scoped_areas, _corpus_area = _service()
+
+    with pytest.raises(ValueError, match="limit must be <= 500"):
+        await service.read_file(_user(), "/workspace/report.md", limit=501)
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_max_chars_above_configured_max(app_context):
+    service, _scoped_areas, _corpus_area = _service()
+
+    with pytest.raises(ValueError, match="max_chars must be <= 50000"):
+        await service.read_file(_user(), "/workspace/report.md", max_chars=50_001)
+
+
+@pytest.mark.asyncio
+async def test_read_file_truncates_rendered_excerpt_to_max_chars(app_context):
+    service, _scoped_areas, _corpus_area = _service()
+
+    async def _cat(user, path):
+        del user, path
+        return "alpha\nbeta\ngamma"
+
+    service.cat = _cat
+
+    excerpt = await service.read_file(_user(), "/workspace/report.md", limit=3, max_chars=10)
+
+    assert excerpt == "1 | alpha"
+
+
+@pytest.mark.asyncio
+async def test_read_file_remains_plain_text_compatible_when_page_metadata_exists(app_context):
+    service, _scoped_areas, _corpus_area = _service()
+
+    async def _cat(user, path):
+        del user, path
+        return "a\nb\nc"
+
+    service.cat = _cat
+
+    excerpt = await service.read_file(_user(), "/workspace/report.md", offset=1, limit=2, max_chars=100)
+
+    assert isinstance(excerpt, str)
+    assert excerpt == "2 | b\n3 | c"
 
 
 @pytest.mark.asyncio

--- a/apps/knowledge-flow-backend/tests/services/test_virtual_fs_contract.py
+++ b/apps/knowledge-flow-backend/tests/services/test_virtual_fs_contract.py
@@ -1,9 +1,11 @@
 import pytest
 
 from knowledge_flow_backend.features.filesystem.virtual_fs_contract import (
+    FileReadPage,
     VirtualArea,
     absolute_virtual_path,
     format_numbered_file_excerpt,
+    format_numbered_file_page,
     normalize_virtual_path,
     resolve_virtual_path,
 )
@@ -35,8 +37,117 @@ def test_format_numbered_file_excerpt_applies_pagination():
     assert excerpt == "2 | b\n3 | c"
 
 
+def test_format_numbered_file_excerpt_applies_max_chars_cap():
+    excerpt = format_numbered_file_excerpt("alpha\nbeta\ngamma", offset=0, limit=3, max_chars=10)
+
+    assert excerpt == "1 | alpha"
+
+
+def test_format_numbered_file_page_returns_safe_next_offset_after_truncation():
+    page = format_numbered_file_page(
+        path="/corpus/documents/doc-1/preview.md",
+        content="alpha\nbeta\ngamma",
+        offset=0,
+        limit=3,
+        max_chars=12,
+        max_read_lines=500,
+        max_read_chars=50_000,
+    )
+
+    assert page == FileReadPage(
+        path="/corpus/documents/doc-1/preview.md",
+        content="1 | alpha",
+        start_line=0,
+        end_line=0,
+        returned_lines=1,
+        total_lines=3,
+        has_more=True,
+        next_offset=1,
+        truncated=True,
+    )
+
+
+def test_format_numbered_file_page_returns_empty_page_beyond_end():
+    page = format_numbered_file_page(
+        path="/workspace/report.md",
+        content="a\nb",
+        offset=5,
+        limit=2,
+        max_chars=20,
+        max_read_lines=500,
+        max_read_chars=50_000,
+    )
+
+    assert page.content == ""
+    assert page.start_line == 5
+    assert page.end_line is None
+    assert page.returned_lines == 0
+    assert page.total_lines == 2
+    assert page.has_more is False
+    assert page.next_offset is None
+    assert page.truncated is False
+
+
+def test_format_numbered_file_page_handles_single_overlong_line_without_loop():
+    page = format_numbered_file_page(
+        path="/workspace/report.md",
+        content="abcdefghijklmnop\nbeta",
+        offset=0,
+        limit=2,
+        max_chars=10,
+        max_read_lines=500,
+        max_read_chars=50_000,
+    )
+
+    assert page.content == "1 | abcde…"
+    assert page.returned_lines == 1
+    assert page.next_offset == 1
+    assert page.has_more is True
+    assert page.truncated is True
+
+
+def test_format_numbered_file_page_handles_exact_page_boundary():
+    page = format_numbered_file_page(
+        path="/workspace/report.md",
+        content="a\nb\nc\nd",
+        offset=0,
+        limit=2,
+        max_chars=100,
+        max_read_lines=500,
+        max_read_chars=50_000,
+    )
+
+    assert page.content == "1 | a\n2 | b"
+    assert page.returned_lines == 2
+    assert page.next_offset == 2
+    assert page.has_more is True
+    assert page.truncated is False
+
+
+def test_format_numbered_file_page_handles_unicode_and_trailing_newlines():
+    page = format_numbered_file_page(
+        path="/workspace/report.md",
+        content="éclair\nbonjour\n",
+        offset=0,
+        limit=5,
+        max_chars=100,
+        max_read_lines=500,
+        max_read_chars=50_000,
+    )
+
+    assert page.content == "1 | éclair\n2 | bonjour"
+    assert page.total_lines == 2
+    assert page.has_more is False
+
+
 def test_format_numbered_file_excerpt_validates_bounds():
     with pytest.raises(ValueError, match="offset must be >= 0"):
         format_numbered_file_excerpt("a", offset=-1)
     with pytest.raises(ValueError, match="limit must be > 0"):
         format_numbered_file_excerpt("a", limit=0)
+    with pytest.raises(ValueError, match="max_chars must be > 0"):
+        format_numbered_file_excerpt("a", max_chars=0)
+    with pytest.raises(ValueError, match="limit must be <= 500"):
+        format_numbered_file_page(path="/x", content="a", limit=501, max_chars=10, max_read_lines=500, max_read_chars=50_000)
+    with pytest.raises(ValueError, match="max_chars must be <= 50000"):
+        format_numbered_file_page(path="/x", content="a", limit=1, max_chars=50_001, max_read_lines=500, max_read_chars=50_000)

--- a/docs/swift/design/FILESYSTEM.md
+++ b/docs/swift/design/FILESYSTEM.md
@@ -97,6 +97,16 @@ document metadata service. Each ingested document appears as a virtual folder, w
         └── preview.md     ← extracted text of the document
 ```
 
+For stable UID-based reads, the corpus VFS also supports compatibility paths
+under:
+
+```text
+/corpus/documents/{document_uid}/preview.md
+```
+
+This is the preferred direct-read path when the runtime context already carries
+`selected_document_uids`.
+
 Writing or deleting under `/corpus` is rejected with a permission error.
 
 ---
@@ -112,7 +122,8 @@ Knowledge Flow backend. The tools are available to any agent that has
 | Tool                                                   | Description                                             |
 | ------------------------------------------------------ | ------------------------------------------------------- |
 | `ls(path)`                                             | List direct children of one directory                   |
-| `read_file(path, offset, limit)`                       | Read one text file with paginated numbered lines        |
+| `read_file(path, offset, limit, max_chars)`            | Read one text file as a backward-compatible numbered excerpt |
+| `read_file_page(path, offset, limit, max_chars)`       | Read one text file as a structured numbered page with safe continuation metadata |
 | `write(path, data)`                                    | Write a text file (creates parent dirs automatically)   |
 | `edit_file(path, old_string, new_string, replace_all)` | In-place string replacement                             |
 | `delete(path)`                                         | Delete one file or directory                            |
@@ -125,6 +136,27 @@ All tools resolve the path through the virtual routing layer and apply ReBAC
 permission checks before any storage access. Corpus paths are automatically
 routed to the read-only virtual backend; workspace/agent/team paths go to
 the writable store.
+
+`read_file` remains the canonical backward-compatible bounded-read surface for
+document previews. `read_file_page` adds typed pagination metadata for agents
+that need reliable continuation after truncation. The backend enforces:
+
+- `offset >= 0`
+- `limit > 0`, with default `100` and maximum `500`
+- `max_chars > 0`, with default `20,000` and absolute maximum `50,000`
+
+When `max_chars` is reached, the backend returns only complete numbered lines.
+The only exception is a single overlong line, which is returned as one
+controlled truncated line with `truncated=true` and a safe `next_offset`.
+
+Invalid bounds are client errors, not internal errors:
+
+- `ValueError` → HTTP `400`
+- `PermissionError` → HTTP `403`
+- `FileNotFoundError` → HTTP `404`
+
+This protects agents from accidentally inlining an unbounded document into the
+LLM context while keeping the familiar filesystem read contract.
 
 **Example — deep agent reading a template:**
 

--- a/docs/swift/rfc/AGENT-FILESYSTEM-RFC.md
+++ b/docs/swift/rfc/AGENT-FILESYSTEM-RFC.md
@@ -42,6 +42,24 @@ runtime model: if skills are the unit of capability, then every skill should be 
 to operate on the same filesystem-shaped substrate without learning a separate file
 story for chat, runtime, or control-plane code.
 
+### 1.1 Follow-up clarification — bounded document reads stay on `read_file`
+
+Knowledge Flow already exposes unrestricted full-preview HTTP reads through
+`GET /knowledge-flow/v1/markdown/{document_uid}`. That endpoint must remain an
+internal backend/UI surface, not an agent-facing tool contract.
+
+Agents read document previews through the filesystem using the existing
+`read_file` contract for plain-text compatibility and the new
+`read_file_page` contract when they need structured pagination metadata. Both
+operate on the existing corpus paths, including the stable UID-oriented path:
+
+```text
+/corpus/documents/{document_uid}/preview.md
+```
+
+This keeps full-document retrieval internal while exposing a bounded,
+paginated document-reading capability to agents.
+
 ---
 
 ## 2. Existing foundation
@@ -58,6 +76,24 @@ already provides:
 
 Operations: `ls`, `read_file`, `glob`, `cat`, `write`, `edit_file`, `mkdir`, `delete`,
 `grep`, `stat`. All are permission-checked via OpenFGA before touching storage.
+
+`read_file` is the canonical bounded-read surface for text and corpus preview
+content. It returns numbered excerpts with server-enforced limits.
+`read_file_page` uses the same bounds but returns typed continuation metadata:
+
+- default `limit`: 100 lines
+- maximum `limit`: 500 lines
+- default `max_chars`: 20,000 characters
+- absolute `max_chars`: 50,000 characters
+
+Hardening rules:
+
+- invalid bounds are rejected as client errors instead of surfacing as HTTP 500s
+- truncation never drops a partial page boundary; pages contain complete numbered
+  lines unless a single line alone exceeds `max_chars`
+- in that single-line overflow case, the backend returns one controlled
+  truncated line, `returned_lines=1`, `truncated=true`, and `next_offset`
+  advanced by one line
 
 This is the filesystem the user described: Unix-style, area-scoped, rebac-enforced.
 The only gaps are four concrete missing pieces (§4).
@@ -174,6 +210,22 @@ Add to the rework chat UI:
 
 `LinkPart` stays as the UI-facing transport — it is already correct. Only the renderer
 is missing.
+
+### 4.5 Bounded corpus document reading
+
+When the runtime context already contains `selected_document_uids`, the agent
+should not be forced to rediscover the document through search before reading.
+The preferred direct-read flow is:
+
+1. Resolve the selected document UID to `/corpus/documents/{document_uid}/preview.md`
+2. Read it through `read_file(path, offset, limit, max_chars)`
+3. Continue with additional paginated reads only as needed
+
+This preserves the "extend, do not duplicate" rule:
+
+- no new `read_document` operation
+- no direct agent exposure of `/markdown/{document_uid}`
+- no duplicate content-loading logic outside `ContentService` and the corpus VFS
 
 ---
 


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

Add bounded document reads to the agent filesystem surface.

- keep `read_file` as the backward-compatible plain-text API while enforcing
  server-side `limit` and `max_chars` bounds
- add `read_file_page` with typed pagination metadata (`next_offset`,
  `has_more`, `truncated`) for safe continuation on long files
- support stable corpus UID preview reads via
  `/corpus/documents/{document_uid}/preview.md`
- map filesystem read validation and permission failures to 400/403/404 instead
  of internal errors
- make read bounds configurable in MCP config and document the contract in the
  filesystem RFC/design docs
- add service, controller, contract, and corpus-path test coverage
---
## 4. Proof of quality

**`make code-quality` executed**

## 5. Docs updated

Work through this line by line. If an item does not apply, write "n/a" and say why.

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    |              |
| New behaviour, API field, or contract change                      |              |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) |              |
| UX component implemented or visual status changed                 |              |
| Phase progress row exists for this area                           |              |
| WORKPLAN sprint item finished                                     |              |
| Code and a design doc now diverge                                 |              |

---



## 7. Risk and rollback

**What breaks if this is wrong?**

**How do we roll back?**
