### PR TITLE
fix(OPS-04): emit ingestion task events in in-memory scheduler

### DIFF
--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/in_memory_scheduler.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/in_memory_scheduler.py
@@ -27,6 +27,7 @@ from knowledge_flow_backend.application_context import ApplicationContext
 from knowledge_flow_backend.common.document_structures import DocumentMetadata
 from knowledge_flow_backend.core.processors.output.base_library_output_processor import LibraryDocumentInput, LibraryOutputProcessor
 from knowledge_flow_backend.features.scheduler.activities import (
+    emit_ingestion_task_event,
     output_process,
 )
 from knowledge_flow_backend.features.scheduler.base_scheduler import BaseScheduler, WorkflowHandle
@@ -56,6 +57,42 @@ def _split_file_kinds(definition: PipelineDefinition) -> tuple[bool, bool]:
     return has_pull, has_push
 
 
+async def _emit_local_ingestion_task_event(
+    file,
+    *,
+    state: str,
+    step: str | None = None,
+    progress: float | None = None,
+    error: str | None = None,
+    document_uid: str | None = None,
+) -> None:
+    """Mirror the Temporal ingestion task events for the in-memory scheduler path.
+
+    Why:
+        Upload & process creates `task_run` rows before local scheduling starts.
+        Without durable events here, those tasks stay `pending` forever even when
+        in-memory processing succeeds, which makes the UI appear blocked.
+    How:
+        Reuse the same `emit_ingestion_task_event(...)` helper as the Temporal
+        workflow path, but call it directly from the local scheduler loop.
+    """
+    task_id = getattr(file, "task_id", None)
+    if not task_id:
+        return
+    await emit_ingestion_task_event(
+        task_id=task_id,
+        state=state,
+        step=step,
+        progress=progress,
+        error=error,
+        processed=1 if state == "succeeded" else 0,
+        total=1,
+        failed=1 if state == "failed" else 0,
+        document_uid=document_uid or getattr(file, "document_uid", None),
+        display_name=getattr(file, "display_name", None),
+    )
+
+
 async def _run_push_ingestion_pipeline(definition: PipelineDefinition) -> str:
     simulated_delay_seconds = 0
     logger.info(
@@ -68,10 +105,41 @@ async def _run_push_ingestion_pipeline(definition: PipelineDefinition) -> str:
         logger.info("[SCHEDULER][IN_MEMORY] Processing push file %s via local ingestion pipeline", file.display_name)
         if simulated_delay_seconds > 0:
             time.sleep(simulated_delay_seconds)
-
-        metadata = await get_push_file_metadata(file)
-        metadata = await push_input_process(user=file.processed_by, metadata=metadata, input_file="", profile=file.profile)
-        _ = await output_process(file=file, metadata=metadata, accept_memory_storage=True)
+        await _emit_local_ingestion_task_event(file, state="running", step="uploading")
+        try:
+            metadata = await get_push_file_metadata(file)
+            await _emit_local_ingestion_task_event(
+                file,
+                state="running",
+                step="processing",
+                progress=0.3,
+                document_uid=metadata.document_uid,
+            )
+            metadata = await push_input_process(
+                user=file.processed_by,
+                metadata=metadata,
+                input_file="",
+                profile=file.profile,
+            )
+            metadata = await output_process(
+                file=file,
+                metadata=metadata,
+                accept_memory_storage=True,
+            )
+            await _emit_local_ingestion_task_event(
+                file,
+                state="succeeded",
+                step="done",
+                progress=1.0,
+                document_uid=metadata.document_uid,
+            )
+        except Exception as exc:
+            await _emit_local_ingestion_task_event(
+                file,
+                state="failed",
+                error=str(exc).strip() or "Processing failed",
+            )
+            raise
 
     return "success"
 
@@ -88,10 +156,40 @@ async def _run_pull_ingestion_pipeline(definition: PipelineDefinition) -> str:
         logger.info("[SCHEDULER][IN_MEMORY] Processing pull file %s via local ingestion pipeline", file.external_path)
         if simulated_delay_seconds > 0:
             time.sleep(simulated_delay_seconds)
-
-        metadata = await create_pull_file_metadata(file)
-        metadata = await pull_input_process(user=file.processed_by, metadata=metadata, profile=file.profile)
-        _ = await output_process(file=file, metadata=metadata, accept_memory_storage=True)
+        await _emit_local_ingestion_task_event(file, state="running", step="uploading")
+        try:
+            metadata = await create_pull_file_metadata(file)
+            await _emit_local_ingestion_task_event(
+                file,
+                state="running",
+                step="processing",
+                progress=0.3,
+                document_uid=metadata.document_uid,
+            )
+            metadata = await pull_input_process(
+                user=file.processed_by,
+                metadata=metadata,
+                profile=file.profile,
+            )
+            metadata = await output_process(
+                file=file,
+                metadata=metadata,
+                accept_memory_storage=True,
+            )
+            await _emit_local_ingestion_task_event(
+                file,
+                state="succeeded",
+                step="done",
+                progress=1.0,
+                document_uid=metadata.document_uid,
+            )
+        except Exception as exc:
+            await _emit_local_ingestion_task_event(
+                file,
+                state="failed",
+                error=str(exc).strip() or "Processing failed",
+            )
+            raise
 
     return "success"
 

--- a/apps/knowledge-flow-backend/tests/core/test_in_memory_scheduler_task_events.py
+++ b/apps/knowledge-flow-backend/tests/core/test_in_memory_scheduler_task_events.py
@@ -1,0 +1,120 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from fred_core import KeycloakUser
+
+from knowledge_flow_backend.features.scheduler import in_memory_scheduler as scheduler_module
+from knowledge_flow_backend.features.scheduler.scheduler_structures import FileToProcess, PipelineDefinition
+
+
+def _build_user() -> KeycloakUser:
+    return KeycloakUser(
+        uid="test-user",
+        username="testuser",
+        email="testuser@localhost",
+        roles=["admin"],
+        groups=["admins"],
+    )
+
+
+def _build_pipeline(user: KeycloakUser) -> PipelineDefinition:
+    return PipelineDefinition(
+        name="test-pipeline",
+        files=[
+            FileToProcess(
+                source_tag="fred",
+                tags=[],
+                display_name="sample.md",
+                document_uid="doc-1",
+                task_id="task-1",
+                processed_by=user,
+            )
+        ],
+        max_parallelism=1,
+    )
+
+
+def test_run_push_ingestion_pipeline_emits_task_events(monkeypatch):
+    async def _scenario() -> None:
+        user = _build_user()
+        definition = _build_pipeline(user)
+        metadata = AsyncMock()
+        metadata.document_uid = "doc-1"
+
+        emitted: list[dict[str, object]] = []
+
+        async def fake_emit_ingestion_task_event(**kwargs):
+            emitted.append(kwargs)
+
+        monkeypatch.setattr(
+            scheduler_module,
+            "get_push_file_metadata",
+            AsyncMock(return_value=metadata),
+        )
+        monkeypatch.setattr(
+            scheduler_module,
+            "push_input_process",
+            AsyncMock(return_value=metadata),
+        )
+        monkeypatch.setattr(
+            scheduler_module,
+            "output_process",
+            AsyncMock(return_value=metadata),
+        )
+        monkeypatch.setattr(
+            scheduler_module,
+            "emit_ingestion_task_event",
+            fake_emit_ingestion_task_event,
+        )
+
+        result = await scheduler_module._run_push_ingestion_pipeline(definition)
+
+        assert result == "success"
+        assert [event["state"] for event in emitted] == ["running", "running", "succeeded"]
+        assert [event["step"] for event in emitted] == ["uploading", "processing", "done"]
+        assert emitted[-1]["progress"] == 1.0
+        assert emitted[-1]["document_uid"] == "doc-1"
+
+    asyncio.run(_scenario())
+
+
+def test_run_push_ingestion_pipeline_emits_failed_task_event(monkeypatch):
+    async def _scenario() -> None:
+        user = _build_user()
+        definition = _build_pipeline(user)
+        metadata = AsyncMock()
+        metadata.document_uid = "doc-1"
+
+        emitted: list[dict[str, object]] = []
+
+        async def fake_emit_ingestion_task_event(**kwargs):
+            emitted.append(kwargs)
+
+        monkeypatch.setattr(
+            scheduler_module,
+            "get_push_file_metadata",
+            AsyncMock(return_value=metadata),
+        )
+        monkeypatch.setattr(
+            scheduler_module,
+            "push_input_process",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        )
+        monkeypatch.setattr(
+            scheduler_module,
+            "emit_ingestion_task_event",
+            fake_emit_ingestion_task_event,
+        )
+
+        try:
+            await scheduler_module._run_push_ingestion_pipeline(definition)
+        except RuntimeError as exc:
+            assert str(exc) == "boom"
+        else:
+            raise AssertionError("Expected RuntimeError from push_input_process")
+
+        assert [event["state"] for event in emitted] == ["running", "running", "failed"]
+        assert emitted[-1]["error"] == "boom"
+        assert emitted[-1]["failed"] == 1
+
+    asyncio.run(_scenario())

--- a/docs/swift/PMO-BOARD.md
+++ b/docs/swift/PMO-BOARD.md
@@ -60,7 +60,7 @@ Last updated: 2026-06-18
 | `MIGR-07` | `MIGRATION-PRODUCTS-REVECTORIZE` | Dimitri | Topic **products** — re-vectorisation sur la cible (Temporal sur output_process, RFC écrit) | [KEA-MIGRATION-BACKLOG §0quater](backlog/KEA-MIGRATION-BACKLOG.md) | [CORPUS-REVECTORIZE-RFC](rfc/CORPUS-REVECTORIZE-RFC.md) | `TBD` |
 | `DEVOPS-FREDLAB` | `DEVOPS-FREDLAB` | Sébastien | **⚠️ CRITIQUE — reste le Helm chart pour GCP / GKE Autopilot interne** | [BACKLOG §3b](backlog/BACKLOG.md) | — | `TBD` |
 | `OPS-01` | `DEVOPS-HELM-CHART` | Simon | A lancer — prerequis CI + Docker clos | [BACKLOG §3b.11](backlog/BACKLOG.md) | [FRED-CHART-MODERNIZATION-RFC](rfc/FRED-CHART-MODERNIZATION-RFC.md) | GitHub issue `#1685` |
-| `OPS-04` | `TASK-EVENT-STREAM` | Dimitri | En cours — correctif local memory scheduler pour debloquer les taches ingestion pending | [BACKLOG §OPS-04](backlog/BACKLOG.md) | [TASK-EVENT-STREAM-RFC](rfc/TASK-EVENT-STREAM-RFC.md) | Waived GitHub issue for local Codex session |
+| `OPS-04` | `TASK-EVENT-STREAM` | Dimitri | En cours — correctif local memory scheduler pour debloquer les taches ingestion pending | [BACKLOG §OPS-04](backlog/BACKLOG.md) | [TASK-EVENT-STREAM-RFC](rfc/TASK-EVENT-STREAM-RFC.md) | Waived GitHub issue for local session |
 | `DEVOPS-FREDLAB` | `DEVOPS-FREDLAB` | Sébastien | **⚠️ CRITIQUE — chart Helm clos, lancer le déploiement interne GKE Autopilot** | [BACKLOG §3b](backlog/BACKLOG.md) | — | `TBD` |
 | `OPS-05` | `DEVOPS-STORAGE-NAMING` | Simon | A lancer — RFC/backlog prets | [BACKLOG §OPS-05](backlog/BACKLOG.md) | [OBJECT-STORAGE-NAMING-RFC](rfc/OBJECT-STORAGE-NAMING-RFC.md) | `TBD` |
 

--- a/docs/swift/PMO-BOARD.md
+++ b/docs/swift/PMO-BOARD.md
@@ -60,6 +60,7 @@ Last updated: 2026-06-18
 | `MIGR-07` | `MIGRATION-PRODUCTS-REVECTORIZE` | Dimitri | Topic **products** — re-vectorisation sur la cible (Temporal sur output_process, RFC écrit) | [KEA-MIGRATION-BACKLOG §0quater](backlog/KEA-MIGRATION-BACKLOG.md) | [CORPUS-REVECTORIZE-RFC](rfc/CORPUS-REVECTORIZE-RFC.md) | `TBD` |
 | `DEVOPS-FREDLAB` | `DEVOPS-FREDLAB` | Sébastien | **⚠️ CRITIQUE — reste le Helm chart pour GCP / GKE Autopilot interne** | [BACKLOG §3b](backlog/BACKLOG.md) | — | `TBD` |
 | `OPS-01` | `DEVOPS-HELM-CHART` | Simon | A lancer — prerequis CI + Docker clos | [BACKLOG §3b.11](backlog/BACKLOG.md) | [FRED-CHART-MODERNIZATION-RFC](rfc/FRED-CHART-MODERNIZATION-RFC.md) | GitHub issue `#1685` |
+| `OPS-04` | `TASK-EVENT-STREAM` | Dimitri | En cours — correctif local memory scheduler pour debloquer les taches ingestion pending | [BACKLOG §OPS-04](backlog/BACKLOG.md) | [TASK-EVENT-STREAM-RFC](rfc/TASK-EVENT-STREAM-RFC.md) | Waived GitHub issue for local Codex session |
 | `DEVOPS-FREDLAB` | `DEVOPS-FREDLAB` | Sébastien | **⚠️ CRITIQUE — chart Helm clos, lancer le déploiement interne GKE Autopilot** | [BACKLOG §3b](backlog/BACKLOG.md) | — | `TBD` |
 | `OPS-05` | `DEVOPS-STORAGE-NAMING` | Simon | A lancer — RFC/backlog prets | [BACKLOG §OPS-05](backlog/BACKLOG.md) | [OBJECT-STORAGE-NAMING-RFC](rfc/OBJECT-STORAGE-NAMING-RFC.md) | `TBD` |
 

--- a/docs/swift/backlog/BACKLOG.md
+++ b/docs/swift/backlog/BACKLOG.md
@@ -1236,6 +1236,7 @@ Execution: GitHub issue `#1664`
 #### OPS-04 Unified task event stream and migration cockpit
 
 RFC ref: `docs/swift/rfc/TASK-EVENT-STREAM-RFC.md`
+Execution: waived GitHub issue for local Codex session
 
 **P1 — Shared infrastructure (fred-core + both backends)**
 

--- a/docs/swift/backlog/BACKLOG.md
+++ b/docs/swift/backlog/BACKLOG.md
@@ -1236,7 +1236,7 @@ Execution: GitHub issue `#1664`
 #### OPS-04 Unified task event stream and migration cockpit
 
 RFC ref: `docs/swift/rfc/TASK-EVENT-STREAM-RFC.md`
-Execution: waived GitHub issue for local Codex session
+Execution: waived GitHub issue for local session
 
 **P1 — Shared infrastructure (fred-core + both backends)**
 

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -539,7 +539,7 @@ items:
     refs:
       backlog: "docs/swift/backlog/BACKLOG.md §OPS-04"
       rfc: "docs/swift/rfc/TASK-EVENT-STREAM-RFC.md"
-      execution: "waived GitHub issue for local Codex session"
+      execution: "waived GitHub issue for local session"
     notes: >
       Lifts narrow IScheduler + IEventBus execution-dispatch primitives to fred-core
       without replacing knowledge-flow BaseScheduler public APIs. Introduces typed

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -534,17 +534,20 @@ items:
 
   - id: OPS-04
     title: "Unified task event stream — shared scheduling infrastructure and SSE progress"
-    status: draft
+    status: in_progress
     owner: Dimitri
     refs:
       backlog: "docs/swift/backlog/BACKLOG.md §OPS-04"
       rfc: "docs/swift/rfc/TASK-EVENT-STREAM-RFC.md"
+      execution: "waived GitHub issue for local Codex session"
     notes: >
       Lifts narrow IScheduler + IEventBus execution-dispatch primitives to fred-core
       without replacing knowledge-flow BaseScheduler public APIs. Introduces typed
       TaskEvent Pydantic unions plus task_event_log-backed SSE replay for control-plane
       and knowledge-flow. Delivers migration cockpit (kea→swift) as first consumer.
       Three phases: P1 infrastructure, P2 migration cockpit, P3 knowledge-flow migration.
+      Current local Codex fix closes the in-memory scheduler gap where upload/process
+      tasks stayed pending because no durable task events were emitted on the memory path.
 
   - id: OPS-05
     title: "Object storage naming cleanup — replace MinIO-specific wording where the contract is S3/object storage"

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -546,7 +546,7 @@ items:
       TaskEvent Pydantic unions plus task_event_log-backed SSE replay for control-plane
       and knowledge-flow. Delivers migration cockpit (kea→swift) as first consumer.
       Three phases: P1 infrastructure, P2 migration cockpit, P3 knowledge-flow migration.
-      Current local Codex fix closes the in-memory scheduler gap where upload/process
+      Current local fix closes the in-memory scheduler gap where upload/process
       tasks stayed pending because no durable task events were emitted on the memory path.
 
   - id: OPS-05


### PR DESCRIPTION
## Summary

Fixes `Upload & process` when Knowledge Flow runs with the `memory` scheduler backend.

Previously, the upload flow created `task_run` rows before scheduling, but the in-memory scheduler never emitted the ingestion task lifecycle events that move those tasks out of `pending`. As a result, the frontend could show uploads as stuck even though metadata/content processing had already completed, which also encouraged retries and led to misleading draft-version conflicts.

This change makes the in-memory scheduler emit the same durable task events as the Temporal workflow path.

## Changes

- emit `running/uploading` task events in the in-memory push/pull scheduler path
- emit `running/processing` task events once metadata has been resolved
- emit terminal `succeeded` or `failed` task events for in-memory ingestion
- reuse the existing `emit_ingestion_task_event(...)` helper instead of introducing a parallel event mechanism
- add regression tests covering success and failure event emission in the in-memory scheduler

## Why

With `scheduler.backend: memory`, ingestion was actually completing, but `task_run` stayed `pending` because no events were ever written to `task_event_log`. The UI then appeared blocked, and repeated uploads of the same file could later hit:
`A draft version already exists ...`

This PR fixes the real root cause: missing task progression for the in-memory scheduler.

## Validation

Ran in `apps/knowledge-flow-backend`:

- `make code-quality`
- `make test`
- raw `basedpyright`

Results:

- `make code-quality` ✅
- `make test` ✅
- `basedpyright` ✅ (`0 errors, 0 warnings, 0 notes`)

## Risk / Impact

Low risk.

The change is limited to the in-memory scheduler path and reuses the existing task event helper already used by the Temporal workflow path, so behavior is converged rather than expanded.