### PR TITLE
fix(CHAT-03): harden MCP chat options form against undeclared config …

### DIFF
--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTemplateSummary } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import { buildAgentFormSubmitPayload } from "./AgentFormModal";
+import { CHAT_OPTION_FIELD_KEYS } from "./chatOptionsConfig";
+
+function makeTemplate(configKeys: string[]): AgentTemplateSummary {
+  return {
+    template_id: "runtime:agent",
+    display_name: "Agent",
+    mcp_servers: [
+      {
+        id: "mcp-knowledge-flow-mcp-text",
+        require_tools: [],
+        config_fields: configKeys.map((key) => ({
+          key,
+          title: key,
+          type: "boolean",
+          required: false,
+        })),
+      },
+    ],
+  } as AgentTemplateSummary;
+}
+
+describe("buildAgentFormSubmitPayload", () => {
+  it("prunes stale undeclared MCP keys before create submit", () => {
+    const payload = buildAgentFormSubmitPayload(
+      {
+        templateId: "runtime:agent",
+        displayName: "  DT Aegis  ",
+        description: "  Guardrails  ",
+        tuningValues: {},
+        selectedMcpServerIds: ["mcp-knowledge-flow-mcp-text"],
+        mcpConfigValues: {
+          "mcp-knowledge-flow-mcp-text": {
+            [CHAT_OPTION_FIELD_KEYS.librariesBinding]: true,
+            [CHAT_OPTION_FIELD_KEYS.librariesSelection]: false,
+          },
+        },
+      },
+      makeTemplate([CHAT_OPTION_FIELD_KEYS.librariesSelection]),
+    );
+
+    expect(payload).toMatchObject({
+      displayName: "DT Aegis",
+      description: "Guardrails",
+      selectedMcpServerIds: ["mcp-knowledge-flow-mcp-text"],
+      mcpConfigValues: {
+        "mcp-knowledge-flow-mcp-text": {
+          [CHAT_OPTION_FIELD_KEYS.librariesSelection]: false,
+        },
+      },
+    });
+    expect(payload.mcpConfigValues["mcp-knowledge-flow-mcp-text"]).not.toHaveProperty(
+      CHAT_OPTION_FIELD_KEYS.librariesBinding,
+    );
+  });
+
+  it("prunes stale undeclared MCP keys before edit submit", () => {
+    const payload = buildAgentFormSubmitPayload(
+      {
+        templateId: "runtime:agent",
+        displayName: "Existing Agent",
+        description: "",
+        tuningValues: {},
+        selectedMcpServerIds: ["mcp-knowledge-flow-mcp-text"],
+        mcpConfigValues: {
+          "mcp-knowledge-flow-mcp-text": {
+            [CHAT_OPTION_FIELD_KEYS.librariesBinding]: true,
+            [CHAT_OPTION_FIELD_KEYS.boundLibraryIds]: ["lib-1"],
+            [CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled]: true,
+          },
+        },
+      },
+      makeTemplate([CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled]),
+    );
+
+    expect(payload.mcpConfigValues).toEqual({
+      "mcp-knowledge-flow-mcp-text": {
+        [CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled]: true,
+      },
+    });
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
@@ -24,6 +24,7 @@ import type {
   ManagedAgentFieldSpec,
   ManagedAgentInstanceSummary,
 } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
+import { sanitizeMcpConfigValuesForTemplate } from "./chatOptionsConfig.ts";
 import { AgentFormBody, type SectionKey } from "./AgentFormBody.tsx";
 import styles from "./AgentFormModal.module.css";
 import { TemplateBrowser } from "./TemplateBrowser/TemplateBrowser.tsx";
@@ -65,6 +66,28 @@ function sectionOfField(field: ManagedAgentFieldSpec): SectionKey {
   if (g === "prompts") return "prompts";
   if (g === "chat") return "chat";
   return "settings";
+}
+
+/**
+ * Builds the submit payload using the selected template contract so stale MCP
+ * keys from previous UI versions cannot leak into create or edit requests.
+ */
+export function buildAgentFormSubmitPayload(
+  form: FormState,
+  selectedTemplate: AgentTemplateSummary | undefined,
+): AgentFormPayload {
+  const lockedIds = (selectedTemplate?.mcp_servers ?? []).filter((server) => server.locked).map((server) => server.id);
+  const effectiveSelection =
+    form.selectedMcpServerIds === null ? null : [...new Set([...form.selectedMcpServerIds, ...lockedIds])];
+
+  return {
+    templateId: form.templateId,
+    displayName: form.displayName.trim(),
+    description: form.description.trim(),
+    tuningFieldValues: form.tuningValues,
+    selectedMcpServerIds: effectiveSelection,
+    mcpConfigValues: sanitizeMcpConfigValuesForTemplate(form.mcpConfigValues, selectedTemplate?.mcp_servers ?? []),
+  };
 }
 
 export default function AgentFormModal({
@@ -180,19 +203,7 @@ export default function AgentFormModal({
       if (firstErrorSection) setActiveSection(firstErrorSection);
       return;
     }
-    // Locked servers are always active regardless of user toggle state.
-    const lockedIds = (selectedTemplate?.mcp_servers ?? []).filter((s) => s.locked).map((s) => s.id);
-    const effectiveSelection =
-      form.selectedMcpServerIds === null ? null : [...new Set([...form.selectedMcpServerIds, ...lockedIds])];
-
-    await onSubmit({
-      templateId: form.templateId,
-      displayName: form.displayName.trim(),
-      description: form.description.trim(),
-      tuningFieldValues: form.tuningValues,
-      selectedMcpServerIds: effectiveSelection,
-      mcpConfigValues: form.mcpConfigValues,
-    });
+    await onSubmit(buildAgentFormSubmitPayload(form, selectedTemplate));
   };
 
   const title =

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/McpServerCard/McpServerCard.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/McpServerCard/McpServerCard.test.tsx
@@ -1,0 +1,92 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { ManagedMcpServerRef } from "../../../../../../slices/controlPlane/controlPlaneOpenApi";
+import { CHAT_OPTION_FIELD_KEYS } from "../chatOptionsConfig";
+import { McpServerCard } from "./McpServerCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (value: string) => value,
+  }),
+}));
+
+vi.mock("@shared/atoms/Switch/Switch.tsx", () => ({
+  default: ({ checked, disabled }: { checked: boolean; disabled: boolean }) => (
+    <div data-switch={checked ? "on" : "off"} data-disabled={disabled ? "true" : "false"} />
+  ),
+}));
+
+vi.mock("@shared/atoms/ButtonGroup/ButtonGroup.tsx", () => ({
+  default: () => <div>button-group</div>,
+}));
+
+vi.mock("@components/pages/TeamAgentsPage/AgentCreateEditModal/SwitchRow/SwitchRow.tsx", () => ({
+  SwitchRow: ({ label, description }: { label: string; description?: string }) => (
+    <div>
+      <span>{label}</span>
+      {description ? <span>{description}</span> : null}
+    </div>
+  ),
+}));
+
+vi.mock(
+  "@components/pages/TeamAgentsPage/AgentCreateEditModal/DocumentLibraryScopePicker/DocumentLibraryScopePicker",
+  () => ({
+    DocumentLibraryScopePicker: () => <div>document-library-scope-picker</div>,
+  }),
+);
+
+function makeServer(keys: string[]): ManagedMcpServerRef {
+  return {
+    id: "mcp-knowledge-flow-mcp-text",
+    display_name: "Knowledge Flow",
+    require_tools: [],
+    config_fields: keys.map((key) => ({
+      key,
+      title: key,
+      description: `${key}.description`,
+      type: "boolean",
+      required: false,
+    })),
+  } as ManagedMcpServerRef;
+}
+
+function renderCard(server: ManagedMcpServerRef, configValues: Record<string, unknown> = {}): string {
+  return renderToStaticMarkup(
+    <McpServerCard
+      server={server}
+      checked={true}
+      disabled={false}
+      configValues={configValues}
+      tuningValues={{}}
+      onToggle={() => undefined}
+      onConfigChange={() => undefined}
+      onTuningChange={() => undefined}
+    />,
+  );
+}
+
+describe("McpServerCard", () => {
+  it("does not render the binding switch when only libraries_selection is declared", () => {
+    const html = renderCard(makeServer([CHAT_OPTION_FIELD_KEYS.librariesSelection]));
+
+    expect(html).not.toContain("agentTuning.fields.library_binding.title");
+  });
+
+  it("renders the binding switch when libraries_binding is declared", () => {
+    const html = renderCard(makeServer([CHAT_OPTION_FIELD_KEYS.librariesBinding]));
+
+    expect(html).toContain("agentTuning.fields.library_binding.title");
+  });
+
+  it("does not render the bound library picker when bound_library_ids is undeclared", () => {
+    const html = renderCard(
+      makeServer([CHAT_OPTION_FIELD_KEYS.librariesBinding]),
+      {
+        [CHAT_OPTION_FIELD_KEYS.librariesBinding]: true,
+      },
+    );
+
+    expect(html).not.toContain("document-library-scope-picker");
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/McpServerCard/McpServerCard.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/McpServerCard/McpServerCard.test.tsx
@@ -80,12 +80,9 @@ describe("McpServerCard", () => {
   });
 
   it("does not render the bound library picker when bound_library_ids is undeclared", () => {
-    const html = renderCard(
-      makeServer([CHAT_OPTION_FIELD_KEYS.librariesBinding]),
-      {
-        [CHAT_OPTION_FIELD_KEYS.librariesBinding]: true,
-      },
-    );
+    const html = renderCard(makeServer([CHAT_OPTION_FIELD_KEYS.librariesBinding]), {
+      [CHAT_OPTION_FIELD_KEYS.librariesBinding]: true,
+    });
 
     expect(html).not.toContain("document-library-scope-picker");
   });

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/McpServerCard/McpServerCard.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/McpServerCard/McpServerCard.tsx
@@ -21,7 +21,7 @@ import type {
   ManagedAgentFieldSpec,
   ManagedMcpServerRef,
 } from "../../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
-import { CHAT_OPTION_FIELD_KEYS, serverCarriesChatOptions } from "../chatOptionsConfig";
+import { CHAT_OPTION_FIELD_KEYS, hasConfigField, serverCarriesChatOptions } from "../chatOptionsConfig";
 import styles from "./McpServerCard.module.css";
 
 interface McpServerCardProps {
@@ -61,9 +61,14 @@ export function McpServerCard({
   const configFields = server.config_fields ?? [];
   const hasOptions = checked && configFields.length > 0;
   const showAttachFilesOption = checked && serverCarriesChatOptions(configFields);
+  const hasLibrariesBindingField = hasConfigField(configFields, CHAT_OPTION_FIELD_KEYS.librariesBinding);
+  const hasLibrariesSelectionField = hasConfigField(configFields, CHAT_OPTION_FIELD_KEYS.librariesSelection);
+  const hasBoundLibraryIdsField = hasConfigField(configFields, CHAT_OPTION_FIELD_KEYS.boundLibraryIds);
   const isLocked = server.locked === true;
   const displayLabel = server.display_name ? t(server.display_name) : server.id;
   const librariesBindingEnabled = Boolean(configValues[CHAT_OPTION_FIELD_KEYS.librariesBinding]);
+  const showLibrariesBindingOption = checked && hasLibrariesBindingField;
+  const showBoundLibraryPicker = showLibrariesBindingOption && librariesBindingEnabled && hasBoundLibraryIdsField;
   const selectedBoundLibraryIds = Array.isArray(configValues[CHAT_OPTION_FIELD_KEYS.boundLibraryIds])
     ? (configValues[CHAT_OPTION_FIELD_KEYS.boundLibraryIds] as string[])
     : [];
@@ -108,34 +113,39 @@ export function McpServerCard({
               onChange={(value) => onTuningChange(CHAT_OPTION_FIELD_KEYS.attachFiles, value)}
             />
           )}
-          <div className={styles.booleanField}>
-            <SwitchRow
-              label={t("agentTuning.fields.library_binding.title")}
-              description={t("agentTuning.fields.library_binding.description")}
-              checked={librariesBindingEnabled}
-              onChange={(value) => {
-                onConfigChange(CHAT_OPTION_FIELD_KEYS.librariesBinding, value);
-                if (value) {
-                  onConfigChange(CHAT_OPTION_FIELD_KEYS.librariesSelection, false);
-                } else {
-                  onConfigChange(CHAT_OPTION_FIELD_KEYS.boundLibraryIds, []);
-                }
-              }}
-            />
-            {librariesBindingEnabled && (
-              <div className={styles.libraryPickerBlock}>
-                <DocumentLibraryScopePicker
-                  teamId={teamId}
-                  selectedTagIds={selectedBoundLibraryIds}
-                  onChange={(tagIds) => onConfigChange(CHAT_OPTION_FIELD_KEYS.boundLibraryIds, tagIds)}
-                />
-              </div>
-            )}
-          </div>
+          {showLibrariesBindingOption && (
+            <div className={styles.booleanField}>
+              <SwitchRow
+                label={t("agentTuning.fields.library_binding.title")}
+                description={t("agentTuning.fields.library_binding.description")}
+                checked={librariesBindingEnabled}
+                onChange={(value) => {
+                  onConfigChange(CHAT_OPTION_FIELD_KEYS.librariesBinding, value);
+                  if (value && hasLibrariesSelectionField) {
+                    onConfigChange(CHAT_OPTION_FIELD_KEYS.librariesSelection, false);
+                  } else if (!value && hasBoundLibraryIdsField) {
+                    onConfigChange(CHAT_OPTION_FIELD_KEYS.boundLibraryIds, []);
+                  }
+                }}
+              />
+              {showBoundLibraryPicker && (
+                <div className={styles.libraryPickerBlock}>
+                  <DocumentLibraryScopePicker
+                    teamId={teamId}
+                    selectedTagIds={selectedBoundLibraryIds}
+                    onChange={(tagIds) => onConfigChange(CHAT_OPTION_FIELD_KEYS.boundLibraryIds, tagIds)}
+                  />
+                </div>
+              )}
+            </div>
+          )}
           {configFields.map((field) => {
             const value = resolveValue(field, configValues);
 
-            if (field.key === CHAT_OPTION_FIELD_KEYS.librariesBinding) {
+            if (
+              field.key === CHAT_OPTION_FIELD_KEYS.librariesBinding ||
+              field.key === CHAT_OPTION_FIELD_KEYS.boundLibraryIds
+            ) {
               return null;
             }
 
@@ -197,8 +207,10 @@ export function McpServerCard({
                     checked={Boolean(value)}
                     onChange={(v) => {
                       onConfigChange(field.key, v);
-                      if (field.key === CHAT_OPTION_FIELD_KEYS.librariesSelection && v) {
+                      if (field.key === CHAT_OPTION_FIELD_KEYS.librariesSelection && v && hasLibrariesBindingField) {
                         onConfigChange(CHAT_OPTION_FIELD_KEYS.librariesBinding, false);
+                      }
+                      if (field.key === CHAT_OPTION_FIELD_KEYS.librariesSelection && v && hasBoundLibraryIdsField) {
                         onConfigChange(CHAT_OPTION_FIELD_KEYS.boundLibraryIds, []);
                       }
                     }}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ManagedMcpServerRef } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 import { CHAT_OPTION_FIELD_KEYS, sanitizeMcpConfigValuesForTemplate } from "./chatOptionsConfig";
 
-function makeServer(
-  id: string,
-  keys: string[],
-): ManagedMcpServerRef {
+function makeServer(id: string, keys: string[]): ManagedMcpServerRef {
   return {
     id,
     require_tools: [],

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { ManagedMcpServerRef } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import { CHAT_OPTION_FIELD_KEYS, sanitizeMcpConfigValuesForTemplate } from "./chatOptionsConfig";
+
+function makeServer(
+  id: string,
+  keys: string[],
+): ManagedMcpServerRef {
+  return {
+    id,
+    require_tools: [],
+    config_fields: keys.map((key) => ({
+      key,
+      title: key,
+      type: "boolean",
+      required: false,
+    })),
+  } as ManagedMcpServerRef;
+}
+
+describe("sanitizeMcpConfigValuesForTemplate", () => {
+  it("removes undeclared keys and empty server entries", () => {
+    expect(
+      sanitizeMcpConfigValuesForTemplate(
+        {
+          "mcp-knowledge-flow-mcp-text": {
+            [CHAT_OPTION_FIELD_KEYS.librariesBinding]: true,
+            [CHAT_OPTION_FIELD_KEYS.librariesSelection]: false,
+          },
+          "stale-server": {
+            [CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled]: true,
+          },
+        },
+        [makeServer("mcp-knowledge-flow-mcp-text", [CHAT_OPTION_FIELD_KEYS.librariesSelection])],
+      ),
+    ).toEqual({
+      "mcp-knowledge-flow-mcp-text": {
+        [CHAT_OPTION_FIELD_KEYS.librariesSelection]: false,
+      },
+    });
+  });
+
+  it("preserves declared keys for each server", () => {
+    expect(
+      sanitizeMcpConfigValuesForTemplate(
+        {
+          "mcp-knowledge-flow-mcp-text": {
+            [CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled]: true,
+            [CHAT_OPTION_FIELD_KEYS.searchPolicy]: "hybrid",
+          },
+        },
+        [
+          makeServer("mcp-knowledge-flow-mcp-text", [
+            CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled,
+            CHAT_OPTION_FIELD_KEYS.searchPolicy,
+          ]),
+        ],
+      ),
+    ).toEqual({
+      "mcp-knowledge-flow-mcp-text": {
+        [CHAT_OPTION_FIELD_KEYS.searchPolicyEnabled]: true,
+        [CHAT_OPTION_FIELD_KEYS.searchPolicy]: "hybrid",
+      },
+    });
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import type { ManagedAgentFieldSpec } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import type { ManagedMcpServerRef } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 
 export const CHAT_OPTION_FIELD_KEYS = {
   attachFiles: "chat_options.attach_files",
@@ -39,6 +40,16 @@ export function isChatOptionField(field: ManagedAgentFieldSpec): boolean {
   return isChatOptionConfigKey(field.key);
 }
 
+/**
+ * Returns whether a managed MCP server explicitly declares a given config key.
+ *
+ * Use this before rendering or writing optional chat-option config so the
+ * frontend never invents undeclared MCP payload fields.
+ */
+export function hasConfigField(fields: ManagedAgentFieldSpec[], key: string): boolean {
+  return fields.some((field) => field.key === key);
+}
+
 export function serverCarriesChatOptions(fields: ManagedAgentFieldSpec[]): boolean {
   const serverScopedKeys = new Set<string>([
     CHAT_OPTION_FIELD_KEYS.attachFiles,
@@ -51,4 +62,31 @@ export function serverCarriesChatOptions(fields: ManagedAgentFieldSpec[]): boole
     CHAT_OPTION_FIELD_KEYS.searchRagScope,
   ]);
   return fields.some((field) => serverScopedKeys.has(field.key));
+}
+
+/**
+ * Drops MCP config keys that are not declared by the current template's
+ * server contract, preserving only user-provided values for known fields.
+ */
+export function sanitizeMcpConfigValuesForTemplate(
+  values: Record<string, Record<string, unknown>>,
+  servers: ManagedMcpServerRef[],
+): Record<string, Record<string, unknown>> {
+  const allowedKeysByServer = new Map(
+    servers.map((server) => [server.id, new Set((server.config_fields ?? []).map((field) => field.key))]),
+  );
+
+  return Object.fromEntries(
+    Object.entries(values)
+      .flatMap(([serverId, serverValues]) => {
+        const allowedKeys = allowedKeysByServer.get(serverId);
+        if (!allowedKeys) return [];
+
+        const sanitizedValues = Object.fromEntries(
+          Object.entries(serverValues).filter(([key]) => allowedKeys.has(key)),
+        );
+
+        return Object.keys(sanitizedValues).length > 0 ? [[serverId, sanitizedValues] as const] : [];
+      }),
+  );
 }

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/chatOptionsConfig.ts
@@ -77,16 +77,13 @@ export function sanitizeMcpConfigValuesForTemplate(
   );
 
   return Object.fromEntries(
-    Object.entries(values)
-      .flatMap(([serverId, serverValues]) => {
-        const allowedKeys = allowedKeysByServer.get(serverId);
-        if (!allowedKeys) return [];
+    Object.entries(values).flatMap(([serverId, serverValues]) => {
+      const allowedKeys = allowedKeysByServer.get(serverId);
+      if (!allowedKeys) return [];
 
-        const sanitizedValues = Object.fromEntries(
-          Object.entries(serverValues).filter(([key]) => allowedKeys.has(key)),
-        );
+      const sanitizedValues = Object.fromEntries(Object.entries(serverValues).filter(([key]) => allowedKeys.has(key)));
 
-        return Object.keys(sanitizedValues).length > 0 ? [[serverId, sanitizedValues] as const] : [];
-      }),
+      return Object.keys(sanitizedValues).length > 0 ? [[serverId, sanitizedValues] as const] : [];
+    }),
   );
 }


### PR DESCRIPTION
## Summary

Harden the managed agent create/edit form so the frontend only renders and submits MCP config keys declared by the selected server contract.

This fixes the case where the UI could submit stale keys like `chat_options.libraries_binding` for MCP servers that do not declare that field in `config_fields`, causing control-plane enrollment/update validation failures.

## What changed

- Added MCP config helpers in `chatOptionsConfig.ts`
- Added sanitization for `mcpConfigValues` against `selectedTemplate.mcp_servers[].config_fields`
- Tightened `McpServerCard` rendering so:
  - `chat_options.libraries_binding` only renders if declared
  - `chat_options.bound_library_ids` picker only renders if both required fields are declared
  - dependent `onConfigChange(...)` calls only happen when the target field is declared
- Sanitized MCP config payloads in `AgentFormModal` before submit for both create and edit
- Added focused frontend tests for:
  - binding switch render gating
  - bound library picker render gating
  - stale MCP config key pruning
  - preservation of declared keys
  - submit-path pruning before create/edit payloads

## Root cause

The frontend treated “server carries chat options” as broad permission to render and write `libraries_binding`-related state, instead of checking whether the individual MCP config fields were explicitly declared by the selected server contract.

## Validation

Ran in `apps/frontend`:

- `npm ci`
- `npm run typecheck`
- `npm run test`
- `npm run build`

Results:

- `typecheck` passed
- `test` passed (`196` tests)
- `build` passed

## Scope

Frontend-only hardening.

No backend validation behavior changed.

## Risk / Notes

- Existing support for declared chat option fields remains intact:
  - `chat_options.libraries_selection`
  - `chat_options.documents_selection`
  - `chat_options.search_policy_enabled`
  - `chat_options.search_policy`
  - `chat_options.search_rag_scope_enabled`
  - `chat_options.search_rag_scope`
- Locked MCP servers remain supported
- Live end-to-end enrollment against a running stack was not part of this change

## Task close-out
- Code: hardened MCP chat option rendering and submit payload sanitization so undeclared MCP config keys are never sent
- Tests: pass — `npm run typecheck`, `npm run test`, `npm run build`
- Docs updated: none — mechanical frontend fix
- Backlog: none — existing `CHAT-03` / `CTRLP-03` coverage
- Skipped steps: RFC skipped because this is a mechanical hardening fix within the existing MCP config contract