### PR TITLE
feat(ppt-filler): support inline bold/italic in filled text values

### DIFF
--- a/agentic-backend/agentic_backend/core/markdown/__init__.py
+++ b/agentic-backend/agentic_backend/core/markdown/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/agentic-backend/agentic_backend/core/markdown/inline.py
+++ b/agentic-backend/agentic_backend/core/markdown/inline.py
@@ -1,0 +1,116 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Format-agnostic inline-Markdown parser shared by the docx export and the PPT filler.
+
+This is the single source of truth for the inline-Markdown SUBSET our document
+generators understand: ``**bold**``, ``*italic*`` / ``_italic_``, ``***both***`` and
+``` `code` ```. It is pure (no docx/pptx import) so the two consumers — the Word export
+([`docx_export.py`](../writable_documents/docx_export.py)) and the PowerPoint filler
+([`ppt_filler/traversal.py`](../../integrations/ppt_filler/traversal.py)) — can never
+diverge on what a marker means: each only owns the thin step of writing the parsed
+:class:`Span` list as its own runs.
+
+Parsing is intentionally FLAT (non-recursive): the first matching span wins and any
+markers left inside it (e.g. the ``_x_`` in ``**_x_**``) are stripped rather than
+re-interpreted. Stray/mismatched markers anywhere in the text are stripped too, so no
+literal ``*`` or ``_`` ever leaks into the output. Code spans are the one exception:
+markers inside backticks are literal and are preserved untouched.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List
+
+# Inline tokens: **bold**, *italic* / _italic_, `code`. Order matters (bold before
+# italic) so ``**x**`` is read as bold, not as two empty italics around ``x``.
+_INLINE_RE = re.compile(
+    r"(\*\*(?P<bold>.+?)\*\*)"
+    r"|(\*(?P<italic_star>.+?)\*)"
+    r"|(_(?P<italic_us>.+?)_)"
+    r"|(`(?P<code>.+?)`)"
+)
+
+# Leftover emphasis markers we strip from text once the outer span is resolved.
+# We only do flat (non-recursive) inline parsing, so nested or mismatched markers
+# (e.g. `**_x_**`, `_a *b* c_`) would otherwise leak through as literal characters.
+# Stripping them keeps clean text — the formatting of the inner span is lost, but
+# no stray `*`/`_` ever appears in the output.
+_STRAY_MARKER_RE = re.compile(r"\*\*|[*_]")
+
+
+def _strip_markers(text: str) -> str:
+    """Remove stray bold/italic markers that flat parsing left behind."""
+    return _STRAY_MARKER_RE.sub("", text)
+
+
+@dataclass(frozen=True)
+class Span:
+    """A run of text plus the inline styles to overlay on it.
+
+    ``bold`` / ``italic`` are the styles the document writers apply. ``code`` flags an
+    inline-code span: the docx export maps it to a Courier font swap, while the pptx
+    filler treats it as plain text (it is outside this feature's bold/italic scope). A
+    plain (un-emphasised) run is a span with all flags ``False``.
+    """
+
+    text: str
+    bold: bool = False
+    italic: bool = False
+    code: bool = False
+
+
+def parse_inline_markdown(text: str) -> List[Span]:
+    """Parse our inline-Markdown subset into a flat list of styled :class:`Span`.
+
+    The grammar is exactly the one the docx export historically owned: ``**bold**``,
+    ``*italic*`` / ``_italic_``, ``***both***`` (read as bold containing a stripped
+    italic marker, i.e. bold) and ``` `code` ```. Parsing is flat; stray/nested markers
+    are stripped from emphasised and plain text alike (never from code spans).
+
+    Always returns at least one span for non-empty input. Plain text with no markup
+    yields a single plain span, so a markup-free value is written as one run — the
+    backward-compatible path.
+    """
+    spans: List[Span] = []
+    pos = 0
+    for m in _INLINE_RE.finditer(text):
+        if m.start() > pos:
+            plain = _strip_markers(text[pos : m.start()])
+            if plain:
+                spans.append(Span(plain))
+        if m.group("bold") is not None:
+            # Inner text may carry nested markers (e.g. **_x_**); strip them so only the
+            # outermost emphasis applies and no markers leak through.
+            spans.append(Span(_strip_markers(m.group("bold")), bold=True))
+        elif m.group("italic_star") is not None:
+            spans.append(Span(_strip_markers(m.group("italic_star")), italic=True))
+        elif m.group("italic_us") is not None:
+            spans.append(Span(_strip_markers(m.group("italic_us")), italic=True))
+        elif m.group("code") is not None:
+            # Code spans are literal: do not strip markers inside backticks.
+            spans.append(Span(m.group("code"), code=True))
+        pos = m.end()
+    if pos < len(text):
+        plain = _strip_markers(text[pos:])
+        if plain:
+            spans.append(Span(plain))
+
+    # Guarantee at least one span so consumers always have a run to write. Stripping can
+    # reduce a markers-only fragment (e.g. "**") to "", which would otherwise yield none.
+    if not spans:
+        spans.append(Span(""))
+    return spans

--- a/agentic-backend/agentic_backend/core/writable_documents/docx_export.py
+++ b/agentic-backend/agentic_backend/core/writable_documents/docx_export.py
@@ -29,26 +29,7 @@ from docx.document import Document as DocxDocument
 from docx.shared import Pt
 from docx.text.paragraph import Paragraph
 
-# Inline tokens: **bold**, *italic* / _italic_, `code`. Order matters (bold before italic).
-_INLINE_RE = re.compile(
-    r"(\*\*(?P<bold>.+?)\*\*)"
-    r"|(\*(?P<italic_star>.+?)\*)"
-    r"|(_(?P<italic_us>.+?)_)"
-    r"|(`(?P<code>.+?)`)"
-)
-
-# Leftover emphasis markers we strip from text once the outer span is resolved.
-# We only do flat (non-recursive) inline parsing, so nested or mismatched markers
-# (e.g. `**_x_**`, `_a *b* c_`) would otherwise leak through as literal characters.
-# Stripping them keeps clean text — the formatting of the inner span is lost, but
-# no stray `*`/`_` ever appears in the output.
-_STRAY_MARKER_RE = re.compile(r"\*\*|[*_]")
-
-
-def _strip_markers(text: str) -> str:
-    """Remove stray bold/italic markers that flat parsing left behind."""
-    return _STRAY_MARKER_RE.sub("", text)
-
+from agentic_backend.core.markdown.inline import parse_inline_markdown
 
 _HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.*)$")
 _BULLET_RE = re.compile(r"^\s*[-*+]\s+(?P<text>.*)$")
@@ -64,26 +45,21 @@ _TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?\s*$")
 
 
 def _add_inline_runs(paragraph: Paragraph, text: str) -> None:
-    """Render a line of Markdown inline formatting into runs on a paragraph."""
-    pos = 0
-    for m in _INLINE_RE.finditer(text):
-        if m.start() > pos:
-            paragraph.add_run(_strip_markers(text[pos : m.start()]))
-        if m.group("bold") is not None:
-            # Inner text may carry nested markers (e.g. **_x_**); strip them so
-            # only the outermost emphasis applies and no markers leak through.
-            paragraph.add_run(_strip_markers(m.group("bold"))).bold = True
-        elif m.group("italic_star") is not None:
-            paragraph.add_run(_strip_markers(m.group("italic_star"))).italic = True
-        elif m.group("italic_us") is not None:
-            paragraph.add_run(_strip_markers(m.group("italic_us"))).italic = True
-        elif m.group("code") is not None:
-            # Code spans are literal: do not strip markers inside backticks.
-            run = paragraph.add_run(m.group("code"))
+    """Render a line of Markdown inline formatting into runs on a paragraph.
+
+    Thin consumer of the shared :func:`parse_inline_markdown`: it owns only the docx
+    step of writing each parsed span as a run, toggling ``.bold`` / ``.italic`` and
+    swapping a code span to Courier. The grammar (which markers mean what, how strays are
+    stripped) lives once in the shared parser.
+    """
+    for span in parse_inline_markdown(text):
+        run = paragraph.add_run(span.text)
+        if span.bold:
+            run.bold = True
+        if span.italic:
+            run.italic = True
+        if span.code:
             run.font.name = "Courier New"
-        pos = m.end()
-    if pos < len(text):
-        paragraph.add_run(_strip_markers(text[pos:]))
 
 
 def _split_table_row(line: str) -> list[str]:

--- a/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
@@ -98,6 +98,15 @@ _OUTPUT_NAME_FIELD = "output_file_name"
 # through the same helper so they can never drift.
 _SLIDE_FIELD_PREFIX = "slide_"
 
+# Appended to every TEXT key's leaf description so the agent knows it may emphasize part
+# of a value with inline Markdown. The supported subset matches the docx export exactly
+# (see ``core/markdown/inline.py``); emphasis overlays bold/italic on the placeholder's
+# own font, leaving size/color/font untouched.
+_TEXT_FORMATTING_HINT = (
+    "You may use inline Markdown to emphasize part of this value: **bold** and "
+    "*italic* (or _italic_). Markup is optional — omit it for plain text."
+)
+
 
 def _slide_field_name(slide_number: int) -> str:
     return f"{_SLIDE_FIELD_PREFIX}{slide_number}"
@@ -209,7 +218,12 @@ def _build_args_schema(schema_slides: "list[SlideSchema]") -> type[BaseModel]:
             if key_field.type == "image":
                 leaf_description = _image_leaf_description(key_field)
             else:
-                leaf_description = key_field.description or ""
+                # Text key: append the inline-formatting hint so the agent knows it may
+                # bold/italic part of the value. The note (if any) leads; the hint follows.
+                note = (key_field.description or "").strip()
+                leaf_description = (
+                    f"{note} {_TEXT_FORMATTING_HINT}" if note else _TEXT_FORMATTING_HINT
+                )
             leaf_fields[key_field.key] = (
                 Optional[str],
                 Field(default=None, description=leaf_description),
@@ -656,7 +670,7 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
             "Optionally set 'output_file_name' to a short, relevant name for the deck "
             "(the '.pptx' extension is added automatically).\n"
             "IMAGE FIELDS: some fields are images (their description says 'its images "
-            "come from working_directory <path>', e.g. 'images/flags'). Before calling "
+            "come from working_directory <path>', e.g. 'my directory/other directory'). Before calling "
             "THIS tool you MUST, for EACH such directory, call the 'list_document_tree' "
             "tool with working_directory set to that exact PATH (it is a folder path, "
             "NOT an id) to see the files it contains. Never invent or guess image values "

--- a/agentic-backend/agentic_backend/integrations/ppt_filler/traversal.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/traversal.py
@@ -32,11 +32,14 @@ the RFC rather than silently mis-handled.
 
 from __future__ import annotations
 
+import copy
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Tuple
 
 from pptx.oxml.ns import qn
+
+from agentic_backend.core.markdown.inline import Span, parse_inline_markdown
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pptx.shapes.base import BaseShape
@@ -108,6 +111,126 @@ def list_keys_on_slide(slide: "Slide") -> List[str]:
     return keys
 
 
+def _styled_spans_for_paragraph(
+    merged: str, value_for: Callable[[str], str]
+) -> List[Span]:
+    """Build the styled spans for a paragraph after substitution.
+
+    Inline Markdown is parsed from the SUBSTITUTED VALUES ONLY, never from the surrounding
+    static template text — so an author's literal ``*`` / ``_`` in slide text is never
+    reinterpreted as emphasis. The merged paragraph string is walked match-by-match: the
+    static text between placeholders becomes one plain span each (verbatim, no parsing),
+    and each placeholder's substituted value is run through
+    :func:`parse_inline_markdown`, so only there can ``**bold**`` / ``*italic*`` take
+    effect.
+    """
+    spans: List[Span] = []
+    pos = 0
+    for match in KEY_PATTERN.finditer(merged):
+        if match.start() > pos:
+            # Static template text: kept verbatim, NOT parsed for markup.
+            spans.append(Span(merged[pos : match.start()]))
+        value = value_for(match.group(1).strip())
+        # The substituted value is the only place inline markup is honored.
+        spans.extend(parse_inline_markdown(value))
+        pos = match.end()
+    if pos < len(merged):
+        spans.append(Span(merged[pos:]))
+    return spans
+
+
+def _styled_run_element(base_r, text: str, *, bold: bool, italic: bool):
+    """Clone ``base_r`` into a new ``<a:r>`` carrying ``text`` and overlaid emphasis.
+
+    The clone inherits every property the author set on the base ``{{key}}`` run (size,
+    color, font name, …) — python-pptx has no public font-copy, so cloning the element is
+    how the whole base style is carried over without enumerating individual properties.
+    Only ``bold`` / ``italic`` are overlaid on top.
+    """
+    new_r = copy.deepcopy(base_r)
+    text_el = new_r.find(qn("a:t"))
+    if text_el is None:
+        text_el = new_r.makeelement(qn("a:t"), {})
+        new_r.append(text_el)
+    text_el.text = text
+    if bold or italic:
+        r_pr = new_r.find(qn("a:rPr"))
+        if r_pr is None:
+            r_pr = new_r.makeelement(qn("a:rPr"), {})
+            new_r.insert(0, r_pr)
+        if bold:
+            r_pr.set("b", "1")
+        if italic:
+            r_pr.set("i", "1")
+    return new_r
+
+
+def _line_break_element(base_r):
+    """Build an ``<a:br/>`` line break carrying the base run's properties.
+
+    A ``\\n`` inside a run's ``<a:t>`` is NOT a valid DrawingML line break: PowerPoint /
+    LibreOffice render it unreliably and bleed the *preceding* run's emphasis across the
+    wrap (a bold title leaks bold onto the body line that follows it). Newlines in a value
+    must therefore become explicit ``<a:br/>`` elements between runs. The break carries a
+    clone of the base ``rPr`` so the line spacing/font of the break matches the text.
+    """
+    br = base_r.makeelement(qn("a:br"), {})
+    base_r_pr = base_r.find(qn("a:rPr"))
+    if base_r_pr is not None:
+        br.append(copy.deepcopy(base_r_pr))
+    return br
+
+
+def _span_elements(base_r, span: Span):
+    """Yield the ``<a:r>`` / ``<a:br/>`` elements for one span, splitting on newlines.
+
+    Each newline in the span text becomes an ``<a:br/>`` between two runs (see
+    :func:`_line_break_element`); a code span carries no pptx emphasis (RFC: treated as
+    plain text), so only ``bold`` / ``italic`` are overlaid.
+    """
+    pieces = span.text.split("\n")
+    elements = []
+    for index, piece in enumerate(pieces):
+        if index > 0:
+            elements.append(_line_break_element(base_r))
+        elements.append(
+            _styled_run_element(base_r, piece, bold=span.bold, italic=span.italic)
+        )
+    return elements
+
+
+def _write_spans_onto_paragraph(paragraph: "_Paragraph", spans: List[Span]) -> None:
+    """Rewrite a paragraph's runs from ``spans``, inheriting the first run's style.
+
+    The first existing run is the BASE STYLE SOURCE: every new run clones its ``<a:r>``
+    XML and only overlays ``bold`` / ``italic`` on top (see :func:`_styled_run_element`).
+    Newlines inside a value become explicit ``<a:br/>`` breaks, NOT literal ``\\n`` in run
+    text, so emphasis never bleeds across a wrapped line (see :func:`_line_break_element`).
+
+    A markup-free, single-line value yields a single plain run with exactly the base run's
+    style — today's behavior, unchanged.
+    """
+    runs = list(paragraph.runs)
+    if not runs:
+        return
+    base_r = runs[0]._r
+
+    new_elements: list = []
+    for span in spans:
+        new_elements.extend(_span_elements(base_r, span))
+
+    # Swap the new elements in for the old runs in place: insert them in order right after
+    # the base run (each after the previous so document order is preserved), then drop
+    # every original run. Doing it in this order keeps ``base_r`` valid while we clone, and
+    # leaves the paragraph holding exactly the new runs/breaks, in order.
+    anchor = base_r
+    for element in new_elements:
+        anchor.addnext(element)
+        anchor = element
+    for run in runs:
+        run._r.getparent().remove(run._r)
+
+
 def replace_keys_on_slide(slide: "Slide", value_for: Callable[[str], str]) -> None:
     """Replace every ``{{key}}`` occurrence in the text-frame shapes of ``slide``.
 
@@ -116,9 +239,12 @@ def replace_keys_on_slide(slide: "Slide", value_for: Callable[[str], str]) -> No
     consistently as long as ``value_for`` is deterministic.
 
     The same run-merging logic as :func:`list_keys_on_slide` is used, so a key split
-    across runs is correctly replaced. After substitution, the rewritten text is written
-    back onto the paragraph's first run and the remaining runs of that paragraph are
-    cleared, which preserves the first run's formatting for the whole paragraph.
+    across runs is correctly replaced. After substitution, the paragraph's runs are
+    rewritten from the styled spans: inline Markdown (``**bold**`` / ``*italic*``) is
+    parsed from the SUBSTITUTED VALUES ONLY and overlaid on top of the first run's
+    inherited formatting; static template text (including any literal ``*`` / ``_``) is
+    kept verbatim. A value with no markup yields a single run with the first run's style,
+    exactly as before.
     """
     for paragraph in _iter_text_paragraphs(slide):
         runs = list(paragraph.runs)
@@ -134,12 +260,19 @@ def replace_keys_on_slide(slide: "Slide", value_for: Callable[[str], str]) -> No
         if replaced == merged:
             continue
 
-        # Collapse the paragraph onto its first run. Merging runs means we cannot keep
-        # per-run formatting for the substituted region, so we keep the first run's
-        # formatting for the whole paragraph (matches the POC behavior).
-        runs[0].text = replaced
-        for extra_run in runs[1:]:
-            extra_run.text = ""
+        spans = _styled_spans_for_paragraph(merged, value_for)
+
+        # Fast path — no value carried emphasis: collapse onto the first run exactly as
+        # before (one run, first run's formatting). This keeps a markup-free fill byte-for-
+        # byte identical to the prior behavior; only an actually-emphasized value takes the
+        # multi-run path below.
+        if not any(span.bold or span.italic for span in spans):
+            runs[0].text = replaced
+            for extra_run in runs[1:]:
+                extra_run.text = ""
+            continue
+
+        _write_spans_onto_paragraph(paragraph, spans)
 
 
 # ---------------------------------------------------------------------------

--- a/agentic-backend/agentic_backend/tests/test_markdown_inline.py
+++ b/agentic-backend/agentic_backend/tests/test_markdown_inline.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from agentic_backend.core.markdown.inline import Span, parse_inline_markdown
+
+
+def test_plain_text_is_a_single_unstyled_span():
+    assert parse_inline_markdown("just text") == [Span("just text")]
+
+
+def test_empty_text_yields_one_empty_span():
+    # Consumers always need at least one run to write; an empty value is one empty span.
+    assert parse_inline_markdown("") == [Span("")]
+
+
+def test_bold_span():
+    assert parse_inline_markdown("a **b** c") == [
+        Span("a "),
+        Span("b", bold=True),
+        Span(" c"),
+    ]
+
+
+def test_italic_star_span():
+    assert parse_inline_markdown("a *b* c") == [
+        Span("a "),
+        Span("b", italic=True),
+        Span(" c"),
+    ]
+
+
+def test_italic_underscore_span():
+    assert parse_inline_markdown("a _b_ c") == [
+        Span("a "),
+        Span("b", italic=True),
+        Span(" c"),
+    ]
+
+
+def test_bold_and_italic_combined_reads_as_bold():
+    # ***x*** is matched as bold whose inner '*x*' markers are stripped (flat parsing),
+    # exactly as the docx export historically rendered it.
+    assert parse_inline_markdown("***x***") == [Span("x", bold=True)]
+
+
+def test_nested_markers_do_not_leak():
+    # Flat parsing keeps the outermost emphasis and strips inner markers; no stray
+    # '*'/'_' ever survives.
+    spans = parse_inline_markdown("**_x_**")
+    assert spans == [Span("x", bold=True)]
+
+
+def test_stray_unmatched_markers_are_stripped():
+    spans = parse_inline_markdown("a lone * and a stray _ here")
+    text = "".join(s.text for s in spans)
+    assert "*" not in text and "_" not in text
+    assert all(not (s.bold or s.italic) for s in spans)
+
+
+def test_code_span_is_flagged_and_kept_literal():
+    spans = parse_inline_markdown("use `a_b * c` now")
+    code = next((s for s in spans if s.code), None)
+    assert code is not None
+    # Markers inside backticks are literal: not stripped, not styled bold/italic.
+    assert code.text == "a_b * c"
+    assert not (code.bold or code.italic)
+
+
+def test_multiple_spans_in_order():
+    assert parse_inline_markdown("**A** and *B*") == [
+        Span("A", bold=True),
+        Span(" and "),
+        Span("B", italic=True),
+    ]

--- a/agentic-backend/tests/test_ppt_filler_text_formatting.py
+++ b/agentic-backend/tests/test_ppt_filler_text_formatting.py
@@ -1,0 +1,214 @@
+"""Offline tests for inline bold/italic formatting in the PPT filler text traversal.
+
+A filled ``{{key}}`` value may carry inline Markdown (``**bold**`` / ``*italic*``);
+the filler parses it into pptx runs that OVERLAY bold/italic on top of the placeholder
+run's own font (size/color/name inherited). Markup is honored only in the substituted
+value — never in the surrounding static template text.
+
+Decks are built in-test with python-pptx (no checked-in binaries), matching the style of
+``test_ppt_filler_parser.py``.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import List
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.util import Inches, Pt
+
+from agentic_backend.integrations.ppt_filler.traversal import (
+    list_keys_on_slide,
+    replace_keys_on_slide,
+)
+
+_FONT_NAME = "Arial"
+_FONT_SIZE = Pt(20)
+_FONT_COLOR = RGBColor(0x12, 0x34, 0x56)
+
+
+def _one_run_deck(body: str) -> bytes:
+    """A one-slide deck whose only text box holds ``body`` in a single styled run.
+
+    The run carries a distinctive size/color/name so tests can assert that emphasized
+    spans INHERIT the base font and only toggle bold/italic.
+    """
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(8), Inches(2))
+    run = textbox.text_frame.paragraphs[0].add_run()
+    run.text = body
+    run.font.name = _FONT_NAME
+    run.font.size = _FONT_SIZE
+    run.font.color.rgb = _FONT_COLOR
+    buffer = io.BytesIO()
+    presentation.save(buffer)
+    return buffer.getvalue()
+
+
+def _fill(deck: bytes, values: dict) -> "Presentation":
+    presentation = Presentation(io.BytesIO(deck))
+    slide = presentation.slides[0]
+    replace_keys_on_slide(slide, lambda key: values[key])
+    return presentation
+
+
+def _runs(presentation) -> List:
+    slide = presentation.slides[0]
+    return [
+        run
+        for shape in slide.shapes
+        if shape.has_text_frame
+        for paragraph in shape.text_frame.paragraphs
+        for run in paragraph.runs
+    ]
+
+
+def _run_named(runs, text):
+    return next((r for r in runs if r.text == text), None)
+
+
+def _paragraph_with(presentation, needle: str):
+    slide = presentation.slides[0]
+    for shape in slide.shapes:
+        if not shape.has_text_frame:
+            continue
+        for paragraph in shape.text_frame.paragraphs:
+            if needle in "".join(r.text for r in paragraph.runs):
+                return paragraph
+    raise AssertionError(f"no paragraph containing {needle!r}")
+
+
+def test_bold_value_becomes_a_bold_run_inheriting_base_font():
+    deck = _one_run_deck("Result: {{val}}")
+    runs = _runs(_fill(deck, {"val": "up **40%** today"}))
+
+    bold = _run_named(runs, "40%")
+    assert bold is not None
+    assert bold.font.bold is True
+    # Base font is inherited on the emphasized span: size/color/name unchanged.
+    assert bold.font.size == _FONT_SIZE
+    assert bold.font.name == _FONT_NAME
+    assert bold.font.color.rgb == _FONT_COLOR
+    # No placeholder remains and the full text reads with markers stripped.
+    assert list_keys_on_slide(_fill(deck, {"val": "up **40%** today"}).slides[0]) == []
+    assert "".join(r.text for r in runs) == "Result: up 40% today"
+
+
+def test_italic_value_becomes_an_italic_run_inheriting_base_font():
+    deck = _one_run_deck("Product: {{name}}")
+    runs = _runs(_fill(deck, {"name": "the *Acme* widget"}))
+
+    italic = _run_named(runs, "Acme")
+    assert italic is not None
+    assert italic.font.italic is True
+    assert italic.font.size == _FONT_SIZE
+    assert italic.font.name == _FONT_NAME
+    assert italic.font.color.rgb == _FONT_COLOR
+
+
+def test_value_with_no_markup_yields_a_single_unchanged_run():
+    deck = _one_run_deck("Hi {{name}}!")
+    presentation = _fill(deck, {"name": "Jane"})
+    runs = _runs(presentation)
+
+    # A markup-free fill collapses onto one run (today's behavior), base font intact.
+    assert len(runs) == 1
+    assert runs[0].text == "Hi Jane!"
+    assert runs[0].font.size == _FONT_SIZE
+    assert runs[0].font.name == _FONT_NAME
+    assert runs[0].font.color.rgb == _FONT_COLOR
+    assert runs[0].font.bold in (None, False)
+    assert runs[0].font.italic in (None, False)
+
+
+def test_literal_star_in_static_template_text_is_left_untouched():
+    # The author's static '*' must NOT be reinterpreted as emphasis — only the value is
+    # parsed. The value here carries no markup, so nothing should become italic/bold.
+    deck = _one_run_deck("Rating {{score}} out of *five*")
+    presentation = _fill(deck, {"score": "4"})
+    runs = _runs(presentation)
+
+    full = "".join(r.text for r in runs)
+    assert full == "Rating 4 out of *five*"  # literal asterisks preserved
+    assert all(r.font.italic in (None, False) for r in runs)
+    assert all(r.font.bold in (None, False) for r in runs)
+
+
+def test_literal_star_in_static_text_survives_alongside_value_markup():
+    # Static '*five*' stays literal even when the VALUE contains real markup that is
+    # honored — the two never bleed into each other.
+    deck = _one_run_deck("{{label}} out of *five*")
+    presentation = _fill(deck, {"label": "scored **4**"})
+    runs = _runs(presentation)
+
+    assert "".join(r.text for r in runs) == "scored 4 out of *five*"
+    bold = _run_named(runs, "4")
+    assert bold is not None and bold.font.bold is True
+    # The literal-asterisk run is plain text, not emphasized.
+    star_run = next(r for r in runs if "*five*" in r.text)
+    assert star_run.font.bold in (None, False)
+    assert star_run.font.italic in (None, False)
+
+
+def test_bold_italic_combined_value_renders_bold():
+    deck = _one_run_deck("{{k}}")
+    runs = _runs(_fill(deck, {"k": "***wow***"}))
+    bold = _run_named(runs, "wow")
+    assert bold is not None and bold.font.bold is True
+
+
+def test_markup_does_not_affect_key_detection_roundtrip():
+    # Markup lives in values, not keys: a value with markup still fills cleanly and leaves
+    # no placeholder behind (the parse->fill->reparse invariant).
+    deck = _one_run_deck("A {{x}} and a {{y}}")
+    presentation = _fill(deck, {"x": "**bold**", "y": "_em_"})
+    assert list_keys_on_slide(presentation.slides[0]) == []
+
+
+def test_newline_becomes_a_line_break_not_literal_in_run_text():
+    # A '\n' in a value must become an <a:br/> element, NOT a literal newline inside a
+    # run's text. A literal '\n' renders unreliably and bleeds the PRECEDING run's bold
+    # across the wrapped line (a bold title leaking onto the body below it).
+    from pptx.oxml.ns import qn
+
+    deck = _one_run_deck("{{body}}")
+    presentation = _fill(deck, {"body": "**Title**\nplain body line"})
+    paragraph = _paragraph_with(presentation, "Title")
+
+    # No run text contains a raw newline...
+    assert all("\n" not in r.text for r in paragraph.runs)
+    # ...and there is a real <a:br/> between the title and the body.
+    assert paragraph._p.findall(qn("a:br"))
+
+
+def test_bold_title_does_not_bleed_onto_following_body_line():
+    # The regression that motivated <a:br/>: with markup-toggled runs, the body run after
+    # a bold title must stay NON-bold (the title's bold must not carry over the line wrap).
+    deck = _one_run_deck("{{body}}")
+    value = "**Innovation Hub Expansion**\nA new hub was inaugurated in Toulouse."
+    presentation = _fill(deck, {"body": value})
+    runs = _runs(presentation)
+
+    title = _run_named(runs, "Innovation Hub Expansion")
+    body = _run_named(runs, "A new hub was inaugurated in Toulouse.")
+    assert title is not None and title.font.bold is True
+    assert body is not None
+    assert body.font.bold in (None, False)
+
+
+def test_multiple_titles_and_bodies_keep_independent_bold():
+    # The full screenshot scenario: three "**Title**\nbody\n\n" blocks. Every title bold,
+    # every body plain — bold never bleeds past its own title.
+    deck = _one_run_deck("{{body}}")
+    value = "**First**\nbody one.\n\n**Second**\nbody two.\n\n**Third**\nbody three."
+    presentation = _fill(deck, {"body": value})
+    runs = _runs(presentation)
+
+    for title in ("First", "Second", "Third"):
+        run = _run_named(runs, title)
+        assert run is not None and run.font.bold is True, title
+    for body in ("body one.", "body two.", "body three."):
+        run = _run_named(runs, body)
+        assert run is not None and run.font.bold in (None, False), body

--- a/agentic-backend/tests/test_ppt_filler_toolkit.py
+++ b/agentic-backend/tests/test_ppt_filler_toolkit.py
@@ -308,14 +308,27 @@ def test_args_schema_is_nested_by_slide_with_leaf_descriptions():
         ref = schema["properties"][slide_field]["$ref"]
         return defs[ref.split("/")[-1]]
 
+    # Each TEXT leaf keeps its note as the lead and appends the inline-formatting hint so
+    # the agent knows it may bold/italic part of the value.
+    from agentic_backend.integrations.ppt_filler.toolkit import _TEXT_FORMATTING_HINT
+
     slide1 = _leaf("slide_1")
     assert set(slide1["properties"]) == {"name", "role"}
-    assert slide1["properties"]["name"]["description"] == "The person's name"
-    assert slide1["properties"]["role"]["description"] == "Their role"
+    assert (
+        slide1["properties"]["name"]["description"]
+        == f"The person's name {_TEXT_FORMATTING_HINT}"
+    )
+    assert (
+        slide1["properties"]["role"]["description"]
+        == f"Their role {_TEXT_FORMATTING_HINT}"
+    )
 
     slide2 = _leaf("slide_2")
     assert set(slide2["properties"]) == {"city"}
-    assert slide2["properties"]["city"]["description"] == "The city"
+    assert (
+        slide2["properties"]["city"]["description"]
+        == f"The city {_TEXT_FORMATTING_HINT}"
+    )
 
 
 def test_no_tool_when_schema_is_empty():

--- a/docs/rfc/PPT-FILLER-IMAGES-RFC.md
+++ b/docs/rfc/PPT-FILLER-IMAGES-RFC.md
@@ -1,6 +1,6 @@
 # PPT Filler Toolkit — Image Support — PRD / RFC
 
-Status: Draft
+Status: Implemented
 Provider key: `ppt_filler` (extends the existing toolkit)
 Area: Agentic Backend (toolkit parsing/validation, fill tool, analyze endpoint) + Frontend (agent creation form) + Knowledge Flow (folder/tag resolution, raw content fetch)
 Extends: [`PPT-FILLER-TOOLKIT-RFC.md`](./PPT-FILLER-TOOLKIT-RFC.md)

--- a/docs/rfc/PPT-FILLER-TEXT-FORMATTING-RFC.md
+++ b/docs/rfc/PPT-FILLER-TEXT-FORMATTING-RFC.md
@@ -1,0 +1,167 @@
+# PPT Filler Toolkit — Inline Text Formatting — PRD / RFC
+
+Status: Draft
+Provider key: `ppt_filler` (extends the existing toolkit)
+Area: Agentic Backend (shared inline-markdown parser, fill-tool text traversal) + writable-documents docx export (refactor to consume the shared parser)
+Extends: [`PPT-FILLER-TOOLKIT-RFC.md`](./PPT-FILLER-TOOLKIT-RFC.md)
+
+---
+
+## Problem Statement
+
+When the PPT Filler toolkit fills a `{{key}}` text placeholder, the value is inserted as a single
+flat string: the substituted run keeps the placeholder run's formatting, but the agent has **no way
+to emphasize part of the value**. A filled value cannot say "make this phrase bold" or "italicize
+this term" — the whole value renders in one style. Real deliverables routinely need that emphasis:
+a bolded key figure in a sentence, an italicized product name, a bolded label inside a longer line.
+
+Today the agent's only options are all-or-nothing (the author styles the entire placeholder) or
+nothing at all. There is no per-span control, so the agent cannot produce the lightly-formatted prose
+a human would naturally write.
+
+Separately, the writable-documents **Word (`.docx`) export already solves exactly this** — it parses
+`**bold**` / `*italic*` from agent-emitted Markdown into styled runs
+([`docx_export.py`](../../agentic-backend/agentic_backend/core/writable_documents/docx_export.py)).
+That logic is written and tested, but it is welded to python-docx objects, so the PPT Filler cannot
+reuse it. Re-implementing the same Markdown subset a second time for pptx would duplicate the parsing
+rules and let the two interpretations drift.
+
+## Solution
+
+Let the agent use **inline Markdown** in any text value it passes to the fill tool — limited to the
+subset already supported by the Word export: `**bold**`, `*italic*` / `_italic_`, and `***both***`.
+When filling a text placeholder, that markup is parsed into styled spans and written as one pptx run
+per span, **overlaying** bold/italic on top of the placeholder run's existing formatting (size, color,
+font, etc. are inherited from the author's `{{key}}` run, unchanged). A value with no markup produces
+exactly one run, identical to today's behavior — so the change is backward compatible.
+
+To stay DRY, the Markdown-subset parsing is **extracted once** into a format-agnostic helper that
+returns styled spans, and is then consumed by **both** the existing docx export and the new pptx
+fill path. There is a single source of truth for "what our inline Markdown means"; each document
+library only owns the thin step of writing those spans as its own runs.
+
+Crucially, the filler parses markup **only in the substituted value**, never in the surrounding
+template text — an author's literal `*` in static slide text must never be reinterpreted as emphasis.
+
+## User Stories
+
+### Using the agent (chat time)
+
+1. As an end user, I want the agent to **emphasize part of a filled value** (a key figure, a term,
+   a label) with bold or italic, so that the filled slide reads like human-written prose instead of
+   one flat style.
+2. As an end user, I want emphasis to use familiar **Markdown** (`**bold**`, `*italic*`), so that the
+   agent produces it reliably without a bespoke syntax it might get wrong.
+3. As an end user, I want a value with **no markup** to look exactly as it does today, so that
+   existing templates and behavior are unaffected.
+
+### Authoring (template author)
+
+4. As a template author, I want emphasis the agent adds to **inherit my placeholder's styling** (the
+   font, size, and color I set on the `{{key}}` run), with only bold/italic toggled, so that agent
+   emphasis never overrides my visual design.
+5. As a template author, I want **literal `*` or `_` characters in my static slide text** to stay
+   literal, so that punctuation in my template is never mistaken for formatting.
+
+### Maintainability (shared logic)
+
+6. As a maintainer, I want the inline-Markdown parsing to live in **one place** shared by the docx
+   export and the PPT filler, so that the two can never diverge on what `**bold**` means and the
+   subset is defined and tested once.
+
+## Implementation Decisions
+
+This feature extends the existing `ppt_filler` toolkit (no new provider) and refactors the existing
+writable-documents docx export to consume a shared helper. No schema, params, endpoint, or frontend
+change is required — markup lives entirely inside the values the agent already passes.
+
+### Supported subset (intentionally minimal)
+
+- Exactly the subset the docx export already supports: **`**bold**`**, **`*italic*`** /
+  **`_italic_`**, and **`***both***`**. No underline, color, size, or font — Markdown has no
+  standard notation for those and they would require a bespoke syntax with no validation feedback
+  loop (deliberately Out of Scope below).
+- The inline-code (`` `code` ``) span the docx export recognizes is **not** applied as a style in the
+  pptx filler (it maps to a Courier font swap in docx, which is outside this feature's bold/italic
+  scope). The shared parser may still surface it; the pptx writer treats such a span as plain text.
+
+### Shared parser (the DRY seam)
+
+- Extract the docx export's `_INLINE_RE`, `_STRAY_MARKER_RE`, and marker-stripping into a
+  **format-agnostic** function in a neutral module, e.g.
+  `core/markdown/inline.py::parse_inline_markdown(text) -> list[Span]`, where a `Span` carries the
+  text plus `bold` / `italic` (and `code`) flags. Pure, no docx/pptx import, fully unit-testable.
+- The existing `_add_inline_runs` in the docx export is **rewritten as a thin consumer**: iterate the
+  spans and `paragraph.add_run(span.text)` setting `.bold` / `.italic` (and the Courier font for a
+  code span). Behavior is unchanged; the existing docx export tests pin that and now also guard the
+  shared parser.
+- The flat (non-recursive) parsing semantics and stray-marker stripping are preserved exactly as the
+  docx export defines them — this RFC moves the logic, it does not change the grammar.
+
+### Fill-tool text traversal (the pptx consumer)
+
+- The change is confined to the shared text traversal's replace step
+  ([`traversal.py` `replace_keys_on_slide`](../../agentic-backend/agentic_backend/integrations/ppt_filler/traversal.py)),
+  the single spot that today collapses a paragraph onto its first run
+  (`runs[0].text = replaced; rest cleared`).
+- Markup is parsed from the **substituted value only**, not from the merged paragraph text, so static
+  template text containing literal `*` / `_` is never reinterpreted. The substitution boundary is the
+  one place the pptx caller genuinely differs from the docx caller (where the whole line is agent
+  Markdown) — which is exactly why the shared piece is the **parser**, not `_add_inline_runs`.
+- The first run is kept as the **base style source**; each parsed span becomes a pptx run that copies
+  the base run's font (size, color, name, …) and **overlays** `bold` / `italic`. python-pptx has no
+  public font-copy, so the base font properties are copied explicitly onto each new run.
+- A value with no markup yields a single span → a single run → today's exact behavior. Image keys are
+  untouched: their `{{key}}` text is preserved for the image pass and never reaches span-writing in a
+  way that matters.
+
+### Agent guidance
+
+- One line in the text-key leaf description builder
+  ([`toolkit.py`](../../agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py), the
+  non-image branch) tells the agent it may use `**bold**` / `*italic*` in text values. No other
+  prompt or tool-description surface changes.
+
+## Testing Decisions
+
+Tests assert **external behavior** and stay offline/fixture-driven, matching the existing
+`ppt_filler` and docx-export suites.
+
+1. **Shared parser seam (new, pure)** — `parse_inline_markdown(text) -> spans`: bold, italic (both
+   marker styles), bold+italic, plain text, stray/mismatched markers stripped, literal text with no
+   markup → single span. This is where the grammar is pinned.
+2. **docx export (reused, unchanged assertions)** — the existing
+   `test_writable_document_docx_export.py` cases (`.bold` / `.italic` runs, nested emphasis, table
+   cells) must still pass after the refactor, now exercising the shared parser through the docx
+   consumer.
+3. **pptx fill (new)** — fill a fixture template whose `{{key}}` value contains `**bold**` / `*italic*`
+   and assert the resulting paragraph has the expected runs with the right `bold` / `italic` flags and
+   that the **base font is inherited** (size/color/name unchanged from the placeholder run). A value
+   with no markup yields a single unchanged run. A template with a **literal `*`** in static text is
+   left untouched. The existing parse → fill → re-parse round-trip guard still holds (markup affects
+   values, not key detection).
+
+## Out of Scope
+
+- Underline, strikethrough, font color, font size, and font family — no standard Markdown notation;
+  they would need a bespoke syntax with no validation feedback loop. Revisit only if a concrete need
+  appears.
+- Block-level Markdown (headings, lists, tables) inside a value — placeholders are inline spans, not
+  documents; block constructs belong to the docx export, not the filler.
+- Markdown in **static template text** — only agent-provided values are parsed, by design.
+- Markdown in **image** key values (they carry a document id, not prose).
+- Any change to schema, params, analyze/save endpoints, or the frontend.
+
+## Further Notes
+
+- **Why a refactor and not a copy:** duplicating the Markdown subset for pptx would let the docx and
+  pptx interpretations of `**bold**` drift. Extracting the parser makes the subset a single tested
+  unit; the docx side gets *safer* (its parsing is now covered as a shared unit) as a side effect.
+- **Highest-risk watch-points:**
+  1. The value-vs-literal boundary — parsing the substituted value only. Get this wrong and an
+     author's literal `*` in static text becomes spurious emphasis. Pinned by the literal-`*` test.
+  2. Explicit base-font copy onto each new pptx run — python-pptx has no public copy, so missing a
+     property (size/color/name) would silently drop the author's styling on emphasized spans. Pinned
+     by the base-font-inherited assertion.
+- **Backward compatibility:** a markup-free value produces one run exactly as today, so no existing
+  template, saved agent, or test changes behavior.

--- a/docs/rfc/PPT-FILLER-TOOLKIT-RFC.md
+++ b/docs/rfc/PPT-FILLER-TOOLKIT-RFC.md
@@ -4,8 +4,9 @@ Status: Implemented
 Provider key: `ppt_filler`
 Area: Agentic Backend (inprocess toolkits, agent tuning) + Frontend (agent creation form)
 
-> Extension: image templating is specified separately in
-> [`PPT-FILLER-IMAGES-RFC.md`](./PPT-FILLER-IMAGES-RFC.md).
+> Extensions, specified separately:
+> - image templating — [`PPT-FILLER-IMAGES-RFC.md`](./PPT-FILLER-IMAGES-RFC.md);
+> - inline text formatting — [`PPT-FILLER-TEXT-FORMATTING-RFC.md`](./PPT-FILLER-TEXT-FORMATTING-RFC.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Lets a `ppt_filler` agent emphasize part of a filled `{{key}}` value with inline Markdown, so filled slides read like human-written prose instead of one flat style.

- **Supported subset** (same as the docx export): `**bold**`, `*italic*` / `_italic_`, `***both***`. No underline/color/size/font (no standard Markdown notation).
- **Value-only parsing**: markup is honored only in the substituted value, never in static template text — an author's literal `*` / `_` stays literal.
- **DRY seam**: the Markdown subset is extracted once into a format-agnostic parser `core/markdown/inline.py::parse_inline_markdown(text) -> list[Span]`, consumed by **both** the docx export and the pptx filler, so the two can never drift. The docx export's `_add_inline_runs` becomes a thin consumer (its existing tests still pin behavior, now through the shared parser).
- **Style inheritance**: each parsed span becomes a pptx run cloned from the placeholder run (size/color/font inherited) with only bold/italic overlaid. A markup-free value yields a single run — today's exact behavior (backward compatible).
- **Newline fix**: newlines in a value are written as `<a:br/>` break elements rather than literal `\n` in run text. A literal `\n` renders unreliably and bleeds a preceding bold title's emphasis across the wrapped body line (the all-bold-body bug seen in testing). Verified by rendering filled decks in LibreOffice.
- One-line agent guidance added to each text key's leaf description; RFC docs updated (new text-formatting RFC, images RFC marked Implemented, cross-link from the toolkit RFC).

No schema, params, endpoint, or frontend change — markup lives entirely inside the values the agent already passes.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

In `agentic-backend/`:

- `make code-quality` → ruff lint + format clean, basedpyright `0 errors, 0 warnings, 0 notes`, detect-secrets clean.
- `make test` → `483 passed` (offline, `-m "not integration"`).
- New tests: `tests/test_ppt_filler_text_formatting.py` (bold/italic runs inherit base font; literal `*` in static text untouched; newline → `<a:br/>`; bold title does not bleed onto its body) and `agentic_backend/tests/test_markdown_inline.py` (the shared parser grammar). Existing docx-export tests pass unchanged through the shared parser.
- End-to-end: drove `fill_ppt_template` with a real agent payload on a real template and rendered the result in LibreOffice — every title bold, every body plain, italic on emphasized terms.

## Risk / Rollback

- **Main risk**: the value-vs-literal boundary (parsing only the substituted value) and the explicit base-run clone (a missed property would drop the author's styling on emphasized spans). Both are pinned by tests.
- **Backward compatibility**: a markup-free value produces one run exactly as before — no existing template, saved agent, or test changes behavior.
- **Rollback**: revert this commit; the shared parser is additive and the docx export reverts to its prior inline logic.
