### PR TITLE
fix(user-profile): truncate long name and username with ellipsis

### DIFF
--- a/frontend/src/rework/components/shared/molecules/UserProfile/UserProfile.module.css
+++ b/frontend/src/rework/components/shared/molecules/UserProfile/UserProfile.module.css
@@ -8,18 +8,30 @@
   height: 3.5rem;
 }
 
+.userProfile > :not(.userIdentity) {
+  flex-shrink: 0;
+}
+
 .userIdentity {
   display: flex;
   flex-direction: column;
   margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .userIdentityName {
+  overflow: hidden;
   color: var(--on-surface);
   font: var(--font-body-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .userIdentityId {
+  overflow: hidden;
   color: var(--on-surface-retreat);
   font: var(--font-body-small);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

Long full names or usernames in the `UserProfile` molecule previously
expanded the identity column, squishing the avatar and pushing the settings
icon out of place.

This change caps the identity column and truncates both lines with an ellipsis:

- `.userIdentity` gets `min-width: 0` + `overflow: hidden` so the flex column
  can shrink instead of forcing the row wider.
- `.userIdentityName` and `.userIdentityId` get
  `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`.
- `.userProfile > :not(.userIdentity)` gets `flex-shrink: 0` so the avatar and
  settings button keep their size and stay anchored.

CSS-only; no behavior or API change.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

- `npx prettier --check` on the changed CSS file: `All matched files use Prettier code style!`
- Verified in the running app (Vite dev server) by injecting long name/username
  strings into the DOM: both lines truncate with an ellipsis, the avatar keeps
  its round size, and the settings icon stays anchored on the right.
  Measured `scrollWidth` (386px) > `clientWidth` (164px) on the username span,
  confirming the overflow is clipped rather than expanding the container.

## Risk / Rollback

Low risk — scoped to one CSS module affecting only the user profile widget.
Rollback by reverting this commit.
