### PR TITLE
fix(summarize): stop sending max_tokens so strict gateways accept the request

### DIFF
--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/summarizer/llm_summarizer.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/summarizer/llm_summarizer.py
@@ -51,21 +51,23 @@ class LLMBasedDocSummarizer(BaseDocSummarizer):
         # Build a tiny chain once: (prompt | chat_model) returns an AIMessage
         self.chain: Runnable = self.prompt | self.model
 
-    def _complete(self, system: str, user: str, *, max_tokens: Optional[int] = None) -> str:
+    def _complete(self, system: str, user: str) -> str:
         """
         Why this helper:
-        - Central place to control generation knobs (e.g., max_tokens).
+        - Central place to issue a single system+user completion.
         - Works across OpenAI/Azure/Ollama since all are LangChain ChatModels.
+
+        Note on output length: we deliberately do NOT bind ``max_tokens`` here.
+        Recent langchain-openai rewrites ``max_tokens`` to ``max_completion_tokens``
+        on the wire, which some OpenAI-compatible gateways reject with HTTP 400
+        (strict OpenAPI validation). Output length is instead bounded by the
+        prompt (``≤max_words``) and overall latency by the model's request_timeout.
         """
         messages = [
             ("system", system),
             ("user", user),
         ]
-        # Cap the output length so generation latency is bounded. Without this the
-        # model can produce a very long (slow) completion — the dominant cost for
-        # on-demand summaries. `bind` is a no-op for providers that ignore it.
-        chain: Runnable = self.chain if max_tokens is None else (self.prompt | self.model.bind(max_tokens=max_tokens))
-        result = chain.invoke({"messages": messages})
+        result = self.chain.invoke({"messages": messages})
         # `result` is an AIMessage for ChatModels; safeguard for plain strings and
         # list-shaped content (some providers return content blocks).
         content = getattr(result, "content", result)
@@ -77,7 +79,7 @@ class LLMBasedDocSummarizer(BaseDocSummarizer):
         else:
             task = f"Write a concise abstract (≤{max_words} words) for engineers. State problem, approach, and key takeaways. Avoid marketing tone."
         user = f"{task}\n\n---\n{text}"
-        return self._complete(_ABSTRACT_SYS, user, max_tokens=700)
+        return self._complete(_ABSTRACT_SYS, user)
 
     def summarize_tokens(self, text: str, *, top_k: int = 24, vocab_hint: Optional[str] = None) -> List[str]:
         user = (
@@ -86,7 +88,7 @@ class LLMBasedDocSummarizer(BaseDocSummarizer):
             "No duplicates, avoid stopwords.\n\n---\n"
             f"{text}"
         )
-        raw = self._complete(_TOKENS_SYS, user, max_tokens=400)
+        raw = self._complete(_TOKENS_SYS, user)
         toks = [t.strip().lower() for t in raw.split(",") if t.strip()]
         seen, out = set(), []
         for t in toks:

--- a/knowledge-flow-backend/tests/processors/output/summarizer/test_instruction_steering.py
+++ b/knowledge-flow-backend/tests/processors/output/summarizer/test_instruction_steering.py
@@ -138,7 +138,7 @@ def test_llm_based_summarizer_blends_instruction_into_prompt(monkeypatch):
     prompt branch when instruction is set, and the default abstract prompt otherwise."""
     captured: dict[str, str] = {}
 
-    def fake_complete(self, system: str, user: str, *, max_tokens=None) -> str:
+    def fake_complete(self, system: str, user: str) -> str:
         captured["system"] = system
         captured["user"] = user
         return "ok"


### PR DESCRIPTION
## Problem

The on-demand `POST /documents/{uid}/summarize` endpoint returns an **empty summary with HTTP 200** in production, while working fine in local dev. The same root cause silently affects ingestion-time abstract/keyword generation too.

Production logs showed the LLM call failing fast (~120 ms) and being swallowed:

```
WARNING  SmartDocSummarizer failed (continuing): BadRequestError("Error code: 400 - {'message': 'Bad Request', 'status': 400, 'detail': 'OASValidation'}")
INFO     Summarize <uid>: chars_in=10237 fetch_ms=8 summarize_ms=123 abstract_chars=0
```

## Root cause

`LLMBasedDocSummarizer._complete` bound `max_tokens` on each completion to bound latency. Recent `langchain-openai` **rewrites `max_tokens` → `max_completion_tokens`** on the wire. The corp OpenAI-compatible gateway validates requests against a strict OpenAPI schema and **rejects `max_completion_tokens` with HTTP 400 (`OASValidation`)**.

`SmartDocSummarizer` is designed to never throw (so ingestion can proceed), so it catches the 400, returns `None`, and the service returns an empty summary with a misleading 200.

Local dev works because the dev provider accepts the field; the corp gateway does not.

Confirmed by reproducing against the gateway directly:
- body with `max_completion_tokens` → **400**
- identical body with `max_tokens` → **200**

## Fix

Drop the `max_tokens` bind in the summarizer. Output length is already bounded by the prompt (`≤max_words`) and overall latency by the model's `request_timeout`, so no functional cap is lost. **Streaming is untouched**, so interactive chat keeps real-time token streaming.

A comment documents *why* `max_tokens` must not be re-introduced here, to prevent regressions.

## Testing

- Reproduced the gateway 400/200 difference with curl (single-variable).
- `make code-quality` — clean (0 errors).
- `make test` — **207 passed**, 2 deselected (integration).

## Follow-ups (not in this PR)

- The interactive `/summarize` endpoint returns **200 on a swallowed LLM error**, which hides failures. Worth surfacing as a 5xx for on-demand callers (the "never throw" behavior is correct only for the ingestion pipeline).
- Any other cluster path that sends a token cap to this gateway via `langchain-openai` will hit the same rewrite; worth an audit.