### PR TITLE
Fix for CHAT-12: human-friendly tool call labels in the chat trace

### DIFF
--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer.tsx
@@ -23,13 +23,12 @@ import {
   detailTextForEntry,
   entryLabel,
   formatLatencyMs,
+  humanizeToolName,
   phaseKeyForEntry,
   sourceForEntry,
   statusForEntry,
   thoughtExtras,
-  toolArgs,
   toolName,
-  toolResultContent,
   toolResultLatencyMs,
   toolResultOk,
 } from "../../../../../utils/traceUtils";
@@ -42,31 +41,15 @@ interface TraceDetailDrawerProps {
   onClose: () => void;
 }
 
-function tryParseJson(s: string): unknown {
-  try {
-    return JSON.parse(s);
-  } catch {
-    return s;
-  }
-}
-
 function toolPayload(entry: Extract<TraceEntry, { kind: "combo" }>): unknown {
-  const callPayload = {
-    call_id:
-      entry.call.parts?.[0] && "call_id" in entry.call.parts[0]
-        ? (entry.call.parts[0] as { call_id: string }).call_id
-        : undefined,
-    tool: toolName(entry.call),
-    args: toolArgs(entry.call),
-  };
-  if (!entry.result) return { call: callPayload };
+  // Expose only the humanized action name and execution outcome.
+  // Raw tool names, arguments, and result payloads must not be shown to end users.
+  const action = humanizeToolName(toolName(entry.call));
+  if (!entry.result) return { action, status: "running" };
   return {
-    call: callPayload,
-    result: {
-      ok: toolResultOk(entry.result),
-      latency: formatLatencyMs(toolResultLatencyMs(entry.result)),
-      content: tryParseJson(toolResultContent(entry.result)),
-    },
+    action,
+    status: toolResultOk(entry.result) ? "completed" : "failed",
+    latency: formatLatencyMs(toolResultLatencyMs(entry.result)),
   };
 }
 

--- a/apps/frontend/src/rework/utils/traceUtils.test.ts
+++ b/apps/frontend/src/rework/utils/traceUtils.test.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from "../../slices/agentic/agenticOpenApi";
 import {
   formatLatencyMs,
   groupTraceEntries,
+  humanizeToolName,
   isTraceChannel,
   isFinalChannel,
   primaryTextForEntry,
@@ -251,17 +252,24 @@ describe("primaryTextForEntry", () => {
     expect(primaryTextForEntry({ kind: "solo", message: m })).toBe("some output");
   });
 
-  it("shows 'name(key=val)' for combo with args", () => {
+  it("returns empty string for combo with args — raw tool name and arguments are suppressed", () => {
     const call = toolCallMsg("c1", "search", { query: "vitest" });
-    const text = primaryTextForEntry({ kind: "combo", call });
-    expect(text).toContain("search");
-    expect(text).toContain("query");
-    expect(text).toContain("vitest");
+    expect(primaryTextForEntry({ kind: "combo", call })).toBe("");
   });
 
-  it("shows only tool name for combo with no args", () => {
+  it("returns empty string for combo with no args", () => {
     const call = toolCallMsg("c1", "refresh", {});
-    expect(primaryTextForEntry({ kind: "combo", call })).toBe("refresh");
+    expect(primaryTextForEntry({ kind: "combo", call })).toBe("");
+  });
+
+  it("shows tool_use thought title (e.g. 'Calling tavily search')", () => {
+    const m = thoughtMsg("", { title: "Calling tavily search", phase: "tool_use" });
+    expect(primaryTextForEntry({ kind: "solo", message: m })).toBe("Calling tavily search");
+  });
+
+  it("shows title for non-tool_use thought phases", () => {
+    const m = thoughtMsg("body", { title: "Planning step", phase: "planning" });
+    expect(primaryTextForEntry({ kind: "solo", message: m })).toBe("Planning step");
   });
 });
 
@@ -273,10 +281,25 @@ describe("secondaryTextForEntry", () => {
     expect(secondaryTextForEntry({ kind: "solo", message: m })).toBe("All good");
   });
 
-  it("returns tool result summary for combo", () => {
+  it("returns latency string for combo with result that has latency", () => {
     const call = toolCallMsg("c1", "search");
-    const result = toolResultMsg("c1", "The answer is 42");
-    expect(secondaryTextForEntry({ kind: "combo", call, result })).toContain("The answer is 42");
+    const result = toolResultMsg("c1", "The answer is 42", true, 1500);
+    expect(secondaryTextForEntry({ kind: "combo", call, result })).toBe("1.5s");
+  });
+
+  it("returns empty string when result has no latency", () => {
+    const call = toolCallMsg("c1", "search");
+    const result = toolResultMsg("c1", '{"raw":"json response"}');
+    expect(secondaryTextForEntry({ kind: "combo", call, result })).toBe("");
+  });
+
+  it("does not expose raw result content", () => {
+    const call = toolCallMsg("c1", "get_issue");
+    const result = toolResultMsg("c1", '{"expand":"renderedFields,names,schema","summary":"Secret data"}');
+    const text = secondaryTextForEntry({ kind: "combo", call, result });
+    expect(text).not.toContain("renderedFields");
+    expect(text).not.toContain("Secret");
+    expect(text).not.toContain("{");
   });
 
   it("returns empty string for pending combo", () => {
@@ -321,5 +344,93 @@ describe("thoughtSummaryLabel", () => {
       { kind: "combo" as const, call: toolCallMsg("c1", "a"), result: toolResultMsg("c1", "r", true, 1500) },
     ];
     expect(thoughtSummaryLabel(entries)).toBe("Thought for 1.5s");
+  });
+});
+
+// ── humanizeToolName ──────────────────────────────────────────────────────────
+
+describe("humanizeToolName", () => {
+  it("handles MCP web_search → 'Searching the web'", () => {
+    expect(humanizeToolName("mcp__tavily__web_search")).toBe("Searching the web");
+  });
+
+  it("handles bare web_search (no mcp prefix)", () => {
+    expect(humanizeToolName("web_search")).toBe("Searching the web");
+  });
+
+  it("handles MCP verb-first with provider: search_issues → 'Searching GitHub issues'", () => {
+    expect(humanizeToolName("mcp__github__search_issues")).toBe("Searching GitHub issues");
+  });
+
+  it("handles MCP create with provider: create_ticket → 'Creating Jira ticket'", () => {
+    expect(humanizeToolName("mcp__jira__create_ticket")).toBe("Creating Jira ticket");
+  });
+
+  it("strips trailing numeric suffix before humanizing", () => {
+    expect(humanizeToolName("mcp__jira__create_ticket_3")).toBe("Creating Jira ticket");
+    expect(humanizeToolName("search_2")).toBe("Searching");
+  });
+
+  it("falls back to title-cased words for unknown tools without verbs", () => {
+    expect(humanizeToolName("my_custom_tool")).toBe("My Custom Tool");
+  });
+
+  it("strips numeric suffix on unknown tools", () => {
+    expect(humanizeToolName("my_custom_tool_3")).toBe("My Custom Tool");
+  });
+
+  it("handles single-word verb tools", () => {
+    expect(humanizeToolName("search")).toBe("Searching");
+    expect(humanizeToolName("create")).toBe("Creating");
+  });
+
+  it("handles tavily-search (raw name from tavily-mcp v0.2.x)", () => {
+    expect(humanizeToolName("tavily-search")).toBe("Searching the web");
+  });
+
+  it("returns 'Tool' for empty string", () => {
+    expect(humanizeToolName("")).toBe("Tool");
+  });
+
+  it("handles verb-at-end pattern (code_search)", () => {
+    const result = humanizeToolName("code_search");
+    expect(result).toContain("Searching");
+    expect(result.toLowerCase()).toContain("code");
+  });
+
+  it("includes provider label for non-web MCP tools with no verb object", () => {
+    expect(humanizeToolName("mcp__github__search")).toBe("Searching GitHub");
+  });
+});
+
+// ── groupTraceEntries — deduplication ────────────────────────────────────────
+
+describe("groupTraceEntries deduplication", () => {
+  it("collapses duplicate tool_call messages with the same call_id into one row", () => {
+    const call1 = toolCallMsg("c1", "search");
+    const call1dup = toolCallMsg("c1", "search"); // same call_id, duplicate
+    const result = toolResultMsg("c1", "found it");
+    const entries = groupTraceEntries([call1, call1dup, result]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "combo", call: call1, result });
+  });
+
+  it("preserves args and result on the surviving combo entry", () => {
+    const call = toolCallMsg("c1", "mcp__tavily__web_search", { query: "hello" });
+    const callDup = toolCallMsg("c1", "mcp__tavily__web_search", { query: "hello" });
+    const result = toolResultMsg("c1", "some result");
+    const entries = groupTraceEntries([call, callDup, result]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe("combo");
+    if (entries[0].kind === "combo") {
+      expect(entries[0].result).toBe(result);
+    }
+  });
+
+  it("does not collapse tool_calls with different call_ids", () => {
+    const call1 = toolCallMsg("c1", "search");
+    const call2 = toolCallMsg("c2", "search");
+    const entries = groupTraceEntries([call1, call2]);
+    expect(entries).toHaveLength(2);
   });
 });

--- a/apps/frontend/src/rework/utils/traceUtils.ts
+++ b/apps/frontend/src/rework/utils/traceUtils.ts
@@ -72,6 +72,119 @@ export function toolName(msg: ChatMessage): string {
   return toolCallPart(msg)?.name ?? "";
 }
 
+// Maps known provider identifiers (from mcp__<provider>__ prefix) to display names.
+// Providers not listed here fall back to title-cased provider string.
+const PROVIDER_DISPLAY: Record<string, string> = {
+  github: "GitHub",
+  gitlab: "GitLab",
+  jira: "Jira",
+  confluence: "Confluence",
+  slack: "Slack",
+  notion: "Notion",
+  google: "Google",
+  linear: "Linear",
+};
+
+// Well-known compound slugs that don't follow the verb-first pattern.
+// Also covers raw tool names emitted by specific MCP servers (no server prefix
+// because langchain-mcp-adapters defaults to tool_name_prefix=False).
+const SLUG_OVERRIDES: Record<string, string> = {
+  web_search: "Searching the web",
+  search_web: "Searching the web",
+  browse_web: "Browsing the web",
+  // tavily-mcp v0.2.x reports its tool as "tavily-search"
+  "tavily-search": "Searching the web",
+  tavily_search: "Searching the web",
+};
+
+// Action verb stems → gerund display form.
+const GERUNDS: Record<string, string> = {
+  search: "Searching",
+  find: "Finding",
+  get: "Getting",
+  fetch: "Fetching",
+  read: "Reading",
+  list: "Listing",
+  create: "Creating",
+  update: "Updating",
+  delete: "Deleting",
+  add: "Adding",
+  remove: "Removing",
+  send: "Sending",
+  post: "Posting",
+  run: "Running",
+  execute: "Executing",
+  query: "Querying",
+  browse: "Browsing",
+};
+
+function toTitleCase(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+}
+
+/**
+ * Converts a raw tool name into a human-friendly label.
+ *
+ * Examples:
+ *   mcp__tavily__web_search   → "Searching the web"
+ *   mcp__github__search_issues → "Searching GitHub issues"
+ *   mcp__jira__create_ticket   → "Creating Jira ticket"
+ *   my_custom_tool_3           → "My Custom Tool"
+ */
+export function humanizeToolName(rawName: string): string {
+  if (!rawName) return "Tool";
+
+  let provider = "";
+  let slug = rawName;
+
+  if (slug.startsWith("mcp__")) {
+    const parts = slug.split("__");
+    if (parts.length >= 3) {
+      provider = parts[1].toLowerCase();
+      slug = parts.slice(2).join("_");
+    } else {
+      slug = parts.slice(1).join("_");
+    }
+  }
+
+  // Strip trailing numeric suffix (e.g. tool_name_3 → tool_name)
+  slug = slug.replace(/_\d+$/, "");
+
+  // Explicit overrides for well-known compound slugs
+  if (SLUG_OVERRIDES[slug]) return SLUG_OVERRIDES[slug];
+
+  const providerLabel = PROVIDER_DISPLAY[provider] ?? "";
+  const words = slug.split("_").filter(Boolean);
+
+  if (words.length === 0) return providerLabel || toTitleCase(rawName) || "Tool";
+
+  // Verb at start: search_issues → "Searching [Provider] issues"
+  const firstWord = words[0].toLowerCase();
+  const startGerund = GERUNDS[firstWord];
+  if (startGerund) {
+    const obj = words.slice(1).join(" ").toLowerCase();
+    if (providerLabel && obj) return `${startGerund} ${providerLabel} ${obj}`;
+    if (providerLabel) return `${startGerund} ${providerLabel}`;
+    if (obj) return `${startGerund} ${obj}`;
+    return startGerund;
+  }
+
+  // Verb at end: code_search → "Searching code" (fallback after SLUG_OVERRIDES)
+  const lastWord = words[words.length - 1].toLowerCase();
+  const endGerund = GERUNDS[lastWord];
+  if (endGerund && words.length > 1) {
+    const obj = words.slice(0, -1).join(" ").toLowerCase();
+    if (providerLabel && obj) return `${endGerund} ${providerLabel} ${obj}`;
+    if (providerLabel) return `${endGerund} ${providerLabel}`;
+    if (obj) return `${endGerund} ${obj}`;
+    return endGerund;
+  }
+
+  // Fallback: title-case each word, append provider in parens if known
+  const humanWords = words.map(toTitleCase).join(" ");
+  return providerLabel ? `${humanWords} (${providerLabel})` : humanWords;
+}
+
 export function toolArgs(msg: ChatMessage): Record<string, unknown> {
   return toolCallPart(msg)?.args ?? {};
 }
@@ -187,7 +300,7 @@ export function entryLabel(entry: TraceEntry): string {
     case "observation":
       return "Observation";
     case "tool_call":
-      return entry.kind === "combo" ? toolName(entry.call) || "Tool" : "Tool call";
+      return entry.kind === "combo" ? humanizeToolName(toolName(entry.call)) || "Tool" : "Tool call";
     case "tool_result":
       return "Tool result";
     case "system_note":
@@ -208,19 +321,12 @@ export function primaryTextForEntry(entry: TraceEntry): string {
     }
     return textOf(entry.message);
   }
-  // combo: show tool name + compact args preview
-  const name = toolName(entry.call);
-  const args = toolArgs(entry.call);
-  const argStr = Object.keys(args).length
-    ? Object.entries(args)
-        .slice(0, 2)
-        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-        .join(", ")
-    : "";
-  return argStr ? `${name}(${argStr})` : name;
+  // combo: the humanized label from entryLabel() is sufficient.
+  // Raw tool name and arguments must not be shown to end users.
+  return "";
 }
 
-// Secondary text shown below primary (e.g., tool result summary, thought conclusion)
+// Secondary text shown below primary (e.g., thought conclusion, tool latency)
 export function secondaryTextForEntry(entry: TraceEntry): string {
   if (entry.kind === "solo" && entry.message.channel === "thought") {
     const extras = thoughtExtras(entry.message);
@@ -228,7 +334,9 @@ export function secondaryTextForEntry(entry: TraceEntry): string {
     if (extras.duration_ms != null) return formatLatencyMs(extras.duration_ms);
   }
   if (entry.kind === "combo" && entry.result) {
-    return summarizeToolResultCompact(entry.result);
+    // Show only the execution latency — never raw result content (which is often
+    // a JSON payload from an external API and must not be exposed to end users).
+    return formatLatencyMs(toolResultLatencyMs(entry.result));
   }
   return "";
 }
@@ -247,10 +355,23 @@ export function statusForEntry(entry: TraceEntry): TraceStatus {
 
 // Groups trace-channel messages from one exchange into TraceEntry[]
 // Pairs tool_call + tool_result by call_id; everything else is solo.
+// Deduplicates tool_call messages sharing the same call_id (keeps first occurrence).
 export function groupTraceEntries(messages: ChatMessage[]): TraceEntry[] {
   const trace = messages.filter((m) => isTraceChannel(m.channel));
+
+  // Remove duplicate tool_call messages for the same call_id (e.g. from stream replay)
+  const seenCallIds = new Set<string>();
+  const unique = trace.filter((m) => {
+    if (isToolCall(m)) {
+      const id = toolCallId(m);
+      if (!id || seenCallIds.has(id)) return false;
+      seenCallIds.add(id);
+    }
+    return true;
+  });
+
   const resultMap = new Map<string, ChatMessage>();
-  for (const m of trace) {
+  for (const m of unique) {
     if (isToolResult(m)) {
       const id = toolResultId(m);
       if (id) resultMap.set(id, m);
@@ -260,7 +381,7 @@ export function groupTraceEntries(messages: ChatMessage[]): TraceEntry[] {
   const entries: TraceEntry[] = [];
   const consumedCallIds = new Set<string>();
 
-  for (const m of trace) {
+  for (const m of unique) {
     if (isToolResult(m)) continue; // handled via combo
     if (isToolCall(m)) {
       const callId = toolCallId(m);
@@ -273,7 +394,7 @@ export function groupTraceEntries(messages: ChatMessage[]): TraceEntry[] {
   }
 
   // Orphan tool_results (no matching call — shouldn't happen but be safe)
-  for (const m of trace) {
+  for (const m of unique) {
     if (isToolResult(m) && !consumedCallIds.has(toolResultId(m))) {
       entries.push({ kind: "solo", message: m });
     }


### PR DESCRIPTION
# Pull Request — Human-friendly tool call labels in the chat trace (issue #1774)

**Branch:** `pdubey28-sketch:Issue#1774` → `pdubey28-sketch:swift`
**Commit:** `d846d0df6dbadfa0cf4f0340b89e654d5bb624c2` (single commit, 3 files, +268 / −53)

---

## 1. What problem does this solve — and where is it tracked?

**ID:** ⚠ **conflict — needs renaming before merge.** The commit message says `CHAT-12`, but `CHAT-12` is already registered in `docs/swift/data/id-legend.yaml:261` for an unrelated, closed feature ("Harmonize popover menus — shared MenuPopover molecule", owner Dimitri, closed 2026-06-19). The next free CHAT id is **`CHAT-13`**. Proposed: rename this work to `CHAT-13 — Human-friendly tool call labels in the chat trace` and add the entry to `id-legend.yaml`. The local report file `docs/swift/CHAT-12-tool-label-humanizer-report.md` should be renamed to `docs/swift/CHAT-13-tool-label-humanizer-report.md` in the same change.

**Problem in one sentence:** The chat tool-trace drawer was rendering raw tool identifiers, arguments, and result payloads (e.g. `mcp__tavily-search` with raw JSON args) to end users, and the same tool call appeared multiple times when the SSE stream replayed events — both unreadable and visually noisy (GitHub issue #1774).

**Backlog ref:** none — no `[ ]` item exists for this work in `docs/swift/backlog/CHAT-UI-BACKLOG.md`. Recommend adding a `## NN Phase CHAT-13 — Human-friendly tool call labels` section there before merge, alongside the renamed id-legend entry.

---

## 2. Before you wrote a single line of code

**RFC written?** Not required — UX-only, frontend-only fix. No new API, no schema change, no new component; the change adds two pure helpers (`humanizeToolName`, dedup filter) plus a one-line callsite update in an existing component. The behavioural spec ("only show humanised action + status, never raw tool name/args/result payloads") is captured in the test names of `traceUtils.test.ts`.

**Plan presented to the team before implementation?** No — the work was implemented directly from issue #1774. The retrospective report is at `docs/swift/CHAT-12-tool-label-humanizer-report.md` (to be renamed `CHAT-13-…` per §1).

**Confirmation received?** No prior confirmation — this PR is the request for review.

---

## 3. What you built

One commit (`d846d0d`) with three coordinated changes, all in `apps/frontend/src/rework/`:

1. **`utils/traceUtils.ts` — new `humanizeToolName(rawName)` helper.** Three-pass resolver: (a) strip `mcp__<provider>__<action>` prefix, (b) strip trailing numeric suffix (`create_ticket_3` → `create_ticket`), (c) resolve against a `SLUG_OVERRIDES` table (e.g. `web_search` → "Searching the web"), then verb-at-start gerund pattern with optional provider (`search_issues` + GitHub → "Searching GitHub issues"), verb-at-end fallback, finally title-case fallback for unknown tools. Supporting tables `PROVIDER_DISPLAY`, `SLUG_OVERRIDES`, `GERUNDS` are module-private constants.
2. **`utils/traceUtils.ts` — `entryLabel()` callsite + `groupTraceEntries()` dedup.** One-line callsite update wraps the existing label lookup with `humanizeToolName(...)`. A new dedup filter at the top of `groupTraceEntries()` keeps only the **first** `tool_call` message per `call_id`, collapsing duplicate rows produced by SSE replay/reconnect (results were already de-duplicated by the `resultMap` last-write-wins).
3. **`components/shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer.tsx` — payload sanitiser.** New `toolPayload` function exposes only the humanised action name plus execution outcome; raw tool names, arguments, and result payloads are no longer rendered. Comment in the source: *"Raw tool names, arguments, and result payloads must not be shown to end users."*

### Files changed

| File | Lines |
| --- | --- |
| `apps/frontend/src/rework/utils/traceUtils.ts` | bulk of +268 / −53 |
| `apps/frontend/src/rework/utils/traceUtils.test.ts` | +121 / −10 |
| `apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer.tsx` | +8 / −25 |

---

## 4. Proof of quality

**Tests added or updated:** ~15 new cases in `apps/frontend/src/rework/utils/traceUtils.test.ts` (+121 / −10), exercising the humaniser and dedup logic.

| Test | File | What it covers |
| ---- | ---- | -------------- |
| `returns empty string for combo with args — raw tool name and arguments are suppressed` | `apps/frontend/src/rework/utils/traceUtils.test.ts` | Sanitiser hides raw args |
| `does not expose raw result content` | same | Sanitiser hides raw result payload |
| `handles MCP web_search → 'Searching the web'` | same | `SLUG_OVERRIDES` web override |
| `handles MCP verb-first with provider: search_issues → 'Searching GitHub issues'` | same | Verb-at-start + provider composition |
| `handles MCP create with provider: create_ticket → 'Creating Jira ticket'` | same | Verb-at-start + provider composition |
| `strips trailing numeric suffix before humanizing` | same | `create_ticket_3` → `create_ticket` |
| `handles tavily-search (raw name from tavily-mcp v0.2.x)` | same | Real-world raw name from tavily-mcp |
| `collapses duplicate tool_call messages with the same call_id into one row` | same | SSE-replay dedup in `groupTraceEntries` |

**`make code-quality` output:**

```
TODO — paste output from `(cd apps/frontend && make code-quality)`
(tsc + prettier per CLAUDE.md §Step 5).
```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

n/a — frontend-only change, no Python package touched.

**`make test` output:**

```
TODO — paste the summary line from `(cd apps/frontend && make test)`.
Local manual confirmation: the ~15 humaniser + dedup cases in
traceUtils.test.ts pass; before merge, paste the full vitest summary
showing total pass count and 0 failures.
```

---

## 5. Docs updated

| What changed | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done | n/a — no pre-existing item; needs a new `## Phase CHAT-13` section in `docs/swift/backlog/CHAT-UI-BACKLOG.md` before merge |
| New behaviour, API field, or contract change | `docs/swift/CHAT-12-tool-label-humanizer-report.md` (new, **to be renamed to CHAT-13**) documents the humaniser logic, dedup rule, and before/after behaviour |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — frontend-only, no contract change |
| UX component implemented or visual status changed | TODO — `docs/swift/ux/COMPONENT-UX.md` should get an entry for `ThoughtTrace` / `TraceDetailDrawer` reflecting the sanitised label behaviour |
| Phase progress row exists for this area | n/a — depends on the new backlog section landing |
| WORKPLAN sprint item finished | n/a — not currently in WORKPLAN |
| Code and a design doc now diverge | Pending — once `CHAT-13` is registered in `id-legend.yaml` and the report file is renamed, the report and id-legend will agree |

---

## 6. Close-out statement

```
## Task close-out
- Code:
    - traceUtils.ts: added humanizeToolName() (mcp__ stripper + numeric-suffix
      stripper + SLUG_OVERRIDES + verb-start gerund + verb-end fallback +
      title-case fallback; supporting PROVIDER_DISPLAY, SLUG_OVERRIDES,
      GERUNDS tables)
    - traceUtils.ts: entryLabel() now wraps tool label with humanizeToolName()
    - traceUtils.ts: groupTraceEntries() now dedups tool_call messages by
      call_id (first-wins) to absorb SSE replay
    - TraceDetailDrawer.tsx: new toolPayload() exposes only the humanised
      action name + execution outcome; raw tool name, arguments, and result
      payload no longer rendered
- Tests: ~15 new cases in apps/frontend/src/rework/utils/traceUtils.test.ts
    covering humaniser variants and call-id dedup
- Docs updated: docs/swift/CHAT-12-tool-label-humanizer-report.md (new,
    pending rename to CHAT-13)
- Backlog: none — needs new "## Phase CHAT-13" section in CHAT-UI-BACKLOG.md
    + new entry in id-legend.yaml before merge
- Skipped steps: Step 1 (RFC) — UX-only mechanical fix; Step 2 (backlog
    entry) — no pre-existing item, must be created before merge to satisfy
    CLAUDE.md prime directive; Step 3 (developer confirmation) — none, this
    PR is the request for confirmation; Step 3.5 (GitHub issue) — #1774
    exists. ⚠ ID collision: commit uses CHAT-12 which is taken; propose
    CHAT-13 before merge.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

- **Humaniser misclassification.** Unknown tool names fall through to title-case (`my_custom_tool` → "My Custom Tool"), so the worst case for an unmapped tool is a slightly awkward but still readable label, not a missing or wrong one.
- **Dedup over-collapse.** If two genuinely distinct tool calls ever share a `call_id` (they should not — `call_id` is the LLM-provider-assigned unique id), one would be hidden. The existing test `collapses duplicate tool_call messages with the same call_id into one row` documents the intended behaviour.
- **Sanitiser hiding too much.** The drawer no longer shows raw arguments or result payloads at all, even for debugging. This is a deliberate UX choice per issue #1774 ("must not be shown to end users"). If a developer needs the raw payload, it remains in the SSE stream / browser network tab; no production telemetry is lost. If a stakeholder objects, the fix is local to `TraceDetailDrawer.tsx::toolPayload`.

**How do we roll back?**

Revert commit `d846d0d`. Frontend-only — rebuild the frontend bundle (`apps/frontend`) and reload; no backend restart, no data migration, no state to clean up. Already-rendered traces are not persisted server-side beyond the SSE stream, so a revert immediately restores the previous raw-label behaviour without any cleanup.
