### PR TITLE
fix(ppt-filler): read PowerPoint-bulleted notes metadata as image keys

### DIFF
--- a/agentic-backend/agentic_backend/integrations/ppt_filler/parser.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/parser.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from pptx import Presentation
+from pptx.oxml.ns import qn
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
 
 from agentic_backend.integrations.ppt_filler.traversal import (
@@ -324,14 +325,53 @@ def _parse_notes_descriptions(notes_text: str) -> Dict[str, _ParsedKeyMeta]:
     return descriptions
 
 
+def _paragraph_has_bullet(paragraph) -> bool:
+    """Return ``True`` when ``paragraph`` carries an actual list bullet.
+
+    PowerPoint's notes editor auto-formats a line the author types as ``- foo`` into a
+    bulleted paragraph: it DROPS the literal ``"- "`` from the run text and records the
+    dash as a paragraph-level bullet (``a:pPr`` → ``a:buChar``/``a:buAutoNum``) instead.
+    LibreOffice does not, so a template authored there keeps the literal dash. To read
+    both the same way we re-synthesize a leading ``"- "`` for bulleted paragraphs (see
+    :func:`_slide_notes_text`), which is exactly the metadata shape the parser expects.
+
+    A paragraph with an explicit ``a:buNone`` (bullets turned off) is NOT bulleted. A
+    paragraph with no bullet element at all is also not bulleted.
+    """
+    pPr = paragraph._p.find(qn("a:pPr"))
+    if pPr is None:
+        return False
+    if pPr.find(qn("a:buNone")) is not None:
+        return False
+    return (
+        pPr.find(qn("a:buChar")) is not None or pPr.find(qn("a:buAutoNum")) is not None
+    )
+
+
 def _slide_notes_text(slide) -> str:
-    """Return the plain text of a slide's notes, or ``""`` if it has none."""
+    """Return the plain text of a slide's notes, or ``""`` if it has none.
+
+    Bulleted paragraphs have their visual bullet re-synthesized as a literal ``"- "``
+    prefix (see :func:`_paragraph_has_bullet`) so a metadata line the author typed as
+    ``- type: image`` reads identically whether PowerPoint turned it into a real bullet
+    (dash stripped from the text) or it was left as a literal dash (LibreOffice). A line
+    that already starts with a literal dash is left untouched so we never double it.
+    """
     if not slide.has_notes_slide:
         return ""
     notes_slide = slide.notes_slide
     if notes_slide.notes_text_frame is None:
         return ""
-    return notes_slide.notes_text_frame.text or ""
+
+    lines: List[str] = []
+    for paragraph in notes_slide.notes_text_frame.paragraphs:
+        text = "".join(run.text for run in paragraph.runs)
+        if _paragraph_has_bullet(paragraph) and not text.lstrip().startswith("-"):
+            stripped = text.lstrip()
+            indent = text[: len(text) - len(stripped)]
+            text = f"{indent}- {stripped}"
+        lines.append(text)
+    return "\n".join(lines)
 
 
 def apply_kept_notes_to_slide(slide) -> None:

--- a/agentic-backend/tests/test_ppt_filler_parser.py
+++ b/agentic-backend/tests/test_ppt_filler_parser.py
@@ -142,6 +142,43 @@ def _build_group_deck(notes: str, textbox_bodies: List[str]) -> bytes:
     return buffer.getvalue()
 
 
+def _build_bulleted_notes_deck(
+    header: str, bullet_lines: List[str], prose: str, body: str
+) -> bytes:
+    """Build a one-slide deck whose metadata lines are real PowerPoint BULLETS.
+
+    Reproduces what PowerPoint's notes editor does to a line the author types as
+    ``- type: image``: it DROPS the literal ``"- "`` from the run text and records the
+    dash as a paragraph bullet (``a:pPr`` → ``a:buChar char="-"``) instead. ``header`` and
+    ``prose`` are plain (unbulleted) paragraphs; each entry in ``bullet_lines`` becomes a
+    bulleted paragraph whose run text has NO leading dash. The parser must still read these
+    as ``- key: value`` metadata. ``body`` is the slide's text-box content (the ``{{key}}``
+    placeholder).
+    """
+    from pptx.oxml.ns import qn
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(8), Inches(2))
+    textbox.text_frame.text = body
+
+    notes_frame = slide.notes_slide.notes_text_frame
+    notes_frame.text = header  # first paragraph: the {{key}}: header (no bullet)
+    for line in bullet_lines:
+        paragraph = notes_frame.add_paragraph()
+        paragraph.text = line  # run text carries NO leading dash
+        # Attach a dash bullet at the paragraph level, exactly as PowerPoint does.
+        pPr = paragraph._p.get_or_add_pPr()
+        pPr.append(pPr.makeelement(qn("a:buFontTx"), {}))
+        pPr.append(pPr.makeelement(qn("a:buChar"), {"char": "-"}))
+    if prose:
+        notes_frame.add_paragraph().text = prose  # trailing prose (no bullet)
+
+    buffer = io.BytesIO()
+    presentation.save(buffer)
+    return buffer.getvalue()
+
+
 def _slide(result, slide_number: int):
     return next(s for s in result.slides if s.slide == slide_number)
 
@@ -593,6 +630,26 @@ def test_metadata_keys_and_type_are_case_insensitive():
     field = _field(result, 1, "flag")
     assert field.type == "image"  # normalized lowercase
     assert field.folder == "X"
+    assert result.errors == []
+
+
+def test_powerpoint_bullet_metadata_is_parsed_like_dashed_metadata():
+    """PowerPoint turns ``- type: image`` typed in the notes into a real bullet: the
+    literal ``"- "`` is stripped from the text and stored as a paragraph ``buChar``.
+    Such metadata must parse identically to a literal-dash line (regression: it used to
+    fall through to a TEXT key, so a chosen image id was rendered as text)."""
+    deck = _build_bulleted_notes_deck(
+        header="{{flag}}:",
+        bullet_lines=["type: image", 'folder: "images/flags"'],
+        prose="Pick the flag.",
+        body="{{flag}}",
+    )
+    result = parse(deck)
+
+    field = _field(result, 1, "flag")
+    assert field.type == "image"
+    assert field.folder == "images/flags"
+    assert field.description == "Pick the flag."
     assert result.errors == []
 
 


### PR DESCRIPTION
## Summary

The PPT Filler treated image keys as text when the template was authored in **PowerPoint** (worked in LibreOffice), so the agent's chosen document id was rendered as literal text in the slide instead of placing the image — with no validation error to warn the author.

**Root cause:** PowerPoint's notes editor auto-formats a line typed as `- type: image` into a real bullet list — it strips the literal `"- "` from the run text and stores the dash as a paragraph property (`<a:buChar char="-"/>`). The metadata parser's line pattern requires a literal leading dash, so the bulleted lines (`type: image`, `folder: "..."`) were read as ordinary description prose. The key parsed as `type=text`, no error fired, and at fill time the document id was substituted as text. LibreOffice keeps the literal dash, so it worked there.

**Fix:** `parser.py::_slide_notes_text` now walks the notes paragraphs and re-synthesizes a leading `- ` for any **bulleted** paragraph (`a:buChar` / `a:buAutoNum`, excluding `a:buNone`). Input is normalized once, so all existing dash-based parsing, error codes, and round-trip logic are unchanged. Mixed decks (some literal-dash, some bulleted) parse correctly.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed (the documented authoring syntax `- type: image` is unchanged — this only makes PowerPoint's bullet rendering of that same syntax parse correctly).

## Validation Notes

- `make code-quality` (agentic-backend) → all checks pass (ruff lint + format, basedpyright 0 errors, detect-secrets clean).
- `make test` (agentic-backend) → `463 passed`.
- New regression test `test_powerpoint_bullet_metadata_is_parsed_like_dashed_metadata` builds a deck whose metadata lines are real `buChar` bullets (dash stripped) and asserts they parse as `type=image` with the folder, no errors.
- Verified against the reproducing template (`template-DRI - with images 2.pptx`): `country_flag` / `country_shape` now parse as `type=image` with their folders instead of silently becoming text.

## Risk / Rollback

Low risk — the change only affects how slide-notes text is read (bulleted paragraphs gain a `- ` prefix). Text keys and non-bulleted notes are unaffected; the additive serialization contract is unchanged. Rollback: revert the single commit.