### PR TITLE
feat(CHAT-13): GeoJSON map rendering in chat (Leaflet)

### DIFF
--- a/apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.module.css
@@ -1,0 +1,77 @@
+.block {
+  margin: var(--spacing-s) 0;
+  border: calc(var(--spacing-3xs) / 4) solid var(--outline-muted);
+  border-radius: var(--radius-s);
+  background: linear-gradient(180deg, var(--surface-container-low), var(--surface-container-lowest));
+  overflow: hidden;
+  color: var(--on-surface);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  border-bottom: calc(var(--spacing-3xs) / 4) solid var(--outline-muted);
+  background: color-mix(in srgb, var(--surface-container) 88%, transparent);
+  padding: var(--spacing-2xs) var(--spacing-s);
+  min-height: calc(var(--spacing-l) + var(--spacing-m));
+  color: var(--on-surface);
+}
+
+.lang {
+  color: var(--on-surface-muted);
+  font: var(--font-label-small);
+  font-family: monospace;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.title {
+  color: var(--on-surface);
+  font: var(--font-label-large);
+}
+
+.content {
+  display: block;
+  padding: var(--spacing-s);
+}
+
+.map {
+  /* position + integer z-index establishes a stacking context so Leaflet's
+     internal pane/control z-indices (up to 1000) stay confined below the
+     floating chat input bar instead of overlapping it on scroll. */
+  position: relative;
+  z-index: 0;
+  border: calc(var(--spacing-3xs) / 4) solid var(--outline-muted);
+  border-radius: var(--radius-s);
+  background: var(--surface-container-lowest);
+  width: 100%;
+  /* Landscape rectangle (like leafletjs.com) rather than a tall square box. */
+  height: 20rem;
+}
+
+/* divIcon wrapper: strip Leaflet's default white box so only the SVG pin shows. */
+.pin {
+  border: none;
+  background: transparent;
+}
+
+.error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+  background: var(--error-container);
+  padding: var(--spacing-m);
+}
+
+.errorLabel {
+  margin: 0;
+  color: var(--on-error-container);
+  font: var(--font-label-large);
+}
+
+.errorText {
+  margin: 0;
+  color: var(--on-error-container);
+  font: var(--font-body-medium);
+}

--- a/apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.tsx
@@ -35,6 +35,11 @@ interface GeoMapBlockProps {
 const FALLBACK_CENTER: [number, number] = [50, 8];
 const FALLBACK_ZOOM = 4;
 
+// GeoJSON properties are agent-supplied and may be untrusted (e.g. RAG content).
+// The `color` property flows into SVG markup and Leaflet path styles, so we only
+// accept hex / rgb(a) / hsl(a) values and fall back to the theme accent otherwise.
+const SAFE_COLOR = /^#[0-9a-f]{3,8}$|^(rgb|hsl)a?\([\d.,%\s/]+\)$/i;
+
 // Self-contained SVG pin rendered via L.divIcon. We deliberately avoid Leaflet's
 // default PNG marker icons: their image paths don't survive Vite bundling and show
 // as broken images. An inline SVG has no external asset, so it always renders.
@@ -125,9 +130,12 @@ export function GeoMapBlock({ code, language = "geojson" }: GeoMapBlockProps) {
     );
   }
 
+  // Validate an agent-supplied color against the allowlist; fall back to accent.
+  const safeColor = (c: unknown): string => (typeof c === "string" && SAFE_COLOR.test(c.trim()) ? c.trim() : accent);
+
   const styleFn = (feature?: Feature<Geometry>): PathOptions => {
     const props = (feature?.properties ?? {}) as Record<string, unknown>;
-    const color = (props.color as string) || accent;
+    const color = safeColor(props.color);
     return {
       color,
       weight: 2,
@@ -139,15 +147,19 @@ export function GeoMapBlock({ code, language = "geojson" }: GeoMapBlockProps) {
 
   const pointToLayer = (feature: Feature<Geometry>, latlng: L.LatLng): Layer => {
     const props = (feature?.properties ?? {}) as Record<string, unknown>;
-    const color = (props.color as string) || accent;
-    return L.marker(latlng, { icon: buildPinIcon(color) });
+    return L.marker(latlng, { icon: buildPinIcon(safeColor(props.color)) });
   };
 
   const onEachFeature = (feature: Feature<Geometry>, layer: Layer) => {
     const props = (feature?.properties ?? {}) as Record<string, unknown>;
     const label = props.name ?? props.title;
     if (label != null && label !== "") {
-      layer.bindPopup(String(label));
+      // Bind a text node, not a string: layer.bindPopup(string) treats its input
+      // as HTML, so an agent-supplied name/title could inject markup. textContent
+      // escapes everything.
+      const el = document.createElement("span");
+      el.textContent = String(label);
+      layer.bindPopup(el);
     }
   };
 

--- a/apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.tsx
@@ -1,0 +1,177 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Renders a fenced GeoJSON block on an interactive Leaflet map. Wired into the
+// markdown renderer next to MindMapBlock and MermaidBlock so ANY agent whose
+// reply contains a ```geojson fence (or a ```json fence holding a GeoJSON
+// FeatureCollection) gets a map instead of a raw code block.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import L from "leaflet";
+import type { Layer, PathOptions } from "leaflet";
+import { GeoJSON, MapContainer, TileLayer, useMap } from "react-leaflet";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
+import "leaflet/dist/leaflet.css";
+import styles from "./GeoMapBlock.module.css";
+
+interface GeoMapBlockProps {
+  code: string;
+  language?: string;
+}
+
+// Default fallback view (roughly central Europe) used only when the data has no
+// resolvable bounds (e.g. an empty FeatureCollection).
+const FALLBACK_CENTER: [number, number] = [50, 8];
+const FALLBACK_ZOOM = 4;
+
+// Self-contained SVG pin rendered via L.divIcon. We deliberately avoid Leaflet's
+// default PNG marker icons: their image paths don't survive Vite bundling and show
+// as broken images. An inline SVG has no external asset, so it always renders.
+function buildPinIcon(color: string) {
+  const html = `
+    <svg viewBox="0 0 24 36" width="24" height="36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 8.25 12 24 12 24s12-15.75 12-24C24 5.37 18.63 0 12 0z"
+            fill="${color}" stroke="#ffffff" stroke-width="1.5"/>
+      <circle cx="12" cy="12" r="4.5" fill="#ffffff"/>
+    </svg>`;
+  return L.divIcon({
+    html,
+    className: styles.pin,
+    iconSize: [24, 36],
+    iconAnchor: [12, 36],
+    popupAnchor: [0, -30],
+  });
+}
+
+interface ParseResult {
+  data: FeatureCollection | null;
+  error: string | null;
+}
+
+/** Parse a fenced block into a GeoJSON FeatureCollection, or report why it can't. */
+export function parseFeatureCollection(code: string): ParseResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(code);
+  } catch (e) {
+    return { data: null, error: `Invalid JSON: ${(e as Error).message}` };
+  }
+  if (!value || typeof value !== "object" || (value as { type?: string }).type !== "FeatureCollection") {
+    return { data: null, error: "Expected a GeoJSON FeatureCollection." };
+  }
+  return { data: value as FeatureCollection, error: null };
+}
+
+/**
+ * Cheap detector used by the markdown renderer to decide whether a generic
+ * ```json fence is actually a GeoJSON FeatureCollection worth rendering as a map.
+ */
+export function isGeoJsonFeatureCollection(code: string): boolean {
+  return parseFeatureCollection(code).data !== null;
+}
+
+/** Fits the map to the data's bounds once, after the GeoJSON layer mounts. */
+function FitBounds({ data }: { data: FeatureCollection }) {
+  const map = useMap();
+  useEffect(() => {
+    try {
+      const bounds = L.geoJSON(data as never).getBounds();
+      if (bounds.isValid()) {
+        map.fitBounds(bounds, { padding: [24, 24] });
+      }
+    } catch {
+      // Malformed geometry — keep the fallback view rather than throwing.
+    }
+  }, [data, map]);
+  return null;
+}
+
+export function GeoMapBlock({ code, language = "geojson" }: GeoMapBlockProps) {
+  const parsed = useMemo(() => parseFeatureCollection(code), [code]);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [accent, setAccent] = useState<string>("#6366f1");
+
+  // Resolve the theme accent once mounted so geometries match the design system.
+  useEffect(() => {
+    const source = rootRef.current ?? document.documentElement;
+    const value = getComputedStyle(source).getPropertyValue("--primary").trim();
+    if (value) setAccent(value);
+  }, []);
+
+  const { data, error: errorMessage } = parsed;
+
+  if (!data) {
+    return (
+      <div ref={rootRef} className={styles.block}>
+        <div className={styles.header}>
+          <span className={styles.lang}>{language}</span>
+        </div>
+        <div className={styles.error}>
+          <span className={styles.errorLabel}>Map could not be rendered</span>
+          <p className={styles.errorText}>{errorMessage}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const styleFn = (feature?: Feature<Geometry>): PathOptions => {
+    const props = (feature?.properties ?? {}) as Record<string, unknown>;
+    const color = (props.color as string) || accent;
+    return {
+      color,
+      weight: 2,
+      opacity: 0.9,
+      fillColor: color,
+      fillOpacity: (props.fillOpacity as number) ?? 0.15,
+    };
+  };
+
+  const pointToLayer = (feature: Feature<Geometry>, latlng: L.LatLng): Layer => {
+    const props = (feature?.properties ?? {}) as Record<string, unknown>;
+    const color = (props.color as string) || accent;
+    return L.marker(latlng, { icon: buildPinIcon(color) });
+  };
+
+  const onEachFeature = (feature: Feature<Geometry>, layer: Layer) => {
+    const props = (feature?.properties ?? {}) as Record<string, unknown>;
+    const label = props.name ?? props.title;
+    if (label != null && label !== "") {
+      layer.bindPopup(String(label));
+    }
+  };
+
+  return (
+    <div ref={rootRef} className={styles.block}>
+      <div className={styles.header}>
+        <span className={styles.lang}>{language}</span>
+        <strong className={styles.title}>Map</strong>
+      </div>
+      <div className={styles.content}>
+        <MapContainer className={styles.map} center={FALLBACK_CENTER} zoom={FALLBACK_ZOOM} scrollWheelZoom={false}>
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <GeoJSON
+            data={data as never}
+            style={styleFn as (feature?: Feature<Geometry>) => PathOptions}
+            pointToLayer={pointToLayer as (feature: Feature<Geometry>, latlng: L.LatLng) => Layer}
+            onEachFeature={onEachFeature as (feature: Feature<Geometry>, layer: Layer) => void}
+          />
+          <FitBounds data={data} />
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.tsx
@@ -22,6 +22,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { CodeBlock } from "../CodeBlock/CodeBlock";
 import { MindMapBlock } from "../MindMapBlock";
 import { MermaidBlock } from "../MermaidBlock/MermaidBlock";
+import { GeoMapBlock, isGeoJsonFeatureCollection } from "../GeoMapBlock/GeoMapBlock";
 import { SourceBadge } from "../../atoms/SourceBadge/SourceBadge";
 import styles from "./MarkdownRenderer.module.css";
 import { getStreamingMarkdownState, type PendingStreamingFence } from "./streamingGuard";
@@ -174,11 +175,18 @@ export function MarkdownRenderer({ text, onSourceClick, streaming = false }: Mar
       // code: mindmap/mermaid fences → custom blocks; other fenced blocks → CodeBlock; inline → CodeBlock inline
       code({ className, children }: { className?: string; children?: React.ReactNode }) {
         const lang = /language-([\w-]+)/.exec(className || "")?.[1];
+        const code = String(children).replace(/\n$/, "");
         if (lang === "mindmap" || lang === "mindmap-json") {
-          return <MindMapBlock code={String(children).replace(/\n$/, "")} language={lang} />;
+          return <MindMapBlock code={code} language={lang} />;
         }
         if (lang === "mermaid") {
-          return <MermaidBlock code={String(children).replace(/\n$/, "")} />;
+          return <MermaidBlock code={code} />;
+        }
+        // GeoJSON → interactive Leaflet map. Explicit ```geojson always renders as a
+        // map; a generic ```json fence renders as a map only when it parses as a
+        // GeoJSON FeatureCollection, otherwise it falls through to CodeBlock.
+        if (lang === "geojson" || (lang === "json" && isGeoJsonFeatureCollection(code))) {
+          return <GeoMapBlock code={code} language={lang} />;
         }
         if (className) {
           return <CodeBlock code={String(children).replace(/\n$/, "")} language={lang} />;

--- a/docs/swift/PMO-BOARD.md
+++ b/docs/swift/PMO-BOARD.md
@@ -40,6 +40,7 @@ Last updated: 2026-06-20
 | `VALID-01` | `VALIDATION-E2E` | Simon | Bloque | [BACKLOG §3b.7](backlog/BACKLOG.md) | — | `TBD` |
 | `CHAT-03` | `CHAT-OPTIONS` | Marc | En cours | [CHAT-UI-BACKLOG §3](backlog/CHAT-UI-BACKLOG.md) | — | GitHub issue `#1730` |
 | `CHAT-11` | `CHAT-VOICE-DICTATION` | Dimitri | En cours | [CHAT-UI-BACKLOG §12](backlog/CHAT-UI-BACKLOG.md) | [CHAT-VOICE-DICTATION-RFC](rfc/CHAT-VOICE-DICTATION-RFC.md) | Waived GitHub issue for local Codex session |
+| `CHAT-13` | `CHAT-GEOJSON-MAP-RENDERING` | Vanshaj | En cours — GeoJSON fences rendus en carte Leaflet (frontend only) | [CHAT-UI-BACKLOG §14](backlog/CHAT-UI-BACKLOG.md) | [CHAT-GEOJSON-MAP-RENDERING-RFC](rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md) | `TBD` |
 | `MEMORY-02` | `MEMORY-CHECKPOINT-ISOLATION` | Marc | En cours | [MEMORY BACKLOG §F.1](backlog/MULTI-AGENT-MEMORY-BACKLOG.md) | [MULTI-AGENT-MEMORY-RFC](rfc/MULTI-AGENT-MEMORY-RFC.md) | `TBD` |
 | `MEMORY-03` | `MEMORY-REMOTE-AGENT` | Dimitri | En cours | [MEMORY BACKLOG §F.2](backlog/MULTI-AGENT-MEMORY-BACKLOG.md) | [MULTI-AGENT-MEMORY-RFC](rfc/MULTI-AGENT-MEMORY-RFC.md) | `TBD` |
 | `MEMORY-04` | `MEMORY-LOCAL-AGENT` | Dimitri | En cours | [MEMORY BACKLOG §F.3](backlog/MULTI-AGENT-MEMORY-BACKLOG.md) | [MULTI-AGENT-MEMORY-RFC](rfc/MULTI-AGENT-MEMORY-RFC.md) | `TBD` |

--- a/docs/swift/backlog/CHAT-UI-BACKLOG.md
+++ b/docs/swift/backlog/CHAT-UI-BACKLOG.md
@@ -1568,6 +1568,53 @@ current values shown inline in muted text.
 
 ---
 
+## 14 Phase CHAT-13 — GeoJSON map rendering
+
+**ID:** CHAT-13  
+**Status:** in progress  
+**Priority:** medium — rich visual rendering for agent-generated GeoJSON  
+**RFC:** `docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md`  
+Execution: TBD
+
+### 14.1 Goal
+
+Render a fenced GeoJSON ` ```geojson ` block — or a ` ```json ` block that parses
+as a GeoJSON `FeatureCollection` — as an interactive Leaflet map in
+`MarkdownRenderer`, alongside the existing `mermaid` / `mindmap-json` blocks.
+Available to every agent (renderer-level), not specific to the test assistant.
+
+### 14.2 Tasks
+
+#### Step 1 — `GeoMapBlock` molecule
+
+- [x] Create `apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/`
+      (react-leaflet `MapContainer` + OSM tiles + `GeoJSON`), exporting
+      `parseFeatureCollection` / `isGeoJsonFeatureCollection`
+- [x] Points render as inline-SVG `divIcon` pins (Leaflet default PNG markers break
+      under Vite); polygons style from feature `color`/`fillOpacity`; popups bind
+      `name`/`title`; auto-fit to bounds
+- [x] Landscape sizing + own stacking context so the map sits behind the chat input
+
+#### Step 2 — `MarkdownRenderer` integration
+
+- [x] Route ` ```geojson ` (always) and ` ```json ` (only when a `FeatureCollection`)
+      to `GeoMapBlock`; keep generic `CodeBlock` fallback for all other JSON
+
+#### Step 3 — Verification
+
+- [x] `make -C apps/frontend code-quality` (tsc + prettier)
+- [ ] Unit tests for `isGeoJsonFeatureCollection` (`GeoMapBlock.test.ts`)
+- [ ] Manual chat validation: `markdown` scenario GeoJSON section renders as a map
+- [ ] `make -C apps/frontend build` with Leaflet bundled (first consumer)
+
+### 14.3 Non-changes
+
+- No backend, runtime, or SSE contract changes
+- The SDK `GeoPart` / `ui_parts` path is unchanged (not used by this renderer)
+- No change to Mermaid/Mindmap rendering beyond coexistence in the dispatch path
+
+---
+
 ## 6 Progress
 
 | Phase                                       | Status               | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -275,6 +275,24 @@ items:
       with inline muted values + chevron sub-menus. The PROMPT-05 "Prompts" row is
       a future drop-in (blocked on PROMPT-03; multi-prompt backend not built).
 
+  - id: CHAT-13
+    title: "GeoJSON map rendering in chat — Leaflet block for geojson/json fences"
+    status: in_progress
+    owner: Vanshaj
+    refs:
+      backlog: "docs/swift/backlog/CHAT-UI-BACKLOG.md (GeoJSON map rendering)"
+      rfc: "docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md"
+      execution: "TBD"
+    notes: >
+      Frontend-only. Adds a GeoMapBlock molecule (react-leaflet) and a
+      MarkdownRenderer branch so a ```geojson fence — or a ```json fence that
+      parses as a GeoJSON FeatureCollection — renders as an interactive map,
+      alongside the existing mermaid/mindmap fenced-block renderers. Points use
+      an inline-SVG divIcon pin (Leaflet's default PNG markers break under Vite),
+      polygons style from feature properties, popups bind name/title, the map
+      auto-fits bounds, sits in its own stacking context (behind the chat input),
+      and is sized as a landscape rectangle. No backend or contract change.
+
   # ── CTRLP ─────────────────────────────────────────────────────────────
 
   - id: CTRLP-01

--- a/docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md
+++ b/docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md
@@ -1,0 +1,179 @@
+# RFC: GeoJSON Map Rendering in Chat (CHAT-13)
+
+**Status:** Implemented (2026-06-24) — live pod validation pending
+**Author:** Vanshaj Behl
+**Date:** 2026-06-24
+**ID:** CHAT-13
+**Backlog:** `docs/swift/backlog/CHAT-UI-BACKLOG.md` (new section — GeoJSON map rendering)
+**Parent RFC:** `docs/swift/rfc/CHAT-RENDERING-SPEC.md`
+**Related:** `docs/swift/rfc/STREAMING-RENDER-GUARD-RFC.md` (CHAT-09) — see §3.4
+**Contract impact:** none — frontend only
+
+---
+
+## 1. Problem
+
+Agent replies frequently contain geographic data as a GeoJSON `FeatureCollection`.
+Today that data renders as a raw ` ```json ` code block: a wall of coordinates the
+user has to read by hand. The chat renderer already turns two other fenced payloads
+into rich visualizations — ` ```mermaid ` → flowchart (`MermaidBlock`) and
+` ```mindmap-json ` → interactive mindmap (`MindMapBlock`) — but there is no
+equivalent for maps.
+
+We want GeoJSON to render as an interactive map (Leaflet), consistent with the
+existing mermaid/mindmap treatment, and we want this to be a **renderer capability
+available to every agent**, not a one-off for the test assistant's hardcoded
+`markdown` scenario.
+
+### 1.1 Why not the `ui_parts` / `GeoPart` path
+
+The SDK already defines a `GeoPart` (`libs/fred-sdk/fred_sdk/contracts/context.py`)
+that an agent can emit in `ui_parts` on the `final` event. An earlier attempt at
+this feature rendered maps from that structured part. It was rejected for this use
+case because:
+
+- It only fires when an agent deliberately emits a `GeoPart`. The actual content
+  users see today — including the test assistant's `markdown` scenario — embeds
+  GeoJSON **inside the markdown text** as a ` ```json ` fence, which the `ui_parts`
+  path never touches.
+- It requires every agent to adopt a new emission pattern to get maps, whereas
+  mermaid/mindmap "just work" from markdown content.
+
+`STREAMING-RENDER-GUARD-RFC.md §1.3` explicitly scoped GeoJSON out, on the
+assumption it would always arrive as a `GeoPart`. This RFC revisits that: GeoJSON
+in a markdown fence is the common case and should render as a map.
+
+The `GeoPart`/`ui_parts` path remains valid and is **not removed** — it is simply
+not the mechanism used here.
+
+---
+
+## 2. Proposed solution
+
+### 2.1 Principle
+
+Add one branch to the `MarkdownRenderer` fenced-code dispatch, alongside the
+existing `mindmap`/`mermaid` branches, that routes GeoJSON to a new `GeoMapBlock`
+molecule rendering an interactive Leaflet map.
+
+### 2.2 Detection rule
+
+| Fence | Rendered as | Rule |
+|---|---|---|
+| ` ```geojson ` | `GeoMapBlock` | Always — explicit opt-in |
+| ` ```json ` | `GeoMapBlock` | Only when the body parses as a GeoJSON `FeatureCollection` |
+| ` ```json ` (non-geo) | `CodeBlock` | Falls through unchanged |
+
+The `json` case is intentionally conservative: it parses the fence and checks
+`type === "FeatureCollection"`. Anything else (plain JSON, a bare `Feature`,
+invalid JSON) falls through to the normal `CodeBlock`, so no existing behavior
+regresses. The detector (`isGeoJsonFeatureCollection`) is a pure function exported
+from `GeoMapBlock` and is unit-testable without a DOM.
+
+### 2.3 `GeoMapBlock` molecule
+
+Mirrors `MindMapBlock`'s shape — a self-contained molecule taking
+`{ code, language }`, parsing the fence, and rendering. Stack:
+`react-leaflet` (`MapContainer` + OpenStreetMap `TileLayer` + `GeoJSON`).
+Dependencies (`leaflet`, `react-leaflet`, `@types/leaflet`) are already in
+`package.json`; this is their first consumer.
+
+Behavioral decisions:
+
+- **Points → SVG pin via `L.divIcon`.** Leaflet's default PNG marker icons
+  (`marker-icon.png` etc.) do not survive Vite bundling and render as broken
+  images. An inline-SVG teardrop pin has no external asset and always renders.
+  (A `circleMarker` variant was also tried; the SVG pin matches the familiar
+  Leaflet look from leafletjs.com and is unambiguous to users.)
+- **Polygons / lines** are styled from the feature's `color` / `fillOpacity`
+  properties, falling back to the theme `--primary` token.
+- **Popups** bind the feature's `name` / `title` property.
+- **Auto-fit** to the data's bounds via a small `FitBounds` child (`useMap` +
+  `L.geoJSON(data).getBounds()`), falling back to a central-Europe view when the
+  bounds are not resolvable.
+
+### 2.4 Layout / stacking
+
+Two CSS rules in `GeoMapBlock.module.css`:
+
+- **Landscape aspect** (`height: 20rem`, `width: 100%`) so the map is a wide
+  rectangle like leafletjs.com, not a tall square.
+- **Own stacking context** (`position: relative; z-index: 0`) on the Leaflet
+  container. Leaflet assigns internal pane/control z-indices up to 1000; without
+  a containing stacking context these escape to page level and overlap the
+  floating chat input bar (`.inputOverlay`, `z-index: 1`) on scroll. Confining
+  them to a `z-index: 0` context keeps the whole map below the input bar.
+
+---
+
+## 3. Alternatives considered
+
+### 3.1 Structured `GeoPart` in `ui_parts` (rejected for this use case)
+
+Render maps from an agent-emitted `GeoPart` on the `final` event, plumbed through
+`ThreadMessage` → `AssistantTurn`. **Rejected:** does not render GeoJSON that lives
+in markdown text (the common case), and forces every agent to adopt a new emission
+pattern. Not removed from the platform — just not the mechanism here. See §1.1.
+
+### 3.2 Leaflet default PNG markers (rejected)
+
+Use `L.Icon.Default` with the bundled `leaflet/dist/images/*.png` URLs.
+**Rejected:** still rendered as broken images in the Vite build (a well-known
+Leaflet+bundler asset-path problem). The inline-SVG `divIcon` removes the external
+asset dependency entirely.
+
+### 3.3 `circleMarker` for points (rejected)
+
+Draw points as SVG circles. **Rejected:** works and needs no assets, but reads as
+a faint dot rather than a recognizable location marker; the SVG pin is clearer and
+matches user expectation from the official Leaflet page.
+
+### 3.4 Render all ` ```json ` fences as maps (rejected)
+
+**Rejected:** would break every non-geographic JSON snippet. The
+`FeatureCollection` discriminator keeps detection safe.
+
+---
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.tsx` | New molecule — parse + Leaflet map + SVG-pin points + fit-bounds; exports `parseFeatureCollection` / `isGeoJsonFeatureCollection` |
+| `apps/frontend/src/rework/components/shared/molecules/GeoMapBlock/GeoMapBlock.module.css` | New — landscape sizing, stacking context, `.pin` (strip default divIcon box), error state |
+| `apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.tsx` | Add the `geojson` / GeoJSON-`json` branch to the fenced-code dispatch |
+
+No backend changes. No contract changes. No new dependencies (Leaflet already
+present).
+
+---
+
+## 5. Acceptance criteria
+
+### 5.1 Functional
+
+- [ ] Sending `markdown` to the test assistant renders the "GeoJSON (map)" section
+  as an interactive Leaflet map instead of a JSON code block.
+- [ ] Point features show as visible location pins (no broken-image boxes); clicking
+  a pin opens a popup with the feature `name`.
+- [ ] Polygon features render styled from their `color` / `fillOpacity` properties.
+- [ ] The map auto-fits to show all features.
+- [ ] On scroll, the map slides **behind** the chat input bar (no overlap).
+- [ ] The map is a landscape rectangle, not a square.
+- [ ] A non-geographic ` ```json ` fence still renders as a normal code block.
+- [ ] An explicit ` ```geojson ` fence from any agent renders as a map.
+
+### 5.2 Unit tests (`GeoMapBlock.test.ts`)
+
+| Input | `isGeoJsonFeatureCollection` |
+|---|---|
+| Valid `FeatureCollection` JSON | `true` |
+| Valid JSON object without `type: "FeatureCollection"` | `false` |
+| A bare `Feature` | `false` |
+| Invalid JSON | `false` |
+
+### 5.3 Non-regression
+
+- [ ] `make -C apps/frontend code-quality` passes (`tsc --noEmit` + prettier).
+- [ ] Existing CHAT-RENDERING-SPEC §5 acceptance criteria still pass.
+- [ ] `make -C apps/frontend build` succeeds with Leaflet bundled (first consumer).

--- a/docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md
+++ b/docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md
@@ -92,7 +92,18 @@ Behavioral decisions:
   `L.geoJSON(data).getBounds()`), falling back to a central-Europe view when the
   bounds are not resolvable.
 
-### 2.4 Layout / stacking
+### 2.4 Untrusted-input hardening
+
+GeoJSON `properties` are agent-supplied and may carry untrusted content (e.g. RAG
+document text), so feature values are treated as data, never HTML:
+
+- **Popup label** binds a DOM text node (`el.textContent = String(label)`), not a
+  string — `layer.bindPopup(string)` would render the input as HTML (XSS).
+- **`color` property** is validated against a hex / `rgb(a)` / `hsl(a)` allowlist
+  (`SAFE_COLOR`) before it reaches the inline-SVG pin markup or Leaflet path style;
+  anything else falls back to the theme `--primary`.
+
+### 2.5 Layout / stacking
 
 Two CSS rules in `GeoMapBlock.module.css`:
 
@@ -166,7 +177,7 @@ present).
 ### 5.2 Unit tests (`GeoMapBlock.test.ts`)
 
 | Input | `isGeoJsonFeatureCollection` |
-|---|---|
+|---|---|[A4I Hackathon_Team007_MardownFile.md](../../../../../Downloads/Fred-Delivarables/Fred-Delivarables/A4I%20Hackathon_Team007_MardownFile.md)
 | Valid `FeatureCollection` JSON | `true` |
 | Valid JSON object without `type: "FeatureCollection"` | `false` |
 | A bare `Feature` | `false` |
@@ -177,3 +188,14 @@ present).
 - [ ] `make -C apps/frontend code-quality` passes (`tsc --noEmit` + prettier).
 - [ ] Existing CHAT-RENDERING-SPEC §5 acceptance criteria still pass.
 - [ ] `make -C apps/frontend build` succeeds with Leaflet bundled (first consumer).
+- [ ] XSS check: a FeatureCollection with a malicious `name`/`title` and `color`
+  renders inert (label escaped, color falls back to accent).
+
+---
+
+## 6. Future follow-ups (non-blocking)
+
+- **Configurable tile source.** The map currently pulls tiles from the public
+  OpenStreetMap server, which exposes viewport + client IP to a third party. For
+  enterprise/offline deployments the tile URL should become configurable (e.g. a
+  frontend config value with an OSM default). Out of scope for this PR.


### PR DESCRIPTION
Closes #1818. Implements RFC docs/swift/rfc/CHAT-GEOJSON-MAP-RENDERING-RFC.md (CHAT-13). Frontend-only; no contract change. Validated with make -C apps/frontend code-quality."