### PR TITLE
feat(CHAT-11): add voice dictation to managed chat composer

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -168,6 +168,7 @@
       "closeAria": "Close markdown preview",
       "empty": "No markdown preview available."
     },
+    "recordAudio": "Record audio",
     "sendMessage": "Send message",
     "sessionAttachments": {
       "deleteAria": "Delete {{name}}",
@@ -182,8 +183,15 @@
     "startConversationVariantDraft": "What's on your mind today?",
     "startConversationVariantExplore": "What are we tackling today?",
     "startConversationVariantSearch": "What should we dive into today, {{username}}?",
+    "stopRecording": "Stop recording",
     "stopResponse": "Stop response",
     "toggleDebugDrawer": "Toggle debug drawer",
+    "transcribingAudio": "Transcribing audio",
+    "voiceInputErrorSummary": "Voice dictation failed",
+    "voiceInputPermissionDenied": "Microphone access was denied.",
+    "voiceInputStartFailed": "Unable to start audio recording.",
+    "voiceInputTranscriptionFailed": "Unable to transcribe the audio clip.",
+    "voiceInputUnavailable": "Voice recording is not available in this browser.",
     "welcomeFallback": "Hello there"
   },
   "comingSoon": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -168,6 +168,7 @@
       "closeAria": "Fermer l'aperçu markdown",
       "empty": "Aucun aperçu markdown disponible."
     },
+    "recordAudio": "Enregistrer de l'audio",
     "sendMessage": "Envoyer le message",
     "sessionAttachments": {
       "deleteAria": "Supprimer {{name}}",
@@ -182,8 +183,15 @@
     "startConversationVariantDraft": "Qu'avez-vous en tête aujourd'hui ?",
     "startConversationVariantExplore": "Sur quoi travaillons-nous aujourd'hui ?",
     "startConversationVariantSearch": "Dans quoi veut-on plonger aujourd'hui, {{username}} ?",
+    "stopRecording": "Arrêter l'enregistrement",
     "stopResponse": "Arrêter la réponse",
     "toggleDebugDrawer": "Afficher ou masquer le tiroir de debug",
+    "transcribingAudio": "Transcription de l'audio",
+    "voiceInputErrorSummary": "Échec de la dictée vocale",
+    "voiceInputPermissionDenied": "L'accès au microphone a été refusé.",
+    "voiceInputStartFailed": "Impossible de démarrer l'enregistrement audio.",
+    "voiceInputTranscriptionFailed": "Impossible de transcrire l'extrait audio.",
+    "voiceInputUnavailable": "L'enregistrement audio n'est pas disponible dans ce navigateur.",
     "welcomeFallback": "Bonjour"
   },
   "comingSoon": {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -27,7 +27,9 @@ import IconButton from "@shared/atoms/IconButton/IconButton";
 import { useManagedChat } from "./useManagedChat";
 import { useFrontendBootstrap } from "../../../../hooks/useFrontendBootstrap";
 import { useGetTeamQuery } from "../../../../slices/controlPlane/controlPlaneApiEnhancements";
+import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { KeyCloakService } from "../../../../security/KeycloakService";
+import { transcribeAudioClip } from "./knowledgeFlowTranscription";
 import styles from "./ManagedChatPage.module.css";
 
 const WELCOME_VARIANT_KEYS = [
@@ -59,8 +61,9 @@ function ManagedChatWelcome() {
 }
 
 export default function ManagedChatPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { teamId, agentInstanceId } = useParams<{ teamId: string; agentInstanceId: string }>();
+  const { showError } = useToast();
 
   if (!teamId || !agentInstanceId) {
     return <div className={styles.error}>{t("chatbot.errors.missingContext")}</div>;
@@ -93,6 +96,18 @@ export default function ManagedChatPage() {
     opts?.search_policy_selection === true ||
     opts?.rag_scope_selection === true;
 
+  const reportVoiceInputError = (message: string) => {
+    showError({
+      summary: t("chatbot.voiceInputErrorSummary"),
+      detail: message,
+    });
+  };
+
+  const handleTranscribeAudio = async (file: File): Promise<string> => {
+    const language = i18n.language?.split("-")[0] || undefined;
+    return transcribeAudioClip(file, { language });
+  };
+
   const handleFilesSelected = (files: FileList | null) => {
     if (!allowChatAttachments) return;
     const selected = Array.from(files ?? []);
@@ -122,6 +137,10 @@ export default function ManagedChatPage() {
       onSend={chat.handleSend}
       onInterrupt={chat.handleAbort}
       disabled={chat.waitResponse || chat.isLoadingHistory}
+      enableVoiceInput
+      onTranscribeAudio={handleTranscribeAudio}
+      voiceInputDisabled={chat.waitResponse || chat.isLoadingHistory}
+      onVoiceInputError={reportVoiceInputError}
       showSendButton
       compactLayout={isInitialState}
       aboveTextSlot={

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/knowledgeFlowTranscription.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/knowledgeFlowTranscription.ts
@@ -1,0 +1,73 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { KeyCloakService } from "../../../../security/KeycloakService";
+
+interface AudioTranscriptionResponse {
+  text: string;
+}
+
+interface TranscribeAudioClipOptions {
+  language?: string;
+}
+
+function isAudioTranscriptionResponse(value: unknown): value is AudioTranscriptionResponse {
+  return typeof value === "object" && value !== null && "text" in value && typeof value.text === "string";
+}
+
+function errorMessageFromPayload(payload: unknown): string | null {
+  if (typeof payload === "object" && payload !== null && "detail" in payload && typeof payload.detail === "string") {
+    return payload.detail;
+  }
+  return null;
+}
+
+/**
+ * Send one recorded audio clip to Knowledge Flow and return the plain transcript.
+ *
+ * Why this exists:
+ * - `ManagedChatPage` needs a minimal MVP dictation path before the generated
+ *   Knowledge Flow client is updated in a later API regeneration pass
+ *
+ * How to use:
+ * - pass a browser `File` produced by `MediaRecorder`
+ * - optionally pass a short language hint such as `en` or `fr`
+ * - the helper uses the existing Keycloak bearer token and ingress-relative API path
+ */
+export async function transcribeAudioClip(file: File, options: TranscribeAudioClipOptions = {}): Promise<string> {
+  await KeyCloakService.ensureFreshToken(30);
+
+  const formData = new FormData();
+  formData.set("file", file);
+  if (options.language) {
+    formData.set("language", options.language);
+  }
+
+  const token = KeyCloakService.GetToken();
+  const response = await fetch("/knowledge-flow/v1/audio/transcriptions", {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    body: formData,
+    cache: "no-store",
+  });
+
+  const payload: unknown = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(errorMessageFromPayload(payload) ?? "Audio transcription failed.");
+  }
+  if (!isAudioTranscriptionResponse(payload)) {
+    throw new Error("Audio transcription returned an invalid response.");
+  }
+  return payload.text;
+}

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
@@ -109,6 +109,12 @@
   margin-left: auto; /* pushes to right edge whether or not bottomLeft is present */
 }
 
+.actionGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+}
+
 @keyframes sendBtnIn {
   from {
     transform: scale(0.7);
@@ -136,6 +142,11 @@
   color: var(--on-primary);
 }
 
+.sendBtn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
 .sendBtn:hover {
   opacity: 0.85;
 }
@@ -156,4 +167,37 @@
   background: currentColor;
   width: 11px;
   height: 11px;
+}
+
+.voiceBtn {
+  background: var(--secondary-container);
+  color: var(--on-secondary-container);
+}
+
+.voiceBtnIdle {
+  background: var(--secondary-container);
+  color: var(--on-secondary-container);
+}
+
+.voiceBtnRecording {
+  background: var(--error-container);
+  color: var(--on-error-container);
+}
+
+.voiceBtnBusy {
+  background: var(--surface-container-highest);
+  color: var(--on-surface);
+}
+
+.spinningIcon {
+  animation: voiceSpin 1s linear infinite;
+}
+
+@keyframes voiceSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { KeyboardEvent, ReactNode, useCallback, useEffect, useRef } from "react";
+import { KeyboardEvent, ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { appendVoiceTranscript, audioFileExtensionForMimeType } from "./voiceInputUtils";
 import styles from "./RichInputField.module.css";
 
 // All three slots and the send button are optional so the component is usable
@@ -40,7 +41,21 @@ interface RichInputFieldProps {
   showSendButton?: boolean;
   /** Renders the command slot inline with the text cursor for compact composer layouts. */
   compactLayout?: boolean;
+  enableVoiceInput?: boolean;
+  onTranscribeAudio?: (file: File) => Promise<string>;
+  voiceInputDisabled?: boolean;
+  onVoiceInputError?: (message: string) => void;
   maxHeight?: number;
+}
+
+type VoiceInputState = "idle" | "recording" | "transcribing";
+
+function getPreferredRecordingMimeType(): string | null {
+  if (typeof MediaRecorder === "undefined" || typeof MediaRecorder.isTypeSupported !== "function") {
+    return null;
+  }
+  const candidates = ["audio/webm;codecs=opus", "audio/webm", "audio/ogg;codecs=opus", "audio/ogg"];
+  return candidates.find((candidate) => MediaRecorder.isTypeSupported(candidate)) ?? null;
 }
 
 export function RichInputField({
@@ -56,10 +71,21 @@ export function RichInputField({
   rightSlot,
   showSendButton = false,
   compactLayout = false,
+  enableVoiceInput = false,
+  onTranscribeAudio,
+  voiceInputDisabled = false,
+  onVoiceInputError,
   maxHeight = 200,
 }: RichInputFieldProps) {
   const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const valueRef = useRef(value);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const [voiceInputState, setVoiceInputState] = useState<VoiceInputState>("idle");
+
+  valueRef.current = value;
 
   const resize = () => {
     const el = textareaRef.current;
@@ -88,6 +114,15 @@ export function RichInputField({
     }
   }, [disabled]);
 
+  const cleanupMediaResources = useCallback(() => {
+    mediaRecorderRef.current = null;
+    audioChunksRef.current = [];
+    mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+    mediaStreamRef.current = null;
+  }, []);
+
+  useEffect(() => () => cleanupMediaResources(), [cleanupMediaResources]);
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && !e.shiftKey && !disabled && !e.nativeEvent.isComposing) {
@@ -101,20 +136,144 @@ export function RichInputField({
   const hasText = value.trim().length > 0;
   const showStop = showSendButton && disabled && !!onInterrupt;
   const showSend = showSendButton && !disabled && hasText;
-  const showBottomRow = !!(topSlot || leftSlot || rightSlot || showStop || showSend);
-  const actionSlot = rightSlot ? (
-    rightSlot
-  ) : showStop ? (
-    <button type="button" className={styles.sendBtn} onClick={onInterrupt} aria-label={t("chatbot.stopResponse")}>
-      <span className={styles.stopIcon} aria-hidden />
-    </button>
-  ) : showSend ? (
-    <button type="button" className={styles.sendBtn} onClick={onSend} aria-label={t("chatbot.sendMessage")}>
-      <span className="material-symbols-outlined" aria-hidden>
-        arrow_upward
-      </span>
-    </button>
-  ) : null;
+  const canUseVoiceInput = enableVoiceInput && !!onTranscribeAudio;
+  const hasDefaultAction = canUseVoiceInput || showStop || showSend;
+  const showBottomRow = !!(topSlot || leftSlot || rightSlot || hasDefaultAction);
+  const voiceControlDisabled = disabled || voiceInputDisabled || voiceInputState === "transcribing";
+
+  const reportVoiceError = useCallback(
+    (message: string) => {
+      onVoiceInputError?.(message);
+    },
+    [onVoiceInputError],
+  );
+
+  const stopRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    if (!onTranscribeAudio) {
+      return;
+    }
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.mediaDevices?.getUserMedia ||
+      typeof MediaRecorder === "undefined"
+    ) {
+      reportVoiceError(t("chatbot.voiceInputUnavailable"));
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mimeType = getPreferredRecordingMimeType();
+      const recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+
+      audioChunksRef.current = [];
+      mediaStreamRef.current = stream;
+      mediaRecorderRef.current = recorder;
+
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      recorder.onstop = () => {
+        const recordedMimeType = recorder.mimeType || mimeType || "audio/webm";
+        const audioBlob = new Blob(audioChunksRef.current, { type: recordedMimeType });
+        cleanupMediaResources();
+        setVoiceInputState("transcribing");
+
+        void (async () => {
+          try {
+            const file = new File([audioBlob], `dictation${audioFileExtensionForMimeType(recordedMimeType)}`, {
+              type: recordedMimeType,
+            });
+            const transcript = await onTranscribeAudio(file);
+            onChange(appendVoiceTranscript(valueRef.current, transcript));
+            requestAnimationFrame(() => resize());
+          } catch (error) {
+            const fallback = t("chatbot.voiceInputTranscriptionFailed");
+            reportVoiceError(error instanceof Error && error.message ? error.message : fallback);
+          } finally {
+            setVoiceInputState("idle");
+          }
+        })();
+      };
+
+      recorder.start();
+      setVoiceInputState("recording");
+    } catch (error) {
+      cleanupMediaResources();
+      const key =
+        error instanceof DOMException && error.name === "NotAllowedError"
+          ? "chatbot.voiceInputPermissionDenied"
+          : "chatbot.voiceInputStartFailed";
+      reportVoiceError(t(key));
+      setVoiceInputState("idle");
+    }
+  }, [cleanupMediaResources, onChange, onTranscribeAudio, reportVoiceError, t]);
+
+  useEffect(() => {
+    if (voiceInputState === "recording" && voiceInputDisabled) {
+      stopRecording();
+    }
+  }, [stopRecording, voiceInputDisabled, voiceInputState]);
+
+  const defaultActionSlot = (
+    <div className={styles.actionGroup}>
+      {canUseVoiceInput && (
+        <button
+          type="button"
+          className={`${styles.sendBtn} ${styles.voiceBtn} ${
+            voiceInputState === "recording"
+              ? styles.voiceBtnRecording
+              : voiceInputState === "transcribing"
+                ? styles.voiceBtnBusy
+                : styles.voiceBtnIdle
+          }`}
+          disabled={voiceControlDisabled && voiceInputState !== "recording"}
+          onClick={voiceInputState === "recording" ? stopRecording : () => void startRecording()}
+          aria-label={
+            voiceInputState === "recording"
+              ? t("chatbot.stopRecording")
+              : voiceInputState === "transcribing"
+                ? t("chatbot.transcribingAudio")
+                : t("chatbot.recordAudio")
+          }
+        >
+          {voiceInputState === "recording" ? (
+            <span className={styles.stopIcon} aria-hidden />
+          ) : (
+            <span
+              className={`material-symbols-outlined ${voiceInputState === "transcribing" ? styles.spinningIcon : ""}`}
+              aria-hidden
+            >
+              {voiceInputState === "transcribing" ? "progress_activity" : "mic"}
+            </span>
+          )}
+        </button>
+      )}
+      {showStop ? (
+        <button type="button" className={styles.sendBtn} onClick={onInterrupt} aria-label={t("chatbot.stopResponse")}>
+          <span className={styles.stopIcon} aria-hidden />
+        </button>
+      ) : showSend ? (
+        <button type="button" className={styles.sendBtn} onClick={onSend} aria-label={t("chatbot.sendMessage")}>
+          <span className="material-symbols-outlined" aria-hidden>
+            arrow_upward
+          </span>
+        </button>
+      ) : null}
+    </div>
+  );
+
+  const actionSlot = rightSlot ? rightSlot : hasDefaultAction ? defaultActionSlot : null;
 
   return (
     <div className={styles.bar}>

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/voiceInputUtils.test.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/voiceInputUtils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { appendVoiceTranscript, audioFileExtensionForMimeType } from "./voiceInputUtils";
+
+describe("appendVoiceTranscript", () => {
+  it("uses the transcript directly when the input is empty", () => {
+    expect(appendVoiceTranscript("", "  hello world  ")).toBe("hello world");
+  });
+
+  it("appends with one separating space when the input has text", () => {
+    expect(appendVoiceTranscript("Need a summary", "of this file")).toBe("Need a summary of this file");
+  });
+
+  it("reuses trailing whitespace when already present", () => {
+    expect(appendVoiceTranscript("Need a summary:\n", "of this file")).toBe("Need a summary:\nof this file");
+  });
+
+  it("keeps the current value when the transcript is blank", () => {
+    expect(appendVoiceTranscript("Keep this", "   ")).toBe("Keep this");
+  });
+});
+
+describe("audioFileExtensionForMimeType", () => {
+  it("maps common mime types to stable file extensions", () => {
+    expect(audioFileExtensionForMimeType("audio/webm")).toBe(".webm");
+    expect(audioFileExtensionForMimeType("audio/ogg;codecs=opus")).toBe(".ogg");
+    expect(audioFileExtensionForMimeType("audio/wav")).toBe(".wav");
+    expect(audioFileExtensionForMimeType("audio/mp4")).toBe(".m4a");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/voiceInputUtils.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/voiceInputUtils.ts
@@ -1,0 +1,35 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function appendVoiceTranscript(currentValue: string, transcript: string): string {
+  const normalizedTranscript = transcript.trim();
+  if (!normalizedTranscript) {
+    return currentValue;
+  }
+  if (!currentValue.trim()) {
+    return normalizedTranscript;
+  }
+  if (/\s$/.test(currentValue)) {
+    return `${currentValue}${normalizedTranscript}`;
+  }
+  return `${currentValue} ${normalizedTranscript}`;
+}
+
+export function audioFileExtensionForMimeType(mimeType: string): string {
+  const normalized = mimeType.toLowerCase();
+  if (normalized.includes("ogg")) return ".ogg";
+  if (normalized.includes("wav")) return ".wav";
+  if (normalized.includes("mp4") || normalized.includes("m4a") || normalized.includes("aac")) return ".m4a";
+  return ".webm";
+}

--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -288,6 +288,16 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
     }),
+    transcribeAudioKnowledgeFlowV1AudioTranscriptionsPost: build.mutation<
+      TranscribeAudioKnowledgeFlowV1AudioTranscriptionsPostApiResponse,
+      TranscribeAudioKnowledgeFlowV1AudioTranscriptionsPostApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/knowledge-flow/v1/audio/transcriptions`,
+        method: "POST",
+        body: queryArg.bodyTranscribeAudioKnowledgeFlowV1AudioTranscriptionsPost,
+      }),
+    }),
     uploadUserFileKnowledgeFlowV1StorageUserUploadPost: build.mutation<
       UploadUserFileKnowledgeFlowV1StorageUserUploadPostApiResponse,
       UploadUserFileKnowledgeFlowV1StorageUserUploadPostApiArg
@@ -1363,6 +1373,11 @@ export type DeleteUserAssetKnowledgeFlowV1UserAssetsKeyDeleteApiArg = {
   /** [AGENT USE ONLY] Explicit user ID of the asset owner (Header) */
   "X-Asset-User-ID"?: string | null;
 };
+export type TranscribeAudioKnowledgeFlowV1AudioTranscriptionsPostApiResponse =
+  /** status 200 Successful Response */ AudioTranscriptionResponse;
+export type TranscribeAudioKnowledgeFlowV1AudioTranscriptionsPostApiArg = {
+  bodyTranscribeAudioKnowledgeFlowV1AudioTranscriptionsPost: BodyTranscribeAudioKnowledgeFlowV1AudioTranscriptionsPost;
+};
 export type UploadUserFileKnowledgeFlowV1StorageUserUploadPostApiResponse = /** status 200 Successful Response */ any;
 export type UploadUserFileKnowledgeFlowV1StorageUserUploadPostApiArg = {
   bodyUploadUserFileKnowledgeFlowV1StorageUserUploadPost: BodyUploadUserFileKnowledgeFlowV1StorageUserUploadPost;
@@ -2309,6 +2324,16 @@ export type BodyUploadUserAssetKnowledgeFlowV1UserAssetsUploadPost = {
   /** [AGENT USE ONLY] Explicit user ID of the asset owner */
   user_id_override?: string | null;
 };
+export type AudioTranscriptionResponse = {
+  /** Plain-text transcript for the uploaded audio clip. */
+  text: string;
+};
+export type BodyTranscribeAudioKnowledgeFlowV1AudioTranscriptionsPost = {
+  /** Audio or video clip to transcribe */
+  file: Blob;
+  /** Optional language hint for Whisper */
+  language?: string | null;
+};
 export type BodyUploadUserFileKnowledgeFlowV1StorageUserUploadPost = {
   /** Binary payload */
   file: Blob;
@@ -2995,6 +3020,7 @@ export const {
   useGetUserAssetKnowledgeFlowV1UserAssetsKeyGetQuery,
   useLazyGetUserAssetKnowledgeFlowV1UserAssetsKeyGetQuery,
   useDeleteUserAssetKnowledgeFlowV1UserAssetsKeyDeleteMutation,
+  useTranscribeAudioKnowledgeFlowV1AudioTranscriptionsPostMutation,
   useUploadUserFileKnowledgeFlowV1StorageUserUploadPostMutation,
   useListUserFilesKnowledgeFlowV1StorageUserGetQuery,
   useLazyListUserFilesKnowledgeFlowV1StorageUserGetQuery,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/audio_processor/audio_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/audio_processor/audio_processor.py
@@ -15,6 +15,7 @@
 import logging
 import tempfile
 from pathlib import Path
+from typing import Optional, TypedDict
 
 from knowledge_flow_backend.core.processors.input.common.base_input_processor import BaseMarkdownProcessor
 
@@ -23,6 +24,29 @@ logger = logging.getLogger(__name__)
 SUPPORTED_AUDIO = {".mp3", ".wav", ".ogg", ".flac", ".m4a", ".aac"}
 SUPPORTED_VIDEO = {".mp4", ".mkv", ".avi", ".mov", ".webm"}
 SUPPORTED_EXTENSIONS = SUPPORTED_AUDIO | SUPPORTED_VIDEO
+SUPPORTED_CONTENT_TYPES = {
+    "audio/aac",
+    "audio/flac",
+    "audio/mp4",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/wav",
+    "audio/webm",
+    "audio/x-m4a",
+    "audio/x-wav",
+    "video/mp4",
+    "video/quicktime",
+    "video/webm",
+    "video/x-matroska",
+    "video/x-msvideo",
+}
+
+
+class AudioTranscriptionResult(TypedDict):
+    text: str
+    lines: list[str]
+    language: str
+    duration: float
 
 
 class AudioProcessor(BaseMarkdownProcessor):
@@ -78,6 +102,31 @@ class AudioProcessor(BaseMarkdownProcessor):
 
     def convert_file_to_markdown(self, file_path: Path, output_dir: Path, document_uid: str | None) -> dict:
         output_dir.mkdir(parents=True, exist_ok=True)
+        transcript = self.transcribe_file_to_text(file_path)
+        content = (
+            f"# Transcript — {file_path.name}\n\n"
+            f"**Langue détectée :** {transcript['language']}  \n"
+            f"**Durée :** {float(transcript['duration']):.1f}s\n\n"
+            "## Contenu\n\n" + "\n".join(transcript["lines"]) + "\n"
+        )
+        md_path = output_dir / "output.md"
+        md_path.write_text(content, encoding="utf-8")
+        return {"doc_dir": str(output_dir), "md_file": str(md_path)}
+
+    def transcribe_file_to_text(self, file_path: Path, language: Optional[str] = None) -> AudioTranscriptionResult:
+        """
+        Transcribe one supported audio/video file and return plain-text segments plus metadata.
+
+        Why this exists:
+        - the ingestion processor needs Whisper output for markdown generation
+        - synchronous API features such as chat dictation need the same model call
+          without triggering the full document-ingestion pipeline
+
+        How to use:
+        - pass a local temporary file path with a supported extension
+        - optionally pass a language hint supported by faster-whisper
+        - consume `text` for plain transcription or `lines`/metadata for richer formatting
+        """
         suffix = file_path.suffix.lower()
 
         if suffix in SUPPORTED_VIDEO:
@@ -88,19 +137,27 @@ class AudioProcessor(BaseMarkdownProcessor):
             audio_path = None
 
         try:
-            segments, info = self._get_model().transcribe(str(transcribe_path), beam_size=5)
-            language = info.language
-            duration = info.duration
+            if language:
+                segments, info = self._get_model().transcribe(str(transcribe_path), beam_size=5, language=language)
+            else:
+                segments, info = self._get_model().transcribe(str(transcribe_path), beam_size=5)
 
-            lines = []
+            lines: list[str] = []
+            plain_segments: list[str] = []
             for seg in segments:
+                text = seg.text.strip()
+                if not text:
+                    continue
+                plain_segments.append(text)
                 ts = self._format_timestamp(seg.start)
-                lines.append(f"[{ts}] {seg.text.strip()}")
+                lines.append(f"[{ts}] {text}")
 
-            content = f"# Transcript — {file_path.name}\n\n**Langue détectée :** {language}  \n**Durée :** {duration:.1f}s\n\n## Contenu\n\n" + "\n".join(lines) + "\n"
-            md_path = output_dir / "output.md"
-            md_path.write_text(content, encoding="utf-8")
-            return {"doc_dir": str(output_dir), "md_file": str(md_path)}
+            return {
+                "text": " ".join(plain_segments).strip(),
+                "lines": lines,
+                "language": info.language,
+                "duration": float(info.duration or 0.0),
+            }
         finally:
             if audio_path and audio_path != file_path:
                 try:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/__init__.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/__init__.py
@@ -1,0 +1,14 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/audio_transcription_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/audio_transcription_controller.py
@@ -1,0 +1,60 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fred_core import Action, KeycloakUser, Resource, authorize_or_raise, get_current_user
+from pydantic import BaseModel, Field
+
+from knowledge_flow_backend.features.audio.audio_transcription_service import AudioTranscriptionService
+
+logger = logging.getLogger(__name__)
+
+
+class AudioTranscriptionResponse(BaseModel):
+    text: str = Field(..., description="Plain-text transcript for the uploaded audio clip.")
+
+
+class AudioTranscriptionController:
+    def __init__(self, router: APIRouter) -> None:
+        self.service = AudioTranscriptionService()
+        self._register_routes(router)
+
+    def _register_routes(self, router: APIRouter) -> None:
+        @router.post(
+            "/audio/transcriptions",
+            tags=["Audio"],
+            summary="Transcribe an uploaded audio clip for chat dictation",
+            response_model=AudioTranscriptionResponse,
+        )
+        async def transcribe_audio(
+            file: UploadFile = File(..., description="Audio or video clip to transcribe"),
+            language: Optional[str] = Form(None, description="Optional language hint for Whisper"),
+            user: KeycloakUser = Depends(get_current_user),
+        ) -> AudioTranscriptionResponse:
+            authorize_or_raise(user, Action.CREATE, Resource.FILES)
+            try:
+                text = await self.service.transcribe_upload(file, language=language)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            except HTTPException:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Audio transcription failed")
+                raise HTTPException(status_code=500, detail="Audio transcription failed.") from exc
+            return AudioTranscriptionResponse(text=text)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/audio_transcription_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/audio_transcription_service.py
@@ -1,0 +1,99 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from fastapi import UploadFile
+
+from knowledge_flow_backend.core.processors.input.audio_processor.audio_processor import (
+    SUPPORTED_CONTENT_TYPES,
+    SUPPORTED_EXTENSIONS,
+    AudioProcessor,
+)
+
+MAX_AUDIO_TRANSCRIPTION_BYTES = 25 * 1024 * 1024
+
+
+class AudioTranscriptionService:
+    """
+    Small synchronous transcription helper for chat dictation uploads.
+
+    Why this exists:
+    - chat dictation needs Whisper transcription without creating documents or
+      triggering the ingestion workflow
+
+    How to use:
+    - pass the uploaded `UploadFile` plus an optional language hint
+    - the service validates the payload, writes one temp file, runs Whisper, and
+      returns plain text
+    """
+
+    def __init__(self, processor: Optional[AudioProcessor] = None) -> None:
+        self._processor = processor or AudioProcessor()
+
+    async def transcribe_upload(self, upload: UploadFile, language: Optional[str] = None) -> str:
+        suffix = self._validate_upload(upload)
+        temp_path = await self._materialize_upload(upload, suffix)
+        try:
+            transcript = self._processor.transcribe_file_to_text(temp_path, language=language)
+            text = str(transcript["text"]).strip()
+            if not text:
+                raise ValueError("Transcription returned no text.")
+            return text
+        finally:
+            temp_path.unlink(missing_ok=True)
+            await upload.close()
+
+    def _validate_upload(self, upload: UploadFile) -> str:
+        filename = Path(upload.filename or "recording").name
+        suffix = Path(filename).suffix.lower()
+        if suffix not in SUPPORTED_EXTENSIONS:
+            supported = ", ".join(sorted(SUPPORTED_EXTENSIONS))
+            raise ValueError(f"Unsupported audio format '{suffix or '(none)'}'. Supported: {supported}")
+
+        raw_content_type = (upload.content_type or "").strip().lower()
+        content_type = raw_content_type.split(";", 1)[0].strip()
+        if content_type and content_type not in SUPPORTED_CONTENT_TYPES:
+            raise ValueError(f"Unsupported content type '{raw_content_type}'.")
+
+        return suffix
+
+    async def _materialize_upload(self, upload: UploadFile, suffix: str) -> Path:
+        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        total_bytes = 0
+        try:
+            with temp_file:
+                while True:
+                    chunk = await upload.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    total_bytes += len(chunk)
+                    if total_bytes > MAX_AUDIO_TRANSCRIPTION_BYTES:
+                        raise ValueError(
+                            f"Audio file exceeds {MAX_AUDIO_TRANSCRIPTION_BYTES} bytes; keep recordings short for dictation.",
+                        )
+                    temp_file.write(chunk)
+        except Exception:
+            Path(temp_file.name).unlink(missing_ok=True)
+            raise
+
+        if total_bytes == 0:
+            Path(temp_file.name).unlink(missing_ok=True)
+            raise ValueError("Uploaded audio file is empty.")
+
+        return Path(temp_file.name)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
@@ -59,6 +59,7 @@ from knowledge_flow_backend.features.content import report_controller
 from knowledge_flow_backend.features.content.asset_controller import AssetController
 from knowledge_flow_backend.features.content.content_controller import ContentController
 from knowledge_flow_backend.features.corpus_manager.corpus_manager_controller import CorpusManagerController
+from knowledge_flow_backend.features.audio.audio_transcription_controller import AudioTranscriptionController
 from knowledge_flow_backend.features.filesystem.mcp_fs_controller import McpFilesystemController
 from knowledge_flow_backend.features.filesystem.workspace_storage_controller import WorkspaceStorageController
 from knowledge_flow_backend.features.ingestion.ingestion_controller import IngestionController
@@ -256,6 +257,7 @@ def create_app() -> FastAPI:
     ModelController(router)
     ContentController(router)
     AssetController(router)
+    AudioTranscriptionController(router)
     WorkspaceStorageController(router)
     IngestionController(router)
     TagController(app, router)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
@@ -54,12 +54,12 @@ from knowledge_flow_backend.compat import fastapi_mcp_patch  # noqa: F401
 from knowledge_flow_backend.core.monitoring.monitoring_controller import (
     MonitoringController,
 )
+from knowledge_flow_backend.features.audio.audio_transcription_controller import AudioTranscriptionController
 from knowledge_flow_backend.features.benchmark.benchmark_controller import BenchmarkController
 from knowledge_flow_backend.features.content import report_controller
 from knowledge_flow_backend.features.content.asset_controller import AssetController
 from knowledge_flow_backend.features.content.content_controller import ContentController
 from knowledge_flow_backend.features.corpus_manager.corpus_manager_controller import CorpusManagerController
-from knowledge_flow_backend.features.audio.audio_transcription_controller import AudioTranscriptionController
 from knowledge_flow_backend.features.filesystem.mcp_fs_controller import McpFilesystemController
 from knowledge_flow_backend.features.filesystem.workspace_storage_controller import WorkspaceStorageController
 from knowledge_flow_backend.features.ingestion.ingestion_controller import IngestionController

--- a/apps/knowledge-flow-backend/tests/features/test_audio_transcription_controller.py
+++ b/apps/knowledge-flow-backend/tests/features/test_audio_transcription_controller.py
@@ -1,0 +1,129 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from fred_core import KeycloakUser, get_current_user
+
+from knowledge_flow_backend.features.audio.audio_transcription_controller import (
+    AudioTranscriptionController,
+)
+from knowledge_flow_backend.features.audio.audio_transcription_service import (
+    MAX_AUDIO_TRANSCRIPTION_BYTES,
+)
+
+
+@pytest.fixture
+def audio_client() -> TestClient:
+    app = FastAPI()
+    router = APIRouter(prefix="/knowledge-flow/v1")
+    AudioTranscriptionController(router)
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: KeycloakUser(
+        uid="test-user",
+        username="testuser",
+        email="testuser@example.com",
+        roles=["admin"],
+        groups=["admins"],
+    )
+    with TestClient(app) as client:
+        yield client
+
+
+def test_transcribe_audio_success(audio_client: TestClient, monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    def _fake_transcribe(self, file_path: Path, language: str | None = None) -> dict[str, object]:
+        captured["suffix"] = file_path.suffix
+        captured["language"] = language
+        captured["content"] = file_path.read_bytes().decode("utf-8")
+        return {
+            "text": "hello from whisper",
+            "lines": ["[00:00:00] hello from whisper"],
+            "language": language or "en",
+            "duration": 1.2,
+        }
+
+    monkeypatch.setattr("knowledge_flow_backend.features.audio.audio_transcription_service.AudioProcessor.transcribe_file_to_text", _fake_transcribe)
+
+    response = audio_client.post(
+        "/knowledge-flow/v1/audio/transcriptions",
+        files={"file": ("clip.webm", b"fake-audio", "audio/webm")},
+        data={"language": "fr"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "hello from whisper"}
+    assert captured == {
+        "suffix": ".webm",
+        "language": "fr",
+        "content": "fake-audio",
+    }
+
+
+def test_transcribe_audio_accepts_codec_parameterized_content_type(audio_client: TestClient, monkeypatch) -> None:
+    def _fake_transcribe(self, file_path: Path, language: str | None = None) -> dict[str, object]:
+        return {
+            "text": "codec ok",
+            "lines": ["[00:00:00] codec ok"],
+            "language": language or "en",
+            "duration": 0.8,
+        }
+
+    monkeypatch.setattr("knowledge_flow_backend.features.audio.audio_transcription_service.AudioProcessor.transcribe_file_to_text", _fake_transcribe)
+
+    response = audio_client.post(
+        "/knowledge-flow/v1/audio/transcriptions",
+        files={"file": ("clip.webm", b"fake-audio", "audio/webm;codecs=opus")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "codec ok"}
+
+
+def test_transcribe_audio_rejects_empty_upload(audio_client: TestClient) -> None:
+    response = audio_client.post(
+        "/knowledge-flow/v1/audio/transcriptions",
+        files={"file": ("clip.webm", b"", "audio/webm")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Uploaded audio file is empty."
+
+
+def test_transcribe_audio_rejects_unsupported_extension(audio_client: TestClient) -> None:
+    response = audio_client.post(
+        "/knowledge-flow/v1/audio/transcriptions",
+        files={"file": ("clip.txt", b"not-audio", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported audio format" in response.json()["detail"]
+
+
+def test_transcribe_audio_rejects_oversized_upload(audio_client: TestClient) -> None:
+    payload = b"a" * (MAX_AUDIO_TRANSCRIPTION_BYTES + 1)
+
+    response = audio_client.post(
+        "/knowledge-flow/v1/audio/transcriptions",
+        files={"file": ("clip.webm", payload, "audio/webm")},
+    )
+
+    assert response.status_code == 400
+    assert "Audio file exceeds" in response.json()["detail"]

--- a/docs/swift/PMO-BOARD.md
+++ b/docs/swift/PMO-BOARD.md
@@ -36,6 +36,7 @@ Last updated: 2026-06-18
 | `CHAT-04` | `CHAT-ATTACHMENTS-OPTION-A` | Simon | A lancer — branch dediee requise | [CHAT-UI-BACKLOG §4](backlog/CHAT-UI-BACKLOG.md) | Option A: composer upload UX, base64 image context, drag-and-drop ingestion; MCP filesystem hardening tracked separately in FILES-01 | GitHub issue #1706 |
 | `VALID-01` | `VALIDATION-E2E` | Simon | Bloque | [BACKLOG §3b.7](backlog/BACKLOG.md) | — | `TBD` |
 | `CHAT-03` | `CHAT-OPTIONS` | Marc | En cours | [CHAT-UI-BACKLOG §3](backlog/CHAT-UI-BACKLOG.md) | — | GitHub issue `#1730` |
+| `CHAT-11` | `CHAT-VOICE-DICTATION` | Dimitri | En cours | [CHAT-UI-BACKLOG §12](backlog/CHAT-UI-BACKLOG.md) | [CHAT-VOICE-DICTATION-RFC](rfc/CHAT-VOICE-DICTATION-RFC.md) | Waived GitHub issue for local Codex session |
 | `MEMORY-02` | `MEMORY-CHECKPOINT-ISOLATION` | Marc | En cours | [MEMORY BACKLOG §F.1](backlog/MULTI-AGENT-MEMORY-BACKLOG.md) | [MULTI-AGENT-MEMORY-RFC](rfc/MULTI-AGENT-MEMORY-RFC.md) | `TBD` |
 | `MEMORY-03` | `MEMORY-REMOTE-AGENT` | Dimitri | En cours | [MEMORY BACKLOG §F.2](backlog/MULTI-AGENT-MEMORY-BACKLOG.md) | [MULTI-AGENT-MEMORY-RFC](rfc/MULTI-AGENT-MEMORY-RFC.md) | `TBD` |
 | `MEMORY-04` | `MEMORY-LOCAL-AGENT` | Dimitri | En cours | [MEMORY BACKLOG §F.3](backlog/MULTI-AGENT-MEMORY-BACKLOG.md) | [MULTI-AGENT-MEMORY-RFC](rfc/MULTI-AGENT-MEMORY-RFC.md) | `TBD` |

--- a/docs/swift/STATUS.md
+++ b/docs/swift/STATUS.md
@@ -86,6 +86,7 @@ Last updated: 2026-06-18
 | CTRLP-10                    | Isolation espace personnel par utilisateur (`personal-{uid}`) | Dimitri | En cours — durcissement core/runtime + §6.4.F (PATCH/DELETE ownership) livrés | [BACKLOG §6.4.F](backlog/BACKLOG.md)                |
 | VALIDATION-E2E              | Validation E2E live stack                                     | Simon   | **Bloqué** — pod manquant                                                     | [BACKLOG §3b.7](backlog/BACKLOG.md)                 |
 | CHAT-OPTIONS                | Chat UI : panneau options                                     | Dimitri | En cours                                                                      | [CHAT-UI-BACKLOG §3](backlog/CHAT-UI-BACKLOG.md)    |
+| CHAT-11                     | Chat UI : dictée vocale dans le composer                      | Dimitri | En cours — MVP dictation Knowledge Flow + mic composer                        | [CHAT-UI-BACKLOG §12](backlog/CHAT-UI-BACKLOG.md)   |
 | PROMPT-CONTEXT-PICKER       | Prompts : sélecteur contexte                                  | Dimitri | En cours (après CHAT-OPTIONS)                                                 | [BACKLOG §3d.9](backlog/BACKLOG.md)                 |
 
 ## File d'attente

--- a/docs/swift/backlog/CHAT-UI-BACKLOG.md
+++ b/docs/swift/backlog/CHAT-UI-BACKLOG.md
@@ -1341,6 +1341,71 @@ and degrades safely when the payload is invalid.
 
 ---
 
+## 12 Phase CHAT-11 — Voice dictation into chat input
+
+**ID:** CHAT-11  
+**Status:** in progress  
+**Priority:** medium — composer input accessibility and faster capture of short prompts  
+Execution: waived GitHub issue for this local Codex session
+
+### 12.1 Goal
+
+Add an MVP dictation flow to the managed chat composer:
+
+- microphone button in `RichInputField`
+- short browser-recorded clip via `MediaRecorder`
+- synchronous transcription through Knowledge Flow
+- returned transcript appended into the existing chat input
+- user reviews/edits before normal send
+
+### 12.2 Tasks
+
+#### Step 1 — Knowledge Flow transcription endpoint
+
+- [ ] Add `POST /knowledge-flow/v1/audio/transcriptions`
+- [ ] Accept `multipart/form-data` with `file` and optional `language`
+- [ ] Reuse local Whisper / `faster-whisper` capability through a small dedicated
+      helper, without document ingestion persistence
+- [ ] Reject empty files and unsupported extensions/MIME hints
+- [ ] Enforce a small synchronous upload cap for MVP safety
+- [ ] Add offline backend tests with fake transcription service / monkeypatch
+
+#### Step 2 — Composer mic control
+
+- [ ] Extend `RichInputField` with optional voice-input props and UI states:
+      idle, recording, transcribing
+- [ ] Use `navigator.mediaDevices.getUserMedia({ audio: true })`
+- [ ] Record with `MediaRecorder`, stop on second click, convert blob to `File`
+- [ ] Keep styling token-based and aligned with existing composer layout
+
+#### Step 3 — Managed chat wiring
+
+- [ ] Wire the Knowledge Flow transcription mutation through existing frontend
+      API conventions
+- [ ] Pass dictation props from `ManagedChatPage`
+- [ ] Append transcript into `chat.input` via controlled state without auto-send
+- [ ] Disable the voice control while streaming or while session history loads
+- [ ] Surface failures through existing toast conventions
+- [ ] Add English and French labels
+
+#### Step 4 — Verification
+
+- [ ] Knowledge Flow: `make code-quality`
+- [ ] Knowledge Flow: `make test`
+- [ ] Frontend: regenerate Knowledge Flow API client if backend OpenAPI changes
+- [ ] Frontend: `npm run typecheck`
+- [ ] Frontend: `npm run test`
+
+### 12.3 Non-changes
+
+- No realtime transcription
+- No voice assistant or auto-send
+- No browser `SpeechRecognition`
+- No OpenAI audio API
+- No runtime/SSE protocol changes
+
+---
+
 ## 6 Progress
 
 | Phase                                       | Status               | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -1356,5 +1421,6 @@ and degrades safely when the payload is invalid.
 | CHAT-07 – Composer state hardening          | ✅ Done (2026-05-24) | RFC: `docs/swift/rfc/CHAT-COMPOSER-STATE-RFC.md`. All 5 steps implemented.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | CHAT-09 – Streaming render guard            | ✅ Done (2026-05-28) | RFC: `docs/swift/rfc/STREAMING-RENDER-GUARD-RFC.md`. Streaming markdown now splits into safe rendered prose plus one pending fence preview block. Any supported open fence (` ```lang `, ` ```mermaid `, `$$`, `:::`) shows a `CodeBlock` shell until completion; Mermaid then hands off to `MermaidBlock` for final SVG rendering. No backend changes, no new deps. Manual live-pod validation remains a non-blocking follow-up.                                                                                                                                                                                                                                                                                                   |
 | CHAT-10 – Mindmap block rendering           | ✅ Done (2026-06-05) | Frontend-only. `MarkdownRenderer` now routes `mindmap` / `mindmap-json` fences to `MindMapBlock`, while Mermaid and generic code paths stay unchanged. `MindMapBlock` validates JSON payloads, enforces safe node-count limits, renders an interactive tree with breadcrumb/detail support, and falls back to raw payload display on parse errors. Manual live-chat validation remains open.                                                                                                                                                                                                                                                                                                                                        |
+| CHAT-11 – Voice dictation into chat input   | 🔄 In progress       | RFC: `docs/swift/rfc/CHAT-VOICE-DICTATION-RFC.md`. MVP scope: authenticated Knowledge Flow transcription endpoint plus `RichInputField` microphone control in `ManagedChatPage`. Transcript must append into the controlled composer without auto-send, while preserving attachment flow and existing typed message flow. |
 
 > **UX review status** (functional ≠ UX-validated): see [`docs/ux/COMPONENT-UX.md`](../ux/COMPONENT-UX.md).

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -184,6 +184,21 @@ items:
       limits, renders an interactive tree with breadcrumb/detail support, and falls
       back to a raw payload preview when parsing fails.
 
+  - id: CHAT-11
+    title: "Voice dictation into managed chat composer"
+    status: in_progress
+    owner: Dimitri
+    refs:
+      backlog: "docs/swift/backlog/CHAT-UI-BACKLOG.md §12"
+      rfc: "docs/swift/rfc/CHAT-VOICE-DICTATION-RFC.md"
+      execution: "waived GitHub issue for local Codex session"
+    notes: >
+      Adds an MVP browser-to-Knowledge-Flow dictation path for managed chat:
+      `MediaRecorder` clip capture in `RichInputField`, authenticated
+      `/knowledge-flow/v1/audio/transcriptions` endpoint backed by the existing
+      local Whisper/faster-whisper capability, transcript append into the
+      controlled composer state, and offline backend/frontend validation.
+
   # ── CTRLP ─────────────────────────────────────────────────────────────
 
   - id: CTRLP-01

--- a/docs/swift/data/sprint.yaml
+++ b/docs/swift/data/sprint.yaml
@@ -136,6 +136,18 @@ in_progress:
     milestone: MILESTONE-chat-ui-phase6
     backlog_ref: "docs/backlog/CHAT-UI-BACKLOG.md §3"
 
+  - id: CHAT-VOICE-DICTATION
+    legacy_id: "CHAT-11"
+    title: "Chat UI : dictée vocale MVP dans le composer géré"
+    owner: Dimitri
+    blocked: false
+    milestone: MILESTONE-chat-ui-phase6
+    backlog_ref: "docs/swift/backlog/CHAT-UI-BACKLOG.md §12"
+    notes: >
+      New MVP slice: browser `MediaRecorder` clip capture, additive Knowledge Flow
+      transcription endpoint backed by local Whisper, and transcript append into
+      the controlled composer without auto-send.
+
   - id: MEMORY-CHECKPOINT-ISOLATION
     legacy_id: "MEMORY-02"
     title: "Mémoire : isolation checkpoints par agent"

--- a/docs/swift/rfc/CHAT-VOICE-DICTATION-RFC.md
+++ b/docs/swift/rfc/CHAT-VOICE-DICTATION-RFC.md
@@ -1,0 +1,201 @@
+# RFC: Voice Dictation Into Managed Chat Composer (CHAT-11)
+
+**Status:** Implemented (2026-06-17)  
+**Author:** Codex  
+**Date:** 2026-06-17  
+**ID:** CHAT-11  
+**Backlog:** `docs/swift/backlog/CHAT-UI-BACKLOG.md §12`  
+**Contract impact:** additive Knowledge Flow OpenAPI endpoint only
+
+---
+
+## 1. Problem
+
+The managed chat composer currently accepts typed text and file attachments only.
+For quick notes, short prompts, and hands-busy usage, users need a simple way to
+dictate a message into the existing text box without changing the runtime
+protocol or introducing a full voice-assistant mode.
+
+The repository already contains most of the required pieces:
+
+- `RichInputField` is a reusable controlled composer component
+- `useManagedChat` already owns `input`, `setInput`, and `handleSend`
+- `knowledge-flow-backend` already ships a local `faster-whisper`-based
+  `AudioProcessor`
+- the frontend already uses the Knowledge Flow API surface via generated RTK
+  Query hooks and existing auth/base-url conventions
+
+What is missing is a narrow, non-streaming transcription path that:
+
+- records one short clip in the browser
+- sends it to Knowledge Flow
+- returns plain text
+- appends that text to the existing composer content without auto-sending
+
+---
+
+## 2. Scope And Constraints
+
+This RFC intentionally keeps the first slice tight.
+
+### In scope
+
+- one authenticated Knowledge Flow transcription endpoint
+- browser microphone capture with `getUserMedia` + `MediaRecorder`
+- `RichInputField` opt-in mic control and UI states
+- transcript insertion into the current managed chat input
+- English and French labels
+- offline backend tests with a fake transcription service
+- frontend type/tests where feasible
+
+### Out of scope
+
+- realtime / partial transcription
+- WebRTC or duplex voice assistant behavior
+- automatic message sending after transcription
+- audio persistence beyond temporary server-side files
+- browser `SpeechRecognition`
+- OpenAI audio APIs
+- runtime / SSE contract changes
+
+---
+
+## 3. Proposed Solution
+
+### 3.1 Backend: dedicated Knowledge Flow transcription surface
+
+Add:
+
+- `POST /knowledge-flow/v1/audio/transcriptions`
+
+Request:
+
+- `multipart/form-data`
+- `file`: uploaded audio blob
+- optional `language`: language hint, nullable
+
+Response:
+
+```json
+{
+  "text": "transcribed text"
+}
+```
+
+Implementation shape:
+
+- new small Knowledge Flow controller under `features/audio/`
+- new helper/service that:
+  - validates filename / extension / MIME hint
+  - rejects empty uploads
+  - writes the payload to a temporary file
+  - calls the existing local Whisper capability
+  - returns plain text
+  - deletes temporary files in `finally`
+- use existing Knowledge Flow user auth dependency and file-read authorization
+  pattern
+
+The service reuses the existing `AudioProcessor` model-loading path instead of
+the ingestion pipeline. We explicitly do **not** create a document, schedule a
+workflow, or persist markdown output for this MVP.
+
+### 3.2 Validation policy
+
+Use the current audio/video extension set already supported by `AudioProcessor`.
+For MVP the endpoint also enforces a small fixed upload cap to prevent accidental
+large recordings from hitting Whisper synchronously. The limit is intentionally
+local to this endpoint and does not alter broader ingestion quotas.
+
+### 3.3 Frontend: opt-in dictation in `RichInputField`
+
+`RichInputField` gains optional props:
+
+- `enableVoiceInput?: boolean`
+- `onTranscribeAudio?: (file: File) => Promise<string>`
+- `voiceInputDisabled?: boolean`
+
+Behavior:
+
+- first click: request mic access and start recording
+- second click: stop recording, convert the blob to a `File`, call
+  `onTranscribeAudio`
+- on success: append the returned text into the controlled composer value
+- never auto-send
+
+State model:
+
+- `idle`
+- `recording`
+- `transcribing`
+
+If the browser lacks `MediaRecorder` / `getUserMedia`, the control stays
+disabled and the page surfaces a normal toast error when the user attempts the
+action.
+
+### 3.4 Managed chat wiring
+
+`ManagedChatPage` passes the opt-in props to `RichInputField`.
+
+`useManagedChat` exposes one small helper to append dictation text into the
+existing controlled `input` state. The helper is responsible for clean spacing:
+
+- empty input -> transcript only
+- existing input ending with whitespace -> direct append
+- otherwise -> prepend one space before the transcript
+
+### 3.5 Frontend API path
+
+Preferred path: regenerate the Knowledge Flow RTK Query client from the backend
+OpenAPI spec and use the generated mutation hook. This keeps the new endpoint on
+the standard authenticated fetch/base-url path and avoids one-off `fetch`
+helpers.
+
+---
+
+## 4. Alternatives Considered
+
+| Alternative | Reason rejected |
+| --- | --- |
+| Browser `SpeechRecognition` | Inconsistent browser support and explicitly out of scope |
+| Reusing the full ingestion/document pipeline | Too heavy for a synchronous chat-composer action; adds persistence and scheduler concerns |
+| OpenAI audio transcription API | Explicitly forbidden for this feature |
+| Frontend-only local WASM transcription | Much larger download/runtime cost than reusing the existing backend model |
+| New runtime endpoint | Wrong boundary; transcription belongs to Knowledge Flow, not chat execution |
+
+---
+
+## 5. Contract Impact
+
+Frozen contracts in `RUNTIME-EXECUTION-CONTRACT.md` and
+`CONTROL-PLANE-PRODUCT-CONTRACT.md` do not change.
+
+Additive contract change:
+
+- Knowledge Flow OpenAPI adds `POST /knowledge-flow/v1/audio/transcriptions`
+
+Frontend impact:
+
+- regenerate `apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts`
+
+---
+
+## 6. File Map
+
+Expected implementation areas:
+
+- `apps/knowledge-flow-backend/knowledge_flow_backend/features/audio/`
+- `apps/knowledge-flow-backend/tests/features/`
+- `apps/frontend/src/rework/components/shared/molecules/RichInputField/`
+- `apps/frontend/src/rework/components/pages/ManagedChatPage/`
+- `apps/frontend/src/locales/en/translation.json`
+- `apps/frontend/src/locales/fr/translation.json`
+- generated Knowledge Flow OpenAPI client
+
+---
+
+## 7. Execution Note
+
+The repository workflow normally requires a GitHub issue between confirmation
+and implementation. For this local Codex session, the developer explicitly asked
+to create the tracking docs and proceed immediately, so the GitHub-issue step is
+treated as waived for this change.


### PR DESCRIPTION
## CHAT-11 — Dictée vocale dans le composer de chat

Intègre la feature de **Marc** (`marcfawaz/fred:feature/dictaphone-chat`),
rebasée sur `swift` à jour. Author d'origine préservé sur le commit.

RFC : `docs/swift/rfc/CHAT-VOICE-DICTATION-RFC.md` · Backlog : CHAT-UI-BACKLOG §12

### Ce que ça fait
Le composer gère un bouton micro : enregistrement d'un clip audio dans le
navigateur (`MediaRecorder`) → envoi à un endpoint de transcription
knowledge-flow → le texte transcrit est inséré dans le champ de saisie
(sans auto-envoi). États : `idle → recording → transcribing`.

### Frontend (`apps/frontend`)
- `RichInputField` : bouton micro, capture `MediaRecorder`, machine à états,
  gestion d'erreurs (permission refusée, navigateur non supporté, échec transcription).
- `voiceInputUtils.ts` (+ test) : helpers purs (append transcript, extension selon MIME).
- `knowledgeFlowTranscription.ts` : client POST du clip.
- `ManagedChatPage` : câblage + toast d'erreur.
- Clés i18n EN/FR (`recordAudio`, `stopRecording`, `transcribingAudio`, `voiceInput*`).

### Backend (`apps/knowledge-flow-backend`)
- Nouvel endpoint `POST /knowledge-flow/v1/audio/transcriptions` :
  reçoit un clip + langue optionnelle, autorisation `Action.CREATE / Resource.FILES`,
  renvoie `{ text }`.
- `AudioTranscriptionService` : valide (taille max 25 Mo, types supportés),
  écrit un seul fichier temp, lance le **Whisper local existant** (`AudioProcessor`),
  nettoie. **Ne crée pas de document et ne déclenche pas l'ingestion** — juste audio → texte.
- `audio_processor.py` : ajout `transcribe_file_to_text()` + constantes types/extensions supportés.
- Route enregistrée dans `main.py`.

### Adaptations faites au rebase sur swift
- Import toast corrigé : `../../../../components/ToastProvider` →
  `@shared/molecules/Toast/ToastProvider` (chemin swift actuel).
- Réinjection des clés i18n `recordAudio`/`stopRecording` supprimées par #1768
  (devenues inutilisées avant cette feature), tri alphabétique respecté.
- Conflits de tracking (PMO/STATUS/id-legend/sprint) résolus sur la base swift à jour.

### Tests
- Frontend : `make code-quality` (tsc + prettier) ✅ · `voiceInputUtils.test.ts` 5/5 ✅
- Knowledge-flow : `make code-quality` ✅ · `make test` **204 passed** ✅
  (dont `test_audio_transcription_controller` : succès / fichier invalide / texte vide)

### À vérifier au review (@Simon)
- Permission `Action.CREATE / Resource.FILES` adaptée pour de la transcription éphémère ?
- Plafond 25 Mo OK pour un clip de dictée ?
