### PR TITLE
feat: rename agent 'System prompt' field to 'Instruction'

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -413,12 +413,12 @@
   },
   "agentTuning": {
     "groups": {
-      "prompts": "Prompts",
+      "prompts": "Instructions",
       "chatOptions": "Chat options"
     },
     "fields": {
       "prompts_system": {
-        "title": "System prompt",
+        "title": "Instruction",
         "description": "Core behavior instructions for the assistant."
       },
       "chat_options_attach_files": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -414,12 +414,12 @@
   },
   "agentTuning": {
     "groups": {
-      "prompts": "Prompts",
+      "prompts": "Instructions",
       "chatOptions": "Options de chat"
     },
     "fields": {
       "prompts_system": {
-        "title": "Prompt système",
+        "title": "Instruction",
         "description": "Instructions de comportement principal pour l'assistant."
       },
       "chat_options_attach_files": {


### PR DESCRIPTION
## Summary

Renames the user-facing "System prompt" tuning field (and its enclosing "Prompts" group header) to **"Instruction"** in the agent create/edit form for v2 React agents.

- The label and group header are driven by i18n keys (`agentTuning.fields.prompts_system.title` and `agentTuning.groups.prompts`), set by the `FieldSpec`/`UIHints` in `basic_react/agent.py`. The displayed text is resolved by `t()` in `TuningForm.tsx`, so this is a frontend-only translation change — no backend change needed.
- Updated both `en` and `fr` locale files.
- Left the field's help/description text unchanged.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed. (N/A — label-only change)

## Validation Notes

Translation-only change (`en` + `fr` JSON). No code logic touched. JSON edits applied to:
- `frontend/src/locales/en/translation.json`
- `frontend/src/locales/fr/translation.json`

## Risk / Rollback

Risk: minimal — cosmetic label change for the agent tuning form. Rollback: revert this commit to restore the "System prompt" / "Prompts" wording.
