### PR TITLE
1850 Remove getting branding conf from control-plane ui bootstrap and rely on frontend config_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,8 +662,8 @@ See `apps/fred-agents/config/models_catalog.yaml` and `apps/knowledge-flow-backe
 
 - Enable Keycloak or another OIDC provider for authentication
 
-  > **Frontend security is configured independently of the backend.**  
-  > The frontend reads `frontend/public/config.json` at startup. Set `user_auth.enabled: true` (plus `realm_url` and `client_id`) to enable real Keycloak OIDC. When `enabled: false` (the default for local dev), the frontend mints local dev tokens — the same code paths run in both modes, so the app stays production-shaped in development. See [`frontend/README.md`](./frontend/README.md#security-configuration) for details.
+  > **Frontend security is backend-driven.**  
+  > The frontend first loads static `/config.json`, then calls the public control-plane `/control-plane/v1/frontend/config` endpoint for the effective `user_auth` and `gcu_version` values. Real Keycloak OIDC is enabled from the backend `security.user` configuration; when disabled for local dev, the frontend mints local dev tokens while keeping the same app code paths. Static branding stays in frontend `config.json` `properties`. See [`apps/frontend/README.md`](./apps/frontend/README.md#configuration-surfaces) for details.
 
 - Persistence options:
   - **Laptop / dev (default):** SQLite for metadata + ChromaDB for vectors (embedded, no external services)

--- a/apps/control-plane-backend/config/schema/configuration.schema.json
+++ b/apps/control-plane-backend/config/schema/configuration.schema.json
@@ -75,9 +75,6 @@
       "properties": {
         "feature_flags": {
           "$ref": "#/$defs/FrontendFeatureFlags"
-        },
-        "ui_settings": {
-          "$ref": "#/$defs/FrontendUiSettings"
         }
       },
       "title": "FrontendBootstrapConfig",
@@ -99,29 +96,6 @@
         }
       },
       "title": "FrontendFeatureFlags",
-      "type": "object",
-      "additionalProperties": false
-    },
-    "FrontendUiSettings": {
-      "description": "Small typed UI settings surface owned by control-plane.",
-      "properties": {
-        "siteDisplayName": {
-          "default": "Fred",
-          "title": "Sitedisplayname",
-          "type": "string"
-        },
-        "agentsNicknameSingular": {
-          "default": "agent",
-          "title": "Agentsnicknamesingular",
-          "type": "string"
-        },
-        "agentsNicknamePlural": {
-          "default": "agents",
-          "title": "Agentsnicknameplural",
-          "type": "string"
-        }
-      },
-      "title": "FrontendUiSettings",
       "type": "object",
       "additionalProperties": false
     },

--- a/apps/control-plane-backend/control_plane_backend/cli/main.py
+++ b/apps/control-plane-backend/control_plane_backend/cli/main.py
@@ -498,7 +498,6 @@ def _print_bootstrap_summary(
     print(f"  Teams:     {len(bootstrap.available_teams)} visible team(s)")
     print(f"  GCU:       {bootstrap.gcu_version or 'not enforced'}")
     print(f"  Features:  {bootstrap.feature_flags.model_dump(mode='json')}")
-    print(f"  UI:        {bootstrap.ui_settings.model_dump(mode='json')}")
     print(f"  Perms:     {permissions}")
 
 

--- a/apps/control-plane-backend/control_plane_backend/config/models.py
+++ b/apps/control-plane-backend/control_plane_backend/config/models.py
@@ -46,19 +46,10 @@ class FrontendFeatureFlags(BaseModel):
     enableElecWarfare: bool = False
 
 
-class FrontendUiSettings(BaseModel):
-    """Small typed UI settings surface owned by control-plane."""
-
-    siteDisplayName: str = "Fred"
-    agentsNicknameSingular: str = "agent"
-    agentsNicknamePlural: str = "agents"
-
-
 class FrontendBootstrapConfig(BaseModel):
     """Static frontend bootstrap configuration served by control-plane."""
 
     feature_flags: FrontendFeatureFlags = Field(default_factory=FrontendFeatureFlags)
-    ui_settings: FrontendUiSettings = Field(default_factory=FrontendUiSettings)
 
 
 class RuntimeCatalogSourceConfig(BaseModel):

--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel, Field
 
 from control_plane_backend.config.models import (
     FrontendFeatureFlags,
-    FrontendUiSettings,
     ManagedAgentFieldSpec,
     ManagedAgentTuning,
     ManagedMcpServerRef,
@@ -40,7 +39,6 @@ class FrontendBootstrap(BaseModel):
     available_teams: list[Team] = Field(default_factory=list)
     gcu_version: str | None = None
     feature_flags: FrontendFeatureFlags
-    ui_settings: FrontendUiSettings
     permissions: PermissionSummary
 
 

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -231,7 +231,6 @@ async def build_frontend_bootstrap(
         available_teams=available_teams,
         gcu_version=deps.configuration.app.gcu_version,
         feature_flags=deps.configuration.platform.frontend.feature_flags,
-        ui_settings=deps.configuration.platform.frontend.ui_settings,
         permissions=_build_permission_summary(user),
     )
 

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -680,9 +680,6 @@ async def test_frontend_bootstrap_returns_typed_phase_3a_surface() -> None:
     app = create_app()
     container = get_application_container_from_app(app)
     container.configuration.app.gcu_version = "V1"
-    container.configuration.platform.frontend.ui_settings.siteDisplayName = (
-        "Fred Control Plane"
-    )
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -696,7 +693,7 @@ async def test_frontend_bootstrap_returns_typed_phase_3a_surface() -> None:
     assert payload["available_teams"][0]["id"] == _PERSONAL_TEAM_ID
     assert payload["gcu_version"] == "V1"
     assert payload["feature_flags"]["enableK8Features"] is False
-    assert payload["ui_settings"]["siteDisplayName"] == "Fred Control Plane"
+    assert "ui_settings" not in payload
     assert "agents:read" in payload["permissions"]["items"]
     assert payload["permissions"]["can_manage_team_agents"] is True
 

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -104,18 +104,33 @@ For teams using this structure, onboarding is faster, testing is easier, and fea
 
 > ✏️ To extend: add lazy-loading for pages, errorElement routes, or a public-only layout if login is skipped.
 
-## Security Configuration
+## Configuration Surfaces
 
-The frontend decides whether to use real Keycloak or local dev tokens by reading `frontend/public/config.json` **before** React renders.
+The frontend reads two configuration surfaces during startup:
+
+| Surface | Owner | Purpose |
+| --- | --- | --- |
+| `/config.json` | frontend static asset / Helm frontend ConfigMap | Router base path, backend URLs, and static branding `properties` such as `siteDisplayName`, `siteTitle`, logos, favicons, agent nicknames, support links, and default avatars/banners. |
+| `/control-plane/v1/frontend/config` | control-plane backend | Public pre-auth runtime settings derived from backend config: `user_auth` and `gcu_version`. |
+
+Authenticated product state is separate: `/control-plane/v1/frontend/bootstrap`
+returns current user, active team, visible teams, permissions, feature flags, and
+the post-auth `gcu_version` mirror. It does **not** carry branding labels; do not
+reintroduce `ui_settings` there. Branding belongs in `config.json.properties`.
+
+### Security Configuration
+
+The frontend decides whether to use real Keycloak or local dev tokens from the
+public control-plane `/frontend/config` response **before** React renders:
 
 ```json
 {
-  "frontend_basename": "/",
   "user_auth": {
     "enabled": false,
     "realm_url": "http://keycloak:8080/realms/fred",
     "client_id": "fred-frontend"
-  }
+  },
+  "gcu_version": null
 }
 ```
 
@@ -124,9 +139,14 @@ The frontend decides whether to use real Keycloak or local dev tokens by reading
 | `user_auth.enabled: false` | No Keycloak. A local dev token is minted with `admin` role using `VITE_DEV_USERNAME` (defaults to your Unix username via `make run`). All auth code paths still execute — the app runs production-shaped. |
 | `user_auth.enabled: true`  | Full Keycloak OIDC PKCE flow. `realm_url` and `client_id` must match your deployment.                                                                                                                     |
 
-**Important:** this is a frontend-only flag, independent of the backend `KEYCLOAK_ENABLED` env var. In a real deployment both must be `true`. For local dev both default to disabled.
+**Important:** this is no longer a hand-edited frontend flag. The control-plane
+derives it from backend `security.user`, the same configuration that drives API
+JWT validation. For local dev it can be disabled there; for secure deployments it
+must match the Keycloak/OIDC deployment.
 
-In Kubernetes, `config.json` is rendered by `deploy/charts/fred/templates/configmap-frontend.yaml` from Helm values — no image rebuild needed. For local dev, edit `frontend/public/config.json` directly.
+In Kubernetes, frontend `config.json` is rendered from Helm values — no image
+rebuild needed. Use it for static frontend settings and branding only; do not add
+`user_auth` or control-plane `ui_settings` branding duplicates.
 
 ## Chat UI
 

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -108,10 +108,10 @@ For teams using this structure, onboarding is faster, testing is easier, and fea
 
 The frontend reads two configuration surfaces during startup:
 
-| Surface | Owner | Purpose |
-| --- | --- | --- |
-| `/config.json` | frontend static asset / Helm frontend ConfigMap | Router base path, backend URLs, and static branding `properties` such as `siteDisplayName`, `siteTitle`, logos, favicons, agent nicknames, support links, and default avatars/banners. |
-| `/control-plane/v1/frontend/config` | control-plane backend | Public pre-auth runtime settings derived from backend config: `user_auth` and `gcu_version`. |
+| Surface                             | Owner                                           | Purpose                                                                                                                                                                                |
+| ----------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/config.json`                      | frontend static asset / Helm frontend ConfigMap | Router base path, backend URLs, and static branding `properties` such as `siteDisplayName`, `siteTitle`, logos, favicons, agent nicknames, support links, and default avatars/banners. |
+| `/control-plane/v1/frontend/config` | control-plane backend                           | Public pre-auth runtime settings derived from backend config: `user_auth` and `gcu_version`.                                                                                           |
 
 Authenticated product state is separate: `/control-plane/v1/frontend/bootstrap`
 returns current user, active team, visible teams, permissions, feature flags, and

--- a/apps/frontend/src/hooks/useFrontendProperties.ts
+++ b/apps/frontend/src/hooks/useFrontendProperties.ts
@@ -14,7 +14,6 @@
 
 import { useMemo } from "react";
 import { getGcuVersion, getProperty } from "../common/config";
-import { useFrontendBootstrap } from "./useFrontendBootstrap";
 
 export interface FrontendProperties {
   agentIconName: string;
@@ -52,14 +51,11 @@ export interface FrontendProperties {
  * - `const { siteDisplayName, agentIconName } = useFrontendProperties();`
  */
 export function useFrontendProperties(): FrontendProperties {
-  const { bootstrap } = useFrontendBootstrap();
-  const ui = bootstrap?.ui_settings;
-
   return useMemo(
     () => ({
       agentIconName: getProperty("agentIconName") || "person",
-      agentsNicknamePlural: ui?.agentsNicknamePlural || getProperty("agentsNicknamePlural") || "Agents",
-      agentsNicknameSingular: ui?.agentsNicknameSingular || getProperty("agentsNicknameSingular") || "Agent",
+      agentsNicknamePlural: getProperty("agentsNicknamePlural") || "Agents",
+      agentsNicknameSingular: getProperty("agentsNicknameSingular") || "Agent",
       contactSupportLink: getProperty("contactSupportLink") || "",
       defaultPersonalAvatarFile: getProperty("defaultPersonalAvatarFile") || "",
       defaultPersonalBannerFile: getProperty("defaultPersonalBannerFile") || "",
@@ -75,13 +71,12 @@ export function useFrontendProperties(): FrontendProperties {
       gcuVersion: getGcuVersion() ?? (getProperty("gcuVersion") || null),
       logoName: getProperty("logoName") || "fred",
       logoNameDark: getProperty("logoNameDark") || "fred-dark",
-      siteDisplayName: ui?.siteDisplayName || getProperty("siteDisplayName") || "Fred",
+      siteDisplayName: getProperty("siteDisplayName") || "Fred",
       siteSubtitle: getProperty("siteSubtitle") || "",
-      siteTitle: getProperty("siteTitle") || ui?.siteDisplayName || "Fred",
+      siteTitle: getProperty("siteTitle") || "Fred",
     }),
     // `gcuVersion` is read from the module-level pre-auth config which is loaded
-    // once at startup and never changes during the app lifetime, so only `ui`
-    // (from the bootstrap query) needs to drive recomputation.
-    [ui],
+    // once at startup and never changes during the app lifetime.
+    [],
   );
 }

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1098,11 +1098,6 @@ export type FrontendFeatureFlags = {
   enableK8Features?: boolean;
   enableElecWarfare?: boolean;
 };
-export type FrontendUiSettings = {
-  siteDisplayName?: string;
-  agentsNicknameSingular?: string;
-  agentsNicknamePlural?: string;
-};
 export type PermissionSummary = {
   items?: string[];
   can_view_team_agents?: boolean;
@@ -1118,7 +1113,6 @@ export type FrontendBootstrap = {
   available_teams?: Team[];
   gcu_version?: string | null;
   feature_flags: FrontendFeatureFlags;
-  ui_settings: FrontendUiSettings;
   permissions: PermissionSummary;
 };
 export type FrontendUserAuthConfig = {

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -11831,29 +11831,6 @@
                           "title": "FrontendFeatureFlags",
                           "type": "object",
                           "additionalProperties": false
-                        },
-                        "ui_settings": {
-                          "description": "Small typed UI settings surface owned by control-plane.",
-                          "properties": {
-                            "siteDisplayName": {
-                              "default": "Fred",
-                              "title": "Sitedisplayname",
-                              "type": "string"
-                            },
-                            "agentsNicknameSingular": {
-                              "default": "agent",
-                              "title": "Agentsnicknamesingular",
-                              "type": "string"
-                            },
-                            "agentsNicknamePlural": {
-                              "default": "agents",
-                              "title": "Agentsnicknameplural",
-                              "type": "string"
-                            }
-                          },
-                          "title": "FrontendUiSettings",
-                          "type": "object",
-                          "additionalProperties": false
                         }
                       },
                       "title": "FrontendBootstrapConfig",
@@ -13467,29 +13444,6 @@
                             }
                           },
                           "title": "FrontendFeatureFlags",
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "ui_settings": {
-                          "description": "Small typed UI settings surface owned by control-plane.",
-                          "properties": {
-                            "siteDisplayName": {
-                              "default": "Fred",
-                              "title": "Sitedisplayname",
-                              "type": "string"
-                            },
-                            "agentsNicknameSingular": {
-                              "default": "agent",
-                              "title": "Agentsnicknamesingular",
-                              "type": "string"
-                            },
-                            "agentsNicknamePlural": {
-                              "default": "agents",
-                              "title": "Agentsnicknameplural",
-                              "type": "string"
-                            }
-                          },
-                          "title": "FrontendUiSettings",
                           "type": "object",
                           "additionalProperties": false
                         }

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -836,6 +836,86 @@ applications:
           sse_read_timeout: 2000
           enabled: true
           auth_mode: "user_token"
+          agent_instructions: |
+            ## Citation contract (enforced by the search tool — non-negotiable)
+
+            Every claim derived from a search result MUST carry an inline citation
+            immediately after the claim, using this exact format: **[Title, p. X]**
+
+            Rules for building the citation:
+            - Title = the `title` field of the search result (required).
+            - Page = the `page` field if present. Otherwise use `section`. Otherwise use
+              `file_name`. Never leave the second part blank.
+            - Example: **[Dossier Technique CIR, p. 4]** or **[rapport_final.pdf, §2]**
+
+            Responses that contain factual statements without inline citations are invalid.
+            Apply citations even in lists and bullet points.
+
+            End every response that cites at least one document with a **Sources**
+            section.
+
+            Format:
+
+            > **Sources**
+            > - *Title* — file_name, p. X (or §Section)
+
+            List each distinct document once. Do not add URLs, links, or document IDs to
+            this section.
+
+            NEVER generate, fabricate, or include any URL, hyperlink, or web address in
+            your response — not even if a URL appears in the search result metadata.
+            Ignore URL or link fields entirely.
+
+            NEVER cite a document you have not retrieved in this turn.
+            NEVER present a claim as factual if retrieval returned no supporting result.
+
+            If the search tool returns no relevant results, say so explicitly before
+            falling back to general knowledge. Label any such claim as
+            "[from general knowledge — not verified in the corpus]".
+          config_fields:
+            - key: "chat_options.libraries_selection"
+              type: "boolean"
+              title: "Document library picker"
+              description: "Show a document library selector in the chat interface."
+              default: true
+            - key: "chat_options.libraries_binding"
+              type: "boolean"
+              title: "Bind to specific libraries"
+              description: "Restrict this agent to a fixed set of document libraries chosen at configuration time."
+              default: false
+            - key: "chat_options.bound_library_ids"
+              type: "array"
+              item_type: "string"
+              title: "Bound document libraries"
+              description: "Restrict the chat library picker to this preselected set of document libraries."
+              default: []
+            - key: "chat_options.documents_selection"
+              type: "boolean"
+              title: "Document picker"
+              description: "Show a document selector in the chat interface."
+              default: true
+            - key: "chat_options.search_policy_enabled"
+              type: "boolean"
+              title: "Search policy picker in chat"
+              description: "Allow users to switch the search policy from the chat interface."
+              default: false
+            - key: "chat_options.search_policy"
+              type: "string"
+              title: "Default search policy"
+              description: "Search strategy used when the user has not overridden it."
+              enum: ["strict", "hybrid", "semantic"]
+              default: "hybrid"
+            - key: "chat_options.search_rag_scope_enabled"
+              type: "boolean"
+              title: "RAG scope picker in chat"
+              description: "Allow users to switch the RAG scope from the chat interface."
+              default: false
+            - key: "chat_options.search_rag_scope"
+              type: "string"
+              title: "Default RAG scope"
+              description: "Scope used when the user has not overridden it."
+              enum: ["corpus_only", "hybrid", "general_only"]
+              default: "hybrid"
 
         - id: "mcp-knowledge-flow-mcp-tabular"
           name: "mcp.servers.tabular.name"

--- a/deploy/local/k3d/values-local.yaml
+++ b/deploy/local/k3d/values-local.yaml
@@ -316,36 +316,6 @@ applications:
               base_url: https://api.mistral.ai/v1
       rules: []
 
-    # -------------------------------------------------------------------------
-    # Fred Agents Runtime — MCP catalog (overrides default: only text search)
-    # -------------------------------------------------------------------------
-    mcp_catalog:
-      version: v1
-      servers:
-        - id: "mcp-knowledge-flow-mcp-text"
-          name: "mcp.servers.search_documents.name"
-          description: "mcp.servers.search_documents.description"
-          transport: "streamable_http"
-          url: "http://knowledge-flow-backend:8000/knowledge-flow/v1/mcp-text"
-          sse_read_timeout: 2000
-          enabled: true
-          auth_mode: "user_token"
-        - id: "mcp-knowledge-flow-prometheus-ops"
-          name: "mcp.servers.prometheus.name"
-          description: "mcp.servers.prometheus.description"
-          transport: "streamable_http"
-          url: "http://knowledge-flow-backend:8000/knowledge-flow/v1/mcp-prometheus-ops"
-          sse_read_timeout: 2000
-          enabled: true
-          auth_mode: "user_token"
-        - id: "mcp-knowledge-flow-mcp-tabular"
-          name: "mcp.servers.tabular.name"
-          description: "mcp.servers.tabular.description"
-          transport: "streamable_http"
-          url: "http://knowledge-flow-backend:8000/knowledge-flow/v1/mcp-tabular"
-          sse_read_timeout: 2000
-          enabled: true
-          auth_mode: "user_token"
   # ===========================================================================
   # FRONTEND
   # ===========================================================================

--- a/docs/FEATURES.html
+++ b/docs/FEATURES.html
@@ -1085,7 +1085,7 @@
         </tr>
         <tr>
           <td>FrontendBootstrap</td>
-          <td><code>GET /control-plane/v1/frontend/bootstrap</code> returns resolved <code>current_user</code>, <code>active_team</code>, <code>available_teams</code>, <code>permissions</code>, <code>feature_flags</code>, <code>ui_settings</code>, <code>gcu_version</code> — single authenticated round-trip for the SPA shell.</td>
+          <td><code>GET /control-plane/v1/frontend/bootstrap</code> returns resolved <code>current_user</code>, <code>active_team</code>, <code>available_teams</code>, <code>permissions</code>, <code>feature_flags</code>, <code>gcu_version</code> — single authenticated round-trip for the SPA shell. Branding labels stay in frontend <code>config.json</code> <code>properties</code>, not in the control-plane bootstrap.</td>
         </tr>
         <tr>
           <td>PermissionSummary</td>

--- a/docs/swift/backlog/FRONTEND-BACKLOG.md
+++ b/docs/swift/backlog/FRONTEND-BACKLOG.md
@@ -396,6 +396,9 @@ Checklist:
       default team/personal banner/avatar assets). Removed the mock branding
       block from `configuration_prod.yaml` so deployments do not carry two
       competing sources of truth.
+- [x] Removed control-plane bootstrap `ui_settings` as a parallel branding
+      source. `FrontendBootstrap` keeps product/team/authenticated state only;
+      `config.json.properties` owns brand display labels.
 - [x] `make code-quality` green on frontend.
 
 ## 18 Progress Snapshot

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -97,8 +97,15 @@ Phase 3a uses one control-plane-owned bootstrap payload:
   - `gcu_version`
     - optional Terms of Use / CGU gating switch exposed by deployment config
   - `feature_flags`
-  - `ui_settings`
   - `permissions`
+
+`FrontendBootstrap` must not carry deployment branding labels. Static branding
+and frontend display strings (`siteDisplayName`, `siteTitle`, `siteSubtitle`,
+agent nicknames, logos, favicons, banners, support links) are owned by the
+frontend static configuration surface, `config.json` `properties`, so a
+deployment has one branding source of truth. The former control-plane
+`ui_settings` bootstrap block was removed; do not reintroduce a parallel
+branding channel in control-plane.
 
 Permissions are exposed via:
 


### PR DESCRIPTION
This allows a cleaner architecture and prevents the fred logo from blinking at startup (bonus)