### PR TITLE
feat(RUNTIME): add deep agent dispatch + Report Generator with web search

### DIFF
--- a/apps/fred-agents/config/mcp_catalog.yaml
+++ b/apps/fred-agents/config/mcp_catalog.yaml
@@ -242,6 +242,14 @@ servers:
     provider: "web_github_readonly"
     auth_mode: "no_token"
 
+  - id: "mcp-web-search-google"
+    name: "Google Web Search"
+    description: "Search the web using Google Custom Search API."
+    enabled: true
+    transport: "inprocess"
+    provider: "web_search_google"
+    auth_mode: "no_token"
+
   - id: "mcp-knowledge-flow-statistics"
     name: "mcp-knowledge-flow-statistics"
     description: "mcp.servers.statistics.description"

--- a/apps/fred-agents/config/mcp_catalog.yaml
+++ b/apps/fred-agents/config/mcp_catalog.yaml
@@ -242,12 +242,12 @@ servers:
     provider: "web_github_readonly"
     auth_mode: "no_token"
 
-  - id: "mcp-web-search-google"
-    name: "Google Web Search"
-    description: "Search the web using Google Custom Search API."
+  - id: "mcp-web-search"
+    name: "Web Search"
+    description: "Search the web using DuckDuckGo."
     enabled: true
     transport: "inprocess"
-    provider: "web_search_google"
+    provider: "web_search"
     auth_mode: "no_token"
 
   - id: "mcp-knowledge-flow-statistics"

--- a/apps/fred-agents/fred_agents/main.py
+++ b/apps/fred-agents/fred_agents/main.py
@@ -30,6 +30,7 @@ from fastapi import FastAPI
 from fred_runtime.app import AgentPodConfig, create_agent_app, load_agent_pod_config
 
 from fred_agents.registry import REGISTRY
+from fred_agents.web_search import inprocess_toolkit_factory
 
 
 def create_app(config: AgentPodConfig | None = None) -> FastAPI:
@@ -52,6 +53,7 @@ def create_app(config: AgentPodConfig | None = None) -> FastAPI:
     return create_agent_app(
         registry=REGISTRY,
         config=resolved_config,
+        inprocess_toolkit_factory=inprocess_toolkit_factory,
     )
 
 

--- a/apps/fred-agents/fred_agents/registry.py
+++ b/apps/fred-agents/fred_agents/registry.py
@@ -26,20 +26,26 @@ Example:
 - `from fred_agents.agents import REGISTRY`
 """
 
-from fred_sdk.contracts.models import DeepAgentDefinition, GraphAgentDefinition, ReActAgentDefinition
+from fred_sdk.contracts.models import (
+    DeepAgentDefinition,
+    GraphAgentDefinition,
+    ReActAgentDefinition,
+)
 
 from fred_agents.comparison import COMPARISON_AGENT
 from fred_agents.general_assistant import GENERAL_ASSISTANT_AGENT
-from fred_agents.report_generator import REPORT_GENERATOR_AGENT
 from fred_agents.mindmap import MINDMAP_AGENT
 from fred_agents.rag_expert import RAG_EXPERT_AGENT
 from fred_agents.react_rag_mcp import REACT_RAG_MCP_AGENT
+from fred_agents.report_generator import REPORT_GENERATOR_AGENT
 from fred_agents.sentinel import SENTINEL_AGENT
 from fred_agents.sql_expert import SQL_EXPERT_AGENT
 from fred_agents.test_assistant.graph_agent import TEST_ASSISTANT_AGENT
 
 
-def build_registry() -> dict[str, ReActAgentDefinition | DeepAgentDefinition | GraphAgentDefinition]:
+def build_registry() -> dict[
+    str, ReActAgentDefinition | DeepAgentDefinition | GraphAgentDefinition
+]:
     """
     Build the pod agent registry.
 
@@ -85,4 +91,6 @@ def build_registry() -> dict[str, ReActAgentDefinition | DeepAgentDefinition | G
     }
 
 
-REGISTRY: dict[str, ReActAgentDefinition | DeepAgentDefinition | GraphAgentDefinition] = build_registry()
+REGISTRY: dict[
+    str, ReActAgentDefinition | DeepAgentDefinition | GraphAgentDefinition
+] = build_registry()

--- a/apps/fred-agents/fred_agents/registry.py
+++ b/apps/fred-agents/fred_agents/registry.py
@@ -26,10 +26,11 @@ Example:
 - `from fred_agents.agents import REGISTRY`
 """
 
-from fred_sdk.contracts.models import GraphAgentDefinition, ReActAgentDefinition
+from fred_sdk.contracts.models import DeepAgentDefinition, GraphAgentDefinition, ReActAgentDefinition
 
 from fred_agents.comparison import COMPARISON_AGENT
 from fred_agents.general_assistant import GENERAL_ASSISTANT_AGENT
+from fred_agents.report_generator import REPORT_GENERATOR_AGENT
 from fred_agents.mindmap import MINDMAP_AGENT
 from fred_agents.rag_expert import RAG_EXPERT_AGENT
 from fred_agents.react_rag_mcp import REACT_RAG_MCP_AGENT
@@ -38,7 +39,7 @@ from fred_agents.sql_expert import SQL_EXPERT_AGENT
 from fred_agents.test_assistant.graph_agent import TEST_ASSISTANT_AGENT
 
 
-def build_registry() -> dict[str, ReActAgentDefinition | GraphAgentDefinition]:
+def build_registry() -> dict[str, ReActAgentDefinition | DeepAgentDefinition | GraphAgentDefinition]:
     """
     Build the pod agent registry.
 
@@ -80,7 +81,8 @@ def build_registry() -> dict[str, ReActAgentDefinition | GraphAgentDefinition]:
         COMPARISON_AGENT.agent_id: COMPARISON_AGENT,
         SQL_EXPERT_AGENT.agent_id: SQL_EXPERT_AGENT,
         TEST_ASSISTANT_AGENT.agent_id: TEST_ASSISTANT_AGENT,
+        REPORT_GENERATOR_AGENT.agent_id: REPORT_GENERATOR_AGENT,
     }
 
 
-REGISTRY: dict[str, ReActAgentDefinition | GraphAgentDefinition] = build_registry()
+REGISTRY: dict[str, ReActAgentDefinition | DeepAgentDefinition | GraphAgentDefinition] = build_registry()

--- a/apps/fred-agents/fred_agents/report_generator.py
+++ b/apps/fred-agents/fred_agents/report_generator.py
@@ -73,7 +73,7 @@ class ReportGeneratorDefinition(DeepAgentDefinition):
     system_prompt_template: str = _SYSTEM_PROMPT
 
     default_mcp_servers: tuple[MCPServerRef, ...] = (
-        MCPServerRef(id="mcp-web-search-google"),
+        MCPServerRef(id="mcp-web-search"),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_CORPUS),
     )

--- a/apps/fred-agents/fred_agents/report_generator.py
+++ b/apps/fred-agents/fred_agents/report_generator.py
@@ -1,0 +1,100 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Report Generator — deep agent that produces structured, grounded reports.
+
+Why this module exists:
+- provides a DeepAgentDefinition-backed template in the Create Agent menu
+  under the "deep" category pill
+- uses DeepAgentRuntime (deepagents planner) rather than plain ReAct so the
+  agent can decompose multi-step research before writing
+
+How to use it:
+- import REPORT_GENERATOR_AGENT and add it to the pod registry
+- user picks it from "Create Agent", asks "generate a report on <topic>"
+"""
+
+from fred_sdk import (
+    MCP_SERVER_KNOWLEDGE_FLOW_CORPUS,
+    MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
+    FieldSpec,
+    MCPServerRef,
+    UIHints,
+    apply_global_base_prompts,
+)
+from fred_sdk.contracts.models import DeepAgentDefinition, ReActPolicy
+
+_SYSTEM_PROMPT = apply_global_base_prompts(
+    """\
+You are a professional report-writing assistant.
+
+When the user asks you to generate a report, you must:
+1. Clarify the topic and scope if not clear.
+2. Search available knowledge sources to gather relevant information.
+3. Organise findings into clearly labelled sections: Executive Summary, \
+Background, Key Findings, Conclusion.
+4. Cite every claim with the source document or tool result that produced it.
+5. Return the full report as structured markdown.
+
+If no search tools are available, state this clearly and produce a best-effort \
+report from your training knowledge, marking all unsourced claims as [unverified].
+"""
+)
+
+
+class ReportGeneratorDefinition(DeepAgentDefinition):
+    """Deep agent that researches a topic and writes a structured report."""
+
+    agent_id: str = "fred.github.report_generator"
+    role: str = "Report Generator"
+    description: str = (
+        "Deep agent that researches a topic across available knowledge sources "
+        "and produces a structured, cited report. Ask it: 'generate a report on <topic>'."
+    )
+    description_by_lang: dict[str, str] | None = {
+        "fr": (
+            "Agent avancé qui recherche un sujet dans les sources de connaissance "
+            "disponibles et produit un rapport structuré et sourcé. "
+            "Demandez-lui : 'génère un rapport sur <sujet>'."
+        )
+    }
+    tags: tuple[str, ...] = ("deep", "report", "research")
+    system_prompt_template: str = _SYSTEM_PROMPT
+
+    default_mcp_servers: tuple[MCPServerRef, ...] = (
+        MCPServerRef(id="mcp-web-search-google"),
+        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
+        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_CORPUS),
+    )
+
+    fields: tuple[FieldSpec, ...] = (
+        FieldSpec(
+            key="prompts.system",
+            type="prompt",
+            title="System prompt",
+            description="Instructions that define the report style and focus.",
+            description_by_lang={
+                "fr": "Instructions définissant le style et le périmètre du rapport."
+            },
+            required=False,
+            default=_SYSTEM_PROMPT,
+            ui=UIHints(group="Prompts", multiline=True, markdown=True, max_lines=12),
+        ),
+    )
+
+    def policy(self) -> ReActPolicy:
+        return ReActPolicy(system_prompt_template=self.system_prompt_template)
+
+
+REPORT_GENERATOR_AGENT = ReportGeneratorDefinition()

--- a/apps/fred-agents/fred_agents/web_search.py
+++ b/apps/fred-agents/fred_agents/web_search.py
@@ -1,0 +1,85 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+DuckDuckGo web search inprocess toolkit.
+
+Provides a single `web_search` LangChain tool that searches the web via
+DuckDuckGo. No API key or account required. Registered as provider
+"web_search_google" so existing mcp_catalog.yaml and agent definitions
+need no change.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from langchain_core.tools import BaseTool, tool
+
+logger = logging.getLogger(__name__)
+
+
+def _ddg_search(query: str, num_results: int = 5) -> str:
+    try:
+        from ddgs import DDGS
+
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, max_results=num_results))
+    except Exception as exc:
+        logger.warning("DuckDuckGo search error: %s", exc)
+        return f"Web search failed: {exc}"
+
+    if not results:
+        return f"No results found for: {query}"
+
+    formatted = [
+        {"title": r.get("title"), "link": r.get("href"), "snippet": r.get("body")}
+        for r in results
+    ]
+    return json.dumps(formatted, ensure_ascii=False, indent=2)
+
+
+@tool
+def web_search(query: str, num_results: int = 5) -> str:
+    """
+    Search the web using DuckDuckGo and return titles, URLs, and snippets.
+
+    Use this tool to find current information, news, recent events, or any topic
+    that benefits from live web results. Returns up to num_results results.
+
+    Args:
+        query: The search query string.
+        num_results: Number of results to return (1-10, default 5).
+    """
+    return _ddg_search(query, num_results=min(max(num_results, 1), 10))
+
+
+class GoogleSearchToolkit:
+    """Inprocess toolkit that exposes the Google Custom Search tool."""
+
+    def tools(self) -> list[BaseTool]:
+        return [web_search]
+
+
+def inprocess_toolkit_factory(provider: str | None) -> GoogleSearchToolkit | None:
+    """
+    Map inprocess provider names to toolkit instances.
+
+    How to use it:
+    - pass this as `inprocess_toolkit_factory` to `create_agent_app` in main.py
+    - add new providers here as the pod grows
+    """
+    if provider == "web_search_google":
+        return GoogleSearchToolkit()
+    return None

--- a/apps/fred-agents/fred_agents/web_search.py
+++ b/apps/fred-agents/fred_agents/web_search.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-DuckDuckGo web search inprocess toolkit.
+Web search inprocess toolkit.
 
 Provides a single `web_search` LangChain tool that searches the web via
-DuckDuckGo. No API key or account required. Registered as provider
-"web_search_google" so existing mcp_catalog.yaml and agent definitions
-need no change.
+the `ddgs` package. No API key or account required. Registered as provider
+"web_search" in mcp_catalog.yaml.
 """
 
 from __future__ import annotations
@@ -30,14 +29,14 @@ from langchain_core.tools import BaseTool, tool
 logger = logging.getLogger(__name__)
 
 
-def _ddg_search(query: str, num_results: int = 5) -> str:
+def _web_search(query: str, num_results: int = 5) -> str:
     try:
         from ddgs import DDGS
 
         with DDGS() as ddgs:
             results = list(ddgs.text(query, max_results=num_results))
     except Exception as exc:
-        logger.warning("DuckDuckGo search error: %s", exc)
+        logger.warning("Web search error: %s", exc)
         return f"Web search failed: {exc}"
 
     if not results:
@@ -53,7 +52,7 @@ def _ddg_search(query: str, num_results: int = 5) -> str:
 @tool
 def web_search(query: str, num_results: int = 5) -> str:
     """
-    Search the web using DuckDuckGo and return titles, URLs, and snippets.
+    Search the web and return titles, URLs, and snippets.
 
     Use this tool to find current information, news, recent events, or any topic
     that benefits from live web results. Returns up to num_results results.
@@ -62,17 +61,17 @@ def web_search(query: str, num_results: int = 5) -> str:
         query: The search query string.
         num_results: Number of results to return (1-10, default 5).
     """
-    return _ddg_search(query, num_results=min(max(num_results, 1), 10))
+    return _web_search(query, num_results=min(max(num_results, 1), 10))
 
 
-class GoogleSearchToolkit:
-    """Inprocess toolkit that exposes the Google Custom Search tool."""
+class WebSearchToolkit:
+    """Inprocess toolkit that exposes the web search tool."""
 
     def tools(self) -> list[BaseTool]:
         return [web_search]
 
 
-def inprocess_toolkit_factory(provider: str | None) -> GoogleSearchToolkit | None:
+def inprocess_toolkit_factory(provider: str | None) -> WebSearchToolkit | None:
     """
     Map inprocess provider names to toolkit instances.
 
@@ -80,6 +79,6 @@ def inprocess_toolkit_factory(provider: str | None) -> GoogleSearchToolkit | Non
     - pass this as `inprocess_toolkit_factory` to `create_agent_app` in main.py
     - add new providers here as the pod grows
     """
-    if provider == "web_search_google":
-        return GoogleSearchToolkit()
+    if provider == "web_search":
+        return WebSearchToolkit()
     return None

--- a/apps/fred-agents/pyproject.toml
+++ b/apps/fred-agents/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "fred-sdk>=3.1.0",
   "fred-runtime[app]>=3.1.0",
   "uvicorn>=0.35",
+  "ddgs>=9.14.4",
 ]
 
 [project.optional-dependencies]

--- a/apps/fred-agents/uv.lock
+++ b/apps/fred-agents/uv.lock
@@ -308,6 +308,40 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -447,6 +481,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "fake-useragent" },
+    { name = "httpx", extra = ["brotli", "http2", "socks"] },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/24/9d29eeb7dd4852c27c3673adcaf30c4dc55ced76b303c1fbb792ce7cae52/ddgs-9.14.4.tar.gz", hash = "sha256:f7b118a2b709a9e9c04a1dca6e96b98c25d4dfaca1a4b0a244d74454fcca48ef", size = 59742, upload-time = "2026-05-15T06:53:45.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/5f/32de4d99220eb559b7b1cd1c529a1856efa8097f7a3e10b6c207aa95e36c/ddgs-9.14.4-py3-none-any.whl", hash = "sha256:acb084c34bf1110c974caf7e5e5a2c1973beb4bd9e170bfd191fe5ed2d2b2d6c", size = 70638, upload-time = "2026-05-15T06:53:44.761Z" },
+]
+
+[[package]]
 name = "deepagents"
 version = "0.6.10"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +565,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +610,7 @@ name = "fred-agents"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "ddgs" },
     { name = "fred-core" },
     { name = "fred-runtime", extra = ["app"] },
     { name = "fred-sdk" },
@@ -585,6 +645,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8.6" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = "==1.31.0" },
+    { name = "ddgs", specifier = ">=9.14.4" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "fred-core", editable = "../../libs/fred-core" },
     { name = "fred-runtime", extras = ["app"], editable = "../../libs/fred-runtime" },
@@ -1130,6 +1191,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1143,6 +1217,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
     { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
     { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -1173,6 +1256,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+brotli = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+]
+http2 = [
+    { name = "h2" },
+]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -1201,6 +1296,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/27/629cfe58c582f92ded066c4a07d1a057ff617118ab7973200f770bd853cb/huggingface_hub-1.19.0.tar.gz", hash = "sha256:fd771622182d40977272a923953ee3b1b13538f9f8a7f5d78398f10af0f1c0bd", size = 824721, upload-time = "2026-06-11T12:33:18.665Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a5/558da89f66464d8d0229ff497e8b8666977de2d8cf48c28a2862ecf1250f/huggingface_hub-1.19.0-py3-none-any.whl", hash = "sha256:1dc72e1f6b4d6df6b30eb72e57d00514ef453d660f04af2b87f0e67267f31ee0", size = 693398, upload-time = "2026-06-11T12:33:16.695Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1559,6 +1663,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/d9/a6681aa9847bbbc5ec21abe20a5e233b94e5edcfe39624db607ac7e8ccb4/langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd", size = 4526988, upload-time = "2026-06-19T13:12:17.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/70/0e0cc80a3b064c8d6c8d697c3125ed86e39d5a7393ec6dc8b07cb1cf13c4/langsmith-0.8.18-py3-none-any.whl", hash = "sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282", size = 508108, upload-time = "2026-06-19T13:12:15.348Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
 ]
 
 [[package]]
@@ -1994,6 +2124,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4b/7efa54f38da7de8df6b70dfed173bb41a52b740b144e4be24c1172db4209/primp-1.3.1.tar.gz", hash = "sha256:b04a5941bf9c876d011c5defaf5a25be093d56e7270b8da52c9788b9df2a829a", size = 1360029, upload-time = "2026-05-23T17:39:25.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/80/c4885a783a7493e396d89a592ba19fce63ef6bd6ad47230924a884a30ec0/primp-1.3.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27b87e6370045a0c65c0e4dfdfacbfe637387d05673ce8ddcce400263f7c27f0", size = 5123967, upload-time = "2026-05-23T17:39:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c1/c965cc23f96a364803d44b4331f33e4465bb6f269add37e39d0ad77ffe33/primp-1.3.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:27a8804eb9a3f641f379ee2b443591428cf85c898816e93d04d3e7b6f229ebcb", size = 4743059, upload-time = "2026-05-23T17:39:15.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/f4248d8d833d43fd8ba78208f2f4bf7fba7d3aec8c516090a95d18d6f550/primp-1.3.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862974796552a51af8e276bb19c5d5e189168ab8bad216aef7ce3726a8d3b1dd", size = 5100121, upload-time = "2026-05-23T17:39:04.64Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/519e32e0184763e1a76c9321fdeac0bb9b30bf85746f12058feec0cc4a27/primp-1.3.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ceb24198994799706f4020a00173ba9c1b491aa9805b1e014d87946677bc3c5d", size = 4738042, upload-time = "2026-05-23T17:39:35.967Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7b/723cb40694b47ec79a142ed8492835c0ecae9fef7acbed014f04b018d1de/primp-1.3.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3298b8afcf0a88ba6622bfc18e78aeb11afbb7d5afa4774f24acf7491f54a2d", size = 5001773, upload-time = "2026-05-23T17:39:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/80a2e3bdab1c51d738b82ea210a5ab93986b443c561e792e42cae296ec10/primp-1.3.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b8d38c5a6d0a863274cbcae9678f265fcdcead3c20d12d152244e88f5f2186b", size = 5334228, upload-time = "2026-05-23T17:39:24.214Z" },
+    { url = "https://files.pythonhosted.org/packages/19/70/c95b8054c7d1fe2d84226ec60a5f48ce6c95a08b7c8b1702d7742082f444/primp-1.3.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96f831c78ddb5900873f51e294bf9bbb4bbfdac3a2f39ce4023f8c558d299332", size = 5157269, upload-time = "2026-05-23T17:38:48.142Z" },
+    { url = "https://files.pythonhosted.org/packages/34/bb/9b66986b7ecf2eff987134cd94bde533142e3085d6f67531f1a369ceaaae/primp-1.3.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329d0c320841f65b39d80801d8bae126732b84ec1094ca17b14fda0bda1b20ff", size = 5347438, upload-time = "2026-05-23T17:39:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/5d127748d06f3c6a3367f3c4974e45b98cda61cd28ea79ef91ad3fe9e093/primp-1.3.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6c3c67670c38a03e9e8da45b212243d35afc8efa018317c46ecdce47f05329d1", size = 5264862, upload-time = "2026-05-23T17:39:20.625Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f3/1aac229425cac142c48418e2de9f70597161ea936543b5e3c9e7476e1921/primp-1.3.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9409a31028a8c62a609d389554ad4f5339aad075130300cd443beef0336d7179", size = 4969889, upload-time = "2026-05-23T17:39:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/a94d6e6166139c76ae42eb941328679309ca85139e8753d639657a24474c/primp-1.3.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:88ca36c2bd1b7c64b96ad07ca367d2d111ac8e9670549be5f232da8bf795d21e", size = 5082679, upload-time = "2026-05-23T17:39:28.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/61/21d297db575ed660c6aaf35c9014c1874ace45d6dcb79d1a4d3d2608bffb/primp-1.3.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74d13800b501aa003fb05c263d38f8d61656c83a60b2951046c0fc412bc73976", size = 5605392, upload-time = "2026-05-23T17:39:38.007Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d6/9262a7ebb1d980a2db0cd505bb902bb3e66acd8a1cb763a4c2921f2f6a5b/primp-1.3.1-cp310-abi3-win32.whl", hash = "sha256:09ada1752629fe89d7b128beeb59cb641f404af462e24177ba36aed1cf322299", size = 4270373, upload-time = "2026-05-23T17:38:44.98Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/68/f0c6a60fadff0c185aef232b951a6fa4bbb64511facc48d34734db14f16f/primp-1.3.1-cp310-abi3-win_amd64.whl", hash = "sha256:c0d1e294466cd5ec7ef173eedf8df25cbdc050138d40447a906e92b8553e7765", size = 4661498, upload-time = "2026-05-23T17:39:32.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/232a52abc77384ac66b9c1741691dec3659b1207bb6c5e55c1e9b59d22f1/primp-1.3.1-cp310-abi3-win_arm64.whl", hash = "sha256:43304cb41cbb46f361de49faf1cbdba57f969f628c9297239c7ed8ef0cac420f", size = 4624481, upload-time = "2026-05-23T17:38:42.724Z" },
 ]
 
 [[package]]
@@ -2530,6 +2683,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]

--- a/apps/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/apps/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -743,7 +743,7 @@ export type ReActProfileSummary = {
   agent_description: string;
   tags: string[];
 };
-export type ExecutionCategory = "graph" | "react" | "proxy";
+export type ExecutionCategory = "graph" | "react" | "deep" | "proxy";
 export type ToolRefRequirement = {
   kind?: "tool_ref";
   required?: boolean;

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -81,6 +81,7 @@ from fred_sdk.contracts.execution import (
 )
 from fred_sdk.contracts.models import (
     AgentTuning,
+    DeepAgentDefinition,
     ExecutionCategory,
     GraphAgentDefinition,
     MCPServerConfiguration,
@@ -104,6 +105,7 @@ from fred_sdk.support.authored_toolsets import (
 from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
 from fred_runtime.common.kf_markdown_media_client import KfMarkdownMediaClient
+from fred_runtime.deep.deep_runtime import DeepAgentRuntime
 from fred_runtime.graph.graph_runtime import GraphRuntime
 from fred_runtime.react.react_runtime import ReActRuntime
 from fred_runtime.runtime_support.checkpoints import load_checkpoint
@@ -1882,7 +1884,7 @@ async def _iterate_runtime_event_payloads(
         invocation_turns=getattr(request, "invocation_turns", ()),
     )
 
-    runtime: ReActRuntime | GraphRuntime | None = None
+    runtime: ReActRuntime | DeepAgentRuntime | GraphRuntime | None = None
     try:
         if isinstance(definition, GraphAgentDefinition):
             runtime = GraphRuntime(
@@ -1905,6 +1907,34 @@ async def _iterate_runtime_event_payloads(
                     {"message": request.message or ""}
                 )
             async for event in executor.stream(graph_input, execution_config):
+                payload = event.model_dump(mode="json")
+                if not isinstance(payload, dict):
+                    raise RuntimeError(
+                        "RuntimeEvent payload must serialize to a JSON object."
+                    )
+                yield payload
+        elif isinstance(definition, DeepAgentDefinition):
+            # DeepAgentDefinition inherits ReActAgentDefinition — must check before
+            # the ReAct fallthrough or it silently runs as plain ReAct.
+            runtime = DeepAgentRuntime(
+                definition=definition,
+                services=services,
+            )
+            runtime.bind(binding)
+            await runtime.activate()
+            executor = await runtime.get_executor()
+            react_input = ReActInput(
+                messages=(
+                    ()
+                    if request.resume_payload is not None
+                    else (
+                        ReActMessage(
+                            role=ReActMessageRole.USER, content=request.message
+                        ),
+                    )
+                ),
+            )
+            async for event in executor.stream(react_input, execution_config):
                 payload = event.model_dump(mode="json")
                 if not isinstance(payload, dict):
                     raise RuntimeError(
@@ -2868,6 +2898,7 @@ def create_agent_app(
     registry: Mapping[str, ReActAgentDefinition | GraphAgentDefinition],
     config: AgentPodConfig,
     extra_routers: list[APIRouter] | None = None,
+    inprocess_toolkit_factory: InprocessToolkitFactory | None = None,
 ) -> FastAPI:
     """
     Create a ready-to-serve FastAPI app for a Fred agent pod.
@@ -2964,6 +2995,7 @@ def create_agent_app(
                     mcp_configuration=config.get_mcp_configuration(),
                     control_plane_url=config.platform.control_plane_url,
                     kpi_writer=container.get_kpi_writer(),
+                    inprocess_toolkit_factory=inprocess_toolkit_factory,
                 )
             )
         )

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -120,6 +120,7 @@ from ..integrations.v2_runtime.adapters import (
     build_default_tracer,
 )
 from ..runtime_context import (
+    InprocessToolkitFactory,
     RuntimeConfig,
     get_runtime_context,
     set_runtime_context,


### PR DESCRIPTION
## Summary
- **Fix dispatch bug**: `DeepAgentDefinition` was silently running as `ReActRuntime` because it inherits `ReActAgentDefinition`. Added `elif isinstance(definition, DeepAgentDefinition)` branch before the ReAct fallthrough so `DeepAgentRuntime` is correctly selected.
- **Add `ReportGeneratorDefinition`**: a `DeepAgentDefinition` that researches a topic and writes a structured cited report. Appears automatically in the Create Agent menu under the `deep` category pill — no frontend change needed.
- **DuckDuckGo web search tool**: free, no API key required. Registered as an inprocess MCP provider (`mcp-web-search-google`) so the agent can search the web before writing reports.
- **Add `inprocess_toolkit_factory` parameter to `create_agent_app`**: allows pods to register custom in-process MCP tool providers.
- **Fix `ExecutionCategory` enum in `agenticOpenApi.ts`**: `"deep"` was missing, causing type errors when the control-plane returned a deep agent category.

## Test plan
- [ ] Go to Create Agent → see **Report Generator** card with `deep` category pill
- [ ] Create an instance, enable **Google Web Search** tool in the Tools tab
- [ ] Ask: `generate a report on cybersecurity threats` — agent searches web then writes structured report

🤖 Generated with [Claude Code](https://claude.com/claude-code)