### PR TITLE
fix: run chart-schema scripts with uv so PEP 723 deps resolve

### DIFF
--- a/scripts/makefiles/chart-schema.mk
+++ b/scripts/makefiles/chart-schema.mk
@@ -15,10 +15,12 @@ _CP_SCHEMA  := $(_CHART_REPO_ROOT)/apps/control-plane-backend/config/schema/conf
 _ALL_BACKEND_SCHEMAS_PRESENT = \
 	$(if $(and $(wildcard $(_FA_SCHEMA)),$(wildcard $(_KF_SCHEMA)),$(wildcard $(_CP_SCHEMA))),yes,)
 
+include $(_CHART_SCHEMA_MK_DIR)/scripts-uv.mk
+
 .PHONY: generate-chart-schema
-generate-chart-schema: ## Regenerate deploy/charts/fred/values.schema.json from all backend config schemas
+generate-chart-schema: $(SCRIPTS_UV_READY) ## Regenerate deploy/charts/fred/values.schema.json from all backend config schemas
 	$(if $(_ALL_BACKEND_SCHEMAS_PRESENT), \
-		python3 $(_GEN_CHART_SCHEMA_SCRIPT) \
+		$(SCRIPTS_UV) run $(_GEN_CHART_SCHEMA_SCRIPT) \
 			--fred-agents    "$(_FA_SCHEMA)" \
 			--knowledge-flow "$(_KF_SCHEMA)" \
 			--control-plane  "$(_CP_SCHEMA)" \
@@ -28,10 +30,10 @@ generate-chart-schema: ## Regenerate deploy/charts/fred/values.schema.json from 
 _CHART_DRIFT_TMP := /tmp/schema-drift-check/chart-values
 
 .PHONY: check-chart-schema-drift
-check-chart-schema-drift: ## Fail if values.schema.json differs from freshly generated one
+check-chart-schema-drift: $(SCRIPTS_UV_READY) ## Fail if values.schema.json differs from freshly generated one
 	$(if $(_ALL_BACKEND_SCHEMAS_PRESENT), \
 		mkdir -p $(_CHART_DRIFT_TMP) && \
-		python3 $(_GEN_CHART_SCHEMA_SCRIPT) \
+		$(SCRIPTS_UV) run $(_GEN_CHART_SCHEMA_SCRIPT) \
 			--fred-agents    "$(_FA_SCHEMA)" \
 			--knowledge-flow "$(_KF_SCHEMA)" \
 			--control-plane  "$(_CP_SCHEMA)" \
@@ -42,7 +44,7 @@ check-chart-schema-drift: ## Fail if values.schema.json differs from freshly gen
 		echo "Skipping chart schema drift check: not all backend schemas are present.")
 
 .PHONY: check-chart-values
-check-chart-values: ## Validate deploy/charts/fred/values.yaml against the generated Helm values schema
+check-chart-values: $(SCRIPTS_UV_READY) ## Validate deploy/charts/fred/values.yaml against the generated Helm values schema
 	$(if $(_ALL_BACKEND_SCHEMAS_PRESENT), \
-		python3 $(_CHECK_CHART_VALUES_SCRIPT) "$(_CHART_SCHEMA_FILE)" "$(_CHART_VALUES_FILE)", \
+		$(SCRIPTS_UV) run $(_CHECK_CHART_VALUES_SCRIPT) "$(_CHART_SCHEMA_FILE)" "$(_CHART_VALUES_FILE)", \
 		echo "Skipping chart values check: not all backend schemas are present.")

--- a/scripts/makefiles/python-deps.mk
+++ b/scripts/makefiles/python-deps.mk
@@ -3,16 +3,9 @@
 # - TARGET
 # - UV
 
+include $(dir $(lastword $(MAKEFILE_LIST)))python-venv-bootstrap.mk
+
 ##@ Dependency Management
-
-$(TARGET)/.venv-created:
-	@echo "🔧 Creating virtualenv..."
-	mkdir -p $(TARGET)
-	flock $(TARGET)/.venv.lock sh -c 'test -f $@ || (python3 -m venv $(VENV) && touch $@)'
-
-$(TARGET)/.uv-installed: $(TARGET)/.venv-created
-	@echo "📦 Installing uv..."
-	flock $(TARGET)/.uv.lock sh -c 'test -f $@ || ($(PIP) install --upgrade pip setuptools wheel && $(PIP) install uv && touch $@)'
 
 $(TARGET)/.compiled: pyproject.toml $(TARGET)/.uv-installed
 	flock $(TARGET)/.compiled.lock sh -c '$(UV) sync --extra dev && touch $@'

--- a/scripts/makefiles/python-venv-bootstrap.mk
+++ b/scripts/makefiles/python-venv-bootstrap.mk
@@ -1,0 +1,15 @@
+# Needs:
+# - PIP
+# - TARGET
+# - VENV
+
+##@ Virtualenv Bootstrap
+
+$(TARGET)/.venv-created:
+	@echo "🔧 Creating virtualenv..."
+	mkdir -p $(TARGET)
+	flock $(TARGET)/.venv.lock sh -c 'test -f $@ || (python3 -m venv $(VENV) && touch $@)'
+
+$(TARGET)/.uv-installed: $(TARGET)/.venv-created
+	@echo "📦 Installing uv..."
+	flock $(TARGET)/.uv.lock sh -c 'test -f $@ || ($(PIP) install --upgrade pip setuptools wheel && $(PIP) install uv && touch $@)'

--- a/scripts/makefiles/scripts-uv.mk
+++ b/scripts/makefiles/scripts-uv.mk
@@ -1,0 +1,25 @@
+# Shared uv bootstrap for standalone scripts under scripts/*.py.
+#
+# These scripts declare their dependencies via PEP 723 inline metadata (the
+# `# /// script` block), which only `uv run` parses — plain `python3` ignores
+# it. We can't assume contributors have a global uv (in this repo it's
+# normally pip-installed into each app's own .venv), so this bootstraps one
+# shared venv for all repo-root scripts and exposes it as $(SCRIPTS_UV).
+#
+# Usage: include this file, then invoke scripts as:
+#   my-target: $(SCRIPTS_UV_READY)
+#   	$(SCRIPTS_UV) run $(SOME_SCRIPT_MK_DIR)/../some_script.py ...
+
+_SCRIPTS_UV_MK_DIR  := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+_SCRIPTS_REPO_ROOT  := $(abspath $(_SCRIPTS_UV_MK_DIR)/../..)
+
+SCRIPTS_TARGET   := $(_SCRIPTS_REPO_ROOT)/target/scripts-venv
+SCRIPTS_VENV     := $(SCRIPTS_TARGET)/venv
+SCRIPTS_PIP      := $(SCRIPTS_VENV)/bin/pip
+SCRIPTS_UV       := $(SCRIPTS_VENV)/bin/uv
+SCRIPTS_UV_READY := $(SCRIPTS_TARGET)/.uv-installed
+
+TARGET := $(SCRIPTS_TARGET)
+VENV   := $(SCRIPTS_VENV)
+PIP    := $(SCRIPTS_PIP)
+include $(_SCRIPTS_UV_MK_DIR)/python-venv-bootstrap.mk


### PR DESCRIPTION
# Pull Request

## 1. What problem does this solve — and where is it tracked?

**ID:** no ID — mechanical fix because it only corrects how an existing script is invoked, no new behaviour, API, or contract

**Problem in one sentence:** `make check-chart-values` (and `generate-chart-schema` / `check-chart-schema-drift`) ran `check_chart_values.py` / `generate_chart_schema.py` with plain `python3`, which silently ignores the scripts' PEP 723 inline dependency metadata (`jsonschema`, `pyyaml`), so the check fails with `ModuleNotFoundError` unless those packages happen to already be on the ambient interpreter.

**Backlog ref:** none — infra/tooling fix, not a tracked feature.

---

## 2. Before you wrote a single line of code

**RFC written?**

Not required — mechanical fix. No design, schema, or contract decision involved; this only changes the command used to invoke two existing scripts so they run with the dependency resolution they already declare.

**Plan presented to the team before implementation?**

No formal plan doc. Walked through the fix interactively: confirmed the failure mode, then discussed the constraint that contributors should not be forced to install `uv` globally (today `uv` is bootstrapped per-app into each app's own `.venv` via pip), and settled on a shared bootstrap venv approach before implementing.

**Confirmation received?**

Confirmed interactively at each design step (approach to fix `python3` → `uv run`, then the venv-bootstrap approach to avoid requiring a global `uv`, then generalizing it into a reusable `scripts-uv.mk` for any root-level script).

---

## 3. What you built

- `scripts/makefiles/chart-schema.mk`: `generate-chart-schema`, `check-chart-schema-drift`, and `check-chart-values` now run the two scripts via `$(SCRIPTS_UV) run ...` instead of `python3 ...`, depending on `$(SCRIPTS_UV_READY)`.
- `scripts/makefiles/scripts-uv.mk` (new): generic, drop-in include that bootstraps one shared venv at `target/scripts-venv` and exposes `$(SCRIPTS_UV)` / `$(SCRIPTS_UV_READY)` for any makefile invoking standalone `scripts/*.py` files — no global `uv` install required.
- `scripts/makefiles/python-venv-bootstrap.mk` (new): extracted the `.venv-created` / `.uv-installed` recipes out of `python-deps.mk` so they're reusable by both per-app Makefiles and `scripts-uv.mk`, without duplicating the bootstrap logic.
- `scripts/makefiles/python-deps.mk`: now includes `python-venv-bootstrap.mk` instead of defining the bootstrap rules inline; behaviour for existing per-app `dev`/`update` targets is unchanged.

---

## 4. Proof of quality

**Tests added or updated:**

None — this is Makefile/script-invocation tooling with no existing test harness covering it.

| Test | File | What it covers |
| ---- | ---- | -------------- |
| n/a  | n/a  | n/a             |

**`make code-quality` output (paste the last line or "all checks passed"):**

```
n/a — change is confined to Makefiles and has no Python/TS sources to lint
```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```
n/a — no Python package touched
```

**`make test` output (paste the summary line — pass count, 0 failures):**

```
n/a — no automated test suite covers Makefiles; verified manually (see below)
```

Manual verification from a clean `target/`:
- `make check-chart-values` → bootstraps `target/scripts-venv`, installs `uv` via pip, runs the script, prints "Values file is valid."
- `make generate-chart-schema` → regenerates `deploy/charts/fred/values.schema.json` with no diff against the previously committed version
- `make check-chart-schema-drift` → passes ("Chart schema drift check passed.")
- Re-running `check-chart-values` reuses the existing venv (no reinstall)
- Confirmed `apps/fred-agents` `make dev` / `make help` still resolve correctly after `python-deps.mk` was refactored to include the new shared bootstrap file (no new warnings, no behaviour change)

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — not backlog-tracked |
| New behaviour, API field, or contract change                      | n/a — no behaviour change, only invocation mechanism |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — not touched |
| UX component implemented or visual status changed                 | n/a — not applicable |
| Phase progress row exists for this area                           | n/a — not applicable |
| WORKPLAN sprint item finished                                     | n/a — not applicable |
| Code and a design doc now diverge                                 | n/a — no design doc describes this script invocation |

---

## 6. Close-out statement

```
## Task close-out
- Code: scripts/makefiles/chart-schema.mk now invokes check_chart_values.py and
  generate_chart_schema.py via a shared uv-backed venv (scripts-uv.mk, new) instead
  of plain python3, so their PEP 723 inline dependencies resolve. Extracted the
  venv/uv bootstrap recipes out of python-deps.mk into python-venv-bootstrap.mk so
  both per-app Makefiles and the new scripts-uv.mk reuse the same logic.
- Tests: none added (no test harness for Makefiles); manually verified
  check-chart-values, generate-chart-schema, and check-chart-schema-drift all pass
  from a clean target/, and that apps/fred-agents' existing dev/update flow is
  unaffected by the python-deps.mk refactor.
- Docs updated: none — mechanical fix, no behaviour/contract change.
- Backlog: none — not tracked, infra/tooling fix.
- Skipped steps: RFC and backlog entry skipped under the mechanical-fix exemption —
  no design or API decision was made, only the invocation mechanism for two
  already-existing scripts was corrected to match their already-declared
  dependencies.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

Low risk: this only affects local/dev-time Makefile targets (`generate-chart-schema`, `check-chart-schema-drift`, `check-chart-values`) used to validate/regenerate the Helm chart values schema. If the shared venv bootstrap failed, those targets would error out the same way they did before this PR (missing dependency), with no impact on the actual application, deployed chart, or other Makefile targets. Verified `apps/fred-agents`' own `dev`/`update` targets are unaffected by the shared `python-venv-bootstrap.mk` extraction.

**How do we roll back?**

Revert this PR's commit — it's a single self-contained commit touching only `scripts/makefiles/*.mk`.
