### PR TITLE
Improve Word export: tables and robust inline formatting

### DIFF
--- a/agentic-backend/agentic_backend/core/writable_documents/docx_export.py
+++ b/agentic-backend/agentic_backend/core/writable_documents/docx_export.py
@@ -37,10 +37,30 @@ _INLINE_RE = re.compile(
     r"|(`(?P<code>.+?)`)"
 )
 
+# Leftover emphasis markers we strip from text once the outer span is resolved.
+# We only do flat (non-recursive) inline parsing, so nested or mismatched markers
+# (e.g. `**_x_**`, `_a *b* c_`) would otherwise leak through as literal characters.
+# Stripping them keeps clean text — the formatting of the inner span is lost, but
+# no stray `*`/`_` ever appears in the output.
+_STRAY_MARKER_RE = re.compile(r"\*\*|[*_]")
+
+
+def _strip_markers(text: str) -> str:
+    """Remove stray bold/italic markers that flat parsing left behind."""
+    return _STRAY_MARKER_RE.sub("", text)
+
+
 _HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.*)$")
 _BULLET_RE = re.compile(r"^\s*[-*+]\s+(?P<text>.*)$")
 _ORDERED_RE = re.compile(r"^\s*\d+[.)]\s+(?P<text>.*)$")
 _FENCE_RE = re.compile(r"^\s*```")
+
+# A table row contains at least one (unescaped) pipe. The separator line that
+# follows the header is made only of pipes, dashes, colons and whitespace, with
+# at least one dash — e.g. `|---|:--:|`. The separator is what distinguishes a
+# real table from a paragraph that happens to contain a literal `|`.
+_TABLE_ROW_RE = re.compile(r"^\s*\|?.*\|.*$")
+_TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?\s*$")
 
 
 def _add_inline_runs(paragraph: Paragraph, text: str) -> None:
@@ -48,19 +68,62 @@ def _add_inline_runs(paragraph: Paragraph, text: str) -> None:
     pos = 0
     for m in _INLINE_RE.finditer(text):
         if m.start() > pos:
-            paragraph.add_run(text[pos : m.start()])
+            paragraph.add_run(_strip_markers(text[pos : m.start()]))
         if m.group("bold") is not None:
-            paragraph.add_run(m.group("bold")).bold = True
+            # Inner text may carry nested markers (e.g. **_x_**); strip them so
+            # only the outermost emphasis applies and no markers leak through.
+            paragraph.add_run(_strip_markers(m.group("bold"))).bold = True
         elif m.group("italic_star") is not None:
-            paragraph.add_run(m.group("italic_star")).italic = True
+            paragraph.add_run(_strip_markers(m.group("italic_star"))).italic = True
         elif m.group("italic_us") is not None:
-            paragraph.add_run(m.group("italic_us")).italic = True
+            paragraph.add_run(_strip_markers(m.group("italic_us"))).italic = True
         elif m.group("code") is not None:
+            # Code spans are literal: do not strip markers inside backticks.
             run = paragraph.add_run(m.group("code"))
             run.font.name = "Courier New"
         pos = m.end()
     if pos < len(text):
-        paragraph.add_run(text[pos:])
+        paragraph.add_run(_strip_markers(text[pos:]))
+
+
+def _split_table_row(line: str) -> list[str]:
+    """Split a Markdown table row into cell texts, honoring escaped pipes (\\|)."""
+    # Replace escaped pipes with a placeholder, split on real pipes, restore.
+    placeholder = "\x00"
+    cells = line.replace(r"\|", placeholder).split("|")
+    # Drop the empty leading/trailing cells produced by surrounding pipes.
+    if cells and cells[0].strip() == "":
+        cells = cells[1:]
+    if cells and cells[-1].strip() == "":
+        cells = cells[:-1]
+    return [c.replace(placeholder, "|").strip() for c in cells]
+
+
+def _is_table_start(lines: list[str], i: int) -> bool:
+    """A table is a row line immediately followed by a separator line."""
+    return (
+        i + 1 < len(lines)
+        and _TABLE_ROW_RE.match(lines[i]) is not None
+        and "|" in lines[i]
+        and _TABLE_SEP_RE.match(lines[i + 1]) is not None
+    )
+
+
+def _add_table(document: DocxDocument, rows: list[list[str]]) -> None:
+    """Render parsed table rows (first row = header) into a styled docx table."""
+    n_cols = max(len(r) for r in rows)
+    table = document.add_table(rows=len(rows), cols=n_cols)
+    table.style = "Table Grid"
+    for r_idx, row in enumerate(rows):
+        for c_idx in range(n_cols):
+            text = row[c_idx] if c_idx < len(row) else ""
+            cell = table.cell(r_idx, c_idx)
+            # add_table seeds each cell with an empty paragraph; reuse it.
+            paragraph = cell.paragraphs[0]
+            _add_inline_runs(paragraph, text)
+            if r_idx == 0:
+                for run in paragraph.runs:
+                    run.bold = True
 
 
 def _add_code_block(document: DocxDocument, lines: list[str]) -> None:
@@ -74,7 +137,7 @@ def markdown_to_docx_bytes(content_md: str, *, title: str | None = None) -> byte
     """Convert Markdown text to a .docx document and return it as bytes."""
     document = Document()
     if title:
-        document.add_heading(title, level=0)
+        _add_inline_runs(document.add_heading(level=0), title)
 
     lines = (content_md or "").splitlines()
     i = 0
@@ -100,8 +163,20 @@ def markdown_to_docx_bytes(content_md: str, *, title: str | None = None) -> byte
         heading = _HEADING_RE.match(line)
         if heading:
             level = len(heading.group("hashes"))
-            document.add_heading(heading.group("text").strip(), level=min(level, 6))
+            paragraph = document.add_heading(level=min(level, 6))
+            _add_inline_runs(paragraph, heading.group("text").strip())
             i += 1
+            continue
+
+        # Table: a row line followed by a separator line. Consume contiguous rows.
+        if _is_table_start(lines, i):
+            header = _split_table_row(lines[i])
+            i += 2  # skip header and separator
+            body = []
+            while i < len(lines) and _TABLE_ROW_RE.match(lines[i]) and "|" in lines[i]:
+                body.append(_split_table_row(lines[i]))
+                i += 1
+            _add_table(document, [header, *body])
             continue
 
         bullet = _BULLET_RE.match(line)

--- a/agentic-backend/agentic_backend/tests/test_writable_document_docx_export.py
+++ b/agentic-backend/agentic_backend/tests/test_writable_document_docx_export.py
@@ -66,3 +66,124 @@ def test_bold_run_is_marked_bold():
     bold_run = next((r for r in runs if r.text == "strong"), None)
     assert bold_run is not None
     assert bold_run.bold is True
+
+
+def test_nested_emphasis_does_not_leak_markers():
+    # Flat parsing can't render nested/combined emphasis; we keep clean text
+    # instead of leaking literal ** or _ characters.
+    data = markdown_to_docx_bytes("## **_Combined *Bold* and _Italic_ Heading_**")
+    heading = _paragraph_by_style(data, "Heading 2")
+    assert "*" not in heading.text
+    assert "_" not in heading.text
+    assert heading.text == "Combined Bold and Italic Heading"
+
+
+def test_stray_unmatched_markers_are_stripped():
+    data = markdown_to_docx_bytes("A lone * and a stray _ in text")
+    doc = Document(io.BytesIO(data))
+    text = " ".join(p.text for p in doc.paragraphs)
+    assert "*" not in text and "_" not in text
+
+
+def test_code_span_keeps_literal_markers():
+    # Markers inside backticks are literal code and must survive untouched.
+    data = markdown_to_docx_bytes("Use `a_b * c` here")
+    doc = Document(io.BytesIO(data))
+    code_run = next(
+        (r for p in doc.paragraphs for r in p.runs if r.text == "a_b * c"), None
+    )
+    assert code_run is not None
+
+
+def _paragraph_by_style(data: bytes, style_name: str):
+    doc = Document(io.BytesIO(data))
+    return next(
+        p for p in doc.paragraphs if p.style is not None and p.style.name == style_name
+    )
+
+
+def test_heading_strips_inline_markers_and_marks_bold():
+    heading = _paragraph_by_style(
+        markdown_to_docx_bytes("## **New section title**"), "Heading 2"
+    )
+    # Markers are stripped from the visible text...
+    assert heading.text == "New section title"
+    # ...and the run is actually bold.
+    assert heading.runs and all(r.bold for r in heading.runs)
+
+
+def test_heading_with_partial_italic():
+    heading = _paragraph_by_style(
+        markdown_to_docx_bytes("# Plan for *Q3*"), "Heading 1"
+    )
+    assert heading.text == "Plan for Q3"
+    italic_run = next((r for r in heading.runs if r.text == "Q3"), None)
+    assert italic_run is not None and italic_run.italic is True
+
+
+def test_title_supports_inline_formatting():
+    title = _paragraph_by_style(
+        markdown_to_docx_bytes("Body", title="**Bold Title**"), "Title"
+    )
+    assert title.text == "Bold Title"
+    assert title.runs and all(r.bold for r in title.runs)
+
+
+def _table_grid(data: bytes) -> list[list[str]]:
+    doc = Document(io.BytesIO(data))
+    assert doc.tables, "expected at least one table"
+    table = doc.tables[0]
+    return [[cell.text for cell in row.cells] for row in table.rows]
+
+
+def test_table_is_rendered_with_header_and_rows():
+    md = (
+        "| Name  | Role     |\n"
+        "|-------|----------|\n"
+        "| Alice | Engineer |\n"
+        "| Bob   | Designer |\n"
+    )
+    data = markdown_to_docx_bytes(md)
+    grid = _table_grid(data)
+    assert grid == [
+        ["Name", "Role"],
+        ["Alice", "Engineer"],
+        ["Bob", "Designer"],
+    ]
+
+
+def test_table_header_cells_are_bold():
+    md = "| A | B |\n|---|---|\n| 1 | 2 |\n"
+    doc = Document(io.BytesIO(markdown_to_docx_bytes(md)))
+    header_cells = doc.tables[0].rows[0].cells
+    for cell in header_cells:
+        runs = [r for p in cell.paragraphs for r in p.runs]
+        assert runs and all(r.bold for r in runs)
+
+
+def test_table_ragged_rows_are_padded():
+    md = "| A | B | C |\n|---|---|---|\n| 1 | 2 |\n"
+    grid = _table_grid(markdown_to_docx_bytes(md))
+    assert grid == [["A", "B", "C"], ["1", "2", ""]]
+
+
+def test_table_supports_inline_formatting_in_cells():
+    md = "| Col |\n|-----|\n| **bold** |\n"
+    doc = Document(io.BytesIO(markdown_to_docx_bytes(md)))
+    body_cell = doc.tables[0].rows[1].cells[0]
+    runs = [r for p in body_cell.paragraphs for r in p.runs]
+    bold_run = next((r for r in runs if r.text == "bold"), None)
+    assert bold_run is not None and bold_run.bold is True
+
+
+def test_table_honors_escaped_pipe():
+    md = "| Expr |\n|------|\n| a \\| b |\n"
+    grid = _table_grid(markdown_to_docx_bytes(md))
+    assert grid == [["Expr"], ["a | b"]]
+
+
+def test_pipe_without_separator_is_not_a_table():
+    md = "This sentence | has a pipe but no separator.\n"
+    doc = Document(io.BytesIO(markdown_to_docx_bytes(md)))
+    assert not doc.tables
+    assert any("has a pipe" in p.text for p in doc.paragraphs)


### PR DESCRIPTION
## Summary

The Markdown → Word (.docx) converter for writable documents had two gaps that made agent-generated deliverables look broken on export:

- **Tables were not rendered at all.**
- **Inline emphasis leaked literal markers** (`**`, `_`) in headings, the title, and nested/combined spans.

This PR addresses both, staying within the file's pragmatic "v1" scope (no new dependency, no full CommonMark rewrite).

- **Tables**: detect a table by a row line followed by a separator line (`|---|:--:|`), consume contiguous rows, pad ragged rows to the header width, render with the built-in `Table Grid` style, bold the header row, and reuse the existing inline-formatting logic inside cells. Escaped pipes (`\|`) are honored; a paragraph containing a stray `|` is not misread as a table.
- **Headings & title**: route both through the inline-formatting path so `## **Title**` renders bold text instead of literal `**`.
- **Nested / mismatched emphasis**: flat parsing can't render nested spans (e.g. `**_x_**`), so leftover markers are stripped to keep clean text rather than leaking `*`/`_`. Markers inside code spans are preserved (literal code).

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

```
$ make code-quality
... ruff / bandit / detect-secrets / basedpyright: 0 errors, 0 warnings

$ uv run pytest agentic_backend/tests/test_writable_document_docx_export.py -q
16 passed
```

New tests cover: table rendering (header + rows), bold header cells, ragged-row padding, inline formatting inside cells, escaped pipe, pipe-without-separator (not a table); inline formatting in headings/title; nested-emphasis marker stripping; stray-marker stripping; and code-span literal-marker preservation.

## Risk / Rollback

Low risk — change is confined to `docx_export.py` (export-only path) and its test module; no API, storage, or runtime-topology changes. Known v1 limitation: nested emphasis loses inner formatting (markers stripped, text kept) and table column alignment is parsed but not applied. Rollback by reverting this commit.