### PR TITLE
Clarify summarize_document document_uid expects a uid, not a name

### DIFF
--- a/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
+++ b/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Optional, Sequence
+from typing import Annotated, Optional, Sequence
 
 import httpx
 from langchain_core.tools import BaseTool, tool
+from pydantic import Field
 
 # from langgraph.prebuilt import ToolRuntime
 from agentic_backend.common.kf_base_client import KnowledgeFlowAgentContext
@@ -204,7 +205,19 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
 
     @tool("summarize_document", response_format="content_and_artifact")
     async def summarize_document(
-        document_uid: str,
+        document_uid: Annotated[
+            str,
+            Field(
+                description=(
+                    "The opaque unique identifier (uid) of the document, NOT its "
+                    "name, title, or filename. Take the exact uid string from a "
+                    "prior search_documents_using_vectorization hit or from the "
+                    "'[document_uid]' shown for each document by list_document_tree. "
+                    "If you only know a document's name, call list_document_tree or "
+                    "search first to resolve its uid — never pass the name here."
+                )
+            ),
+        ],
         instruction: Optional[str] = None,
         max_chars: Optional[int] = None,
     ) -> tuple[str, ToolInvocationResult]:
@@ -216,8 +229,10 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
         reads the whole document (using map-reduce for large documents) and
         returns just the summary.
 
-        Get `document_uid` from a prior search_documents_using_vectorization hit
-        or from list_document_tree.
+        `document_uid` MUST be a document's opaque uid, not its name or title.
+        Get it from a prior search_documents_using_vectorization hit or from
+        list_document_tree (the value shown in '[document_uid]'). If you only
+        have a name, resolve the uid with one of those tools first.
 
         Pass `instruction` to steer the summary: focus area, what to look for,
         audience, tone, desired length — e.g. "focus on financial risks and list


### PR DESCRIPTION
## Summary

Agents calling the `summarize_document` tool sometimes passed a document **name/title** as `document_uid` instead of the opaque uid, causing the Knowledge Flow summarize call to fail.

This change makes the contract explicit to the model:
- Adds an `Annotated[str, Field(description=...)]` to `document_uid` so the constraint appears directly in the per-argument tool schema the model sees (not just buried in the docstring).
- Tightens the docstring to state the uid must come from a prior `search_documents_using_vectorization` hit or `list_document_tree`, and to resolve the uid first when only a name is known.

No runtime/logic change — guidance only.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

- `make code-quality` (agentic-backend): `0 errors, 0 warnings, 0 notes`; bandit `No issues identified`.
- `make test` (agentic-backend): `275 passed in 26.27s`, including `tests/test_kf_vector_search_tools.py`.

## Risk / Rollback

Low risk — only a tool argument description and docstring change; no behavior change. Rollback by reverting the single commit.