### PR TITLE
feat(FILES-02): deepen mindmap rendering and transcript coverage - us…

### DIFF
--- a/apps/fred-agents/fred_agents/mindmap/README.md
+++ b/apps/fred-agents/fred_agents/mindmap/README.md
@@ -1,0 +1,88 @@
+# Mindmap — selected-document transcript visualizer
+
+Mindmap is a **GraphAgent** that turns transcript or script documents selected
+with Fred's **Documents** picker into a structured `mindmap-json` block for
+frontend rendering.
+
+## Workflow
+
+```mermaid
+flowchart TD
+    A[analyze_request] --> B[resolve_selected_documents]
+    B --> C[read_selected_documents]
+    C --> D[build_document_digest]
+    D --> E[extract_mindmap]
+    E --> F[refine_mindmap]
+    F --> G[render_response]
+```
+
+## What it does
+
+- Uses the Fred **Documents** picker and reads `runtime_context.selected_document_uids`
+- Reads each selected document through bounded Knowledge Flow filesystem pagination
+  on `/corpus/documents/{document_uid}/preview.md`
+- Summarizes transcript pages incrementally instead of concatenating full
+  document previews into one prompt
+- Merges page summaries into a global digest that preserves concrete transcript
+  sections such as implementation details, risks, tests, acceptance criteria,
+  and roadmap items when present
+- Extracts a hierarchical mindmap payload
+- Returns a valid `mindmap-json` fenced block for custom frontend rendering
+- Defaults to `initialDepth: 2`, `layout: "orthogonal"`, `max_depth: 4`, and
+  `max_children_per_node: 8` for richer first-screen coverage
+
+## Runtime dependencies
+
+- `MCP_SERVER_KNOWLEDGE_FLOW_TEXT`
+- `MCP_SERVER_KNOWLEDGE_FLOW_FS`
+
+`knowledge.search` is kept only as an explicit fallback path and is disabled by
+default. The normal mode is strict selected-document reading.
+
+## User flow
+
+1. The user selects one or more transcript/script documents with the
+   **Documents** picker.
+2. The runtime passes those ids in `selected_document_uids`.
+3. The agent reads the selected document previews page by page with
+   `read_file_page`.
+4. The agent summarizes pages, merges the summaries into one digest, and
+   generates the final mindmap with concrete transcript branches instead of
+   generic labels whenever the source supports them.
+
+If no document is selected, the agent returns a message asking the user to use
+the **Documents** picker before trying again.
+
+## How to run locally
+
+```bash
+cd apps/fred-agents
+make run
+```
+
+Then select the agent in chat:
+
+```text
+/agent fred.dt.mindmap.graph
+```
+
+## Frontend expectation
+
+This backend returns:
+
+```text
+```mindmap-json
+{ ...valid JSON payload... }
+```
+```
+
+The Fred frontend can then detect `mindmap-json` fences and render them with a
+custom ECharts tree block.
+
+## Validation
+
+```bash
+cd apps/fred-agents
+make code-quality
+make test
+```

--- a/apps/fred-agents/fred_agents/mindmap/__init__.py
+++ b/apps/fred-agents/fred_agents/mindmap/__init__.py
@@ -1,0 +1,17 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .graph_agent import MINDMAP_AGENT, MINDMAP_AGENT_ID
+
+__all__ = ["MINDMAP_AGENT", "MINDMAP_AGENT_ID"]

--- a/apps/fred-agents/fred_agents/mindmap/graph_agent.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_agent.py
@@ -34,10 +34,10 @@ from .graph_steps import (
     analyze_request_step,
     build_document_digest_step,
     extract_mindmap_step,
-    refine_mindmap_step,
     read_selected_documents_step,
-    resolve_selected_documents_step,
+    refine_mindmap_step,
     render_response_step,
+    resolve_selected_documents_step,
 )
 
 MINDMAP_AGENT_ID = "fred.dt.mindmap.graph"

--- a/apps/fred-agents/fred_agents/mindmap/graph_agent.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_agent.py
@@ -1,0 +1,241 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from fred_core.store import VectorSearchHit
+from fred_sdk import (
+    MCP_SERVER_KNOWLEDGE_FLOW_FS,
+    MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
+    TOOL_REF_KNOWLEDGE_SEARCH,
+    FieldSpec,
+    GraphAgent,
+    GraphExecutionOutput,
+    GraphWorkflow,
+    MCPServerRef,
+    ToolRefRequirement,
+    UIHints,
+)
+from pydantic import BaseModel
+
+from .graph_state import MindmapInput, MindmapState
+from .graph_steps import (
+    analyze_request_step,
+    build_document_digest_step,
+    extract_mindmap_step,
+    refine_mindmap_step,
+    read_selected_documents_step,
+    resolve_selected_documents_step,
+    render_response_step,
+)
+
+MINDMAP_AGENT_ID = "fred.dt.mindmap.graph"
+
+
+class MindmapGraphAgent(GraphAgent):
+    agent_id: str = MINDMAP_AGENT_ID
+    role: str = "Mindmap — Knowledge Flow transcript visualizer"
+    description: str = (
+        "Generates an exhaustive mindmap from transcript/script documents "
+        "explicitly selected in Fred's Documents picker. Reads selected "
+        "Knowledge Flow documents through bounded paginated filesystem access "
+        "and summarizes them before generating the mindmap."
+    )
+    tags: tuple[str, ...] = (
+        "document-picker",
+        "paginated-read",
+        "transcript",
+        "script",
+        "mindmap",
+        "knowledge-flow",
+    )
+
+    default_mcp_servers: tuple[MCPServerRef, ...] = (
+        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
+        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_FS),
+    )
+
+    declared_tool_refs: tuple[ToolRefRequirement, ...] = (
+        ToolRefRequirement(
+            tool_ref=TOOL_REF_KNOWLEDGE_SEARCH,
+            description=(
+                "Search selected Knowledge Flow transcript libraries and return grounded snippets."
+            ),
+        ),
+    )
+
+    fields: tuple[FieldSpec, ...] = (
+        FieldSpec(
+            key="settings.top_k",
+            type="integer",
+            title="Top K",
+            description="Maximum number of transcript chunks retrieved per fallback search query.",
+            default=16,
+            min=4,
+            max=30,
+            ui=UIHints(group="Fallback"),
+        ),
+        FieldSpec(
+            key="settings.require_selected_documents",
+            type="boolean",
+            title="Require selected documents",
+            description=(
+                "Require the user to select transcript/script documents with "
+                "the Documents picker before generating a mindmap."
+            ),
+            default=True,
+            ui=UIHints(group="Document reading"),
+        ),
+        FieldSpec(
+            key="settings.page_line_limit",
+            type="integer",
+            title="Page line limit",
+            description="Maximum number of document lines read per paginated call.",
+            default=120,
+            min=20,
+            max=500,
+            ui=UIHints(group="Document reading"),
+        ),
+        FieldSpec(
+            key="settings.page_max_chars",
+            type="integer",
+            title="Page max characters",
+            description="Maximum number of characters read per paginated call.",
+            default=18000,
+            min=4000,
+            max=50000,
+            ui=UIHints(group="Document reading"),
+        ),
+        FieldSpec(
+            key="settings.max_pages_per_document",
+            type="integer",
+            title="Max pages per document",
+            description="Safety limit for the number of pages read from each selected document.",
+            default=20,
+            min=1,
+            max=100,
+            ui=UIHints(group="Document reading"),
+        ),
+        FieldSpec(
+            key="settings.max_selected_documents",
+            type="integer",
+            title="Max selected documents",
+            description="Maximum number of selected documents processed in one request.",
+            default=5,
+            min=1,
+            max=20,
+            ui=UIHints(group="Document reading"),
+        ),
+        FieldSpec(
+            key="settings.allow_search_fallback",
+            type="boolean",
+            title="Allow search fallback",
+            description=(
+                "Allow the agent to fall back to Knowledge Flow search when no "
+                "document is selected. Disabled by default because exhaustive "
+                "mindmaps require full document coverage."
+            ),
+            default=False,
+            ui=UIHints(group="Fallback"),
+        ),
+        FieldSpec(
+            key="settings.max_depth",
+            type="integer",
+            title="Max depth",
+            description="Maximum depth of the generated mindmap tree.",
+            default=4,
+            min=2,
+            max=6,
+            ui=UIHints(group="Mindmap"),
+        ),
+        FieldSpec(
+            key="settings.max_children_per_node",
+            type="integer",
+            title="Max children per node",
+            description="Maximum number of children under each mindmap node.",
+            default=8,
+            min=2,
+            max=10,
+            ui=UIHints(group="Mindmap"),
+        ),
+        FieldSpec(
+            key="settings.output_language",
+            type="select",
+            title="Output language",
+            description="Language used for labels and summaries.",
+            default="auto",
+            enum=["auto", "fr", "en"],
+            ui=UIHints(group="Mindmap"),
+        ),
+        FieldSpec(
+            key="settings.include_evidence",
+            type="boolean",
+            title="Include evidence",
+            description="Attach source references and supporting notes to mindmap nodes when available.",
+            default=True,
+            ui=UIHints(group="Grounding"),
+        ),
+        FieldSpec(
+            key="prompts.system",
+            type="prompt",
+            title="System prompt",
+            description="Optional operator override for the Mindmap extraction behavior.",
+            required=False,
+            ui=UIHints(group="Prompts", multiline=True, markdown=True, max_lines=12),
+        ),
+    )
+
+    input_schema = MindmapInput
+    state_schema = MindmapState
+    input_to_state = {"message": "latest_user_text"}
+    output_state_field = "final_text"
+
+    workflow = GraphWorkflow(
+        entry="analyze_request",
+        nodes={
+            "analyze_request": analyze_request_step,
+            "resolve_selected_documents": resolve_selected_documents_step,
+            "read_selected_documents": read_selected_documents_step,
+            "build_document_digest": build_document_digest_step,
+            "extract_mindmap": extract_mindmap_step,
+            "refine_mindmap": refine_mindmap_step,
+            "render_response": render_response_step,
+        },
+        edges={
+            "analyze_request": "resolve_selected_documents",
+            "resolve_selected_documents": "read_selected_documents",
+            "read_selected_documents": "build_document_digest",
+            "build_document_digest": "extract_mindmap",
+            "extract_mindmap": "refine_mindmap",
+            "refine_mindmap": "render_response",
+        },
+        error_routes={
+            "analyze_request": "render_response",
+            "resolve_selected_documents": "render_response",
+            "read_selected_documents": "render_response",
+            "build_document_digest": "render_response",
+            "extract_mindmap": "render_response",
+            "refine_mindmap": "render_response",
+        },
+    )
+
+    def build_output(self, state: BaseModel) -> BaseModel:
+        assert isinstance(state, MindmapState)
+        sources: tuple[VectorSearchHit, ...] = ()
+        for raw in state.source_refs:
+            sources = (*sources, VectorSearchHit.model_validate(raw))
+        return GraphExecutionOutput(content=state.final_text or "", sources=sources)
+
+
+MINDMAP_AGENT = MindmapGraphAgent()

--- a/apps/fred-agents/fred_agents/mindmap/graph_state.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_state.py
@@ -1,0 +1,72 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class MindmapInput(BaseModel):
+    message: str = Field(..., min_length=1)
+
+
+class DocumentPage(BaseModel):
+    document_uid: str
+    path: str
+    page_index: int
+    start_line: int | None = None
+    end_line: int | None = None
+    total_lines: int | None = None
+    has_more: bool = False
+    next_offset: int | None = None
+    truncated: bool = False
+    content: str = ""
+
+
+class DocumentSegmentSummary(BaseModel):
+    document_uid: str
+    page_index: int
+    line_range: str
+    title: str
+    summary: str
+    key_points: list[str] = Field(default_factory=list)
+    actions: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
+    notable_terms: list[str] = Field(default_factory=list)
+
+
+class MindmapState(BaseModel):
+    latest_user_text: str
+
+    detected_language: str | None = None
+    output_language: str = "auto"
+    selected_document_uids: list[str] = Field(default_factory=list)
+    needs_document_selection: bool = False
+    use_search_fallback: bool = False
+
+    retrieval_queries: list[str] = Field(default_factory=list)
+    coverage_warnings: list[str] = Field(default_factory=list)
+    document_segment_summaries: list[dict[str, object]] = Field(default_factory=list)
+
+    # Stored as VectorSearchHit.model_dump() dicts so the state stays JSON-friendly.
+    transcript_hits: list[dict[str, object]] = Field(default_factory=list)
+    source_refs: list[dict[str, object]] = Field(default_factory=list)
+
+    document_digest: str | None = None
+    mindmap_payload: dict[str, object] | None = None
+    final_text: str | None = None
+    done_reason: str | None = None
+
+    # Set by the runtime when a node raises and on_error routing fires.
+    node_error: str = ""

--- a/apps/fred-agents/fred_agents/mindmap/graph_steps.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_steps.py
@@ -1,0 +1,1649 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from typing import Literal
+
+from fred_core.store import VectorSearchHit
+from fred_sdk import (
+    TOOL_REF_KNOWLEDGE_SEARCH,
+    GraphNodeContext,
+    StepResult,
+    load_agent_prompt_markdown,
+    model_text_step,
+    structured_model_step,
+    typed_node,
+)
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from .graph_state import DocumentPage, DocumentSegmentSummary, MindmapState
+
+_DOCUMENT_PICKER_MESSAGE = """## Please select transcript document(s)
+
+This Mindmap agent needs the full transcript/script to generate an exhaustive mindmap.
+
+Use the **Documents** picker in the composer to select one or more transcript/script documents, then ask again.
+"""
+
+
+def _as_int(value: object, default: int) -> int:
+    """
+    Convert one tuning value to an integer with a safe fallback.
+
+    Why this exists:
+    - graph tuning values arrive as loosely typed scalars
+    - the agent should degrade predictably when a field is blank or malformed
+
+    How to use it:
+    - pass the raw tuning value and the default business value
+    - receive a best-effort integer without raising parsing errors
+    """
+
+    return int(value) if isinstance(value, (int, float)) else default
+
+
+def _as_bool(value: object, default: bool = False) -> bool:
+    """
+    Convert one tuning value to a boolean with a safe fallback.
+
+    Why this exists:
+    - optional boolean tuning values may be absent in direct or older runs
+    - small coercion helpers keep the business steps readable
+
+    How to use it:
+    - pass the raw tuning value and the fallback boolean
+    - receive the original boolean only when the value is already typed
+    """
+
+    return value if isinstance(value, bool) else default
+
+
+def _as_text(value: object) -> str:
+    """
+    Normalize one optional tuning or payload value to stripped text.
+
+    Why this exists:
+    - operator prompts and small runtime values should not leak `None` checks
+      into every step
+    - the agent prefers empty strings over ad hoc sentinel handling
+
+    How to use it:
+    - pass any optional scalar-like value
+    - receive stripped text or the empty string
+    """
+
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _coerce_text(value: object) -> str:
+    """
+    Convert a payload field to plain text without raising validation errors.
+
+    Why this exists:
+    - runtime tool payloads may be dicts, Pydantic models, or partial objects
+    - document-page parsing should stay defensive at the adapter boundary
+
+    How to use it:
+    - pass one raw field value from a runtime tool response
+    - receive a string or the empty string when the field is not text
+    """
+
+    return value if isinstance(value, str) else ""
+
+
+def _coerce_int(value: object) -> int | None:
+    """
+    Convert a payload field to an integer when possible.
+
+    Why this exists:
+    - filesystem pagination metadata should stay typed once it enters graph
+      state
+    - callers should not need repeated `isinstance` checks for every field
+
+    How to use it:
+    - pass one raw runtime-tool field
+    - receive an integer or `None` when the value is missing or invalid
+    """
+
+    return int(value) if isinstance(value, int | float) else None
+
+
+def _runtime_context_selected_uids(context: GraphNodeContext) -> list[str]:
+    """
+    Read the selected document uids from the bound runtime context.
+
+    Why this exists:
+    - the selected-document flow is the primary entry point for this agent
+    - the runtime context shape should be touched in one place only
+
+    How to use it:
+    - call inside routing or document-resolution steps
+    - the result is always a plain list, never `None`
+    """
+
+    runtime_context = getattr(context.binding, "runtime_context", None)
+    raw_uids = getattr(runtime_context, "selected_document_uids", None)
+    if not isinstance(raw_uids, list):
+        return []
+    return [uid.strip() for uid in raw_uids if isinstance(uid, str) and uid.strip()]
+
+
+def _output_language(context: GraphNodeContext, detected: str | None) -> str:
+    """
+    Resolve the effective output language for summaries and mindmap labels.
+
+    Why this exists:
+    - operators may force a language, but request detection should still win
+      when no explicit override was configured
+    - keeping the policy centralized avoids prompt drift across steps
+
+    How to use it:
+    - pass the detected request language when available
+    - receive one of `fr` or `en`
+    """
+
+    forced = _as_text(context.tuning_values.get("settings.output_language")) or "auto"
+    if forced in {"fr", "en"}:
+        return forced
+    if detected in {"fr", "en"}:
+        return detected
+    return "en"
+
+
+def _system_override(context: GraphNodeContext) -> str:
+    """
+    Return the optional operator prompt override for this agent.
+
+    Why this exists:
+    - the managed-agent form exposes one small override channel for operators
+    - every model step should apply it consistently when present
+
+    How to use it:
+    - call before building a system prompt
+    - append the returned text only when it is non-empty
+    """
+
+    return _as_text(context.tuning_values.get("prompts.system"))
+
+
+def _top_k(context: GraphNodeContext) -> int:
+    """
+    Resolve the fallback search retrieval depth.
+
+    Why this exists:
+    - the legacy search path remains available behind an explicit opt-in flag
+    - keeping the bound here isolates fallback-only retrieval tuning
+
+    How to use it:
+    - call only in search-fallback code paths
+    - the value is clamped to the historic search bounds
+    """
+
+    return max(4, min(30, _as_int(context.tuning_values.get("settings.top_k"), 16)))
+
+
+def _require_selected_documents(context: GraphNodeContext) -> bool:
+    """
+    Return whether the agent should require document-picker selection.
+
+    Why this exists:
+    - the selected-document mode is the default product behavior
+    - the routing step should express the policy directly from managed tuning
+
+    How to use it:
+    - call during document-resolution before any fallback path is considered
+    """
+
+    return _as_bool(
+        context.tuning_values.get("settings.require_selected_documents"),
+        True,
+    )
+
+
+def _allow_search_fallback(context: GraphNodeContext) -> bool:
+    """
+    Return whether knowledge search may run as a secondary path.
+
+    Why this exists:
+    - exhaustive transcript mindmaps should not silently drop back to partial
+      vector coverage
+    - the fallback needs one explicit gate the operator can audit
+
+    How to use it:
+    - call only when no selected documents are available
+    """
+
+    return _as_bool(context.tuning_values.get("settings.allow_search_fallback"), False)
+
+
+def _page_line_limit(context: GraphNodeContext) -> int:
+    """
+    Resolve the bounded filesystem line limit for one page read.
+
+    Why this exists:
+    - page size should be operator-tunable but still clamped to backend-safe
+      bounds
+    - every paginated read should use the same resolved limit
+
+    How to use it:
+    - call before invoking `read_file_page`
+    - the result is always between 20 and 500 lines
+    """
+
+    return max(
+        20,
+        min(500, _as_int(context.tuning_values.get("settings.page_line_limit"), 120)),
+    )
+
+
+def _page_max_chars(context: GraphNodeContext) -> int:
+    """
+    Resolve the bounded character budget for one page read.
+
+    Why this exists:
+    - large transcript pages must stay bounded before entering the model path
+    - the filesystem contract already exposes a safe upper bound we can mirror
+
+    How to use it:
+    - call before invoking `read_file_page`
+    - the result is always between 4,000 and 50,000 characters
+    """
+
+    return max(
+        4000,
+        min(
+            50000, _as_int(context.tuning_values.get("settings.page_max_chars"), 18000)
+        ),
+    )
+
+
+def _max_pages_per_document(context: GraphNodeContext) -> int:
+    """
+    Resolve the per-document pagination safety limit.
+
+    Why this exists:
+    - the agent needs a hard stop even when a transcript is unexpectedly large
+    - callers should not repeat the same clamping logic around each read loop
+
+    How to use it:
+    - call once before iterating one selected document
+    - the result is always between 1 and 100 pages
+    """
+
+    return max(
+        1,
+        min(
+            100,
+            _as_int(context.tuning_values.get("settings.max_pages_per_document"), 20),
+        ),
+    )
+
+
+def _max_selected_documents(context: GraphNodeContext) -> int:
+    """
+    Resolve the selected-document processing cap for one request.
+
+    Why this exists:
+    - a single composer turn may include many selected documents
+    - the agent should fail soft by trimming scope rather than overloading the
+      prompt budget
+
+    How to use it:
+    - call in the document-resolution step before storing selected uids
+    - the result is always between 1 and 20 documents
+    """
+
+    return max(
+        1,
+        min(
+            20, _as_int(context.tuning_values.get("settings.max_selected_documents"), 5)
+        ),
+    )
+
+
+def _max_depth(context: GraphNodeContext) -> int:
+    """
+    Resolve the final mindmap depth cap.
+
+    Why this exists:
+    - downstream extraction and normalization both need the same policy value
+    - keeping it centralized prevents prompt/config divergence
+
+    How to use it:
+    - call during extraction, refinement, and normalization
+    """
+
+    return max(2, min(6, _as_int(context.tuning_values.get("settings.max_depth"), 4)))
+
+
+def _max_children_per_node(context: GraphNodeContext) -> int:
+    """
+    Resolve the final child-count cap for each mindmap node.
+
+    Why this exists:
+    - the visual payload should remain navigable in the frontend tree renderer
+    - prompts and payload normalization should share one consistent limit
+
+    How to use it:
+    - call during extraction, refinement, and normalization
+    """
+
+    return max(
+        2,
+        min(
+            10,
+            _as_int(context.tuning_values.get("settings.max_children_per_node"), 6),
+        ),
+    )
+
+
+def _include_evidence(context: GraphNodeContext) -> bool:
+    """
+    Return whether evidence links should be preserved in the final payload.
+
+    Why this exists:
+    - some teams want concise maps while others want grounded drill-down
+    - one helper keeps the evidence policy shared across extraction stages
+
+    How to use it:
+    - call before normalization or prompt construction
+    """
+
+    return _as_bool(context.tuning_values.get("settings.include_evidence"), True)
+
+
+def _is_final(state: MindmapState) -> bool:
+    """
+    Report whether a prior step already produced the final user response.
+
+    Why this exists:
+    - the graph runtime uses direct edges rather than conditional flow here
+    - downstream nodes need a clean no-op check after picker guidance or errors
+
+    How to use it:
+    - guard early in every downstream step
+    - return an empty `StepResult` when this function returns `True`
+    """
+
+    return bool((state.final_text or "").strip())
+
+
+def _trim_text(text: str | None, limit: int) -> str:
+    """
+    Trim one text block to a bounded display or prompt budget.
+
+    Why this exists:
+    - segment summaries and evidence quotes should remain compact
+    - repeated truncation logic would otherwise obscure the workflow steps
+
+    How to use it:
+    - pass optional text and a positive limit
+    - receive a bounded string with an ellipsis only when trimming happened
+    """
+
+    clean = (text or "").strip()
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 1].rstrip() + "…"
+
+
+def _slugify(label: str) -> str:
+    """
+    Convert one label into a stable node id slug.
+
+    Why this exists:
+    - the frontend mindmap renderer needs unique node ids
+    - model-produced ids are often missing or too loose to trust directly
+
+    How to use it:
+    - pass one model-generated label or fallback token
+    - receive a lowercase slug safe for JSON ids
+    """
+
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return slug or "node"
+
+
+def _dedupe_key(hit: VectorSearchHit) -> str:
+    """
+    Build one stable deduplication key for fallback search hits.
+
+    Why this exists:
+    - fallback retrieval can surface the same logical snippet through multiple
+      broad queries
+    - mindmap prompts benefit from a compact, non-redundant evidence set
+
+    How to use it:
+    - call while folding search hits into a map keyed by source identity
+    """
+
+    if hit.uid:
+        return f"uid:{hit.uid}|page:{hit.page}|section:{hit.section}"
+    title = (hit.title or "").strip()
+    file_name = (hit.file_name or "").strip()
+    page = "" if hit.page is None else str(hit.page)
+    section = (hit.section or "").strip()
+    content_prefix = (hit.content or "")[:80]
+    return f"meta:{title}|{file_name}|{page}|{section}|{content_prefix}"
+
+
+def dedupe_hits(hits: Sequence[VectorSearchHit]) -> list[VectorSearchHit]:
+    """
+    Deduplicate fallback search hits while keeping the best-scoring variant.
+
+    Why this exists:
+    - coverage-oriented fallback queries intentionally overlap
+    - the graph state should carry only the strongest variant for each snippet
+
+    How to use it:
+    - pass any hit sequence collected from multiple search calls
+    - receive a compact list with one best hit per dedupe key
+    """
+
+    best_by_key: dict[str, VectorSearchHit] = {}
+    for hit in hits:
+        key = _dedupe_key(hit)
+        current = best_by_key.get(key)
+        if current is None:
+            best_by_key[key] = hit
+            continue
+        if hit.score is not None and (
+            current.score is None or hit.score > current.score
+        ):
+            best_by_key[key] = hit
+    return list(best_by_key.values())
+
+
+def _compact_hits(hits: Sequence[VectorSearchHit], max_chars: int = 12000) -> str:
+    """
+    Render compact grounded evidence blocks for prompts and fallbacks.
+
+    Why this exists:
+    - search hits and document-summary pseudo-hits share one prompt shape
+    - the extractor should not see an unbounded pile of source text
+
+    How to use it:
+    - pass the source hits already stored in state
+    - receive a bounded multi-block string for prompt injection
+    """
+
+    blocks: list[str] = []
+    total = 0
+    for index, hit in enumerate(hits, start=1):
+        locator_parts: list[str] = []
+        if hit.file_name:
+            locator_parts.append(hit.file_name)
+        if hit.page is not None:
+            locator_parts.append(f"p. {hit.page}")
+        elif hit.section:
+            locator_parts.append(f"§{hit.section}")
+        locator = ", ".join(locator_parts) if locator_parts else "source"
+        title = (hit.title or "").strip() or (hit.file_name or f"source {index}")
+        content = _trim_text(hit.content, 900)
+        block = (
+            f"Source {index}\nTitle: {title}\nLocator: {locator}\nSnippet:\n{content}\n"
+        )
+        if total + len(block) > max_chars:
+            break
+        blocks.append(block)
+        total += len(block)
+    return "\n".join(blocks).strip()
+
+
+def _line_range(page: DocumentPage) -> str:
+    """
+    Convert page pagination metadata into a compact human-readable range.
+
+    Why this exists:
+    - segment summaries should preserve chronology and location
+    - prompts and UI notes both benefit from one consistent range label
+
+    How to use it:
+    - pass one `DocumentPage`
+    - receive a `Lx-Ly` style label or a coarse page fallback
+    """
+
+    if page.start_line is None and page.end_line is None:
+        return f"page {page.page_index + 1}"
+    if page.start_line is None:
+        return f"L?-L{page.end_line}"
+    if page.end_line is None:
+        return f"L{page.start_line}-L?"
+    return f"L{page.start_line}-L{page.end_line}"
+
+
+def _normalize_page_payload(payload: object) -> dict[str, object]:
+    """
+    Normalize one runtime-tool page payload to a plain mapping.
+
+    Why this exists:
+    - `invoke_runtime_tool` may return dicts, Pydantic models, or similar
+      objects depending on runtime plumbing
+    - page parsing should work from one consistent mapping shape
+
+    How to use it:
+    - pass the raw result from `context.invoke_runtime_tool(...)`
+    - receive a best-effort `dict[str, object]`
+    """
+
+    if isinstance(payload, BaseModel):
+        return payload.model_dump(mode="python")
+    if hasattr(payload, "model_dump"):
+        model_dump = getattr(payload, "model_dump")
+        if callable(model_dump):
+            dumped = model_dump(mode="python")
+            if isinstance(dumped, dict):
+                return dumped
+    if isinstance(payload, dict):
+        return dict(payload)
+    return {}
+
+
+def _pseudo_hit_from_summary(summary: DocumentSegmentSummary) -> VectorSearchHit:
+    """
+    Build one lightweight grounded source from a document segment summary.
+
+    Why this exists:
+    - the final graph output expects `VectorSearchHit`-shaped sources
+    - selected-document mode still needs stable evidence indexes for the
+      mindmap payload without keeping raw page text in state
+
+    How to use it:
+    - pass one persisted `DocumentSegmentSummary`
+    - receive a small synthetic source entry suitable for prompts and output
+    """
+
+    return VectorSearchHit(
+        uid=summary.document_uid,
+        title=f"Document {summary.document_uid}",
+        content=_trim_text(summary.summary, 900),
+        file_name="preview.md",
+        type="document-segment",
+        page=summary.page_index + 1,
+        section=summary.line_range,
+        score=1.0,
+    )
+
+
+def _segment_summaries_to_text(
+    summaries: Sequence[DocumentSegmentSummary],
+    *,
+    max_chars: int = 14000,
+) -> str:
+    """
+    Render persisted segment summaries into a bounded digest-building prompt.
+
+    Why this exists:
+    - the agent should merge many bounded page summaries without concatenating
+      raw transcript pages
+    - one shared renderer keeps prompt structure consistent across turns
+
+    How to use it:
+    - pass the summaries already stored in graph state
+    - receive a bounded text block ready for a digest model step
+    """
+
+    blocks: list[str] = []
+    total = 0
+    for summary in summaries:
+        block = (
+            f"Document: {summary.document_uid}\n"
+            f"Segment: {summary.line_range}\n"
+            f"Title: {summary.title}\n"
+            f"Summary: {summary.summary}\n"
+            f"Key points: {', '.join(summary.key_points) or '-'}\n"
+            f"Actions: {', '.join(summary.actions) or '-'}\n"
+            f"Risks: {', '.join(summary.risks) or '-'}\n"
+            f"Notable terms: {', '.join(summary.notable_terms) or '-'}\n"
+        )
+        if total + len(block) > max_chars:
+            break
+        blocks.append(block)
+        total += len(block)
+    return "\n".join(blocks).strip()
+
+
+def _render_missing_transcript_response() -> str:
+    """
+    Render the fallback-search miss response for insufficient corpus coverage.
+
+    Why this exists:
+    - the strict selected-document path and the optional search path fail in
+      different ways
+    - the search miss should still return a direct, user-readable next step
+
+    How to use it:
+    - call from the render step when fallback search returned no useful hits
+    """
+
+    return (
+        "## I could not find enough transcript content\n\n"
+        "I did not find sufficient transcript or script material to build an "
+        "exhaustive mindmap. Please select the transcript/script documents "
+        "with the **Documents** picker and ask again."
+    )
+
+
+def _render_document_read_failure_response() -> str:
+    """
+    Render the response used when selected documents could not be read safely.
+
+    Why this exists:
+    - a selected-document run can fail after picker selection because the
+      preview is missing, unauthorized, or empty
+    - the user should get one clear remediation message rather than a raw error
+
+    How to use it:
+    - call from the render step when document reads produced no usable summary
+    """
+
+    return (
+        "## I could not read enough document content\n\n"
+        "The selected transcript/script documents did not yield enough readable "
+        "preview content for an exhaustive mindmap. Please verify the selected "
+        "documents and try again."
+    )
+
+
+def _fallback_outline(hits: Sequence[VectorSearchHit]) -> str:
+    """
+    Render a compact fallback outline when JSON mindmap generation fails.
+
+    Why this exists:
+    - the workflow should still return useful grounded content when the
+      extraction payload is malformed
+    - a short outline is safer than returning nothing after successful reads
+
+    How to use it:
+    - pass the best available grounded sources from state
+    - receive a human-readable markdown fallback
+    """
+
+    lines = [
+        "## Mindmap generation needs refinement",
+        "",
+        "I gathered enough transcript material, but I could not produce a reliable mindmap JSON payload this time.",
+        "",
+        "### Transcript highlights",
+    ]
+    for index, hit in enumerate(hits[:6], start=1):
+        title = (hit.title or "").strip() or (hit.file_name or f"Source {index}")
+        snippet = _trim_text(hit.content, 180)
+        lines.append(f"- {title}: {snippet}")
+    return "\n".join(lines)
+
+
+class RequestAnalysis(BaseModel):
+    detected_language: Literal["fr", "en", "unknown"] = Field(
+        description="Detected language of the request."
+    )
+    normalized_request: str = Field(
+        description="Short rewritten request used for downstream processing."
+    )
+    transcript_title_hint: str = Field(
+        default="",
+        description="Possible transcript title, project, or domain hint if present.",
+    )
+
+
+class MindMapEvidence(BaseModel):
+    sourceIndex: int | None = None
+    quote: str = ""
+
+
+class MindMapNode(BaseModel):
+    id: str = ""
+    name: str = Field(..., min_length=1)
+    summary: str = ""
+    detail: str = ""
+    evidence: list[MindMapEvidence] = Field(default_factory=list)
+    children: list["MindMapNode"] = Field(default_factory=list)
+
+
+class MindMapPresentation(BaseModel):
+    initialDepth: int = 2
+    layout: Literal["orthogonal", "radial"] = "orthogonal"
+    focusMode: bool = True
+
+
+class MindMapPayload(BaseModel):
+    version: str = "1.0"
+    title: str = Field(..., min_length=1)
+    summary: str = ""
+    root: MindMapNode
+    presentation: MindMapPresentation = Field(default_factory=MindMapPresentation)
+
+
+MindMapNode.model_rebuild()
+
+
+def _normalize_evidence(
+    evidence: Sequence[MindMapEvidence],
+    *,
+    max_source_index: int,
+    include_evidence: bool,
+) -> list[dict[str, object]]:
+    """
+    Filter model-generated evidence items to valid source indexes.
+
+    Why this exists:
+    - the frontend expects source indexes to point at actual `sources` entries
+    - selected-document mode may carry fewer grounded sources than the model
+      tries to cite
+
+    How to use it:
+    - pass the raw model evidence plus the number of available sources
+    - receive a compact list of safe evidence payloads
+    """
+
+    if not include_evidence or max_source_index <= 0:
+        return []
+    normalized: list[dict[str, object]] = []
+    for item in evidence:
+        source_index = item.sourceIndex
+        if not isinstance(source_index, int) or not (
+            1 <= source_index <= max_source_index
+        ):
+            continue
+        normalized.append(
+            {
+                "sourceIndex": source_index,
+                "quote": _trim_text(item.quote, 220),
+            }
+        )
+    return normalized[:3]
+
+
+def _normalize_node(
+    node: MindMapNode,
+    *,
+    fallback_id: str,
+    seen_ids: set[str],
+    depth: int,
+    max_depth: int,
+    max_children: int,
+    max_source_index: int,
+    include_evidence: bool,
+) -> dict[str, object]:
+    """
+    Normalize one recursively nested mindmap node for frontend rendering.
+
+    Why this exists:
+    - model output is loosely structured and may contain duplicate ids or
+      oversized child sets
+    - the renderer benefits from one deterministic, bounded payload shape
+
+    How to use it:
+    - call from `normalize_mindmap_payload(...)`
+    - pass the recursive traversal limits and seen-id set
+    """
+
+    raw_name = _trim_text(node.name, 80) or "Untitled topic"
+    raw_id = _slugify(node.id or raw_name or fallback_id)
+    final_id = raw_id
+    suffix = 2
+    while final_id in seen_ids:
+        final_id = f"{raw_id}-{suffix}"
+        suffix += 1
+    seen_ids.add(final_id)
+
+    children: list[dict[str, object]] = []
+    if depth < max_depth:
+        for index, child in enumerate(node.children[:max_children], start=1):
+            children.append(
+                _normalize_node(
+                    child,
+                    fallback_id=f"{final_id}-{index}",
+                    seen_ids=seen_ids,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_children=max_children,
+                    max_source_index=max_source_index,
+                    include_evidence=include_evidence,
+                )
+            )
+
+    return {
+        "id": final_id,
+        "name": raw_name,
+        "summary": _trim_text(node.summary, 220),
+        "detail": _trim_text(node.detail, 700),
+        "evidence": _normalize_evidence(
+            node.evidence,
+            max_source_index=max_source_index,
+            include_evidence=include_evidence,
+        ),
+        "children": children,
+    }
+
+
+def normalize_mindmap_payload(
+    payload: MindMapPayload,
+    *,
+    max_depth: int,
+    max_children: int,
+    include_evidence: bool,
+    max_source_index: int,
+) -> dict[str, object]:
+    """
+    Normalize the model-produced payload to the frontend contract.
+
+    Why this exists:
+    - the frontend mindmap block expects bounded ids, child counts, and
+      evidence indexes
+    - keeping the shaping here lets prompts stay focused on business meaning
+
+    How to use it:
+    - pass the raw `MindMapPayload` plus rendering bounds
+    - receive a stable JSON-serializable dict for the fenced response
+    """
+
+    seen_ids: set[str] = set()
+    root = _normalize_node(
+        payload.root,
+        fallback_id="root",
+        seen_ids=seen_ids,
+        depth=1,
+        max_depth=max_depth,
+        max_children=max_children,
+        max_source_index=max_source_index,
+        include_evidence=include_evidence,
+    )
+    root["id"] = "root"
+    seen_ids.add("root")
+    initial_depth = max(1, min(max_depth, payload.presentation.initialDepth))
+    return {
+        "version": "1.0",
+        "title": _trim_text(payload.title, 120) or "Mindmap",
+        "summary": _trim_text(payload.summary, 320),
+        "root": root,
+        "presentation": {
+            "initialDepth": initial_depth,
+            "layout": payload.presentation.layout,
+            "focusMode": bool(payload.presentation.focusMode),
+        },
+    }
+
+
+def render_mindmap_markdown(
+    payload: dict[str, object],
+    *,
+    coverage_warnings: Sequence[str] = (),
+) -> str:
+    """
+    Render the final fenced `mindmap-json` response shown in chat.
+
+    Why this exists:
+    - the frontend already knows how to render mindmap payloads from fenced
+      markdown
+    - keeping the response assembly in one helper makes close-out notes and
+      warning blocks consistent
+
+    How to use it:
+    - pass the normalized payload and any coverage warnings
+    - receive the final markdown text stored in `state.final_text`
+    """
+
+    summary = str(payload.get("summary") or "").strip()
+    root = payload.get("root") if isinstance(payload.get("root"), dict) else {}
+    branch_names: list[str] = []
+    if isinstance(root, dict):
+        children = root.get("children")
+        if isinstance(children, list):
+            for child in children[:5]:
+                if isinstance(child, dict) and isinstance(child.get("name"), str):
+                    branch_names.append(child["name"].strip())
+
+    notes = ""
+    if branch_names:
+        notes = "\n### Reading notes\n- Main themes: " + ", ".join(branch_names) + "."
+
+    warning_block = ""
+    if coverage_warnings:
+        warning_lines = "\n".join(f"- {warning}" for warning in coverage_warnings)
+        warning_block = f"\n### Coverage notes\n{warning_lines}\n"
+
+    body = json.dumps(payload, ensure_ascii=True, indent=2)
+    intro = (
+        "## Mindmap generated from the selected transcript\n\n"
+        "I read the selected transcript/script documents through paginated Knowledge "
+        "Flow previews and generated a hierarchical mindmap. Use the interactive "
+        "block below to zoom, pan, expand/collapse, and drill into topics.\n"
+    )
+    summary_text = f"\nSummary: {summary}\n" if summary else "\n"
+    return (
+        f"{intro}{summary_text}\n```mindmap-json\n{body}\n```\n{warning_block}{notes}\n"
+    ).rstrip()
+
+
+async def read_document_pages(
+    context: GraphNodeContext,
+    document_uid: str,
+    *,
+    page_line_limit: int,
+    page_max_chars: int,
+    max_pages: int,
+) -> list[DocumentPage]:
+    """
+    Read one selected document through bounded filesystem pagination.
+
+    Why this exists:
+    - exhaustive transcript coverage needs sequential reads instead of vector
+      relevance sampling
+    - the helper centralizes pagination normalization and stop conditions
+
+    How to use it:
+    - pass the graph context plus one selected document uid and read bounds
+    - continue summarization from the returned ordered page list
+    """
+
+    path = f"/corpus/documents/{document_uid}/preview.md"
+    pages: list[DocumentPage] = []
+    offset = 0
+
+    for page_index in range(max_pages):
+        raw_page = await context.invoke_runtime_tool(
+            "read_file_page",
+            {
+                "path": path,
+                "offset": offset,
+                "limit": page_line_limit,
+                "max_chars": page_max_chars,
+            },
+        )
+        payload = _normalize_page_payload(raw_page)
+        page = DocumentPage(
+            document_uid=document_uid,
+            path=_coerce_text(payload.get("path")) or path,
+            page_index=page_index,
+            start_line=_coerce_int(payload.get("start_line")),
+            end_line=_coerce_int(payload.get("end_line")),
+            total_lines=_coerce_int(payload.get("total_lines")),
+            has_more=_as_bool(payload.get("has_more"), False),
+            next_offset=_coerce_int(payload.get("next_offset")),
+            truncated=_as_bool(payload.get("truncated"), False),
+            content=_coerce_text(payload.get("content")).strip(),
+        )
+        pages.append(page)
+
+        if not page.has_more:
+            break
+        if page.next_offset is None:
+            break
+        offset = page.next_offset
+
+    return pages
+
+
+async def _summarize_document_page(
+    context: GraphNodeContext,
+    page: DocumentPage,
+) -> DocumentSegmentSummary:
+    """
+    Summarize one bounded transcript page for later digest merging.
+
+    Why this exists:
+    - the workflow must preserve chronology without concatenating full document
+      previews into one large prompt
+    - storing compact structured summaries keeps graph state JSON-friendly and
+      bounded
+
+    How to use it:
+    - pass one `DocumentPage` returned by `read_document_pages(...)`
+    - receive a compact `DocumentSegmentSummary`
+    """
+
+    line_range = _line_range(page)
+    if context.model is None:
+        return DocumentSegmentSummary(
+            document_uid=page.document_uid,
+            page_index=page.page_index,
+            line_range=line_range,
+            title=f"Segment {page.page_index + 1}",
+            summary=_trim_text(page.content, 500),
+        )
+
+    system_prompt = (
+        "Summarize this transcript/script segment for mindmap generation.\n\n"
+        "Rules:\n"
+        "- Use only the segment content.\n"
+        "- Preserve chronology.\n"
+        "- Extract key concepts, actions, decisions, risks, and transitions.\n"
+        "- Keep labels short.\n"
+        "- Do not invent missing context."
+    )
+    messages = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(
+            content=(
+                f"Document UID: {page.document_uid}\n"
+                f"Segment: {line_range}\n\n"
+                f"Content:\n{page.content or '(empty)'}"
+            )
+        ),
+    ]
+    try:
+        summary = await context.invoke_structured_model(
+            DocumentSegmentSummary,
+            messages,
+            operation="mindmap_summarize_document_page",
+        )
+        return DocumentSegmentSummary.model_validate(summary)
+    except Exception:
+        return DocumentSegmentSummary(
+            document_uid=page.document_uid,
+            page_index=page.page_index,
+            line_range=line_range,
+            title=f"Segment {page.page_index + 1}",
+            summary=_trim_text(page.content, 500),
+        )
+
+
+def _build_fallback_queries(request_text: str) -> list[str]:
+    """
+    Build a small deterministic fallback search query set.
+
+    Why this exists:
+    - the explicit search fallback should stay lightweight and avoid adding a
+      second planning LLM call to the graph
+    - broad deterministic queries are good enough for the fallback path
+
+    How to use it:
+    - pass the normalized user request
+    - receive deduplicated coverage-oriented search queries
+    """
+
+    seed = " ".join(request_text.split()).strip()
+    candidates = [
+        seed,
+        f"{seed} transcript script overview main themes",
+        f"{seed} introduction conclusion key topics decisions action items",
+    ]
+    seen: set[str] = set()
+    queries: list[str] = []
+    for query in candidates:
+        normalized = " ".join(query.split())
+        lowered = normalized.lower()
+        if not normalized or lowered in seen:
+            continue
+        seen.add(lowered)
+        queries.append(normalized)
+    return queries or [seed]
+
+
+async def _retrieve_fallback_hits(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> tuple[list[VectorSearchHit], list[str]]:
+    """
+    Retrieve fallback search hits when no selected documents were provided.
+
+    Why this exists:
+    - search fallback is still supported, but only behind an explicit setting
+    - isolating it here keeps the main document-reading step easy to follow
+
+    How to use it:
+    - call only when `state.use_search_fallback` is true
+    - receive the deduplicated hits plus the queries that were executed
+    """
+
+    queries = _build_fallback_queries(state.latest_user_text)
+    all_hits: list[VectorSearchHit] = []
+    for query in queries:
+        if not query.strip():
+            continue
+        result = await context.invoke_tool(
+            TOOL_REF_KNOWLEDGE_SEARCH,
+            {"query": query, "top_k": _top_k(context)},
+        )
+        all_hits.extend(list(result.sources))
+        for block in result.blocks:
+            block_kind = getattr(block.kind, "value", block.kind)
+            if block_kind != "json" or not isinstance(block.data, dict):
+                continue
+            raw_hits = block.data.get("hits")
+            if not isinstance(raw_hits, list):
+                continue
+            for raw_hit in raw_hits:
+                if not isinstance(raw_hit, dict):
+                    continue
+                try:
+                    all_hits.append(VectorSearchHit.model_validate(raw_hit))
+                except (TypeError, ValueError):
+                    continue
+    deduped = dedupe_hits(all_hits)
+    deduped.sort(key=lambda hit: (hit.score is None, -(hit.score or 0.0)))
+    return deduped, queries
+
+
+@typed_node(MindmapState)
+async def analyze_request_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Normalize the user request and detect the output language.
+
+    Why this exists:
+    - later steps should reason over a compact normalized request rather than
+      free-form user phrasing
+    - language detection keeps summary and label prompts consistent
+
+    How to use it:
+    - this is the graph entry step
+    - it stores the normalized request back into `latest_user_text`
+    """
+
+    context.emit_status("analyze_request", "Analyzing the transcript mapping request.")
+    system_prompt = (
+        "You analyze a request for a transcript-to-mindmap workflow.\n"
+        "Return structured output only."
+    )
+    override = _system_override(context)
+    if override:
+        system_prompt = f"{system_prompt}\n\nAdditional instructions:\n{override}"
+    analysis = await structured_model_step(
+        context,
+        operation="mindmap_analyze_request",
+        output_model=RequestAnalysis,
+        system_prompt=system_prompt,
+        user_prompt=state.latest_user_text,
+        fallback_output={
+            "detected_language": "unknown",
+            "normalized_request": state.latest_user_text.strip(),
+            "transcript_title_hint": "",
+        },
+    )
+    detected = (
+        analysis.detected_language if analysis.detected_language != "unknown" else None
+    )
+    normalized_request = (
+        analysis.normalized_request.strip() or state.latest_user_text.strip()
+    )
+    return StepResult(
+        state_update={
+            "detected_language": detected,
+            "output_language": _output_language(context, detected),
+            "latest_user_text": normalized_request,
+        }
+    )
+
+
+@typed_node(MindmapState)
+async def resolve_selected_documents_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Resolve the selected-document routing mode for the current request.
+
+    Why this exists:
+    - the agent must prefer explicit document selection over search
+    - the workflow needs one place to decide between selected-document mode,
+      picker guidance, and the optional fallback path
+
+    How to use it:
+    - this step runs immediately after request analysis
+    - downstream steps simply inspect the flags stored here
+    """
+
+    if _is_final(state):
+        return StepResult()
+
+    context.emit_status(
+        "resolve_selected_documents",
+        "Resolving selected documents from the runtime context.",
+    )
+    selected_uids = _runtime_context_selected_uids(context)
+    max_selected = _max_selected_documents(context)
+    coverage_warnings: list[str] = []
+    if len(selected_uids) > max_selected:
+        coverage_warnings.append(
+            f"Processed only the first {max_selected} selected documents out of {len(selected_uids)}."
+        )
+        selected_uids = selected_uids[:max_selected]
+
+    if selected_uids:
+        return StepResult(
+            state_update={
+                "selected_document_uids": selected_uids,
+                "coverage_warnings": coverage_warnings,
+                "needs_document_selection": False,
+                "use_search_fallback": False,
+            }
+        )
+
+    if _allow_search_fallback(context) and not _require_selected_documents(context):
+        return StepResult(
+            state_update={
+                "use_search_fallback": True,
+                "needs_document_selection": False,
+                "selected_document_uids": [],
+            }
+        )
+
+    return StepResult(
+        state_update={
+            "final_text": _DOCUMENT_PICKER_MESSAGE,
+            "needs_document_selection": True,
+            "done_reason": "needs_document_selection",
+            "selected_document_uids": [],
+            "use_search_fallback": False,
+        }
+    )
+
+
+@typed_node(MindmapState)
+async def read_selected_documents_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Read selected transcript documents or execute the explicit fallback search.
+
+    Why this exists:
+    - selected-document mode needs bounded sequential reads and incremental page
+      summarization
+    - the graph keeps the legacy search path only as a guarded secondary mode
+
+    How to use it:
+    - this step follows document-resolution
+    - it persists compact segment summaries or fallback search hits into state
+    """
+
+    if _is_final(state):
+        return StepResult()
+
+    if state.use_search_fallback:
+        context.emit_status(
+            "read_selected_documents",
+            "No selected documents were provided; running explicit search fallback.",
+        )
+        hits, queries = await _retrieve_fallback_hits(state, context)
+        return StepResult(
+            state_update={
+                "retrieval_queries": queries,
+                "transcript_hits": [hit.model_dump() for hit in hits],
+                "source_refs": [hit.model_dump() for hit in hits],
+                "done_reason": None if hits else "no_transcript_hits",
+            }
+        )
+
+    context.emit_status(
+        "read_selected_documents",
+        f"Reading {len(state.selected_document_uids)} selected document(s) through paginated previews.",
+    )
+    segment_summaries: list[DocumentSegmentSummary] = []
+    source_refs: list[dict[str, object]] = []
+    coverage_warnings = list(state.coverage_warnings)
+    page_line_limit = _page_line_limit(context)
+    page_max_chars = _page_max_chars(context)
+    max_pages = _max_pages_per_document(context)
+
+    for document_uid in state.selected_document_uids:
+        try:
+            pages = await read_document_pages(
+                context,
+                document_uid,
+                page_line_limit=page_line_limit,
+                page_max_chars=page_max_chars,
+                max_pages=max_pages,
+            )
+        except Exception as exc:
+            coverage_warnings.append(
+                f"Could not read document `{document_uid}`: {type(exc).__name__}."
+            )
+            continue
+
+        if not pages:
+            coverage_warnings.append(
+                f"Document `{document_uid}` returned no readable preview pages."
+            )
+            continue
+
+        last_page = pages[-1]
+        if (
+            last_page.has_more
+            and last_page.next_offset is not None
+            and len(pages) >= max_pages
+        ):
+            coverage_warnings.append(
+                f"Stopped reading document `{document_uid}` after {max_pages} pages for safety."
+            )
+        elif last_page.has_more and last_page.next_offset is None:
+            coverage_warnings.append(
+                f"Stopped reading document `{document_uid}` because pagination metadata had no next offset."
+            )
+
+        for page in pages:
+            if not page.content:
+                continue
+            if page.truncated:
+                coverage_warnings.append(
+                    f"Document `{document_uid}` segment {_line_range(page)} was truncated by filesystem bounds."
+                )
+            summary = await _summarize_document_page(context, page)
+            segment_summaries.append(summary)
+            source_refs.append(_pseudo_hit_from_summary(summary).model_dump())
+
+    done_reason = None if segment_summaries else "no_document_content"
+    return StepResult(
+        state_update={
+            "document_segment_summaries": [
+                summary.model_dump() for summary in segment_summaries
+            ],
+            "source_refs": source_refs,
+            "coverage_warnings": coverage_warnings,
+            "done_reason": done_reason,
+        }
+    )
+
+
+@typed_node(MindmapState)
+async def build_document_digest_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Merge selected-document summaries or fallback hits into one global digest.
+
+    Why this exists:
+    - the mindmap extractor should work from one coherent transcript digest
+      rather than raw pages or scattered snippets
+    - this keeps the workflow bounded while still preserving chronology
+
+    How to use it:
+    - this step runs after document reads or fallback retrieval
+    - it stores the merged digest in `state.document_digest`
+    """
+
+    if _is_final(state):
+        return StepResult()
+
+    context.emit_status("build_document_digest", "Building a global transcript digest.")
+
+    if state.use_search_fallback:
+        hits = [VectorSearchHit.model_validate(raw) for raw in state.transcript_hits]
+        if not hits:
+            return StepResult(
+                state_update={
+                    "document_digest": "",
+                    "done_reason": state.done_reason or "no_transcript_hits",
+                }
+            )
+        evidence_text = _compact_hits(hits)
+        system_prompt = (
+            "You condense transcript evidence into a faithful digest for mindmap extraction.\n"
+            "Preserve chronology, topic transitions, decisions, and action items.\n"
+            "Preserve concrete section-level topics from the transcript. Keep implementation details, decisions, risks, action items, test scenarios, acceptance criteria, and roadmap items separate when present.\n"
+            "Avoid merging distinct sections into generic categories.\n"
+            "Do not invent material. Write concise bullet points in the requested language."
+        )
+        override = _system_override(context)
+        if override:
+            system_prompt = f"{system_prompt}\n\nAdditional instructions:\n{override}"
+        digest = await model_text_step(
+            context,
+            operation="mindmap_build_fallback_digest",
+            system_prompt=system_prompt,
+            user_prompt=(
+                f"Output language: {state.output_language}\n\n"
+                f"User request:\n{state.latest_user_text}\n\n"
+                f"Transcript evidence:\n{evidence_text}"
+            ),
+            fallback_text=evidence_text,
+        )
+        return StepResult(state_update={"document_digest": digest.strip()})
+
+    summaries = [
+        DocumentSegmentSummary.model_validate(raw)
+        for raw in state.document_segment_summaries
+    ]
+    if not summaries:
+        return StepResult(
+            state_update={
+                "document_digest": "",
+                "done_reason": state.done_reason or "no_document_content",
+            }
+        )
+
+    digest_input = _segment_summaries_to_text(summaries)
+    system_prompt = (
+        "You merge transcript/script segment summaries into one global digest for mindmap generation.\n"
+        "Rules:\n"
+        "- Preserve chronology across segments and across documents.\n"
+        "- Preserve concrete section-level topics from the transcript.\n"
+        "- Keep implementation details, decisions, risks, action items, test scenarios, acceptance criteria, and roadmap items separate when present.\n"
+        "- Avoid merging distinct sections into generic categories.\n"
+        "- Highlight themes, transitions, decisions, actions, risks, and conclusions.\n"
+        "- Keep labels concise and grounded.\n"
+        "- Do not invent context missing from the summaries."
+    )
+    override = _system_override(context)
+    if override:
+        system_prompt = f"{system_prompt}\n\nAdditional instructions:\n{override}"
+    digest = await model_text_step(
+        context,
+        operation="mindmap_build_document_digest",
+        system_prompt=system_prompt,
+        user_prompt=(
+            f"Output language: {state.output_language}\n\n"
+            f"User request:\n{state.latest_user_text}\n\n"
+            f"Segment summaries:\n{digest_input}"
+        ),
+        fallback_text=digest_input,
+    )
+    return StepResult(state_update={"document_digest": digest.strip()})
+
+
+@typed_node(MindmapState)
+async def extract_mindmap_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Generate the first structured mindmap draft from the global digest.
+
+    Why this exists:
+    - the extractor turns the merged transcript digest into the stable JSON
+      contract expected by the frontend renderer
+    - separating extraction from refinement gives the model one smaller prompt
+      at each stage
+
+    How to use it:
+    - this step runs after digest generation
+    - it stores the raw draft payload in `state.mindmap_payload`
+    """
+
+    if _is_final(state):
+        return StepResult()
+
+    if not (state.document_digest or "").strip():
+        return StepResult(
+            state_update={
+                "done_reason": state.done_reason or "mindmap_generation_failed"
+            }
+        )
+
+    context.emit_status("extract_mindmap", "Extracting a first mindmap structure.")
+    hits = [VectorSearchHit.model_validate(raw) for raw in state.source_refs]
+    system_prompt = load_agent_prompt_markdown(
+        package="fred_agents.mindmap",
+        file_name="extract_mindmap.md",
+    )
+    override = _system_override(context)
+    if override:
+        system_prompt = f"{system_prompt}\n\nAdditional instructions:\n{override}"
+    payload = await structured_model_step(
+        context,
+        operation="mindmap_extract_mindmap",
+        output_model=MindMapPayload,
+        system_prompt=system_prompt,
+        user_prompt=(
+            f"User request:\n{state.latest_user_text}\n\n"
+            f"Output language: {state.output_language}\n"
+            f"Maximum depth: {_max_depth(context)}\n"
+            f"Maximum children per node: {_max_children_per_node(context)}\n"
+            f"Include evidence: {_include_evidence(context)}\n\n"
+            f"Transcript digest:\n{state.document_digest or '(empty)'}\n\n"
+            f"Grounded supporting summaries:\n{_compact_hits(hits)}"
+        ),
+        fallback_output={
+            "version": "1.0",
+            "title": "Transcript mindmap",
+            "summary": "Fallback transcript overview.",
+            "root": {
+                "id": "root",
+                "name": "Transcript",
+                "summary": "Transcript overview",
+                "detail": "The transcript was processed but the first mindmap extraction fell back to a minimal structure.",
+                "evidence": [],
+                "children": [],
+            },
+            "presentation": {
+                "initialDepth": min(2, _max_depth(context)),
+                "layout": "orthogonal",
+                "focusMode": True,
+            },
+        },
+    )
+    return StepResult(state_update={"mindmap_payload": payload.model_dump()})
+
+
+@typed_node(MindmapState)
+async def refine_mindmap_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Refine and normalize the first draft before rendering.
+
+    Why this exists:
+    - a second pass improves hierarchy quality while the normalizer enforces the
+      frontend-safe contract
+    - this is the last model step before markdown rendering
+
+    How to use it:
+    - this step runs after extraction
+    - it writes the normalized payload back into `state.mindmap_payload`
+    """
+
+    if _is_final(state):
+        return StepResult()
+
+    raw_payload = state.mindmap_payload or {}
+    if not raw_payload:
+        return StepResult(
+            state_update={
+                "done_reason": state.done_reason or "mindmap_generation_failed"
+            }
+        )
+
+    context.emit_status("refine_mindmap", "Refining the mindmap structure.")
+    hits = [VectorSearchHit.model_validate(raw) for raw in state.source_refs]
+    system_prompt = load_agent_prompt_markdown(
+        package="fred_agents.mindmap",
+        file_name="refine_mindmap.md",
+    )
+    override = _system_override(context)
+    if override:
+        system_prompt = f"{system_prompt}\n\nAdditional instructions:\n{override}"
+    refined = await structured_model_step(
+        context,
+        operation="mindmap_refine_mindmap",
+        output_model=MindMapPayload,
+        system_prompt=system_prompt,
+        user_prompt=(
+            f"User request:\n{state.latest_user_text}\n\n"
+            f"Output language: {state.output_language}\n"
+            f"Maximum depth: {_max_depth(context)}\n"
+            f"Maximum children per node: {_max_children_per_node(context)}\n"
+            f"Include evidence: {_include_evidence(context)}\n\n"
+            f"Current mindmap draft:\n{json.dumps(raw_payload, ensure_ascii=True, indent=2)}\n\n"
+            f"Transcript digest:\n{state.document_digest or '(empty)'}\n\n"
+            f"Grounded supporting summaries:\n{_compact_hits(hits, max_chars=9000)}"
+        ),
+        fallback_output=raw_payload,
+    )
+    normalized = normalize_mindmap_payload(
+        refined,
+        max_depth=_max_depth(context),
+        max_children=_max_children_per_node(context),
+        include_evidence=_include_evidence(context),
+        max_source_index=len(hits),
+    )
+    return StepResult(state_update={"mindmap_payload": normalized})
+
+
+@typed_node(MindmapState)
+async def render_response_step(
+    state: MindmapState,
+    context: GraphNodeContext,
+) -> StepResult:
+    """
+    Render the final markdown response for chat.
+
+    Why this exists:
+    - the frontend renderer consumes a fenced `mindmap-json` payload rather than
+      a raw Python object
+    - this step also translates terminal failure states into user-readable
+      messages
+
+    How to use it:
+    - this is the final graph node
+    - it always writes the user-facing text into `state.final_text`
+    """
+
+    context.emit_status("render_response", "Rendering the response.")
+
+    if _is_final(state) and state.done_reason == "needs_document_selection":
+        return StepResult(state_update={"final_text": state.final_text})
+
+    if state.done_reason == "no_transcript_hits":
+        return StepResult(
+            state_update={"final_text": _render_missing_transcript_response()}
+        )
+
+    if state.done_reason == "no_document_content":
+        return StepResult(
+            state_update={"final_text": _render_document_read_failure_response()}
+        )
+
+    payload = state.mindmap_payload
+    if not isinstance(payload, dict):
+        hits = [VectorSearchHit.model_validate(raw) for raw in state.source_refs]
+        return StepResult(state_update={"final_text": _fallback_outline(hits)})
+
+    _ = load_agent_prompt_markdown(
+        package="fred_agents.mindmap",
+        file_name="render_response.md",
+    )
+    final_text = render_mindmap_markdown(
+        payload,
+        coverage_warnings=state.coverage_warnings,
+    )
+    if state.node_error:
+        final_text = (
+            f"{final_text}\n\n### Note\n"
+            "The workflow completed with an internal recovery path, so please review "
+            "the generated structure before using it as a presentation outline."
+        )
+    return StepResult(
+        state_update={"final_text": final_text, "done_reason": "completed"}
+    )

--- a/apps/fred-agents/fred_agents/mindmap/prompts/extract_mindmap.md
+++ b/apps/fred-agents/fred_agents/mindmap/prompts/extract_mindmap.md
@@ -1,0 +1,22 @@
+You are Mindmap, a transcript-to-mindmap extraction assistant.
+
+Produce a structured mindmap payload from grounded transcript evidence.
+
+Rules:
+- Return structured output only.
+- Create one clear root concept that best represents the transcript.
+- Top-level branches must be distinct and non-overlapping.
+- Create a coverage-oriented transcript mindmap.
+- Preserve the major concrete sections of the transcript.
+- Do not collapse distinct topics into generic labels when the source contains specific subjects.
+- Use the transcript's actual topics as first-level or second-level branches.
+- Preserve chronology where it helps understanding.
+- Include decisions, risks, action items, implementation plan, tests, acceptance criteria, and roadmap when present.
+- Keep labels short, but not generic.
+- Prefer concrete branches such as "Frontend MVP", "Knowledge Flow Integration", "Graph Agent Implementation", "Testing Strategy", and "Roadmap" over vague branches such as "Scope" or "Workflow".
+- Put longer explanations in `summary` and `detail`.
+- Capture the main ideas, transitions, decisions, risks, and action items only when grounded in the transcript.
+- Do not hallucinate topics that are not supported by the digest or snippets.
+- Preserve the transcript language unless the requested output language forces French or English.
+- Respect the requested maximum depth and maximum children per node.
+- When evidence is requested, attach concise evidence entries with `sourceIndex` values that point to the provided transcript snippets.

--- a/apps/fred-agents/fred_agents/mindmap/prompts/refine_mindmap.md
+++ b/apps/fred-agents/fred_agents/mindmap/prompts/refine_mindmap.md
@@ -1,0 +1,19 @@
+You refine a transcript-derived mindmap payload so it is ready for frontend rendering.
+
+Rules:
+- Return structured output only.
+- Keep one clear root concept.
+- Ensure top-level branches are mutually distinct.
+- Create a coverage-oriented transcript mindmap.
+- Preserve the major concrete sections of the transcript.
+- Do not collapse distinct topics into generic labels when the source contains specific subjects.
+- Use the transcript's actual topics as first-level or second-level branches.
+- Preserve chronology where it helps understanding.
+- Include decisions, risks, action items, implementation plan, tests, acceptance criteria, and roadmap when present.
+- Keep labels short, but not generic.
+- Prefer concrete branches such as "Frontend MVP", "Knowledge Flow Integration", "Graph Agent Implementation", "Testing Strategy", and "Roadmap" over vague branches such as "Scope" or "Workflow".
+- Shorten labels that are too verbose for visual display.
+- Remove weak, duplicate, or speculative branches.
+- Preserve grounded details, decisions, and action items when supported by evidence.
+- Respect the requested maximum depth and maximum children per node.
+- Keep evidence concise and only reference valid `sourceIndex` values from the provided transcript snippets.

--- a/apps/fred-agents/fred_agents/mindmap/prompts/render_response.md
+++ b/apps/fred-agents/fred_agents/mindmap/prompts/render_response.md
@@ -1,0 +1,7 @@
+You render the final assistant response for a transcript-derived mindmap.
+
+Rules:
+- The final answer must include a fenced code block whose language is `mindmap-json`.
+- The JSON must be valid JSON, not Python syntax.
+- Add a short introductory paragraph that explains the block is interactive.
+- Keep any extra commentary concise and helpful.

--- a/apps/fred-agents/fred_agents/registry.py
+++ b/apps/fred-agents/fred_agents/registry.py
@@ -29,6 +29,7 @@ Example:
 from fred_sdk.contracts.models import GraphAgentDefinition, ReActAgentDefinition
 
 from fred_agents.general_assistant import GENERAL_ASSISTANT_AGENT
+from fred_agents.mindmap import MINDMAP_AGENT
 from fred_agents.rag_expert import RAG_EXPERT_AGENT
 from fred_agents.react_rag_mcp import REACT_RAG_MCP_AGENT
 from fred_agents.sentinel import SENTINEL_AGENT
@@ -56,6 +57,9 @@ def build_registry() -> dict[str, ReActAgentDefinition | GraphAgentDefinition]:
                                library picker, search policy, and RAG scope in
                                the Tools tab. Operator sets the name at
                                enrollment time.
+    - fred.dt.mindmap.graph     Graph agent that turns grounded transcript
+                               material into a structured `mindmap-json`
+                               payload for frontend visualization.
     - fred.github.test_assistant  No-LLM graph agent. Exercises every SSE event
                                type without any external service. Used for UI
                                validation and integration scenario testing.
@@ -67,6 +71,7 @@ def build_registry() -> dict[str, ReActAgentDefinition | GraphAgentDefinition]:
         SENTINEL_AGENT.agent_id: SENTINEL_AGENT,
         RAG_EXPERT_AGENT.agent_id: RAG_EXPERT_AGENT,
         REACT_RAG_MCP_AGENT.agent_id: REACT_RAG_MCP_AGENT,
+        MINDMAP_AGENT.agent_id: MINDMAP_AGENT,
         SQL_EXPERT_AGENT.agent_id: SQL_EXPERT_AGENT,
         TEST_ASSISTANT_AGENT.agent_id: TEST_ASSISTANT_AGENT,
     }

--- a/apps/fred-agents/pyproject.toml
+++ b/apps/fred-agents/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "setuptools.build_meta"
 include = ["fred_agents*"]
 
 [tool.setuptools.package-data]
-"fred_agents" = ["prompts/*.md"]
+"fred_agents" = ["prompts/*.md", "mindmap/prompts/*.md"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/apps/fred-agents/tests/test_mindmap_graph.py
+++ b/apps/fred-agents/tests/test_mindmap_graph.py
@@ -18,19 +18,18 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-
 from fred_sdk import GraphNodeContext, load_agent_prompt_markdown
 
 from fred_agents.mindmap.graph_agent import MINDMAP_AGENT
 from fred_agents.mindmap.graph_state import DocumentSegmentSummary, MindmapState
 from fred_agents.mindmap.graph_steps import (
     _DOCUMENT_PICKER_MESSAGE,
+    MindMapPayload,
     build_document_digest_step,
     normalize_mindmap_payload,
     read_selected_documents_step,
     render_mindmap_markdown,
     resolve_selected_documents_step,
-    MindMapPayload,
 )
 
 

--- a/apps/fred-agents/tests/test_mindmap_graph.py
+++ b/apps/fred-agents/tests/test_mindmap_graph.py
@@ -1,0 +1,408 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from fred_sdk import GraphNodeContext, load_agent_prompt_markdown
+
+from fred_agents.mindmap.graph_agent import MINDMAP_AGENT
+from fred_agents.mindmap.graph_state import DocumentSegmentSummary, MindmapState
+from fred_agents.mindmap.graph_steps import (
+    _DOCUMENT_PICKER_MESSAGE,
+    build_document_digest_step,
+    normalize_mindmap_payload,
+    read_selected_documents_step,
+    render_mindmap_markdown,
+    resolve_selected_documents_step,
+    MindMapPayload,
+)
+
+
+class _FakeContext:
+    """
+    Minimal graph-node context used by the mindmap step unit tests.
+
+    Why this exists:
+    - the business steps only need a small slice of the runtime protocol
+    - keeping the fake tiny makes the tests easy to read and adapt
+
+    How to use it:
+    - configure `selected_document_uids`, `tuning_values`, and optional tool
+      payloads per test case
+    - cast the instance to `GraphNodeContext` at the call site
+    """
+
+    def __init__(
+        self,
+        *,
+        selected_document_uids: list[str] | None = None,
+        tuning_values: dict[str, object] | None = None,
+        runtime_tool_pages: list[object] | None = None,
+    ) -> None:
+        self.binding = SimpleNamespace(
+            runtime_context=SimpleNamespace(
+                selected_document_uids=selected_document_uids,
+            )
+        )
+        self.tuning_values = dict(tuning_values or {})
+        self.model = None
+        self._runtime_tool_pages = list(runtime_tool_pages or [])
+        self.runtime_tool_calls: list[tuple[str, dict[str, object]]] = []
+        self.statuses: list[tuple[str, str | None]] = []
+
+    def emit_status(self, status: str, detail: str | None = None) -> None:
+        self.statuses.append((status, detail))
+
+    async def invoke_runtime_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, object],
+    ) -> object:
+        self.runtime_tool_calls.append((tool_name, dict(arguments)))
+        if not self._runtime_tool_pages:
+            raise AssertionError("No fake runtime tool payload configured.")
+        return self._runtime_tool_pages.pop(0)
+
+    async def invoke_tool(self, tool_ref: str, payload: dict[str, object]):
+        raise AssertionError(
+            f"Unexpected tool invocation in this test: {tool_ref} {payload}"
+        )
+
+    async def invoke_model(self, messages, *, operation: str = "default"):
+        raise AssertionError(f"Unexpected model invocation in this test: {operation}")
+
+    async def invoke_structured_model(
+        self, output_model, messages, *, operation: str = "default"
+    ):
+        raise AssertionError(
+            f"Unexpected structured model invocation in this test: {output_model} {operation}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_selected_documents_requests_picker_when_nothing_selected() -> (
+    None
+):
+    """
+    Verify strict mode asks the user to use the document picker.
+
+    Why this test exists:
+    - selected-document mode is the default contract for the final mindmap
+      agent
+    - the graph should stop early with explicit picker guidance instead of
+      drifting into search
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    state = MindmapState(latest_user_text="build a transcript mindmap")
+    context = cast(GraphNodeContext, _FakeContext(selected_document_uids=None))
+
+    result = await resolve_selected_documents_step(state, context)
+
+    assert result.state_update["final_text"] == _DOCUMENT_PICKER_MESSAGE
+    assert result.state_update["needs_document_selection"] is True
+    assert result.state_update["done_reason"] == "needs_document_selection"
+
+
+@pytest.mark.asyncio
+async def test_resolve_selected_documents_can_enable_explicit_search_fallback() -> None:
+    """
+    Verify the graph can opt into the legacy search path explicitly.
+
+    Why this test exists:
+    - fallback search must stay behind an explicit setting
+    - the routing step is where that guardrail lives
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    state = MindmapState(latest_user_text="build a transcript mindmap")
+    context = cast(
+        GraphNodeContext,
+        _FakeContext(
+            selected_document_uids=[],
+            tuning_values={
+                "settings.allow_search_fallback": True,
+                "settings.require_selected_documents": False,
+            },
+        ),
+    )
+
+    result = await resolve_selected_documents_step(state, context)
+
+    assert result.state_update["use_search_fallback"] is True
+    assert result.state_update["needs_document_selection"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_selected_documents_uses_paginated_preview_reads() -> None:
+    """
+    Verify selected-document mode reads multiple filesystem pages sequentially.
+
+    Why this test exists:
+    - the main refactor replaces chunk search with paginated preview coverage
+    - the graph must keep only compact summaries and synthetic grounded sources
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    state = MindmapState(
+        latest_user_text="build a transcript mindmap",
+        selected_document_uids=["doc-1"],
+    )
+    fake_context = _FakeContext(
+        selected_document_uids=["doc-1"],
+        runtime_tool_pages=[
+            {
+                "path": "/corpus/documents/doc-1/preview.md",
+                "content": "1 | intro\n2 | agenda",
+                "start_line": 1,
+                "end_line": 2,
+                "total_lines": 4,
+                "has_more": True,
+                "next_offset": 2,
+                "truncated": False,
+            },
+            {
+                "path": "/corpus/documents/doc-1/preview.md",
+                "content": "3 | decision\n4 | action",
+                "start_line": 3,
+                "end_line": 4,
+                "total_lines": 4,
+                "has_more": False,
+                "next_offset": None,
+                "truncated": False,
+            },
+        ],
+    )
+    context = cast(GraphNodeContext, fake_context)
+
+    result = await read_selected_documents_step(state, context)
+
+    raw_summaries = cast(
+        list[object],
+        result.state_update["document_segment_summaries"],
+    )
+    summaries = [DocumentSegmentSummary.model_validate(raw) for raw in raw_summaries]
+    source_refs = cast(list[object], result.state_update["source_refs"])
+    assert len(summaries) == 2
+    assert summaries[0].document_uid == "doc-1"
+    assert summaries[0].line_range == "L1-L2"
+    assert summaries[1].line_range == "L3-L4"
+    assert len(source_refs) == 2
+    assert result.state_update["done_reason"] is None
+    assert fake_context.runtime_tool_calls == [
+        (
+            "read_file_page",
+            {
+                "path": "/corpus/documents/doc-1/preview.md",
+                "offset": 0,
+                "limit": 120,
+                "max_chars": 18000,
+            },
+        ),
+        (
+            "read_file_page",
+            {
+                "path": "/corpus/documents/doc-1/preview.md",
+                "offset": 2,
+                "limit": 120,
+                "max_chars": 18000,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_document_digest_falls_back_to_compact_summary_text_without_model() -> (
+    None
+):
+    """
+    Verify digest building still works in offline no-model test mode.
+
+    Why this test exists:
+    - the helper-based steps should remain testable without a live model
+    - fallback text keeps the graph runnable in smoke and unit tests
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    summary = DocumentSegmentSummary(
+        document_uid="doc-1",
+        page_index=0,
+        line_range="L1-L2",
+        title="Opening",
+        summary="Introduces the topic and agenda.",
+        key_points=["topic", "agenda"],
+    )
+    state = MindmapState(
+        latest_user_text="build a transcript mindmap",
+        document_segment_summaries=[summary.model_dump()],
+        output_language="en",
+    )
+    context = cast(GraphNodeContext, _FakeContext(selected_document_uids=["doc-1"]))
+
+    result = await build_document_digest_step(state, context)
+
+    digest = cast(str, result.state_update["document_digest"])
+    assert "Document: doc-1" in digest
+    assert "Summary: Introduces the topic and agenda." in digest
+
+
+def test_mindmap_prompts_and_defaults_favor_coverage_and_depth() -> None:
+    """
+    Verify the shipped prompts and defaults favor concrete transcript coverage.
+
+    Why this test exists:
+    - the regression in this task was caused by overly executive prompt wording
+      plus a too-tight default branch cap
+    - checking the shipped prompt files and agent defaults guards the intended
+      behavior without needing a live model
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    extract_prompt = load_agent_prompt_markdown(
+        package="fred_agents.mindmap",
+        file_name="extract_mindmap.md",
+    )
+    refine_prompt = load_agent_prompt_markdown(
+        package="fred_agents.mindmap",
+        file_name="refine_mindmap.md",
+    )
+
+    assert "Prefer an executive mindmap" not in extract_prompt
+    assert "coverage-oriented transcript mindmap" in extract_prompt
+    assert "Do not collapse distinct topics into generic labels" in extract_prompt
+    assert "coverage-oriented transcript mindmap" in refine_prompt
+
+    max_children_field = next(
+        field
+        for field in MINDMAP_AGENT.fields
+        if field.key == "settings.max_children_per_node"
+    )
+    assert max_children_field.default == 8
+
+
+def test_normalized_payload_preserves_initial_depth_two() -> None:
+    """
+    Verify payload normalization keeps an explicit initial depth of two.
+
+    Why this test exists:
+    - the frontend renderer now respects `presentation.initialDepth`
+    - the backend should therefore preserve an explicit depth when the model
+      asks for it
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    payload = MindMapPayload.model_validate(
+        {
+            "title": "Transcript mindmap",
+            "root": {
+                "id": "root",
+                "name": "Fred-native Audio-to-Mindmap Agent",
+                "children": [],
+            },
+            "presentation": {
+                "initialDepth": 2,
+                "layout": "orthogonal",
+                "focusMode": True,
+            },
+        }
+    )
+
+    normalized = normalize_mindmap_payload(
+        payload,
+        max_depth=4,
+        max_children=8,
+        include_evidence=True,
+        max_source_index=0,
+    )
+
+    presentation = cast(dict[str, object], normalized["presentation"])
+    assert presentation["initialDepth"] == 2
+
+
+def test_rendered_markdown_keeps_concrete_branches_in_mindmap_json() -> None:
+    """
+    Verify rendered markdown exposes concrete transcript branches in the payload.
+
+    Why this test exists:
+    - this task specifically targets generic, over-compressed branch labels
+    - checking the rendered fenced payload guards the final frontend contract
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+    """
+
+    payload = {
+        "version": "1.0",
+        "title": "Fred-native Audio-to-Mindmap Agent",
+        "summary": "Concrete transcript branches are preserved.",
+        "root": {
+            "id": "root",
+            "name": "Fred-native Audio-to-Mindmap Agent",
+            "children": [
+                {"id": "objective", "name": "Objective", "children": []},
+                {"id": "frontend-mvp", "name": "Frontend MVP", "children": []},
+                {
+                    "id": "backend-graph-agent",
+                    "name": "Backend Graph Agent",
+                    "children": [],
+                },
+                {
+                    "id": "knowledge-flow-integration",
+                    "name": "Knowledge Flow Integration",
+                    "children": [],
+                },
+                {"id": "ux-requirements", "name": "UX Requirements", "children": []},
+                {"id": "retrieval-risks", "name": "Retrieval Risks", "children": []},
+                {"id": "testing-strategy", "name": "Testing Strategy", "children": []},
+                {"id": "roadmap", "name": "Roadmap", "children": []},
+            ],
+        },
+        "presentation": {
+            "initialDepth": 2,
+            "layout": "orthogonal",
+            "focusMode": True,
+        },
+    }
+
+    markdown = render_mindmap_markdown(payload)
+
+    assert "```mindmap-json" in markdown
+    for branch in (
+        "Objective",
+        "Frontend MVP",
+        "Backend Graph Agent",
+        "Knowledge Flow Integration",
+        "UX Requirements",
+        "Retrieval Risks",
+        "Testing Strategy",
+        "Roadmap",
+    ):
+        assert branch in markdown

--- a/apps/fred-agents/tests/test_smoke.py
+++ b/apps/fred-agents/tests/test_smoke.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from fred_runtime.app import agent_app as agent_app_module
+from fred_sdk import load_agent_prompt_markdown
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
 
@@ -211,12 +212,14 @@ def test_fred_agents_pod_registers_and_streams_sentinel_offline(
         registered = list_response.json()
         assert "fred.github.sentinel" in registered
         assert "fred.github.rag_expert" in registered
+        assert "fred.dt.mindmap.graph" in registered
 
         templates_response = client.get("/fred/agents/v2/agents/templates")
         assert templates_response.status_code == 200
         template_ids = {
             template["template_agent_id"] for template in templates_response.json()
         }
+        assert "fred.dt.mindmap.graph" in template_ids
         assert "fred.github.sentinel" in template_ids
         assert "fred.github.rag_expert" in template_ids
         assert "fred.github.test_assistant" in template_ids
@@ -355,3 +358,30 @@ def test_fred_test_assistant_model_probe_uses_operation_aware_routing(
     assert "operation **`routing`**" in str(payloads[-1]["content"])
     assert "Routing probe model response." in str(payloads[-1]["content"])
     assert "routing" in factory.requested_operations
+
+
+def test_mindmap_prompt_files_load_from_packaged_module() -> None:
+    """
+    Verify packaged mindmap prompts resolve through the shipped module path.
+
+    Why this test exists:
+    - the graph steps load prompt markdown dynamically from the package name
+    - a stale package reference breaks the agent at runtime even when imports succeed
+
+    How to use it:
+    - run via `make test` from the `fred-agents` project
+
+    Example:
+    - `pytest tests/test_smoke.py -q`
+    """
+
+    for prompt_name in (
+        "extract_mindmap.md",
+        "refine_mindmap.md",
+        "render_response.md",
+    ):
+        prompt = load_agent_prompt_markdown(
+            package="fred_agents.mindmap",
+            file_name=prompt_name,
+        )
+        assert prompt.strip()

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.test.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.test.ts
@@ -25,9 +25,7 @@ const theme = {
   emphasisBorderWidth: 2,
 };
 
-function payload(
-  presentation: MindMapPayload["presentation"],
-): MindMapPayload {
+function payload(presentation: MindMapPayload["presentation"]): MindMapPayload {
   return {
     title: "Transcript",
     root: {
@@ -53,20 +51,14 @@ function payload(
 
 describe("buildMindMapChartOption", () => {
   it("uses payload presentation.initialDepth instead of a hardcoded level", () => {
-    const option = buildMindMapChartOption(
-      payload({ initialDepth: 2, layout: "orthogonal", focusMode: true }),
-      theme,
-    );
+    const option = buildMindMapChartOption(payload({ initialDepth: 2, layout: "orthogonal", focusMode: true }), theme);
 
     const series = option.series[0];
     expect(series.initialTreeDepth).toBe(2);
   });
 
   it("maps orthogonal layout to ECharts orthogonal + LR orientation", () => {
-    const option = buildMindMapChartOption(
-      payload({ initialDepth: 2, layout: "orthogonal", focusMode: true }),
-      theme,
-    );
+    const option = buildMindMapChartOption(payload({ initialDepth: 2, layout: "orthogonal", focusMode: true }), theme);
 
     const series = option.series[0];
     expect(series.layout).toBe("orthogonal");
@@ -74,10 +66,7 @@ describe("buildMindMapChartOption", () => {
   });
 
   it("maps radial layout to ECharts radial layout without RL orientation", () => {
-    const option = buildMindMapChartOption(
-      payload({ initialDepth: 2, layout: "radial", focusMode: true }),
-      theme,
-    );
+    const option = buildMindMapChartOption(payload({ initialDepth: 2, layout: "radial", focusMode: true }), theme);
 
     const series = option.series[0];
     expect(series.layout).toBe("radial");

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.test.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMindMapChartOption } from "./MindMapBlock";
+import type { MindMapPayload } from "./mindmapParser";
+
+const theme = {
+  tooltipBackground: "#111",
+  tooltipBorder: "#222",
+  tooltipText: "#fff",
+  lineColor: "#333",
+  nodeColor: "#444",
+  nodeBorder: "#555",
+  labelColor: "#666",
+  labelBackground: "#777",
+  emphasisNodeColor: "#888",
+  emphasisNodeBorder: "#999",
+  emphasisLabelColor: "#aaa",
+  emphasisLabelBackground: "#bbb",
+  nodeSize: 12,
+  labelFontSize: 14,
+  labelRadius: 8,
+  labelPaddingBlock: 4,
+  labelPaddingInline: 8,
+  nodeBorderWidth: 1,
+  emphasisBorderWidth: 2,
+};
+
+function payload(
+  presentation: MindMapPayload["presentation"],
+): MindMapPayload {
+  return {
+    title: "Transcript",
+    root: {
+      id: "root",
+      name: "Overview",
+      children: [
+        {
+          id: "child-1",
+          name: "Frontend MVP",
+          children: [
+            {
+              id: "child-1a",
+              name: "Markdown pipeline",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    presentation,
+  };
+}
+
+describe("buildMindMapChartOption", () => {
+  it("uses payload presentation.initialDepth instead of a hardcoded level", () => {
+    const option = buildMindMapChartOption(
+      payload({ initialDepth: 2, layout: "orthogonal", focusMode: true }),
+      theme,
+    );
+
+    const series = option.series[0];
+    expect(series.initialTreeDepth).toBe(2);
+  });
+
+  it("maps orthogonal layout to ECharts orthogonal + LR orientation", () => {
+    const option = buildMindMapChartOption(
+      payload({ initialDepth: 2, layout: "orthogonal", focusMode: true }),
+      theme,
+    );
+
+    const series = option.series[0];
+    expect(series.layout).toBe("orthogonal");
+    expect(series.orient).toBe("LR");
+  });
+
+  it("maps radial layout to ECharts radial layout without RL orientation", () => {
+    const option = buildMindMapChartOption(
+      payload({ initialDepth: 2, layout: "radial", focusMode: true }),
+      theme,
+    );
+
+    const series = option.series[0];
+    expect(series.layout).toBe("radial");
+    expect(series.orient).toBe("LR");
+    expect(series.orient).not.toBe("RL");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.tsx
@@ -16,7 +16,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import ReactECharts from "echarts-for-react";
 import { useIsDark } from "../../../../core/hooks/useIsDark";
 import styles from "./MindMapBlock.module.css";
-import { escapeHtml, findNodeById, findPathToNode, parseMindMapPayload, type MindMapNode } from "./mindmapParser";
+import {
+  escapeHtml,
+  findNodeById,
+  findPathToNode,
+  parseMindMapPayload,
+  type MindMapNode,
+  type MindMapPayload,
+} from "./mindmapParser";
 
 interface MindMapBlockProps {
   code: string;
@@ -43,6 +50,19 @@ type MindMapTheme = {
   labelPaddingInline: number;
   nodeBorderWidth: number;
   emphasisBorderWidth: number;
+};
+
+export type MindMapChartOption = {
+  backgroundColor: string;
+  tooltip: {
+    trigger: string;
+    triggerOn: string;
+    formatter: (params: { data?: { name?: string; summary?: string; detail?: string } }) => string;
+    backgroundColor: string;
+    borderColor: string;
+    textStyle: { color: string };
+  };
+  series: Array<Record<string, unknown>>;
 };
 
 function chartNode(node: MindMapNode): Record<string, unknown> {
@@ -123,6 +143,95 @@ function buildMindMapTheme(source: HTMLElement): MindMapTheme {
     labelPaddingInline,
     nodeBorderWidth,
     emphasisBorderWidth,
+  };
+}
+
+export function buildMindMapChartOption(
+  payload: MindMapPayload,
+  theme: MindMapTheme,
+): MindMapChartOption {
+  const initialDepth = Math.max(1, Math.min(payload.presentation?.initialDepth ?? 2, 6));
+  const isRadial = payload.presentation?.layout === "radial";
+
+  return {
+    backgroundColor: "transparent",
+    tooltip: {
+      trigger: "item",
+      triggerOn: "mousemove",
+      formatter: (params: { data?: { name?: string; summary?: string; detail?: string } }) => {
+        const name = escapeHtml(params.data?.name ?? "Topic");
+        const summary = escapeHtml(params.data?.summary ?? "");
+        const detail = escapeHtml(params.data?.detail ?? "");
+        const parts = [`<strong>${name}</strong>`];
+        if (summary) parts.push(`<div>${summary}</div>`);
+        if (detail) parts.push(`<div>${detail}</div>`);
+        return parts.join("");
+      },
+      backgroundColor: theme.tooltipBackground,
+      borderColor: theme.tooltipBorder,
+      textStyle: { color: theme.tooltipText },
+    },
+    series: [
+      {
+        type: "tree",
+        data: [chartNode(payload.root)],
+        top: "6%",
+        left: "10%",
+        bottom: "6%",
+        right: "18%",
+        symbol: "circle",
+        symbolSize: theme.nodeSize,
+        roam: true,
+        expandAndCollapse: true,
+        initialTreeDepth: initialDepth,
+        layout: isRadial ? "radial" : "orthogonal",
+        orient: "LR",
+        animationDuration: 350,
+        animationDurationUpdate: 450,
+        lineStyle: {
+          color: theme.lineColor,
+          width: theme.nodeBorderWidth,
+          curveness: 0.35,
+        },
+        itemStyle: {
+          color: theme.nodeColor,
+          borderColor: theme.nodeBorder,
+          borderWidth: theme.nodeBorderWidth,
+        },
+        label: {
+          position: "left",
+          verticalAlign: "middle",
+          align: "right",
+          color: theme.labelColor,
+          fontSize: theme.labelFontSize,
+          backgroundColor: theme.labelBackground,
+          borderRadius: theme.labelRadius,
+          padding: [theme.labelPaddingBlock, theme.labelPaddingInline],
+        },
+        leaves: {
+          label: {
+            position: "right",
+            verticalAlign: "middle",
+            align: "left",
+          },
+        },
+        emphasis: {
+          focus: "none",
+          itemStyle: {
+            color: theme.emphasisNodeColor,
+            borderColor: theme.emphasisNodeBorder,
+            borderWidth: theme.emphasisBorderWidth,
+          },
+          label: {
+            color: theme.emphasisLabelColor,
+            fontWeight: 700,
+            backgroundColor: theme.emphasisLabelBackground,
+            borderRadius: theme.labelRadius,
+            padding: [theme.labelPaddingBlock, theme.labelPaddingInline],
+          },
+        },
+      },
+    ],
   };
 }
 
@@ -212,90 +321,8 @@ export function MindMapBlock({ code, language = "mindmap-json" }: MindMapBlockPr
   const payload = parsed.payload;
   const selectedNode = findNodeById(payload.root, selectedNodeId) ?? payload.root;
   const breadcrumb = findPathToNode(payload.root, selectedNode.id) ?? [payload.root];
-  const initialDepth = 1;
 
-  const option = useMemo(
-    () => ({
-      backgroundColor: "transparent",
-      tooltip: {
-        trigger: "item",
-        triggerOn: "mousemove",
-        formatter: (params: { data?: { name?: string; summary?: string; detail?: string } }) => {
-          const name = escapeHtml(params.data?.name ?? "Topic");
-          const summary = escapeHtml(params.data?.summary ?? "");
-          const detail = escapeHtml(params.data?.detail ?? "");
-          const parts = [`<strong>${name}</strong>`];
-          if (summary) parts.push(`<div>${summary}</div>`);
-          if (detail) parts.push(`<div>${detail}</div>`);
-          return parts.join("");
-        },
-        backgroundColor: theme.tooltipBackground,
-        borderColor: theme.tooltipBorder,
-        textStyle: { color: theme.tooltipText },
-      },
-      series: [
-        {
-          type: "tree",
-          data: [chartNode(payload.root)],
-          top: "6%",
-          left: "25%",
-          bottom: "6%",
-          right: "25%",
-          symbol: "circle",
-          symbolSize: theme.nodeSize,
-          roam: true,
-          expandAndCollapse: true,
-          initialTreeDepth: initialDepth,
-          orient: payload.presentation?.layout === "radial" ? "RL" : "LR",
-          animationDuration: 350,
-          animationDurationUpdate: 450,
-          lineStyle: {
-            color: theme.lineColor,
-            width: theme.nodeBorderWidth,
-            curveness: 0.35,
-          },
-          itemStyle: {
-            color: theme.nodeColor,
-            borderColor: theme.nodeBorder,
-            borderWidth: theme.nodeBorderWidth,
-          },
-          label: {
-            position: "left",
-            verticalAlign: "middle",
-            align: "right",
-            color: theme.labelColor,
-            fontSize: theme.labelFontSize,
-            backgroundColor: theme.labelBackground,
-            borderRadius: theme.labelRadius,
-            padding: [theme.labelPaddingBlock, theme.labelPaddingInline],
-          },
-          leaves: {
-            label: {
-              position: "right",
-              verticalAlign: "middle",
-              align: "left",
-            },
-          },
-          emphasis: {
-            focus: "none",
-            itemStyle: {
-              color: theme.emphasisNodeColor,
-              borderColor: theme.emphasisNodeBorder,
-              borderWidth: theme.emphasisBorderWidth,
-            },
-            label: {
-              color: theme.emphasisLabelColor,
-              fontWeight: 700,
-              backgroundColor: theme.emphasisLabelBackground,
-              borderRadius: theme.labelRadius,
-              padding: [theme.labelPaddingBlock, theme.labelPaddingInline],
-            },
-          },
-        },
-      ],
-    }),
-    [initialDepth, payload.presentation?.layout, payload.root, theme],
-  );
+  const option = useMemo(() => buildMindMapChartOption(payload, theme), [payload, theme]);
 
   return (
     <div ref={rootRef} className={`${styles.block} ${expanded ? styles.expanded : ""}`}>

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.tsx
@@ -146,10 +146,7 @@ function buildMindMapTheme(source: HTMLElement): MindMapTheme {
   };
 }
 
-export function buildMindMapChartOption(
-  payload: MindMapPayload,
-  theme: MindMapTheme,
-): MindMapChartOption {
+export function buildMindMapChartOption(payload: MindMapPayload, theme: MindMapTheme): MindMapChartOption {
   const initialDepth = Math.max(1, Math.min(payload.presentation?.initialDepth ?? 2, 6));
   const isRadial = payload.presentation?.layout === "radial";
 

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/README.md
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/README.md
@@ -30,6 +30,7 @@ const code = JSON.stringify({
     ],
   },
   presentation: {
+    initialDepth: 2,
     layout: "orthogonal",
   },
 });
@@ -69,6 +70,9 @@ Notes:
 - If `root.id` is missing, the parser generates a fallback id.
 - Child nodes without a valid `name` are ignored.
 - Payloads over 200 nodes are rejected for safe rendering.
+- `presentation.initialDepth` is respected and clamped to the safe range `1..6`.
+- `"orthogonal"` keeps the root on the left with `LR` flow.
+- `"radial"` uses ECharts radial tree layout rather than forcing a right-to-left tree.
 
 ## Minimal valid payload
 

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/mindmapParser.test.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/mindmapParser.test.ts
@@ -56,4 +56,26 @@ describe("parseMindMapPayload", () => {
     const path = findPathToNode(parsed.payload.root, "topic-1a");
     expect(path?.map((node) => node.id)).toEqual(["root", "topic-1", "topic-1a"]);
   });
+
+  it("preserves presentation.initialDepth and layout when provided", () => {
+    const parsed = parseMindMapPayload(`{
+      "title": "Transcript",
+      "root": {
+        "id": "root",
+        "name": "Overview",
+        "children": []
+      },
+      "presentation": {
+        "initialDepth": 2,
+        "layout": "radial",
+        "focusMode": true
+      }
+    }`);
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.payload.presentation?.initialDepth).toBe(2);
+    expect(parsed.payload.presentation?.layout).toBe("radial");
+    expect(parsed.payload.presentation?.focusMode).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

This PR improves the Mindmap agent and frontend renderer so selected transcript documents produce a richer, more natural, coverage-oriented mindmap.

### Frontend
- Respect `presentation.initialDepth` instead of hardcoding first-level expansion
- Map `layout: "orthogonal"` to ECharts `layout: "orthogonal"` with `orient: "LR"`
- Map `layout: "radial"` to ECharts `layout: "radial"` without forcing `orient: "RL"`
- Adjust tree margins to improve first-screen readability
- Add frontend regression tests for `initialDepth` and layout mapping

### Mindmap agent
- Replace executive-style prompt guidance with coverage-oriented transcript instructions
- Preserve concrete transcript sections instead of collapsing into generic labels
- Strengthen digest guidance to keep implementation details, decisions, risks, actions, tests, acceptance criteria, and roadmap items distinct when present
- Increase default `settings.max_children_per_node` from `6` to `8`
- Keep fallback/default presentation aligned with `initialDepth: 2` and `layout: "orthogonal"`
- Add regression tests for prompt wording, defaults, normalized payload depth, and concrete branch rendering

### Docs
- Update the Mindmap agent README
- Update the `MindMapBlock` README

## Validation

### Frontend
- `npm run typecheck`
- `npm run test -- MindMapBlock mindmapParser`
- `npm run build`

### Agents
- `.venv/bin/uv run pytest tests/test_mindmap_graph.py -q`
- `make code-quality`
- `make test`
- `.venv/bin/uv run basedpyright`

## Results
- Frontend typecheck: passed
- Frontend targeted tests: passed
- Frontend build: passed
- Focused mindmap agent tests: passed
- `make code-quality`: passed
- `make test`: passed
- Raw `basedpyright`: passed

## Linked work
- `FILES-02`