### PR TITLE
fix(ppt-filler): discover and fill keys in table cells and grouped shapes

### DIFF
--- a/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
@@ -34,9 +34,9 @@ hardcoded slide indices):
 3. **Download** — render to bytes, upload to SESSION-SCOPED user storage, and return a
    :class:`LinkPart` (``kind=download``) so the UI renders a download button.
 
-Scope limit (carried from the POC / RFC "Out of Scope"): only ``has_text_frame`` shapes
-are filled — table cells and grouped shapes are intentionally not supported in v1. This
-is enforced by the shared traversal, not re-implemented here.
+Shape coverage is defined by the shared traversal, not re-implemented here: text boxes,
+table cells, and shapes nested inside groups are all filled. SmartArt and chart text
+remain out of scope (no clean ``text_frame`` API in python-pptx).
 
 NOTE on imports: ``build_ppt_filler_tools`` is imported directly from this submodule by
 ``core/tools/inprocess_toolkit_registry.py`` (NOT re-exported via the package
@@ -264,9 +264,8 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
             return message, ToolInvocationResult(tool_ref=_TOOL_REF, is_error=True)
 
         # 2. Open the template and fill, per-slide, via the SHARED traversal. Mapping
-        #    slide_<n> -> the n-th (1-based) slide; only has_text_frame shapes are filled
-        #    (the shared traversal enforces this; table cells / grouped shapes are out of
-        #    scope in v1).
+        #    slide_<n> -> the n-th (1-based) slide; text boxes, table cells, and grouped
+        #    shapes are all filled (the shared traversal defines coverage).
         try:
             presentation = Presentation(io.BytesIO(blob.bytes))
             slides = list(presentation.slides)

--- a/agentic-backend/agentic_backend/integrations/ppt_filler/traversal.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/traversal.py
@@ -16,9 +16,18 @@ one paragraph (e.g. because of autocorrect or spell-check spans). Both direction
 therefore merge the run texts of a paragraph, operate on the merged string, and map the
 result back onto the runs.
 
-Scope limit (matches the POC and the RFC): only ``has_text_frame`` shapes are walked.
-Table cells and grouped shapes are intentionally **not** traversed in v1 — they are
-documented as out of scope rather than silently dropped.
+Shape coverage. A placeholder is fillable wherever python-pptx exposes a text frame, so
+the traversal walks, recursively:
+
+- plain text boxes, titles, and other placeholders (``has_text_frame`` shapes);
+- **table** cells (each cell is a text frame);
+- **grouped** shapes — recursing into the group, so a text box / table nested at any
+  depth is reached.
+
+Still out of scope (no clean ``text_frame`` API in python-pptx; text lives in low-level
+DrawingML XML): **SmartArt** (``DIAGRAM`` / ``IGX_GRAPHIC``) and **chart** text. Keys
+placed there are not seen by the parser and therefore not filled; this is documented in
+the RFC rather than silently mis-handled.
 """
 
 from __future__ import annotations
@@ -27,6 +36,7 @@ import re
 from typing import TYPE_CHECKING, Callable, List
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pptx.shapes.base import BaseShape
     from pptx.slide import Slide
     from pptx.text.text import _Paragraph
 
@@ -35,17 +45,47 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 KEY_PATTERN = re.compile(r"\{\{([^}]+)\}\}")
 
 
-def _iter_text_paragraphs(slide: "Slide") -> List["_Paragraph"]:
-    """Yield every paragraph of every ``has_text_frame`` shape on ``slide``.
+def _iter_shape_paragraphs(shape: "BaseShape") -> List["_Paragraph"]:
+    """Yield every text paragraph reachable from ``shape``, recursing as needed.
 
-    Table cells and grouped shapes are intentionally skipped (v1 scope limit).
+    Three text-bearing shape kinds are handled, in priority order:
+
+    - a **group** (``shape_type`` GROUP, exposing ``.shapes``): recurse into each child
+      so nested text boxes / tables at any depth are reached;
+    - a **table** (``has_table``): every cell is a text frame;
+    - a plain **text frame** (``has_text_frame``): its own paragraphs.
+
+    Any other shape (pictures, media, OLE, ink, lines, and — for now — SmartArt and
+    charts) contributes no paragraphs.
     """
     paragraphs: List["_Paragraph"] = []
+
+    # Group: recurse. Checked first because a group is itself neither has_text_frame nor
+    # has_table, but its children may be either.
+    if getattr(shape, "shapes", None) is not None and not shape.has_text_frame:
+        for child in shape.shapes:  # type: ignore[attr-defined]
+            paragraphs.extend(_iter_shape_paragraphs(child))
+        return paragraphs
+
+    # Table: each cell carries its own text frame.
+    if getattr(shape, "has_table", False):
+        for row in shape.table.rows:  # type: ignore[attr-defined]
+            for cell in row.cells:
+                paragraphs.extend(cell.text_frame.paragraphs)
+        return paragraphs
+
+    # Plain text frame (text box, title, other placeholder, auto-shape, ...).
+    if shape.has_text_frame:
+        paragraphs.extend(shape.text_frame.paragraphs)  # type: ignore[attr-defined]
+
+    return paragraphs
+
+
+def _iter_text_paragraphs(slide: "Slide") -> List["_Paragraph"]:
+    """Yield every fillable paragraph on ``slide``, descending into tables and groups."""
+    paragraphs: List["_Paragraph"] = []
     for shape in slide.shapes:
-        if not shape.has_text_frame:
-            continue
-        for paragraph in shape.text_frame.paragraphs:  # type: ignore[attr-defined]
-            paragraphs.append(paragraph)
+        paragraphs.extend(_iter_shape_paragraphs(shape))
     return paragraphs
 
 

--- a/agentic-backend/tests/test_ppt_filler_parser.py
+++ b/agentic-backend/tests/test_ppt_filler_parser.py
@@ -18,7 +18,6 @@ from agentic_backend.integrations.ppt_filler.parser import (
     parse,
 )
 from agentic_backend.integrations.ppt_filler.traversal import (
-    KEY_PATTERN,
     list_keys_on_slide,
     replace_keys_on_slide,
 )
@@ -70,6 +69,66 @@ def _build_split_run_deck(
         for run_text in extra_runs:
             run = second.add_run()
             run.text = run_text
+    if notes:
+        slide.notes_slide.notes_text_frame.text = notes
+    buffer = io.BytesIO()
+    presentation.save(buffer)
+    return buffer.getvalue()
+
+
+def _build_table_deck(notes: str, cell_texts: List[str]) -> bytes:
+    """Build a one-slide deck whose only key-bearing shape is a TABLE.
+
+    ``cell_texts`` fills the cells of a 1xN table row-major; ``{{key}}`` placeholders in
+    those cells must be discovered (and fillable) exactly like text-box keys.
+    """
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    rows, cols = 1, len(cell_texts)
+    table = slide.shapes.add_table(
+        rows, cols, Inches(1), Inches(1), Inches(8), Inches(1)
+    ).table
+    for col, text in enumerate(cell_texts):
+        table.cell(0, col).text = text
+    if notes:
+        slide.notes_slide.notes_text_frame.text = notes
+    buffer = io.BytesIO()
+    presentation.save(buffer)
+    return buffer.getvalue()
+
+
+def _build_group_deck(notes: str, textbox_bodies: List[str]) -> bytes:
+    """Build a one-slide deck whose key-bearing text boxes live inside a GROUP shape.
+
+    python-pptx cannot author groups via the public API, so we build separate text boxes
+    and then wrap their XML in a ``<p:grpSp>`` element — mirroring how PowerPoint nests
+    shapes inside ``Groupe 1`` in real decks.
+    """
+    from pptx.oxml.ns import qn
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    spTree = slide.shapes._spTree
+
+    boxes = []
+    for i, body in enumerate(textbox_bodies):
+        box = slide.shapes.add_textbox(Inches(1), Inches(1 + i), Inches(4), Inches(1))
+        box.text_frame.text = body
+        boxes.append(box)
+
+    # Wrap the just-added text boxes into a single group shape.
+    grpSp = spTree.makeelement(qn("p:grpSp"), {})
+    nvGrpSpPr = grpSp.makeelement(qn("p:nvGrpSpPr"), {})
+    cNvPr = nvGrpSpPr.makeelement(qn("p:cNvPr"), {"id": "999", "name": "TestGroup"})
+    nvGrpSpPr.append(cNvPr)
+    nvGrpSpPr.append(nvGrpSpPr.makeelement(qn("p:cNvGrpSpPr"), {}))
+    nvGrpSpPr.append(nvGrpSpPr.makeelement(qn("p:nvPr"), {}))
+    grpSp.append(nvGrpSpPr)
+    grpSp.append(grpSp.makeelement(qn("p:grpSpPr"), {}))
+    for box in boxes:
+        grpSp.append(box._element)  # reparent the sp under the group
+    spTree.append(grpSp)
+
     if notes:
         slide.notes_slide.notes_text_frame.text = notes
     buffer = io.BytesIO()
@@ -273,6 +332,55 @@ def test_replace_keys_traversal_handles_split_runs():
     assert text == "Jane!"
 
 
+# --- Tables and grouped shapes are walked too -------------------------------------
+
+
+def test_keys_in_table_cells_are_discovered():
+    deck = _build_table_deck(
+        "{{header}}, {{body}}:\nA cell value",
+        ["{{header}}", "{{body}}"],
+    )
+    result = parse(deck)
+
+    assert _keys(result, 1) == ["header", "body"]
+    assert result.errors == []
+
+
+def test_keys_in_grouped_shapes_are_discovered():
+    deck = _build_group_deck(
+        "{{a}}, {{b}}:\nValues in a group",
+        ["{{a}}", "{{b}}"],
+    )
+    result = parse(deck)
+
+    assert _keys(result, 1) == ["a", "b"]
+    assert result.errors == []
+
+
+def test_fill_replaces_keys_in_table_cells():
+    deck = _build_table_deck("{{x}}:\nThe x", ["before {{x}} after"])
+    presentation = Presentation(io.BytesIO(deck))
+    slide = presentation.slides[0]
+
+    assert list_keys_on_slide(slide) == ["x"]
+    replace_keys_on_slide(slide, lambda key: {"x": "FILLED"}[key])
+    assert list_keys_on_slide(slide) == []  # nothing left in the table cell
+
+    # And the literal replacement landed in the table cell text.
+    table = next(s.table for s in slide.shapes if s.has_table)
+    assert "FILLED" in table.cell(0, 0).text
+
+
+def test_fill_replaces_keys_in_grouped_shapes():
+    deck = _build_group_deck("{{g}}:\nThe g", ["start {{g}} end"])
+    presentation = Presentation(io.BytesIO(deck))
+    slide = presentation.slides[0]
+
+    assert list_keys_on_slide(slide) == ["g"]
+    replace_keys_on_slide(slide, lambda key: {"g": "DONE"}[key])
+    assert list_keys_on_slide(slide) == []
+
+
 # --- The round-trip regression guard ---------------------------------------------
 
 
@@ -311,13 +419,11 @@ def test_round_trip_parse_fill_reparse_leaves_no_placeholders():
     reparsed = parse(filled_bytes)
     assert reparsed.slides == []
 
-    # And no raw {{...}} survives anywhere in the filled deck's text frames.
+    # And no raw {{...}} survives anywhere the shared traversal can reach (text frames,
+    # table cells, and grouped shapes).
     refilled = Presentation(io.BytesIO(filled_bytes))
     for slide in refilled.slides:
-        for shape in slide.shapes:
-            if not shape.has_text_frame:
-                continue
-            assert not KEY_PATTERN.search(shape.text_frame.text)
+        assert list_keys_on_slide(slide) == []
 
 
 def test_parse_accepts_path(tmp_path):

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -268,7 +268,7 @@ x-kf-document-sources: &kf-document-sources
 
 x-kf-embedding-model: &kf-embedding-model
   provider: openai           # CUSTOMIZE: openai | azure | ollama
-  name: text-embedding-3-large  
+  name: text-embedding-3-large
   settings: {}
   type: "openai"
 
@@ -294,12 +294,12 @@ x-kf-crossencoder-model: &kf-crossencoder-model
     local_path: /home/fred-user/.cache/huggingface/hub
 
 x-kf-storage: &kf-storage
-  postgres:                  
+  postgres:
     host: localhost
     port: 5432
     database: fred
     username: admin
-  opensearch:                
+  opensearch:
     host: https://localhost:9200
     secure: true
     verify_certs: false
@@ -453,7 +453,7 @@ applications:
     #       - my-service.example.internal
     image:
       repository: ghcr.io/thalesgroup/fred-agent/agentic-backend
-      tag: ""                    
+      tag: ""
       pullPolicy: IfNotPresent
     command:
       enabled: true
@@ -742,12 +742,12 @@ applications:
 
       # ── Storage backends — defaults to DuckDB, switch to postgres/opensearch for prod ──
       storage:
-        postgres:              
+        postgres:
           host: localhost
           port: 5432
           database: fred
           username: admin
-        opensearch:            
+        opensearch:
           host: https://localhost:9200
           secure: true
           verify_certs: false
@@ -788,7 +788,7 @@ applications:
           type: "in_memory"
 
     # ── Sensitive environment variables (rendered as Kubernetes Secret) ────
-    dotenv:                   
+    dotenv:
       AZURE_OPENAI_API_KEY: ""
       KEYCLOAK_AGENTIC_CLIENT_SECRET: ""
       OPENAI_API_KEY: ""
@@ -1029,6 +1029,22 @@ applications:
           enabled: true
           auth_mode: "user_token"
 
+        - id: "mcp-writable-documents"
+          name: "mcp.servers.writable_documents.name"
+          description: "mcp.servers.writable_documents.description"
+          enabled: true
+          transport: "inprocess"
+          provider: "writable_documents"
+          auth_mode: "no_token"
+
+        - id: "mcp-ppt-filler"
+          name: "mcp.servers.ppt_filler.name"
+          description: "mcp.servers.ppt_filler.description"
+          enabled: true
+          transport: "inprocess"
+          provider: "ppt_filler"
+          auth_mode: "no_token"
+
         - id: "mcp-knowledge-flow-opensearch-ops"
           name: "mcp.servers.search_opensearch.name"
           description: "mcp.servers.search_opensearch.description"
@@ -1223,7 +1239,7 @@ applications:
       maxUnavailable: 0
     image:
       repository: ghcr.io/thalesgroup/fred-agent/knowledge-flow-backend
-      tag: ""                 
+      tag: ""
     command:
       enabled: true
       data: |-
@@ -1389,7 +1405,7 @@ applications:
       filesystem:      *kf-filesystem
 
     # ── Sensitive environment variables (rendered as Kubernetes Secret) ────
-    dotenv:                  
+    dotenv:
       KEYCLOAK_KNOWLEDGE_FLOW_CLIENT_SECRET: ""
       MINIO_SECRET_KEY: ""
       OPENAI_API_KEY: ""
@@ -1419,7 +1435,7 @@ applications:
       maxUnavailable: 0
     image:
       repository: ghcr.io/thalesgroup/fred-agent/knowledge-flow-backend
-      tag: ""                 
+      tag: ""
     command:
       enabled: true
       data: |-

--- a/docs/rfc/PPT-FILLER-TOOLKIT-RFC.md
+++ b/docs/rfc/PPT-FILLER-TOOLKIT-RFC.md
@@ -237,9 +237,10 @@ The extracted template schema is **grouped by slide**, not a flat key list:
   schema** — no positional `zip`, no hardcoded slide indices, `{{double}}` braces.
 - Output: render to a temp file, upload to **user storage** (session-scoped
   `upload_user_blob`), and return a `LinkPart(kind=download)` for the UI download button.
-- Scope limit (carried over from the POC, to be improved later): only `has_text_frame`
-  shapes are walked. Table cells and grouped shapes are **not** supported in v1 and are
-  documented as such rather than silently dropped.
+- Shape coverage: the traversal walks `has_text_frame` shapes, **table cells**, and
+  **grouped shapes** (recursively). SmartArt (`DIAGRAM`/`IGX_GRAPHIC`) and chart text are
+  still **not** supported (no clean `text_frame` API in python-pptx) and are documented as
+  such rather than silently dropped.
 
 ### Save flow — generic "toolkit asset processor" seam
 
@@ -347,8 +348,9 @@ Seams, highest first:
 
 ## Out of Scope
 
-- Table cells and grouped shapes as key sources (v1 walks `has_text_frame` shapes only,
-  matching the POC). To be improved later.
+- SmartArt (`DIAGRAM`/`IGX_GRAPHIC`) and chart text as key sources: python-pptx exposes
+  no clean `text_frame` for them (text lives in low-level DrawingML XML). Text boxes,
+  table cells, and grouped shapes **are** supported.
 - The future `slide_purpose` notation describing a whole slide's purpose (reserved in the
   schema shape; not implemented).
 - Multiple templates per agent (v1 is one template per agent; replacing swaps it).


### PR DESCRIPTION
## Summary

Real PowerPoint templates place `{{key}}` placeholders inside **table cells** and **grouped shapes**, not only plain text boxes. The PPT Filler shared traversal walked `has_text_frame` shapes only, so those keys were invisible:

- **Analyze** reported present keys as `described_but_not_in_slide` (the notes described them, but the parser couldn't see them in the slide).
- **Fill** would have silently skipped them.

This was hit by a real template (`template-DRI.pptx`): 8 of 9 keys lived in tables/groups and all 8 were falsely flagged as errors.

The fix extends the **single shared traversal seam** (`_iter_text_paragraphs` in `traversal.py`) to recurse into:
- **table cells** — each cell is a text frame;
- **grouped shapes** — recursively, at any depth (a table nested in a group included).

Because the parser (`list_keys_on_slide`) and filler (`replace_keys_on_slide`) both funnel through this one helper, analyze and fill gain the support together and the parse↔fill round-trip invariant holds by construction.

SmartArt (`DIAGRAM`/`IGX_GRAPHIC`) and chart text remain out of scope — python-pptx exposes no clean `text_frame` for them. The RFC scope notes and toolkit docstrings are updated to reflect the new coverage.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project. *(Ran the full `ppt_filler` suite — see notes; did not run the entire agentic-backend `make test`.)*
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

```
# agentic-backend
make code-quality        # All checks passed (ruff, basedpyright, detect-secrets)

uv run pytest tests/test_ppt_filler_parser.py tests/test_ppt_filler_params.py \
  tests/test_ppt_filler_toolkit.py \
  agentic_backend/tests/test_ppt_filler_processor.py \
  agentic_backend/tests/test_ppt_filler_save_controller.py \
  agentic_backend/tests/test_ppt_filler_analyze_controller.py
# 62 passed
```

Added 4 tests: key discovery + fill for table cells and for grouped shapes. The round-trip regression guard now asserts no `{{...}}` survives anywhere the shared traversal reaches (text frames, tables, groups), not just text frames.

Manual check on `template-DRI.pptx`: previously 1/9 keys found with 8 false errors → now **9/9 keys found, 0 errors**, and a fill round-trip leaves no placeholders.

## Risk / Rollback

Low risk: the change is additive to one traversal helper and covered by the round-trip invariant test. The main behavior change is that tables/groups are now in scope (previously documented as out of scope) — if that scope freeze was intentional for a release, revert this commit. Rollback is a single `git revert`.