### PR TITLE
Make document tools work uniformly for corpus and session attachments

### DIFF
--- a/agentic-backend/agentic_backend/core/chatbot/session_orchestrator.py
+++ b/agentic-backend/agentic_backend/core/chatbot/session_orchestrator.py
@@ -101,6 +101,7 @@ from agentic_backend.core.session.attachement_processing import AttachementProce
 from agentic_backend.core.session.session_cache import CachedSession, SessionCache
 from agentic_backend.core.session.stores.base_session_attachment_store import (
     BaseSessionAttachmentStore,
+    SessionAttachmentRecord,
 )
 from agentic_backend.core.session.stores.base_writable_document_store import (
     BaseWritableDocumentStore,
@@ -714,6 +715,39 @@ class SessionOrchestrator:
                 await self._emit(callback, sys_note)
                 next_rank_cursor += 1
                 # Make the model aware of the edit on this turn.
+                lc_history.append(SystemMessage(note_text))
+
+            # 4b-bis) If the user uploaded any attachment since the previous exchange,
+            # inject a system note so the agent knows the file exists and can summarize
+            # or search it by its document_uid (same pattern as writable-doc edits above).
+            new_attachments = await self._collect_new_attachments(
+                session_id=session.id, since=last_activity_at
+            )
+            for att in new_attachments:
+                note_text = (
+                    f"The user uploaded the attachment '{att.name}' "
+                    f"(document_uid={att.document_uid}) to this conversation. "
+                    "Use that document_uid like any other document: summarize_document "
+                    "to read it, or a document_uids filter in "
+                    "search_documents_using_vectorization."
+                )
+                sys_note = ChatMessage(
+                    session_id=session.id,
+                    exchange_id=exchange_id,
+                    rank=next_rank_cursor,
+                    timestamp=_utcnow_dt(),
+                    role=Role.system,
+                    channel=Channel.system_note,
+                    parts=[TextPart(text=note_text)],
+                    metadata=ChatMetadata(
+                        agent_id=effective_agent_id,
+                        extras={"attachment_document_uid": att.document_uid},
+                    ),
+                )
+                all_msgs.append(sys_note)
+                await self._emit(callback, sys_note)
+                next_rank_cursor += 1
+                # Make the model aware of the upload on this turn.
                 lc_history.append(SystemMessage(note_text))
 
             # 4c) Remind the agent which documents already exist in this session (id +
@@ -2022,6 +2056,49 @@ class SessionOrchestrator:
                 [d.document_id for d in edited],
             )
         return edited
+
+    async def _collect_new_attachments(
+        self, *, session_id: str, since: Optional[datetime]
+    ) -> list[SessionAttachmentRecord]:
+        """Return attachments uploaded to the session since the previous exchange.
+
+        An attachment qualifies when it was created after ``since`` (the session's
+        last-activity time captured before this turn) and was successfully
+        vectorized (has a document_uid, so the agent can actually target it).
+        Returns an empty list when attachments are disabled or nothing is new.
+
+        Note: uploading an attachment does not bump ``session.updated_at`` (it goes
+        through a separate endpoint), so ``created_at > since`` cleanly identifies
+        files added between the prior turn and this one.
+        """
+        if self.attachments_store is None:
+            return []
+        try:
+            records = await self.attachments_store.list_for_session(session_id)
+        except Exception:
+            logger.exception(
+                "[SESSIONS][ATTACH] failed to list attachments for session=%s",
+                session_id,
+            )
+            return []
+
+        new: list[SessionAttachmentRecord] = []
+        for rec in records:
+            if not rec.document_uid:
+                continue
+            if since is not None and rec.created_at is not None:
+                # Compare as aware datetimes; storage may return naive on some backends.
+                if _ensure_aware(rec.created_at) <= _ensure_aware(since):
+                    continue
+            new.append(rec)
+        if new:
+            logger.info(
+                "[SESSIONS][ATTACH] session=%s injecting %d new-attachment note(s): %s",
+                session_id,
+                len(new),
+                [r.document_uid for r in new],
+            )
+        return new
 
     async def _restore_history(
         self,

--- a/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
+++ b/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
@@ -62,6 +62,54 @@ def _kf_tool_failure(
     return message, ToolInvocationResult(tool_ref=tool_ref, is_error=True)
 
 
+async def _render_session_attachments(runtime_context) -> Optional[str]:
+    """Render files attached to the current conversation as a text section appended
+    to the document tree.
+
+    Session attachments live outside the folder tree (they are session-scoped, not
+    library tags) but the agent still needs their document_uids to summarize or
+    search them. The agentic backend persists each attachment's name, uid and
+    upload date in the session attachment store, keyed by session_id — so listing
+    them here needs no extra Knowledge Flow call.
+
+    Returns None when there is no session, no attachment store, or no attachments,
+    so the caller can skip the section entirely.
+    """
+    session_id = getattr(runtime_context, "session_id", None)
+    if not session_id:
+        return None
+
+    # Imported lazily to avoid a module-level dependency on the application context
+    # in this integration module (and the circular import it would create).
+    from agentic_backend.application_context import get_session_attachment_store
+
+    store = get_session_attachment_store()
+    if store is None:
+        return None
+
+    try:
+        records = await store.list_for_session(session_id)
+    except Exception:
+        logger.exception(
+            "[OBS][TREE][TOOL] failed to list session attachments session=%s",
+            session_id,
+        )
+        return None
+
+    lines: list[str] = []
+    for rec in sorted(records, key=lambda r: r.name):
+        # Only attachments that were vectorized (have a document_uid) are usable as
+        # a summarize/search target; skip any that failed to ingest.
+        if not rec.document_uid:
+            continue
+        when = rec.created_at.date().isoformat() if rec.created_at else "unknown date"
+        lines.append(f"{rec.name} [{rec.document_uid}] (uploaded {when})")
+
+    if not lines:
+        return None
+    return "Session attachments:\n" + "\n".join(lines)
+
+
 def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
     """Return in-process LangChain tools for Knowledge Flow vector search."""
 
@@ -153,10 +201,22 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
 
         Call this first to orient on what's available before searching or
         summarizing — it shows folder structure and, for each document, its
-        name, uid, and upload date, not its content. Each document is rendered
-        as "name [document_uid] (uploaded date)" — use that uid as the
-        `document_uid` argument to summarize_document, or in search's
+        name, uid, and upload date, not its content.
+
+        Folders are rendered as "name [tag_id]/" — use that tag_id as the
+        `document_library_tags_ids` filter for search_documents_using_vectorization
+        to restrict a search to that folder (and its subfolders). Synthetic
+        grouping folders that are not real tags appear as plain "name/" with no
+        id to filter on.
+
+        Documents are rendered as "name [document_uid] (uploaded date)" — use that
+        uid as the `document_uid` argument to summarize_document, or in search's
         `document_uids` filter.
+
+        Files the user attached to THIS conversation are listed in a final
+        "Session attachments" section (with the same "name [document_uid]" format)
+        — they live outside the folder tree but can still be summarized or searched
+        by their uid.
 
         `working_directory` narrows the listing to a specific folder (e.g.
         "Sales/HR"); omit it to start from the root. The tree is rendered as
@@ -193,14 +253,19 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
                 message,
             )
             return message, artifact
+        attachments_section = await _render_session_attachments(agent.runtime_context)
+        tree_text = result.tree
+        if attachments_section:
+            tree_text = f"{tree_text}\n\n{attachments_section}"
         logger.info(
-            "[OBS][TREE][TOOL] working_directory=%r max_chars=%d truncated=%s",
+            "[OBS][TREE][TOOL] working_directory=%r max_chars=%d truncated=%s attachments=%s",
             working_directory,
             max_chars,
             result.truncated,
+            bool(attachments_section),
         )
         artifact = ToolInvocationResult(tool_ref="list_document_tree")
-        return result.tree, artifact
+        return tree_text, artifact
 
     @tool("summarize_document", response_format="content_and_artifact")
     async def summarize_document(

--- a/agentic-backend/tests/test_kf_vector_search_tools.py
+++ b/agentic-backend/tests/test_kf_vector_search_tools.py
@@ -94,6 +94,88 @@ async def test_list_document_tree_returns_rendered_tree_text(
 
 
 @pytest.mark.asyncio
+async def test_list_document_tree_appends_session_attachments(
+    monkeypatch, _stub_request_with_token_refresh
+):
+    """Files attached to the current conversation are listed in a trailing
+    'Session attachments' section, in the same 'name [uid] (uploaded date)'
+    format as tree docs, so the agent can summarize/search them by uid."""
+    from datetime import datetime, timezone
+
+    from agentic_backend.core.session.stores.base_session_attachment_store import (
+        SessionAttachmentRecord,
+    )
+
+    _stub_request_with_token_refresh["/documents/tree"] = _response(
+        {"tree": "Sales/\n  HR/\n", "truncated": False}
+    )
+
+    records = [
+        SessionAttachmentRecord(
+            session_id="sess-1",
+            attachment_id="att-1",
+            name="report.pdf",
+            summary_md="",
+            document_uid="doc-att-1",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        ),
+        # No document_uid -> failed to ingest -> must be skipped (not summarizable).
+        SessionAttachmentRecord(
+            session_id="sess-1",
+            attachment_id="att-2",
+            name="broken.pdf",
+            summary_md="",
+            document_uid=None,
+        ),
+    ]
+
+    class _FakeStore:
+        async def list_for_session(self, session_id):
+            assert session_id == "sess-1"
+            return records
+
+    monkeypatch.setattr(
+        "agentic_backend.application_context.get_session_attachment_store",
+        lambda: _FakeStore(),
+    )
+
+    agent = _FakeAgent(
+        agent_settings=AgentSettings(id="a-1", name="Agent"),
+        runtime_context=RuntimeContext(session_id="sess-1"),
+    )
+    tools = build_kf_vector_search_tools(agent)
+    list_document_tree = _tool_by_name(tools, "list_document_tree")
+
+    content, _ = await list_document_tree.coroutine()
+
+    assert "Sales/\n  HR/\n" in content
+    assert "Session attachments:" in content
+    assert "report.pdf [doc-att-1] (uploaded 2026-06-01)" in content
+    assert "broken.pdf" not in content
+
+
+@pytest.mark.asyncio
+async def test_list_document_tree_without_session_has_no_attachments_section(
+    _stub_request_with_token_refresh,
+):
+    """No session_id -> no attachment lookup -> the tree text is returned as-is."""
+    _stub_request_with_token_refresh["/documents/tree"] = _response(
+        {"tree": "Sales/\n", "truncated": False}
+    )
+    agent = _FakeAgent(
+        agent_settings=AgentSettings(id="a-1", name="Agent"),
+        runtime_context=RuntimeContext(),
+    )
+    tools = build_kf_vector_search_tools(agent)
+    list_document_tree = _tool_by_name(tools, "list_document_tree")
+
+    content, _ = await list_document_tree.coroutine()
+
+    assert content == "Sales/\n"
+    assert "Session attachments" not in content
+
+
+@pytest.mark.asyncio
 async def test_list_document_tree_respects_hard_library_binding(
     monkeypatch, _stub_request_with_token_refresh
 ):

--- a/agentic-backend/tests/test_session_attachment_notes.py
+++ b/agentic-backend/tests/test_session_attachment_notes.py
@@ -1,0 +1,121 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SessionOrchestrator._collect_new_attachments -- the filter that
+decides which freshly uploaded attachments get a system note injected on a turn.
+
+The helper only reads self.attachments_store, so we exercise it against a tiny
+stub `self` rather than constructing a full orchestrator (which needs SQL stores,
+KPI writers, agent factories, etc.)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from agentic_backend.core.chatbot.session_orchestrator import SessionOrchestrator
+from agentic_backend.core.session.stores.base_session_attachment_store import (
+    SessionAttachmentRecord,
+)
+
+_BASE = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _record(name: str, *, uid: str | None, created_at: datetime | None) -> SessionAttachmentRecord:
+    return SessionAttachmentRecord(
+        session_id="sess-1",
+        attachment_id=f"att-{name}",
+        name=name,
+        summary_md="",
+        document_uid=uid,
+        created_at=created_at,
+    )
+
+
+class _FakeStore:
+    def __init__(self, records: list[SessionAttachmentRecord]):
+        self._records = records
+
+    async def list_for_session(self, session_id: str, session=None):
+        assert session_id == "sess-1"
+        return self._records
+
+
+async def _collect(records, *, since):
+    """Invoke the helper against a stub `self` carrying only attachments_store."""
+    fake_self = cast(SessionOrchestrator, SimpleNamespace(attachments_store=_FakeStore(records)))
+    return await SessionOrchestrator._collect_new_attachments(
+        fake_self, session_id="sess-1", since=since
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_attachments_created_after_since_are_returned():
+    records = [
+        _record("old.pdf", uid="doc-old", created_at=_BASE - timedelta(minutes=5)),
+        _record("new.pdf", uid="doc-new", created_at=_BASE + timedelta(minutes=5)),
+    ]
+
+    new = await _collect(records, since=_BASE)
+
+    assert [r.document_uid for r in new] == ["doc-new"]
+
+
+@pytest.mark.asyncio
+async def test_attachment_without_document_uid_is_skipped():
+    """A failed ingest has no document_uid -> the agent can't target it, so no note."""
+    records = [
+        _record("broken.pdf", uid=None, created_at=_BASE + timedelta(minutes=5)),
+        _record("good.pdf", uid="doc-good", created_at=_BASE + timedelta(minutes=5)),
+    ]
+
+    new = await _collect(records, since=_BASE)
+
+    assert [r.document_uid for r in new] == ["doc-good"]
+
+
+@pytest.mark.asyncio
+async def test_no_since_returns_all_vectorized_attachments():
+    """First turn (no prior activity): every successfully ingested attachment qualifies."""
+    records = [
+        _record("a.pdf", uid="doc-a", created_at=_BASE),
+        _record("b.pdf", uid="doc-b", created_at=_BASE),
+    ]
+
+    new = await _collect(records, since=None)
+
+    assert {r.document_uid for r in new} == {"doc-a", "doc-b"}
+
+
+@pytest.mark.asyncio
+async def test_disabled_attachment_store_yields_nothing():
+    fake_self = cast(SessionOrchestrator, SimpleNamespace(attachments_store=None))
+    new = await SessionOrchestrator._collect_new_attachments(
+        fake_self, session_id="sess-1", since=None
+    )
+    assert new == []
+
+
+@pytest.mark.asyncio
+async def test_naive_created_at_is_compared_without_error():
+    """Some backends return naive datetimes; the helper must coerce, not crash."""
+    naive_after = (_BASE + timedelta(minutes=5)).replace(tzinfo=None)
+    records = [_record("n.pdf", uid="doc-n", created_at=naive_after)]
+
+    new = await _collect(records, since=_BASE)
+
+    assert [r.document_uid for r in new] == ["doc-n"]

--- a/agentic-backend/tests/test_session_attachment_notes.py
+++ b/agentic-backend/tests/test_session_attachment_notes.py
@@ -35,7 +35,9 @@ from agentic_backend.core.session.stores.base_session_attachment_store import (
 _BASE = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def _record(name: str, *, uid: str | None, created_at: datetime | None) -> SessionAttachmentRecord:
+def _record(
+    name: str, *, uid: str | None, created_at: datetime | None
+) -> SessionAttachmentRecord:
     return SessionAttachmentRecord(
         session_id="sess-1",
         attachment_id=f"att-{name}",
@@ -57,7 +59,9 @@ class _FakeStore:
 
 async def _collect(records, *, since):
     """Invoke the helper against a stub `self` carrying only attachments_store."""
-    fake_self = cast(SessionOrchestrator, SimpleNamespace(attachments_store=_FakeStore(records)))
+    fake_self = cast(
+        SessionOrchestrator, SimpleNamespace(attachments_store=_FakeStore(records))
+    )
     return await SessionOrchestrator._collect_new_attachments(
         fake_self, session_id="sess-1", since=since
     )

--- a/knowledge-flow-backend/knowledge_flow_backend/features/summarize/service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/summarize/service.py
@@ -71,9 +71,60 @@ class SummarizeService:
             splitter=self.context.get_text_splitter(),
         )
 
+    async def _get_document_markdown(self, user: KeycloakUser, document_uid: str) -> str:
+        """Resolve the document's text for summarization, uniformly across both
+        document sources Fred exposes to agents:
+
+        - Corpus documents have a stored markdown preview (the normal path).
+        - Session attachments (chat uploads) are fast-ingested as vectors only --
+          no metadata record, no preview artifact -- so the corpus lookup 404s.
+          We reconstruct their text from the session vectors instead.
+
+        This mirrors vector search, which already queries corpus + session scopes
+        and merges them: the agent uses one document_uid and never has to know
+        which source it came from.
+        """
+        try:
+            return await self.content_service.get_markdown_preview(user, document_uid)
+        except FileNotFoundError:
+            # Not a corpus document -- try the session-attachment vectors.
+            text = await asyncio.to_thread(self._reconstruct_attachment_text, user, document_uid)
+            if text:
+                return text
+            # Genuinely unknown uid (or not this user's attachment): let the caller
+            # surface the original 404 rather than summarizing empty text.
+            raise
+
+    def _reconstruct_attachment_text(self, user: KeycloakUser, document_uid: str) -> str:
+        """Rebuild a session attachment's text from its vector chunks.
+
+        Security: attachments have no metadata-store RBAC record, so the vectors'
+        own ``user_id`` is the access gate. We only join chunks owned by the
+        requesting user -- a uid belonging to someone else's attachment yields no
+        chunks and is treated as not found. Chunks are ordered by page (fast-ingest
+        stores one chunk per page) so the reconstructed text reads in order.
+        """
+        store = self.context.get_create_vector_store(self.context.get_embedder())
+        try:
+            chunks = store.get_chunks_for_document(document_uid)
+        except NotImplementedError:
+            # Backend can't fetch chunks by document -- nothing we can do here.
+            return ""
+
+        owned = [c for c in chunks if (c.get("metadata") or {}).get("user_id") == user.uid]
+        if not owned:
+            return ""
+
+        def _page(chunk: dict) -> int:
+            page = (chunk.get("metadata") or {}).get("page")
+            return page if isinstance(page, int) else 0
+
+        owned.sort(key=_page)
+        return "\n\n".join((c.get("text") or "") for c in owned).strip()
+
     async def summarize_document(self, user: KeycloakUser, document_uid: str, request: SummarizeDocumentRequest) -> SummarizeDocumentResponse:
         started = time.monotonic()
-        markdown = await self.content_service.get_markdown_preview(user, document_uid)
+        markdown = await self._get_document_markdown(user, document_uid)
         fetch_ms = (time.monotonic() - started) * 1000
         document = Document(page_content=markdown, metadata={})
 

--- a/knowledge-flow-backend/knowledge_flow_backend/features/tree/service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/tree/service.py
@@ -65,7 +65,7 @@ class TreeService:
         all_uids = sorted({uid for t in tags for uid in t.item_ids})
         leaves_by_uid = await self._resolve_leaves(user, all_uids)
 
-        folders: List[Tuple[str, List[str]]] = [(t.full_path, t.item_ids) for t in tags]
+        folders: List[Tuple[str, List[str], str]] = [(t.full_path, t.item_ids, t.id) for t in tags]
         root = build_tree(folders=folders, leaves_by_uid=leaves_by_uid)
         text, truncated = render_tree(root, max_chars=request.max_chars)
         return DocumentTreeResponse(tree=text, truncated=truncated)

--- a/knowledge-flow-backend/knowledge_flow_backend/features/tree/tree_builder.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/tree/tree_builder.py
@@ -51,10 +51,16 @@ class TreeNode:
     placeholders) -- kept separate from `docs` so every DocLeaf always represents
     a real document with a real uid; `_format_leaf` never has to handle a
     synthetic one.
+
+    `tag_id` is the folder's tag id, rendered on the folder line so a caller can
+    pass it back as a `document_library_tags_ids` / `tag_ids` filter. It is None
+    for synthetic grouping nodes -- intermediate path segments that were never a
+    real tag (e.g. "Sales" when only "Sales/HR" exists) have no id to filter on.
     """
 
     name: str
     full_path: str
+    tag_id: Optional[str] = None
     children: Dict[str, "TreeNode"] = field(default_factory=dict)
     docs: List[DocLeaf] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
@@ -72,25 +78,33 @@ class TreeNode:
 
 def build_tree(
     *,
-    folders: List[Tuple[str, List[str]]],
+    folders: List[Tuple],
     leaves_by_uid: Dict[str, Tuple[str, Optional[datetime]]],
 ) -> TreeNode:
     """
-    `folders`: list of (full_path, item_ids) pairs, one per matched tag.
+    `folders`: list of (full_path, item_ids) or (full_path, item_ids, tag_id)
+    tuples, one per matched tag. The tag_id is optional for backward
+    compatibility; when present it is attached to the matched folder node and
+    rendered so callers can filter on it.
     `leaves_by_uid`: document_uid -> (document_name, created), resolved separately.
 
     Intermediate path segments that aren't themselves a real tag (e.g. "Sales" was
     never created but "Sales/HR" was) become synthetic grouping nodes with no docs
     of their own -- same as how a real filesystem tree shows an implied parent dir.
+    Only the node whose full_path matches the tag gets the tag_id; synthesized
+    ancestors keep tag_id=None.
     """
     root = TreeNode(name="", full_path="")
-    for full_path, item_ids in folders:
+    for folder in folders:
+        full_path, item_ids = folder[0], folder[1]
+        tag_id = folder[2] if len(folder) > 2 else None
         segments = [s for s in full_path.split("/") if s]
         node = root
         acc: List[str] = []
         for seg in segments:
             acc.append(seg)
             node = node.child(seg, "/".join(acc))
+        node.tag_id = tag_id
         for uid in item_ids:
             resolved = leaves_by_uid.get(uid)
             if resolved is None:
@@ -103,6 +117,14 @@ def build_tree(
 def _format_leaf(doc: DocLeaf) -> str:
     when = doc.created.date().isoformat() if doc.created else "unknown date"
     return f"{doc.document_name} [{doc.document_uid}] (uploaded {when})"
+
+
+def _format_folder(node: TreeNode) -> str:
+    """Folder line: ``name/`` for synthetic grouping nodes, ``name [tag_id]/``
+    for real tags -- the id is what a caller passes back as a tag filter."""
+    if node.tag_id:
+        return f"{node.name} [{node.tag_id}]/"
+    return f"{node.name}/"
 
 
 def render_tree(root: TreeNode, *, max_chars: int) -> Tuple[str, bool]:
@@ -133,7 +155,7 @@ def _render(node: TreeNode, *, depth: int) -> str:
     indent = "  " * depth
     for child_name in sorted(node.children):
         child = node.children[child_name]
-        lines.append(f"{indent}{child.name}/")
+        lines.append(f"{indent}{_format_folder(child)}")
         lines.append(_render(child, depth=depth + 1))
     for doc in sorted(node.docs, key=lambda d: d.document_name):
         lines.append(f"{indent}{_format_leaf(doc)}")
@@ -165,7 +187,7 @@ def _count_items(node: TreeNode) -> int:
 
 def _render_budgeted_root(node: TreeNode, *, max_chars: int) -> str:
     """Even the top level alone overflows: keep as many root-level lines as fit."""
-    candidate_lines = [f"{name}/" for name in sorted(node.children)]
+    candidate_lines = [_format_folder(node.children[name]) for name in sorted(node.children)]
     candidate_lines += [_format_leaf(d) for d in sorted(node.docs, key=lambda d: d.document_name)]
 
     # Reserve room for the longest possible omitted-count line (its count can have

--- a/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
@@ -553,14 +553,23 @@ class VectorSearchService:
             if document_library_tags_ids:
                 authorized_tag_ids = set(document_library_tags_ids) & authorized_tag_ids
 
-            # Validate document_uids against ReBAC permissions
+            # A caller-supplied document_uids list means "restrict to exactly these
+            # documents". We must distinguish that from "no uid filter" (None/empty),
+            # because the two scopes resolve the restriction differently below.
+            uids_requested = bool(document_uids)
+
+            # Validate document_uids against corpus ReBAC permissions. Note this only
+            # recognises corpus documents — a session attachment uid is NOT in the
+            # ReBAC document graph, so it never survives this filter. The corpus scope
+            # uses this set; the session scope authorizes uids implicitly via the
+            # user_id/session_id/scope=session metadata instead (see below).
             authorized_document_uids: set[str] = set()
-            if document_uids:
+            if uids_requested:
                 with self._phase_timer(
                     phase="vector_search_filter_document_uids",
                     user=user,
                 ):
-                    authorized_document_uids = await self.metadata_service.filter_readable_document_uids(user, document_uids)
+                    authorized_document_uids = await self.metadata_service.filter_readable_document_uids(user, list(document_uids or []))
 
             # Search function dispatch
             policy_key = policy_name or SearchPolicyName.hybrid
@@ -593,8 +602,14 @@ class VectorSearchService:
                     "session_id": [session_id],
                     "scope": ["session"],
                 }
-                if authorized_document_uids:
-                    attachment_metadata["document_uid"] = list(authorized_document_uids)
+                # Within session scope the uid filter is the caller's requested uids
+                # verbatim: the user_id/session_id/scope=session terms already restrict
+                # results to this user's own attachments in this session, which is the
+                # authorization boundary. Using the corpus-ReBAC-filtered set here would
+                # be wrong — attachment uids are never in that set, so it would drop the
+                # filter entirely and leak every attachment in the session.
+                if uids_requested:
+                    attachment_metadata["document_uid"] = list(document_uids or [])
                 logger.debug(
                     "[VECTOR][SEARCH][ATTACH] session=%s user=%s policy=%s question=%r top_k=%d",
                     session_id,
@@ -621,9 +636,20 @@ class VectorSearchService:
                 )
 
             # Corpus/library query (scoped by authorized tags, excludes session vectors)
+            #
+            # When the caller requested specific uids but none of them are readable
+            # corpus documents (e.g. they were all session attachments), the corpus
+            # scope must yield nothing — searching it without a uid filter would
+            # ignore the requested restriction and return the whole library.
+            corpus_uid_filter_empty = uids_requested and not authorized_document_uids
             if include_corpus_scope and not authorized_tag_ids:
                 logger.warning("[OBS][SEARCH] session=%s — no authorized libs, corpus search skipped", session_id)
-            if include_corpus_scope and authorized_tag_ids:
+            if include_corpus_scope and corpus_uid_filter_empty:
+                logger.info(
+                    "[OBS][SEARCH] session=%s — requested document_uids resolve to no readable corpus document, corpus search skipped",
+                    session_id,
+                )
+            if include_corpus_scope and authorized_tag_ids and not corpus_uid_filter_empty:
                 corpus_metadata: dict[str, Any] = {"scope": ["!session"]}
                 if authorized_document_uids:
                     corpus_metadata["document_uid"] = list(authorized_document_uids)

--- a/knowledge-flow-backend/tests/features/test_tree_builder.py
+++ b/knowledge-flow-backend/tests/features/test_tree_builder.py
@@ -47,6 +47,45 @@ def test_leaf_includes_document_uid_so_callers_can_target_other_tools():
     assert "[doc-abc-123]" in text
 
 
+def test_folder_renders_its_tag_id_so_callers_can_filter_on_it():
+    """The folder line must expose the tag id -- it's what an agent passes back as
+    a document_library_tags_ids / tag_ids filter to scope a search to that folder."""
+    folders = [("Sales", ["doc-1"], "tag-sales"), ("Sales/HR", ["doc-2"], "tag-hr")]
+    leaves = {"doc-1": ("Overview.pdf", None), "doc-2": ("Onboarding.pdf", None)}
+
+    root = build_tree(folders=folders, leaves_by_uid=leaves)
+    text, _ = render_tree(root, max_chars=10_000)
+
+    assert "Sales [tag-sales]/" in text
+    assert "HR [tag-hr]/" in text
+
+
+def test_synthetic_parent_folder_has_no_tag_id():
+    """'Sales' was never a real tag (only 'Sales/HR' was) -- it is a synthetic
+    grouping node and must render without a bracketed id to filter on."""
+    folders = [("Sales/HR", ["doc-1"], "tag-hr")]
+    leaves = {"doc-1": ("Doc.pdf", None)}
+
+    root = build_tree(folders=folders, leaves_by_uid=leaves)
+    text, _ = render_tree(root, max_chars=10_000)
+
+    assert "Sales/" in text
+    assert "Sales [" not in text
+    assert "HR [tag-hr]/" in text
+
+
+def test_folders_without_tag_id_stay_backward_compatible():
+    """Two-tuple folders (no tag id) still render as plain 'name/'."""
+    folders = [("Sales", ["doc-1"])]
+    leaves = {"doc-1": ("Overview.pdf", None)}
+
+    root = build_tree(folders=folders, leaves_by_uid=leaves)
+    text, _ = render_tree(root, max_chars=10_000)
+
+    assert "Sales/" in text
+    assert "Sales [" not in text
+
+
 def test_document_in_multiple_folders_appears_as_a_leaf_under_each():
     folders = [("Sales/HR", ["doc-1"]), ("Sales/Legal", ["doc-1"])]
     leaves = {"doc-1": ("Policy.pdf", None)}

--- a/knowledge-flow-backend/tests/services/test_summarize_attachment_fallback.py
+++ b/knowledge-flow-backend/tests/services/test_summarize_attachment_fallback.py
@@ -1,0 +1,131 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SummarizeService's uniform text resolution.
+
+summarize_document must work for BOTH corpus documents (markdown preview) and
+session attachments (chat uploads, which exist only as vectors). These tests
+exercise the resolution + attachment-reconstruction logic directly, bypassing the
+LLM summarizer."""
+
+from __future__ import annotations
+
+import pytest
+from fred_core import KeycloakUser
+
+from knowledge_flow_backend.features.summarize.service import SummarizeService
+
+
+def _user(uid: str = "u-1") -> KeycloakUser:
+    return KeycloakUser(uid=uid, username="tester", email="t@example.com", roles=["admin"], groups=[])
+
+
+class _ContentServiceStub:
+    """Mimics corpus markdown preview: returns text for known uids, raises
+    FileNotFoundError (the real 404 trigger) for everything else."""
+
+    def __init__(self, by_uid: dict[str, str]) -> None:
+        self._by_uid = by_uid
+
+    async def get_markdown_preview(self, user, document_uid: str) -> str:
+        del user
+        if document_uid not in self._by_uid:
+            raise FileNotFoundError(f"No metadata found for document {document_uid}")
+        return self._by_uid[document_uid]
+
+
+class _VectorStoreStub:
+    def __init__(self, chunks_by_uid: dict[str, list[dict]]) -> None:
+        self._chunks_by_uid = chunks_by_uid
+
+    def get_chunks_for_document(self, document_uid: str) -> list[dict]:
+        return list(self._chunks_by_uid.get(document_uid, []))
+
+
+class _ContextStub:
+    def __init__(self, store: _VectorStoreStub) -> None:
+        self._store = store
+
+    def get_embedder(self):
+        return object()
+
+    def get_create_vector_store(self, _embedder):
+        return self._store
+
+
+def _service(*, corpus: dict[str, str], attachment_chunks: dict[str, list[dict]]) -> SummarizeService:
+    service = SummarizeService.__new__(SummarizeService)  # bypass __init__ (no ApplicationContext)
+    service.content_service = _ContentServiceStub(corpus)
+    service.context = _ContextStub(_VectorStoreStub(attachment_chunks))
+    return service
+
+
+def _chunk(text: str, *, user_id: str, page: int | None = None) -> dict:
+    md: dict = {"user_id": user_id, "document_uid": "att-1", "scope": "session"}
+    if page is not None:
+        md["page"] = page
+    return {"chunk_uid": f"c-{page}", "text": text, "metadata": md}
+
+
+@pytest.mark.asyncio
+async def test_corpus_document_uses_markdown_preview():
+    service = _service(corpus={"doc-1": "Corpus body."}, attachment_chunks={})
+
+    text = await service._get_document_markdown(_user(), "doc-1")
+
+    assert text == "Corpus body."
+
+
+@pytest.mark.asyncio
+async def test_attachment_falls_back_to_reconstructed_vector_text():
+    """No corpus record -> rebuild the text from the session vectors, in page order."""
+    chunks = [
+        _chunk("Second page.", user_id="u-1", page=2),
+        _chunk("First page.", user_id="u-1", page=1),
+    ]
+    service = _service(corpus={}, attachment_chunks={"att-1": chunks})
+
+    text = await service._get_document_markdown(_user("u-1"), "att-1")
+
+    assert text == "First page.\n\nSecond page."
+
+
+@pytest.mark.asyncio
+async def test_attachment_of_another_user_is_treated_as_not_found():
+    """Attachments have no metadata-RBAC record; the vectors' user_id is the gate.
+    A uid owned by someone else must not be summarizable -> original 404 surfaces."""
+    chunks = [_chunk("Secret.", user_id="other-user", page=1)]
+    service = _service(corpus={}, attachment_chunks={"att-1": chunks})
+
+    with pytest.raises(FileNotFoundError):
+        await service._get_document_markdown(_user("u-1"), "att-1")
+
+
+@pytest.mark.asyncio
+async def test_unknown_uid_raises_not_found():
+    service = _service(corpus={}, attachment_chunks={})
+
+    with pytest.raises(FileNotFoundError):
+        await service._get_document_markdown(_user(), "does-not-exist")
+
+
+@pytest.mark.asyncio
+async def test_chunks_without_page_metadata_still_reconstruct():
+    """Single combined-doc fallback ingests have no 'page'; must not crash on sort."""
+    chunks = [_chunk("Whole doc.", user_id="u-1", page=None)]
+    service = _service(corpus={}, attachment_chunks={"att-1": chunks})
+
+    text = await service._get_document_markdown(_user("u-1"), "att-1")
+
+    assert text == "Whole doc."

--- a/knowledge-flow-backend/tests/services/test_tree_service.py
+++ b/knowledge-flow-backend/tests/services/test_tree_service.py
@@ -95,8 +95,8 @@ async def test_tree_lists_nested_folders_from_root():
     result = await service.get_tree(_user(), DocumentTreeRequest())
 
     assert not result.truncated
-    assert "Sales/" in result.tree
-    assert "HR/" in result.tree
+    assert "Sales/" in result.tree  # synthetic parent: no tag of its own
+    assert "HR [tag-1]/" in result.tree  # real tag exposes its id so callers can filter on it
     assert "Onboarding.pdf" in result.tree
     assert "[doc-1]" in result.tree  # uid must be present so callers can target summarize_document/search
 

--- a/knowledge-flow-backend/tests/services/test_vector_search_service.py
+++ b/knowledge-flow-backend/tests/services/test_vector_search_service.py
@@ -39,9 +39,14 @@ class DummyVectorStore:
     """
     Mock vector store that simulates similarity search with dummy results.
     Raises ValueError on empty question.
+    Records every search_filter it receives so tests can assert on scoping.
     """
 
+    def __init__(self):
+        self.calls: list = []
+
     def ann_search(self, query, *, k=10, search_filter=None):
+        self.calls.append(search_filter)
         if not query:
             raise ValueError("Question must not be empty")
         if k <= 0:
@@ -111,16 +116,44 @@ class DummyMetadataService:
         return set(document_uids or [])
 
 
+class DummyMetadataServiceNoCorpusDocs:
+    """Simulates document_uids that are NOT readable corpus documents (e.g. session
+    attachments): the corpus ReBAC filter drops them all."""
+
+    async def filter_readable_document_uids(self, _user, _document_uids):
+        return set()
+
+
+def _document_uid_terms(search_filter):
+    """Extract the document_uid term filter a search_filter carries, if any."""
+    if search_filter is None or not search_filter.metadata_terms:
+        return None
+    return search_filter.metadata_terms.get("document_uid")
+
+
+def _is_corpus_filter(search_filter):
+    """A corpus-scope query is the one excluding session vectors (scope=!session)."""
+    if search_filter is None or not search_filter.metadata_terms:
+        return False
+    return list(search_filter.metadata_terms.get("scope") or []) == ["!session"]
+
+
 class DummyContext:
     """
     Mock application context that returns dummy embedder and vector store.
+
+    Reuses a single vector store instance per context so tests can inspect the
+    search filters it recorded.
     """
+
+    def __init__(self):
+        self.vector_store = DummyVectorStore()
 
     def get_embedder(self):
         return "dummy_embedder"
 
     def get_create_vector_store(self, embedder):
-        return DummyVectorStore()
+        return self.vector_store
 
     def get_crossencoder_model(self):
         return None
@@ -199,3 +232,81 @@ async def test_similarity_search_zero_k(monkeypatch, test_user):
     )
     assert isinstance(results, list)
     assert results == []
+
+
+# ----------------------------
+# 🔒 document_uids scoping
+# ----------------------------
+
+
+async def test_document_uids_skip_corpus_when_not_readable_corpus_docs(monkeypatch, test_user):
+    """Requested uids that are not readable corpus documents (e.g. session attachments)
+    must NOT cause an unfiltered corpus search — the corpus scope is skipped entirely.
+
+    This is the regression guard for the leak where a session-attachment uid filter,
+    dropped by corpus ReBAC, degraded the corpus query to "return the whole library".
+    """
+    monkeypatch.setattr(vector_search_service.ApplicationContext, "get_instance", DummyContext)
+    monkeypatch.setattr(vector_search_service, "TagService", DummyTagService)
+    monkeypatch.setattr(vector_search_service, "MetadataService", DummyMetadataServiceNoCorpusDocs)
+    vector_svc = VectorSearchService()
+    await vector_svc.search(
+        question="What is in the attachment?",
+        user=test_user,
+        top_k=5,
+        document_library_tags_ids=None,
+        document_uids=["attachment-uid"],
+        policy_name=SearchPolicyName.semantic,
+        session_id="session-1",
+    )
+
+    # No corpus query should have run at all — the requested uid was not a readable
+    # corpus document, so the corpus scope is skipped rather than searched unfiltered.
+    # (Asserting on the recorded filters, not returned hits: the dummy store does not
+    # itself apply metadata filters.)
+    calls = vector_svc.vector_store.calls
+    assert not any(_is_corpus_filter(sf) for sf in calls)
+
+
+async def test_document_uids_filter_attachment_scope_by_requested_uids(monkeypatch, test_user):
+    """The session/attachment query must be filtered by the caller's requested uids
+    verbatim — not by the corpus-ReBAC-filtered set (which never contains attachment
+    uids)."""
+    monkeypatch.setattr(vector_search_service.ApplicationContext, "get_instance", DummyContext)
+    monkeypatch.setattr(vector_search_service, "TagService", DummyTagService)
+    monkeypatch.setattr(vector_search_service, "MetadataService", DummyMetadataServiceNoCorpusDocs)
+    vector_svc = VectorSearchService()
+    await vector_svc.search(
+        question="What is in the attachment?",
+        user=test_user,
+        top_k=5,
+        document_library_tags_ids=None,
+        document_uids=["attachment-uid"],
+        policy_name=SearchPolicyName.semantic,
+        session_id="session-1",
+    )
+
+    attachment_calls = [sf for sf in vector_svc.vector_store.calls if sf is not None and sf.metadata_terms and list(sf.metadata_terms.get("scope") or []) == ["session"]]
+    assert attachment_calls, "expected a session-scope attachment query"
+    assert list(_document_uid_terms(attachment_calls[0]) or []) == ["attachment-uid"]
+
+
+async def test_document_uids_filter_corpus_scope_by_readable_uids(monkeypatch, test_user):
+    """When requested uids ARE readable corpus documents, the corpus query is filtered
+    by them (the normal corpus case is preserved)."""
+    monkeypatch.setattr(vector_search_service.ApplicationContext, "get_instance", DummyContext)
+    monkeypatch.setattr(vector_search_service, "TagService", DummyTagService)
+    monkeypatch.setattr(vector_search_service, "MetadataService", DummyMetadataService)
+    vector_svc = VectorSearchService()
+    await vector_svc.search(
+        question="What is AI?",
+        user=test_user,
+        top_k=5,
+        document_library_tags_ids=None,
+        document_uids=["doc-1"],
+        policy_name=SearchPolicyName.semantic,
+    )
+
+    corpus_calls = [sf for sf in vector_svc.vector_store.calls if _is_corpus_filter(sf)]
+    assert corpus_calls, "expected a corpus-scope query"
+    assert list(_document_uid_terms(corpus_calls[0]) or []) == ["doc-1"]


### PR DESCRIPTION
## Summary

Unifies the agent's document tools so chat attachments behave like any other document — discoverable in the tree, scoped by folder, and usable by uid across both search and summarize.

- **Tree shows tag ids** — folders now render as `name [tag_id]/`, so the agent can pass that id as a `document_library_tags_ids` filter to scope a search to a folder (and its subfolders). Synthetic grouping folders (never a real tag) stay as plain `name/`.
- **Tree lists session attachments** — files attached to the conversation appear in a trailing `Session attachments` section (`name [document_uid] (uploaded date)`), sourced from the existing agentic session attachment store (no extra Knowledge Flow call).
- **Upload system-note** — when the user uploads a file mid-conversation, a system note announces it (name + document_uid) on the next turn, mirroring the existing writable-document edit notes. Driven by `created_at > last_activity_at`; uploads don't bump `session.updated_at`, so the cutoff is clean.
- **Uniform summarize** — `summarize_document` previously 404'd on attachments because it only resolved corpus documents (metadata + markdown preview). It now falls back to reconstructing the attachment's text from its session vectors when no corpus record exists, so one `document_uid` works regardless of source — matching how vector search already merges corpus + session scopes.
- **Fix `document_uids` filter leaking the whole corpus** — filtering a search by a session-attachment uid returned every document in the authorized library instead of just the attachment. The uid was dropped by the corpus ReBAC check (session attachments have no ReBAC document record), leaving an empty authorized set that the corpus query treated as "no filter". The fix separates *uids requested* from *uids readable in corpus*: the session scope is now filtered by the requested uids verbatim (its `user_id`/`session_id`/`scope=session` terms are the authorization boundary), and the corpus query is skipped entirely when the requested uids resolve to no readable corpus document.

### Security note
Session attachments have no metadata-store RBAC record; their access gate is the vectors' own `user_id`. The summarize fallback only joins chunks owned by the requesting user — a uid belonging to another user's attachment yields no chunks and surfaces the original 404. The search `document_uids` filter follows the same boundary: the session scope is constrained by `user_id`/`session_id`, and the corpus scope only honours uids that pass corpus ReBAC.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed (tool docstrings).

## Validation Notes

Knowledge Flow:
```
uv run --extra dev pytest tests/services/test_summarize_attachment_fallback.py \
  tests/services/test_tree_service.py tests/features/test_tree_builder.py \
  tests/services/test_vector_search_service.py -q
# 26 passed
```
Agentic:
```
uv run --extra dev pytest tests/test_kf_vector_search_tools.py \
  tests/test_session_attachment_notes.py -q
# 24 passed
```
ruff + basedpyright clean on all touched files.

## Risk / Rollback

Low risk; changes are additive. The summarize fallback only triggers on the corpus-miss path that previously 404'd, so corpus behavior is unchanged. The tree tag-id rendering changed the folder line format — callers that parsed the old `name/` format should read the bracketed id. The `document_uids` search fix is a tightening of scope (it can only return fewer, more correct results — a previously over-broad corpus search is narrowed or skipped). Rollback by reverting the commit.
