### PR TITLE
feat(ppt-filler): PDF preview pane for filled decks

### DIFF
--- a/agentic-backend/agentic_backend/common/kf_workspace_client.py
+++ b/agentic-backend/agentic_backend/common/kf_workspace_client.py
@@ -121,6 +121,10 @@ class KfWorkspaceClient(KfBaseClient):
         return "/storage/user/upload"
 
     @staticmethod
+    def _path_user_presigned(key: str) -> str:
+        return f"/storage/user/presigned/{key}"
+
+    @staticmethod
     def _path_agent_config_download(agent_id: str, key: str) -> str:
         logical_key = (key or "").strip().replace("\\", "/").split("/")[-1]
         return f"/storage/agent-config/{agent_id}/{logical_key}"
@@ -395,6 +399,33 @@ class KfWorkspaceClient(KfBaseClient):
         """Upload a user-space file (for example a downloadable report)."""
         path = self._path_user_upload()
         return await self._upload_blob(path, key, file_content, filename, content_type)
+
+    async def presigned_user_url(
+        self, key: str, access_token: Optional[str] = None
+    ) -> Optional[str]:
+        """
+        Return a temporary, browser-reachable presigned URL for a user-scoped file.
+
+        Best-effort: returns ``None`` (rather than raising) when the backend cannot presign
+        (local/dev storage → 501), the object is missing (404), or any other error occurs.
+        The caller (e.g. the PPT preview) degrades by omitting the preview.
+        """
+        path = self._path_user_presigned(key)
+        try:
+            r = await self._request_with_token_refresh(
+                "GET",
+                path,
+                phase_name="kf_workspace_presign",
+                access_token=access_token,
+            )
+            r.raise_for_status()
+            url = r.json().get("url")
+            return url or None
+        except (
+            Exception
+        ) as e:  # best-effort: never let a preview problem break the fill
+            logger.warning("Presigned URL unavailable for user key=%s: %s", key, e)
+            return None
 
     async def upload_agent_config_blob(
         self,

--- a/agentic-backend/agentic_backend/core/agents/v2/contracts/context.py
+++ b/agentic-backend/agentic_backend/core/agents/v2/contracts/context.py
@@ -51,6 +51,7 @@ from agentic_backend.core.chatbot.chat_schema import (
     GeoPart,
     LinkKind,
     LinkPart,
+    PptPreviewPart,
     WritableDocumentPart,
 )
 
@@ -114,7 +115,8 @@ class ToolContentBlock(FrozenModel):
 
 
 UiPart = Annotated[
-    LinkPart | GeoPart | WritableDocumentPart | ChartPart, Field(discriminator="type")
+    LinkPart | GeoPart | WritableDocumentPart | PptPreviewPart | ChartPart,
+    Field(discriminator="type"),
 ]
 
 

--- a/agentic-backend/agentic_backend/core/chatbot/chat_schema.py
+++ b/agentic-backend/agentic_backend/core/chatbot/chat_schema.py
@@ -145,10 +145,18 @@ class PptPreviewPart(BaseModel):
         opens a blocking drawer). The card carries both open-preview and .pptx download,
         so a separate download chip is redundant.
 
+    Durability (why we store a KF href, not a presigned URL):
+      - A presigned URL is short-lived (≈1h). This part is PERSISTED in the conversation, so
+        baking a presigned URL in here means reopening the chat an hour later hands the
+        browser an EXPIRED signature → 403. Instead we store `pdf_presign_url`, a durable,
+        bearer-protected KF endpoint (`…/storage/user/presigned/{key}`). The frontend calls
+        it at open time to mint a FRESH presigned GET URL, mirroring how the `.pptx` download
+        stays durable (it re-hits `…/storage/user/{key}` every time rather than freezing a URL).
+
     Freshness (the edit→preview loop):
-      - `version` is stamped per fill. The frontend appends it to the PDF URL (`?v=…`) and
-        uses it as the react-pdf remount key, so a re-fill under the same storage key still
-        yields a fresh fetch and the open pane updates live instead of showing a cached deck.
+      - `version` is stamped per fill and used as the react-pdf remount key, so a re-fill
+        under the same storage key still yields a fresh fetch and the open pane updates live
+        instead of showing a cached deck.
     """
 
     type: Literal["ppt_preview"] = "ppt_preview"
@@ -156,7 +164,9 @@ class PptPreviewPart(BaseModel):
         str  # stable id for this deck within the session (usually the storage key)
     )
     title: str
-    pdf_url: str  # presigned, browser-reachable, Range-capable PDF URL
+    pdf_presign_url: (
+        str  # durable KF href; the frontend calls it to mint a fresh presigned PDF URL
+    )
     version: str  # per-fill token; drives cache-busting + react-pdf remount
     pptx_download_url: Optional[str] = None  # href to download the source .pptx
     file_name: Optional[str] = None  # .pptx download file name

--- a/agentic-backend/agentic_backend/core/chatbot/chat_schema.py
+++ b/agentic-backend/agentic_backend/core/chatbot/chat_schema.py
@@ -134,6 +134,34 @@ class WritableDocumentPart(BaseModel):
     updated_by: WritableDocumentAuthor = WritableDocumentAuthor.agent
 
 
+class PptPreviewPart(BaseModel):
+    """
+    Why this exists:
+      - After a PPT-filler fill, the deck is shown as a read-only PDF preview in a
+        resizable side pane (mirroring the writable-document pane pattern), so the user
+        can glance at the result and ask for a correction without downloading anything.
+      - It is deliberately NOT a `writable_document` part (read-only, no autosave, and the
+        payload is a PDF URL rather than markdown) and NOT a `LinkPart(kind=view)` (which
+        opens a blocking drawer). The card carries both open-preview and .pptx download,
+        so a separate download chip is redundant.
+
+    Freshness (the edit→preview loop):
+      - `version` is stamped per fill. The frontend appends it to the PDF URL (`?v=…`) and
+        uses it as the react-pdf remount key, so a re-fill under the same storage key still
+        yields a fresh fetch and the open pane updates live instead of showing a cached deck.
+    """
+
+    type: Literal["ppt_preview"] = "ppt_preview"
+    preview_id: (
+        str  # stable id for this deck within the session (usually the storage key)
+    )
+    title: str
+    pdf_url: str  # presigned, browser-reachable, Range-capable PDF URL
+    version: str  # per-fill token; drives cache-busting + react-pdf remount
+    pptx_download_url: Optional[str] = None  # href to download the source .pptx
+    file_name: Optional[str] = None  # .pptx download file name
+
+
 class ChartType(str, Enum):
     bar = "bar"
     line = "line"
@@ -233,6 +261,7 @@ MessagePart: TypeAlias = Annotated[
         LinkPart,
         GeoPart,
         WritableDocumentPart,
+        PptPreviewPart,
         ChartPart,
     ],
     Field(discriminator="type"),

--- a/agentic-backend/agentic_backend/core/chatbot/message_part.py
+++ b/agentic-backend/agentic_backend/core/chatbot/message_part.py
@@ -28,6 +28,7 @@ from agentic_backend.core.chatbot.chat_schema import (
     ImageUrlPart,
     LinkPart,
     MessagePart,
+    PptPreviewPart,
     TextPart,
     WritableDocumentPart,
 )
@@ -120,6 +121,8 @@ def hydrate_fred_parts(additional_kwargs: dict) -> List[MessagePart]:
                 parts.append(ChartPart(**raw))
             elif t == "writable_document":
                 parts.append(WritableDocumentPart(**raw))
+            elif t == "ppt_preview":
+                parts.append(PptPreviewPart(**raw))
         except ValidationError:
             continue
     return parts

--- a/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
@@ -150,6 +150,26 @@ def _pdf_key_for(pptx_upload_key: str) -> str:
     return f"{base}{_PDF_SUFFIX}"
 
 
+def _pdf_presign_href_from_download(
+    pptx_download_url: str, pdf_key: str
+) -> Optional[str]:
+    """Durable KF href the frontend calls to mint a FRESH presigned PDF URL at open time.
+
+    We deliberately store this durable endpoint instead of a presigned URL: a presigned URL
+    expires (~1h) but this part is persisted in the conversation, so a frozen URL 403s when
+    the chat is reopened later. The `.pptx` download URL is origin-relative
+    (``/…/storage/user/{pptx_key}``); the presign endpoint lives at the sibling path
+    ``/…/storage/user/presigned/{pdf_key}``. We derive one from the other so the API prefix
+    stays whatever KF actually served, with no host/prefix config duplicated here.
+    """
+    marker = "/storage/user/"
+    idx = pptx_download_url.find(marker)
+    if idx == -1:
+        return None
+    prefix = pptx_download_url[: idx + len(marker)]  # ".../storage/user/"
+    return f"{prefix}presigned/{pdf_key.lstrip('/')}"
+
+
 def _preview_version(pdf_bytes: bytes) -> str:
     """Per-fill freshness token derived from the PDF content.
 
@@ -664,13 +684,15 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
             upload_result.download_url,
         )
 
-        # 4. Best-effort PDF preview: convert the filled deck to PDF, upload it beside the
-        #    .pptx under the same session-scoped key, and presign it so the browser can
-        #    stream it directly. Any failure (conversion unavailable/timeout, or no
-        #    presigned URL — e.g. local dev storage) degrades to the plain download chip so
-        #    a preview problem never costs the user the deck.
+        # 4. Best-effort PDF preview: convert the filled deck to PDF and upload it beside the
+        #    .pptx under the same session-scoped key. We store a DURABLE presign href (a KF
+        #    endpoint the frontend calls at open time), NOT a presigned URL — a presigned URL
+        #    expires (~1h) while this part is persisted, so a frozen URL would 403 when the
+        #    chat is reopened later. Any failure (conversion unavailable/timeout, upload
+        #    error, or no presign href — e.g. local dev storage) degrades to the plain
+        #    download chip so a preview problem never costs the user the deck.
         pdf_bytes = await convert_pptx_bytes_to_pdf(filled_bytes)
-        preview_url: Optional[str] = None
+        presign_href: Optional[str] = None
         if pdf_bytes is not None:
             pdf_key = _pdf_key_for(upload_key)
             try:
@@ -680,19 +702,22 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
                     filename=_pdf_key_for(output_file_name),
                     content_type=_PDF_CONTENT_TYPE,
                 )
-                preview_url = await client.presigned_user_url(pdf_key, access_token)
+                if upload_result.download_url:
+                    presign_href = _pdf_presign_href_from_download(
+                        upload_result.download_url, pdf_key
+                    )
             except Exception as exc:  # best-effort: keep the .pptx on any preview error
                 logger.warning(
-                    "[PPTFILL][TOOL] preview upload/presign failed (deck still returned): %s",
+                    "[PPTFILL][TOOL] preview upload failed (deck still returned): %s",
                     exc,
                 )
 
-        if preview_url:
+        if presign_href:
             version = _preview_version(pdf_bytes) if pdf_bytes is not None else ""
             preview = PptPreviewPart(
                 preview_id=upload_key,
                 title=output_file_name,
-                pdf_url=preview_url,
+                pdf_presign_url=presign_href,
                 version=version,
                 pptx_download_url=upload_result.download_url,
                 file_name=upload_result.file_name,

--- a/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
@@ -45,11 +45,13 @@ NOTE on imports: ``build_ppt_filler_tools`` is imported directly from this submo
 
 from __future__ import annotations
 
+import hashlib
 import io
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
+from fred_core import convert_pptx_bytes_to_pdf
 from langchain_core.tools import BaseTool, StructuredTool
 from PIL import Image, UnidentifiedImageError
 from pptx import Presentation
@@ -59,7 +61,7 @@ from agentic_backend.common.kf_base_client import KnowledgeFlowAgentContext
 from agentic_backend.common.kf_document_client import KfDocumentClient
 from agentic_backend.common.kf_workspace_client import KfWorkspaceClient
 from agentic_backend.core.agents.v2.contracts.context import ToolInvocationResult
-from agentic_backend.core.chatbot.chat_schema import LinkKind, LinkPart
+from agentic_backend.core.chatbot.chat_schema import LinkKind, LinkPart, PptPreviewPart
 from agentic_backend.integrations.ppt_filler.parser import apply_kept_notes_to_slide
 from agentic_backend.integrations.ppt_filler.ppt_filler_params import (
     PPT_FILLER_PROVIDER,
@@ -80,8 +82,10 @@ _TOOL_REF = "ppt_filler_fill"
 _PPTX_CONTENT_TYPE = (
     "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 )
+_PDF_CONTENT_TYPE = "application/pdf"
 _OUTPUT_FILE_NAME = "filled_presentation.pptx"
 _PPTX_SUFFIX = ".pptx"
+_PDF_SUFFIX = ".pdf"
 
 # Pillow ``format`` values python-pptx's ``add_picture`` can actually embed. Anything KF
 # ingests outside this set (WEBP, ICO, ...) decodes in Pillow but is rejected by
@@ -132,6 +136,29 @@ def _sanitize_output_file_name(raw: object) -> str:
     if not name:
         return _OUTPUT_FILE_NAME
     return f"{name}{_PPTX_SUFFIX}"
+
+
+def _pdf_key_for(pptx_upload_key: str) -> str:
+    """Storage key for the preview PDF: the ``.pptx`` key with a ``.pdf`` suffix.
+
+    Sharing the session prefix means the PDF is cleaned up on session delete exactly like
+    the ``.pptx`` (``/storage/user`` keys are ``{session_id}``-scoped).
+    """
+    base = pptx_upload_key
+    if base.lower().endswith(_PPTX_SUFFIX):
+        base = base[: -len(_PPTX_SUFFIX)]
+    return f"{base}{_PDF_SUFFIX}"
+
+
+def _preview_version(pdf_bytes: bytes) -> str:
+    """Per-fill freshness token derived from the PDF content.
+
+    A re-fill that changes the deck yields different bytes → a different token → the
+    frontend refetches (new ``?v=`` URL + react-pdf remount key). Identical re-fills keep
+    the same token, so an unchanged deck is not needlessly refetched. Content-hashing is
+    deterministic, which keeps the "version changes on re-fill" behaviour testable offline.
+    """
+    return hashlib.sha256(pdf_bytes).hexdigest()[:16]
 
 
 def _slide_number_from_field(field_name: str) -> Optional[int]:
@@ -630,6 +657,55 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
             logger.exception("[PPTFILL][TOOL] upload FAILED -> %s", message)
             return message, ToolInvocationResult(tool_ref=_TOOL_REF, is_error=True)
 
+        logger.info(
+            "[PPTFILL][TOOL] filled deck uploaded session=%s key=%s url=%s",
+            session_id,
+            upload_result.key,
+            upload_result.download_url,
+        )
+
+        # 4. Best-effort PDF preview: convert the filled deck to PDF, upload it beside the
+        #    .pptx under the same session-scoped key, and presign it so the browser can
+        #    stream it directly. Any failure (conversion unavailable/timeout, or no
+        #    presigned URL — e.g. local dev storage) degrades to the plain download chip so
+        #    a preview problem never costs the user the deck.
+        pdf_bytes = await convert_pptx_bytes_to_pdf(filled_bytes)
+        preview_url: Optional[str] = None
+        if pdf_bytes is not None:
+            pdf_key = _pdf_key_for(upload_key)
+            try:
+                await client.upload_user_blob(
+                    key=pdf_key,
+                    file_content=pdf_bytes,
+                    filename=_pdf_key_for(output_file_name),
+                    content_type=_PDF_CONTENT_TYPE,
+                )
+                preview_url = await client.presigned_user_url(pdf_key, access_token)
+            except Exception as exc:  # best-effort: keep the .pptx on any preview error
+                logger.warning(
+                    "[PPTFILL][TOOL] preview upload/presign failed (deck still returned): %s",
+                    exc,
+                )
+
+        if preview_url:
+            version = _preview_version(pdf_bytes) if pdf_bytes is not None else ""
+            preview = PptPreviewPart(
+                preview_id=upload_key,
+                title=output_file_name,
+                pdf_url=preview_url,
+                version=version,
+                pptx_download_url=upload_result.download_url,
+                file_name=upload_result.file_name,
+            )
+            artifact = ToolInvocationResult(tool_ref=_TOOL_REF, ui_parts=(preview,))
+            return (
+                f"The presentation '{output_file_name}' has been filled. A preview opens "
+                "beside the chat and a download button is shown automatically; do not write "
+                "a download link yourself.",
+                artifact,
+            )
+
+        # Preview unavailable → fall back to the download chip and say so.
         link = LinkPart(
             href=upload_result.download_url,
             title=f"Download {upload_result.file_name}",
@@ -638,16 +714,11 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
             document_uid=upload_result.document_uid,
             file_name=upload_result.file_name,
         )
-        logger.info(
-            "[PPTFILL][TOOL] filled deck uploaded session=%s key=%s url=%s",
-            session_id,
-            upload_result.key,
-            upload_result.download_url,
-        )
         artifact = ToolInvocationResult(tool_ref=_TOOL_REF, ui_parts=(link,))
         return (
-            f"The presentation '{output_file_name}' has been filled. A download button "
-            "is shown to the user automatically; do not write a download link yourself.",
+            f"The presentation '{output_file_name}' has been filled (the preview could not "
+            "be generated, so only the download is available). A download button is shown to "
+            "the user automatically; do not write a download link yourself.",
             artifact,
         )
 
@@ -679,10 +750,10 @@ def build_ppt_filler_tools(agent: KnowledgeFlowAgentContext) -> list[BaseTool]:
             "field's value (not its name, not text). If a directory is missing or empty, "
             "leave that field unset and tell the user an owner/editor must fix the "
             "template's image directory.\n"
-            "After the tool runs, a download button for the filled PowerPoint is shown "
-            "to the user automatically — do NOT write, invent, or repeat any download "
-            "link or URL in your reply, and do not tell the user to click a link you "
-            "wrote. Just briefly confirm the deck is ready."
+            "After the tool runs, the filled PowerPoint is surfaced to the user automatically "
+            "(a preview beside the chat when available, otherwise a download button) — do NOT "
+            "write, invent, or repeat any download link or URL in your reply, and do not tell "
+            "the user to click a link you wrote. Just briefly confirm the deck is ready."
         ),
         args_schema=args_schema,
     )

--- a/agentic-backend/tests/test_ppt_filler_toolkit.py
+++ b/agentic-backend/tests/test_ppt_filler_toolkit.py
@@ -106,10 +106,18 @@ class _FakeWorkspaceClient:
     template_bytes: bytes = b""
     fetch_calls: list[dict] = []
     upload_calls: list[dict] = []
+    presign_calls: list[str] = []
+    # URL returned by ``presigned_user_url`` — ``None`` means "backend cannot presign"
+    # (the fill tool then falls back to the plain download chip).
+    presigned_url: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         # The tool constructs ``KfWorkspaceClient(agent=agent)``; accept and ignore.
         pass
+
+    async def presigned_user_url(self, key, access_token=None):
+        type(self).presign_calls.append(key)
+        return type(self).presigned_url
 
     async def fetch_agent_config_blob(self, key, access_token=None, agent_id=None):
         type(self).fetch_calls.append(
@@ -147,19 +155,44 @@ class _FakeWorkspaceClient:
 
 @pytest.fixture
 def fake_ws(monkeypatch):
-    """Install a fresh fake KfWorkspaceClient for one test."""
+    """Install a fresh fake KfWorkspaceClient for one test.
+
+    By default the PDF preview is disabled (``convert_pptx_bytes_to_pdf`` stubbed to return
+    ``None``) so the fill returns the plain download chip — this keeps the offline suite
+    independent of a real ``soffice`` binary. Tests that exercise the preview path override
+    the stub (see ``_enable_preview``).
+    """
 
     class _Client(_FakeWorkspaceClient):
         template_bytes = b""
         fetch_calls = []
         upload_calls = []
+        presign_calls = []
+        presigned_url = None
 
     monkeypatch.setattr(kf_ws, "KfWorkspaceClient", _Client)
     # The toolkit imported the symbol by name, so patch it there too.
     import agentic_backend.integrations.ppt_filler.toolkit as toolkit_mod
 
     monkeypatch.setattr(toolkit_mod, "KfWorkspaceClient", _Client)
+
+    # Preview off by default: no PDF is produced, so no second upload / presign happens.
+    async def _no_pdf(_bytes, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(toolkit_mod, "convert_pptx_bytes_to_pdf", _no_pdf)
     return _Client
+
+
+def _enable_preview(monkeypatch, fake_ws, *, pdf_bytes: bytes = b"%PDF-1.5 fake"):
+    """Turn the best-effort preview on for a test: stub conversion + a presigned URL."""
+    import agentic_backend.integrations.ppt_filler.toolkit as toolkit_mod
+
+    async def _pdf(_bytes, *args, **kwargs):
+        return pdf_bytes
+
+    monkeypatch.setattr(toolkit_mod, "convert_pptx_bytes_to_pdf", _pdf)
+    fake_ws.presigned_url = "https://minio.example/preview.pdf?sig=abc"
 
 
 def _the_tool(agent):
@@ -393,6 +426,93 @@ async def test_fill_repeated_keys_on_slide_uses_one_value(fake_ws):
     assert link.file_name == "filled_presentation.pptx"
     assert link.href and link.href.startswith("https://example.test/storage/user/")
     assert isinstance(content, str) and content.strip()
+
+
+# --- PDF preview (best-effort) ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_fill_emits_ppt_preview_and_uploads_pdf(fake_ws, monkeypatch):
+    """A successful fill converts to PDF, uploads it beside the .pptx, and emits a
+    ppt_preview part (with the presigned PDF url + a version + the .pptx download) instead
+    of a standalone download LinkPart."""
+    from agentic_backend.core.chatbot.chat_schema import PptPreviewPart
+
+    _enable_preview(monkeypatch, fake_ws)
+    deck = _build_deck([("{{name}}", "{{name}}:\nThe name")])
+    fake_ws.template_bytes = deck
+    params = PptFillerParams(schema=_schema_slides(deck))
+    tool = _the_tool(_FakeAgent(params=params, session_id="sess-9"))
+
+    _content, artifact = await tool.coroutine(slide_1={"name": "Jane"})
+
+    assert artifact.is_error is False
+    # Two uploads: the .pptx then the preview .pdf, both session-scoped and sibling keys.
+    assert len(fake_ws.upload_calls) == 2
+    pptx_up, pdf_up = fake_ws.upload_calls
+    assert pptx_up["key"].endswith(".pptx") and pptx_up["key"].startswith("sess-9/")
+    assert pdf_up["key"] == pptx_up["key"][: -len(".pptx")] + ".pdf"
+    assert pdf_up["content_type"] == "application/pdf"
+    assert fake_ws.presign_calls == [pdf_up["key"]]
+
+    # Exactly one ppt_preview part, no standalone download LinkPart.
+    assert len(artifact.ui_parts) == 1
+    part = artifact.ui_parts[0]
+    assert isinstance(part, PptPreviewPart)
+    assert not any(isinstance(p, LinkPart) for p in artifact.ui_parts)
+    assert part.pdf_url == "https://minio.example/preview.pdf?sig=abc"
+    assert part.version  # a freshness token is stamped
+    assert part.pptx_download_url and part.pptx_download_url.startswith(
+        "https://example.test/"
+    )
+    assert part.file_name == "filled_presentation.pptx"
+
+
+@pytest.mark.asyncio
+async def test_failed_conversion_still_returns_pptx_with_note(fake_ws):
+    """When conversion is unavailable (the default), the fill still returns the .pptx via a
+    download LinkPart and the message states the preview could not be generated."""
+    deck = _build_deck([("{{name}}", "{{name}}:\nThe name")])
+    fake_ws.template_bytes = deck
+    params = PptFillerParams(schema=_schema_slides(deck))
+    tool = _the_tool(_FakeAgent(params=params, session_id="sess-9"))
+
+    content, artifact = await tool.coroutine(slide_1={"name": "Jane"})
+
+    assert artifact.is_error is False
+    # No PDF upload / presign happened; only the .pptx was stored.
+    assert len(fake_ws.upload_calls) == 1
+    assert fake_ws.presign_calls == []
+    assert len(artifact.ui_parts) == 1
+    assert isinstance(artifact.ui_parts[0], LinkPart)
+    assert artifact.ui_parts[0].kind == LinkKind.download
+    assert "preview" in content.lower()
+
+
+@pytest.mark.asyncio
+async def test_preview_version_changes_on_refill(fake_ws, monkeypatch):
+    """A re-fill that changes the deck yields a different preview version token (the
+    cache-busting key that makes the open pane update live)."""
+    from agentic_backend.core.chatbot.chat_schema import PptPreviewPart
+
+    deck = _build_deck([("{{name}}", "{{name}}:\nThe name")])
+    fake_ws.template_bytes = deck
+    params = PptFillerParams(schema=_schema_slides(deck))
+    tool = _the_tool(_FakeAgent(params=params, session_id="sess-9"))
+
+    # First fill: the PDF conversion yields one set of bytes.
+    _enable_preview(monkeypatch, fake_ws, pdf_bytes=b"%PDF-1.5 first")
+    _c1, a1 = await tool.coroutine(slide_1={"name": "Jane"})
+    v1 = a1.ui_parts[0]
+    assert isinstance(v1, PptPreviewPart)
+
+    # Second fill producing a different PDF (a real re-fill re-renders the deck).
+    _enable_preview(monkeypatch, fake_ws, pdf_bytes=b"%PDF-1.5 second-different")
+    _c2, a2 = await tool.coroutine(slide_1={"name": "Bob"})
+    v2 = a2.ui_parts[0]
+    assert isinstance(v2, PptPreviewPart)
+
+    assert v1.version != v2.version
 
 
 @pytest.mark.asyncio

--- a/agentic-backend/tests/test_ppt_filler_toolkit.py
+++ b/agentic-backend/tests/test_ppt_filler_toolkit.py
@@ -106,18 +106,10 @@ class _FakeWorkspaceClient:
     template_bytes: bytes = b""
     fetch_calls: list[dict] = []
     upload_calls: list[dict] = []
-    presign_calls: list[str] = []
-    # URL returned by ``presigned_user_url`` — ``None`` means "backend cannot presign"
-    # (the fill tool then falls back to the plain download chip).
-    presigned_url: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         # The tool constructs ``KfWorkspaceClient(agent=agent)``; accept and ignore.
         pass
-
-    async def presigned_user_url(self, key, access_token=None):
-        type(self).presign_calls.append(key)
-        return type(self).presigned_url
 
     async def fetch_agent_config_blob(self, key, access_token=None, agent_id=None):
         type(self).fetch_calls.append(
@@ -167,8 +159,6 @@ def fake_ws(monkeypatch):
         template_bytes = b""
         fetch_calls = []
         upload_calls = []
-        presign_calls = []
-        presigned_url = None
 
     monkeypatch.setattr(kf_ws, "KfWorkspaceClient", _Client)
     # The toolkit imported the symbol by name, so patch it there too.
@@ -176,7 +166,7 @@ def fake_ws(monkeypatch):
 
     monkeypatch.setattr(toolkit_mod, "KfWorkspaceClient", _Client)
 
-    # Preview off by default: no PDF is produced, so no second upload / presign happens.
+    # Preview off by default: no PDF is produced, so no second upload happens.
     async def _no_pdf(_bytes, *args, **kwargs):
         return None
 
@@ -185,14 +175,18 @@ def fake_ws(monkeypatch):
 
 
 def _enable_preview(monkeypatch, fake_ws, *, pdf_bytes: bytes = b"%PDF-1.5 fake"):
-    """Turn the best-effort preview on for a test: stub conversion + a presigned URL."""
+    """Turn the best-effort preview on for a test by stubbing conversion to yield PDF bytes.
+
+    No presigned URL is stubbed: the tool no longer presigns at fill time (a presigned URL
+    would expire while the part is persisted). It instead derives a DURABLE presign href from
+    the .pptx download URL, which the fake upload already returns.
+    """
     import agentic_backend.integrations.ppt_filler.toolkit as toolkit_mod
 
     async def _pdf(_bytes, *args, **kwargs):
         return pdf_bytes
 
     monkeypatch.setattr(toolkit_mod, "convert_pptx_bytes_to_pdf", _pdf)
-    fake_ws.presigned_url = "https://minio.example/preview.pdf?sig=abc"
 
 
 def _the_tool(agent):
@@ -434,8 +428,8 @@ async def test_fill_repeated_keys_on_slide_uses_one_value(fake_ws):
 @pytest.mark.asyncio
 async def test_successful_fill_emits_ppt_preview_and_uploads_pdf(fake_ws, monkeypatch):
     """A successful fill converts to PDF, uploads it beside the .pptx, and emits a
-    ppt_preview part (with the presigned PDF url + a version + the .pptx download) instead
-    of a standalone download LinkPart."""
+    ppt_preview part carrying a DURABLE presign href (not a frozen presigned URL) + a version
+    + the .pptx download, instead of a standalone download LinkPart."""
     from agentic_backend.core.chatbot.chat_schema import PptPreviewPart
 
     _enable_preview(monkeypatch, fake_ws)
@@ -453,14 +447,18 @@ async def test_successful_fill_emits_ppt_preview_and_uploads_pdf(fake_ws, monkey
     assert pptx_up["key"].endswith(".pptx") and pptx_up["key"].startswith("sess-9/")
     assert pdf_up["key"] == pptx_up["key"][: -len(".pptx")] + ".pdf"
     assert pdf_up["content_type"] == "application/pdf"
-    assert fake_ws.presign_calls == [pdf_up["key"]]
 
     # Exactly one ppt_preview part, no standalone download LinkPart.
     assert len(artifact.ui_parts) == 1
     part = artifact.ui_parts[0]
     assert isinstance(part, PptPreviewPart)
     assert not any(isinstance(p, LinkPart) for p in artifact.ui_parts)
-    assert part.pdf_url == "https://minio.example/preview.pdf?sig=abc"
+    # The preview points at the DURABLE presign endpoint for the PDF key (the browser mints a
+    # fresh presigned URL from it at open time), NOT a baked, expiring presigned URL.
+    assert (
+        part.pdf_presign_url
+        == f"https://example.test/storage/user/presigned/{pdf_up['key']}"
+    )
     assert part.version  # a freshness token is stamped
     assert part.pptx_download_url and part.pptx_download_url.startswith(
         "https://example.test/"
@@ -480,9 +478,8 @@ async def test_failed_conversion_still_returns_pptx_with_note(fake_ws):
     content, artifact = await tool.coroutine(slide_1={"name": "Jane"})
 
     assert artifact.is_error is False
-    # No PDF upload / presign happened; only the .pptx was stored.
+    # No PDF upload happened; only the .pptx was stored.
     assert len(fake_ws.upload_calls) == 1
-    assert fake_ws.presign_calls == []
     assert len(artifact.ui_parts) == 1
     assert isinstance(artifact.ui_parts[0], LinkPart)
     assert artifact.ui_parts[0].kind == LinkKind.download

--- a/docs/rfc/PPT-FILLER-PREVIEW-PANE-RFC.md
+++ b/docs/rfc/PPT-FILLER-PREVIEW-PANE-RFC.md
@@ -1,0 +1,185 @@
+# PPT Filler Toolkit — PDF Preview Pane — PRD / RFC
+
+Status: Draft
+Provider key: `ppt_filler` (extends the existing toolkit)
+Area: Agentic Backend (fill tool) + `fred-core` (shared pptx→pdf) + Knowledge Flow (user-storage presigned URL) + Frontend (resizable preview pane)
+Extends: [`PPT-FILLER-TOOLKIT-RFC.md`](./PPT-FILLER-TOOLKIT-RFC.md)
+
+---
+
+## Problem Statement
+
+Today a PPT Filler agent fills the template and returns a **download link**. To see whether the deck
+is right, the user must download the `.pptx`, open it in PowerPoint, notice something to change, come
+back to the chat, ask for the change, and download again. Every iteration is a full round-trip through
+an external app. For a "fill my deck" feature whose whole value is getting a *good* deck, that
+feedback loop is the main friction — the user cannot glance at the result and say "change the title"
+without leaving Fred.
+
+There is no way to **see the filled deck in the UI**, so there is no tight loop between "agent fills"
+and "user asks for a correction."
+
+## Solution
+
+After a fill, show the filled deck as a **PDF preview in a resizable side pane** to the right of the
+chat — the same pane pattern as the writable-documents editor
+([`WritableDocumentPane`](../../frontend/src/components/chatbot/WritableDocumentPane.tsx)). The pane
+**auto-opens the first time** an agent produces a deck, and the **chat stays fully usable** beside it,
+so the user can read the preview and immediately type "make the title bigger" without downloading
+anything. When the agent re-fills, the pane **updates in place** to the new version — a real
+edit → preview → correct loop.
+
+The deck is rendered by converting the filled `.pptx` to **PDF** (LibreOffice, already used in Knowledge
+Flow) and displaying it with the existing `react-pdf` viewer. PDF is the only reliable way to show a
+faithful deck in the browser; the conversion reuses proven code rather than inventing a renderer.
+
+The preview is **best-effort and never blocks the deliverable**: if conversion fails or times out, the
+user still gets the `.pptx` and is told in chat that the preview could not be generated.
+
+## User Stories
+
+### Using the agent (chat time)
+
+1. As an end user, when an agent fills a deck, I want a **preview to open automatically** beside the
+   chat, so that I can see the result immediately without downloading and opening PowerPoint.
+2. As an end user, I want the **chat to stay usable while I view the preview**, so that I can ask for
+   changes without closing the deck.
+3. As an end user, I want the pane to be **resizable**, so that I can balance reading the deck and
+   reading the chat.
+4. As an end user, when I ask for a change and the agent **re-fills**, I want the open preview to
+   **update to the new version**, so that I always see the latest deck without reopening anything.
+5. As an end user, I want a **single card in the chat** for the produced deck — click it to (re)open
+   the preview, and a button to **download the `.pptx`** — so that the deck is one clear object.
+6. As an end user, if the preview can't be generated, I want to **still get the `.pptx`** and a clear
+   note that the preview failed, so that a rendering problem never costs me the deck.
+
+### Maintainability (shared logic)
+
+7. As a maintainer, I want the `.pptx`→PDF conversion to live in **one shared place** used by both
+   backends, so that the two do not each carry their own LibreOffice call.
+8. As a maintainer, I want the **resizable pane shell** and the **in-chat artifact card** to be shared
+   components, so that the writable-documents pane and the PPT preview do not duplicate layout, resize,
+   and chip code.
+
+## Implementation Decisions
+
+This feature extends the existing `ppt_filler` toolkit (no new provider) and adds a read-only preview
+surface. It does **not** touch the analyze/save flow, the template schema, or agent params.
+
+### Conversion (shared, in `fred-core`)
+
+- The LibreOffice `.pptx`→PDF conversion (today
+  [`convert_pptx_to_pdf`](../../knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pptx_markdown_processor/utils/pptx_slide_renderer.py)
+  in Knowledge Flow) is **moved into `fred-core`**, the package both backends already depend on, so
+  there is one implementation and one place to harden. `soffice` is already installed in both backend
+  images.
+- The shared helper must be **non-blocking and bounded**: run `soffice` off the event loop
+  (`asyncio.to_thread`) with a **timeout**, in a `TemporaryDirectory`. Today's call is a bare, un-timed,
+  blocking `subprocess.run` — acceptable inside a KF processor, not inside the async fill tool.
+
+### Fill tool (eager conversion, graceful degradation)
+
+- After the existing `.pptx` upload, the fill tool **converts the filled bytes to PDF eagerly** (every
+  fill) and uploads the PDF **beside the `.pptx`** in the same session-scoped user storage
+  (`{session_id}/…`), so the preview is ready the instant the deck is produced and the PDF is
+  **auto-cleaned on session delete** exactly like the `.pptx`.
+- On conversion failure/timeout the tool **still returns the `.pptx`**, omits the preview, and the
+  success message **states the preview could not be generated**. The deck is never lost to a preview
+  problem.
+- The tool emits **one** new `ppt_preview` UI part (below) **instead of** the current standalone
+  download `LinkPart` — the card carries both open-preview and download, so a separate download chip is
+  redundant.
+
+### PDF delivery (session-scoped, presigned URL)
+
+- The PDF is stored in the **same `/storage/user` store** as the `.pptx`, and the browser fetches it
+  **directly from object storage via a short-lived MinIO presigned GET URL** — not proxied through a
+  Knowledge Flow streaming endpoint. Presigned GETs are **range-capable natively**, which is what
+  `react-pdf` needs, and serving the bytes straight from MinIO keeps large-file transfer **off the app
+  server** (consistent with the presigned-URL usage already elsewhere in the platform, e.g. tabular and
+  content stores).
+- Knowledge Flow exposes a small **bearer-protected `GET /storage/user/presigned/{key}`** endpoint that
+  returns the presigned URL for a session-scoped key (it does not stream bytes). The fill tool calls it
+  after uploading the PDF and puts the resulting URL on the preview part.
+- Presigning is added to the **user-storage `MinioFilesystem`** (the backend `/storage/user` already
+  uses), signing against the configured **public/ingress endpoint** so the URL is browser-reachable,
+  mirroring `MinioStorageBackend`'s public-client pattern (`public_endpoint`/`public_secure`).
+- The store choice is deliberate: `/storage/user` keys are `{session_id}`-prefixed and cleaned up on
+  session delete, unlike the user-scoped asset store (no session cleanup) or KF ingestion (which would
+  mint a library document and pollute the corpus).
+- **Local/standalone caveat:** the local filesystem backend cannot presign; there the preview URL is
+  simply omitted and the deck degrades to the `.pptx` download chip (below). MinIO deployments get the
+  full preview. This is an accepted, known gap — local mode is not the priority.
+
+### Preview part (new, specific)
+
+- A new **`ppt_preview`** message part, mirroring the `writable_document` part plumbing (Pydantic model
+  in the `MessagePart`/`UiPart` union; one branch in `hydrate_fred_parts`; regenerated OpenAPI types).
+  It is **not** the `writable_document` part (different data, read-only, no autosave) and **not**
+  `LinkPart(kind=view)` (a download-chip model that opens a blocking drawer).
+- The part carries: the **presigned PDF URL**, a **version token** stamped per fill, a **title**, and the
+  **`.pptx` download href** — enough for the card to be self-contained.
+- **Freshness (the loop):** the version token is used as the `react-pdf` remount key, mirroring the
+  writable-doc `updated_at` pattern. A re-fill yields a new version (derived from the PDF content hash),
+  and — because presigning runs per fill — a brand-new presigned URL (fresh signature/date). New remount
+  key + new URL → fresh fetch → the open pane updates live rather than showing a browser-cached stale
+  deck. Note: the version must **not** be appended as an extra query param on the presigned URL — the
+  presigned signature covers the whole query string, so an added `?v=` yields a `403 SignatureDoesNotMatch`.
+
+### Frontend (shared shell + shared card)
+
+- Extract a shared **`ResizablePaneShell`** from the existing ChatBotView pane markup + `useResizablePane`
+  (divider, drag, open/close animation). **One pane is active at a time**: opening the PDF preview swaps
+  the writable-doc pane and vice versa; each remains reachable from its chat card. This keeps the current
+  single-surface layout.
+- Extract a shared **artifact card** (icon + title + click-to-open-pane + download button) used by
+  **both** the writable-doc chip and the ppt preview. For the ppt card, open → PDF pane, download →
+  `.pptx`. The generic piece is the **card**, not the part: parts stay specific (rule of three — factor a
+  shared part only when a third side-pane tool appears).
+- A small `usePptPreview` controller mirrors `useWritableDocuments`: it reads `ppt_preview` parts,
+  auto-opens the pane on first appearance, and points the viewer at the presigned PDF URL. The pane
+  reuses the existing `react-pdf` rendering (same worker/`<Document>`/`<Page>` setup as
+  [`PdfStreamingDocumentViewer`](../../frontend/src/common/PdfStreamingDocumentViewer.tsx)) inside the
+  shared resizable pane shell rather than the blocking drawer.
+
+## Testing Decisions
+
+Tests assert **external behavior** and stay offline/fixture-driven.
+
+1. **Shared conversion helper (`fred-core`, new)** — given a fixture `.pptx`, returns PDF bytes;
+   respects the timeout (a stubbed slow/hung `soffice` returns the failure signal, not a hang); missing
+   `soffice` degrades to the failure signal rather than raising through the caller.
+2. **Fill tool (extended)** — a successful fill emits a `ppt_preview` part (PDF key + version + `.pptx`
+   href) and no standalone download `LinkPart`; a **failed conversion** still returns the `.pptx` and a
+   message noting the preview was skipped; the version token **changes on re-fill**.
+3. **User-storage presign (KF, new)** — `WorkspaceFilesystem.presigned_url` signs the correct
+   session-scoped `root/owner/key` path and delegates to the backend; a backend without presigning (local
+   disk) raises `NotImplementedError` (the endpoint maps it to `501` and the fill tool degrades). MinIO
+   signing against the public endpoint is covered by the existing content-store presign tests.
+
+## Out of Scope
+
+- **Editing** the deck in the pane — the preview is read-only; corrections go through the chat/agent.
+- **Live/streaming** slide-by-slide rendering, thumbnails, or per-slide navigation beyond what
+  `react-pdf` gives for free.
+- **Two panes at once** (writable-doc + preview side by side / tabs) — one active pane; revisit only if
+  a real need appears.
+- Any change to the **analyze/save** flow, template **schema**, **params**, or agent **tool args**.
+- Reusing the existing **PDF drawer** (`usePdfDocumentViewer`) — it blocks the chat, which defeats the
+  loop.
+
+## Further Notes
+
+- **Why reuse, not rebuild:** conversion (LibreOffice), the PDF viewer (`react-pdf`), the resizable pane,
+  and the auto-open pattern all already exist — this feature mostly **wires proven pieces** together and
+  extracts two of them (conversion into `fred-core`, pane shell + card into shared components).
+- **Highest-risk watch-points:**
+  1. **Stale preview on re-fill** — if the version token is missing from the URL/remount key, a
+     same-named re-fill shows the cached old deck and silently breaks the loop. Pinned by the
+     version-changes-on-re-fill test.
+  2. **Blocking/hanging conversion** — a bare synchronous `soffice` call inside the async fill tool
+     stalls the agent turn; the helper must offload and time out. Pinned by the timeout test.
+  3. **Preview failure taking the deck down** — conversion is best-effort; a failure must still return
+     the `.pptx`. Pinned by the failed-conversion test.
+- **Backward compatibility:** agents and templates are unchanged; the only chat-surface change is the
+  produced-deck card (open-preview + `.pptx` download) replacing the bare download chip.

--- a/docs/rfc/PPT-FILLER-TEXT-FORMATTING-RFC.md
+++ b/docs/rfc/PPT-FILLER-TEXT-FORMATTING-RFC.md
@@ -1,6 +1,6 @@
 # PPT Filler Toolkit — Inline Text Formatting — PRD / RFC
 
-Status: Draft
+Status: Implemented
 Provider key: `ppt_filler` (extends the existing toolkit)
 Area: Agentic Backend (shared inline-markdown parser, fill-tool text traversal) + writable-documents docx export (refactor to consume the shared parser)
 Extends: [`PPT-FILLER-TOOLKIT-RFC.md`](./PPT-FILLER-TOOLKIT-RFC.md)

--- a/docs/rfc/PPT-FILLER-TOOLKIT-RFC.md
+++ b/docs/rfc/PPT-FILLER-TOOLKIT-RFC.md
@@ -6,7 +6,8 @@ Area: Agentic Backend (inprocess toolkits, agent tuning) + Frontend (agent creat
 
 > Extensions, specified separately:
 > - image templating — [`PPT-FILLER-IMAGES-RFC.md`](./PPT-FILLER-IMAGES-RFC.md);
-> - inline text formatting — [`PPT-FILLER-TEXT-FORMATTING-RFC.md`](./PPT-FILLER-TEXT-FORMATTING-RFC.md).
+> - inline text formatting — [`PPT-FILLER-TEXT-FORMATTING-RFC.md`](./PPT-FILLER-TEXT-FORMATTING-RFC.md);
+> - PDF preview pane — [`PPT-FILLER-PREVIEW-PANE-RFC.md`](./PPT-FILLER-PREVIEW-PANE-RFC.md).
 
 ---
 

--- a/fred-core/fred_core/__init__.py
+++ b/fred-core/fred_core/__init__.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from fred_core.conversion import (
+    DEFAULT_PPTX_PDF_TIMEOUT_SECONDS,
+    convert_pptx_bytes_to_pdf,
+    convert_pptx_file_to_pdf,
+)
 from fred_core.filesystem.local_filesystem import LocalFilesystem
 from fred_core.filesystem.minio_filesystem import MinioFilesystem
 from fred_core.filesystem.structures import (
@@ -120,6 +125,9 @@ __all__ = [
     "UserSecurity",
     "TODO_PASS_REAL_USER",
     "NO_AUTHZ_CHECK_USER",
+    "convert_pptx_bytes_to_pdf",
+    "convert_pptx_file_to_pdf",
+    "DEFAULT_PPTX_PDF_TIMEOUT_SECONDS",
     "BaseFilesystem",
     "LocalFilesystem",
     "MinioFilesystem",

--- a/fred-core/fred_core/conversion/__init__.py
+++ b/fred-core/fred_core/conversion/__init__.py
@@ -1,0 +1,25 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fred_core.conversion.pptx_pdf import (
+    DEFAULT_PPTX_PDF_TIMEOUT_SECONDS,
+    convert_pptx_bytes_to_pdf,
+    convert_pptx_file_to_pdf,
+)
+
+__all__ = [
+    "DEFAULT_PPTX_PDF_TIMEOUT_SECONDS",
+    "convert_pptx_bytes_to_pdf",
+    "convert_pptx_file_to_pdf",
+]

--- a/fred-core/fred_core/conversion/pptx_pdf.py
+++ b/fred-core/fred_core/conversion/pptx_pdf.py
@@ -1,0 +1,147 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared, best-effort PPTX→PDF conversion using headless LibreOffice.
+
+Why this lives in ``fred-core``:
+- Both Knowledge Flow (slide vision enrichment) and the Agentic PPT-filler preview
+  need the exact same ``soffice`` invocation. Keeping one implementation here means
+  there is a single place to harden (timeout, error handling) instead of two drifting
+  ``subprocess.run`` calls.
+
+Contract:
+- The conversion is **best-effort**: any failure (missing ``soffice``, a non-zero exit,
+  a timeout, or no PDF produced) returns ``None`` (for the bytes helper) rather than
+  raising through the caller. Callers decide how to degrade — the preview pane, for
+  instance, still returns the ``.pptx`` when the PDF cannot be produced.
+- The bytes helper (:func:`convert_pptx_bytes_to_pdf`) is **async and bounded**: it runs
+  ``soffice`` off the event loop via ``asyncio.to_thread`` with a timeout, so it is safe
+  to call from an async tool without stalling the turn.
+
+``soffice`` is expected to be installed in both backend images.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess  # nosec: controlled command arguments, shell=False
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# LibreOffice can occasionally hang (font server, first-run profile init). A bounded
+# timeout keeps a stuck conversion from stalling an async agent turn indefinitely.
+DEFAULT_PPTX_PDF_TIMEOUT_SECONDS = 60.0
+
+# Same export filter the Knowledge Flow processor has used in production: embed standard
+# fonts and pin the PDF version so the rendered deck is faithful across viewers.
+_PDF_EXPORT_FILTER = "pdf:writer_pdf_Export:EmbedStandardFonts=True,SelectPdfVersion=1"
+
+
+def convert_pptx_file_to_pdf(
+    pptx_path: Path,
+    timeout_seconds: float = DEFAULT_PPTX_PDF_TIMEOUT_SECONDS,
+) -> Path | None:
+    """Convert a ``.pptx`` file to a PDF next to it using headless LibreOffice.
+
+    Blocking; returns the produced ``.pdf`` path, or ``None`` when ``soffice`` is
+    missing, fails, times out, or produces no file. Prefer :func:`convert_pptx_bytes_to_pdf`
+    from async code — this variant exists for synchronous callers (e.g. the Knowledge Flow
+    slide renderer) that already own a temp directory.
+    """
+    pdf_path = pptx_path.with_suffix(".pdf")
+    soffice_path = shutil.which("soffice")
+    if not soffice_path:
+        logger.error(
+            "[PPTX2PDF] LibreOffice (soffice) is not installed or not in PATH."
+        )
+        return None
+
+    try:
+        subprocess.run(  # nosec: controlled command arguments, shell=False
+            [
+                soffice_path,
+                "--headless",
+                "--nologo",
+                "--nofirststartwizard",
+                "--convert-to",
+                _PDF_EXPORT_FILTER,
+                "--outdir",
+                str(pptx_path.parent),
+                str(pptx_path),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "[PPTX2PDF] LibreOffice conversion timed out after %.0fs.", timeout_seconds
+        )
+        return None
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "[PPTX2PDF] LibreOffice conversion failed: %s",
+            exc.stderr.decode(errors="ignore") if exc.stderr else exc,
+        )
+        return None
+
+    if pdf_path.exists():
+        logger.info("[PPTX2PDF] Converted PPTX to PDF: %s", pdf_path)
+        return pdf_path
+
+    logger.warning("[PPTX2PDF] Conversion completed but PDF not found: %s", pdf_path)
+    return None
+
+
+async def convert_pptx_bytes_to_pdf(
+    pptx_bytes: bytes,
+    timeout_seconds: float = DEFAULT_PPTX_PDF_TIMEOUT_SECONDS,
+) -> bytes | None:
+    """Convert in-memory ``.pptx`` bytes to PDF bytes, off the event loop and bounded.
+
+    Returns the PDF bytes, or ``None`` when the conversion is unavailable or fails (missing
+    ``soffice``, non-zero exit, timeout, or no PDF produced). Never raises for a conversion
+    problem, so a caller can treat the preview as best-effort.
+
+    Example:
+    ```python
+    pdf = await convert_pptx_bytes_to_pdf(filled_bytes)
+    if pdf is None:
+        ...  # keep the .pptx, skip the preview
+    ```
+    """
+
+    def _run() -> bytes | None:
+        with tempfile.TemporaryDirectory(prefix="pptx2pdf-") as tmp:
+            pptx_path = Path(tmp) / "deck.pptx"
+            pptx_path.write_bytes(pptx_bytes)
+            pdf_path = convert_pptx_file_to_pdf(
+                pptx_path, timeout_seconds=timeout_seconds
+            )
+            if pdf_path is None:
+                return None
+            return pdf_path.read_bytes()
+
+    try:
+        return await asyncio.to_thread(_run)
+    except (
+        Exception
+    ):  # pragma: no cover - defensive: never let conversion break the caller
+        logger.exception("[PPTX2PDF] Unexpected error during PPTX→PDF conversion.")
+        return None

--- a/fred-core/fred_core/filesystem/minio_filesystem.py
+++ b/fred-core/fred_core/filesystem/minio_filesystem.py
@@ -14,11 +14,13 @@
 
 import logging
 import re
+from datetime import timedelta
 from io import BytesIO
 from typing import List, Set
 from urllib.parse import urlparse
 
 from minio import Minio
+from minio.error import S3Error
 
 from fred_core.filesystem.structures import (
     BaseFilesystem,
@@ -44,6 +46,8 @@ class MinioFilesystem(BaseFilesystem):
         secret_key: str,
         bucket_name: str,
         secure: bool,
+        public_endpoint: str | None = None,
+        public_secure: bool | None = None,
     ):
         """
         Initialize a MinIO client and create the bucket if it does not exist.
@@ -54,6 +58,12 @@ class MinioFilesystem(BaseFilesystem):
             secret_key (str): Secret key.
             bucket_name (str): Name of the bucket to use.
             secure (bool): Whether to use TLS.
+            public_endpoint (str | None): Browser-reachable endpoint used to sign presigned
+                URLs. Presigned signatures are bound to the host, so URLs handed to a browser
+                must be signed against the ingress the browser actually reaches, not the
+                internal endpoint. Falls back to ``endpoint`` when unset.
+            public_secure (bool | None): TLS for the public endpoint; inferred from the
+                public endpoint scheme when unset.
         """
         parsed = urlparse(endpoint)
         if parsed.path not in (None, "") and parsed.path != "/":
@@ -74,12 +84,63 @@ class MinioFilesystem(BaseFilesystem):
             secure=secure,
         )
 
+        # Separate client for presigned URLs. The signature is bound to the hostname, so
+        # browser-facing URLs must be signed against the public ingress. Mirrors
+        # MinioStorageBackend's public-client pattern; falls back to the internal client.
+        if public_endpoint:
+            parsed_public = urlparse(public_endpoint)
+            clean_public = parsed_public.netloc or public_endpoint.replace(
+                "https://", ""
+            ).replace("http://", "")
+            inferred_secure = (
+                public_secure
+                if public_secure is not None
+                else (parsed_public.scheme == "https")
+            )
+            self.public_client = Minio(
+                clean_public,
+                access_key=access_key,
+                secret_key=secret_key,
+                secure=inferred_secure,
+            )
+        else:
+            self.public_client = self.client
+
         # Prefix injected externally by the app if needed (ex: user_id/)
         self.prefix: str | None = None
 
         if not self.client.bucket_exists(bucket_name):
             self.client.make_bucket(bucket_name)
             logger.info(f"Bucket '{bucket_name}' created.")
+
+    def presigned_get_url(
+        self, path: str, expires: timedelta = timedelta(hours=1)
+    ) -> str:
+        """
+        Return a temporary, browser-reachable download URL for ``path``.
+
+        The URL is signed against the public endpoint (ingress) so a browser can fetch the
+        object directly — offloading large-file transfer from the backend. Presigned GETs
+        support HTTP Range, which is what ``react-pdf`` needs to stream a PDF.
+
+        Raises:
+            FileNotFoundError: when the object does not exist.
+            S3Error: on any other MinIO error.
+        """
+        resolved = self._resolve_path(path)
+        try:
+            return self.public_client.presigned_get_object(
+                self.bucket_name, resolved, expires=expires
+            )
+        except S3Error as exc:
+            if getattr(exc, "code", "") in {
+                "NoSuchKey",
+                "NoSuchObject",
+                "NoSuchBucket",
+            }:
+                raise FileNotFoundError(path) from exc
+            logger.error("[MINIO_PRESIGN] failed for path=%s: %s", resolved, exc)
+            raise
 
     def _resolve_path(self, path: str) -> str:
         """

--- a/fred-core/fred_core/tests/conversion/test_pptx_pdf.py
+++ b/fred-core/fred_core/tests/conversion/test_pptx_pdf.py
@@ -1,0 +1,138 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for the shared PPTX→PDF conversion helper.
+
+These do not invoke the real ``soffice`` binary: they stub ``shutil.which`` and
+``subprocess.run`` so the timeout / missing-binary / success behaviours are asserted
+deterministically without any external dependency. A separate ``integration``-marked
+test exercises the real LibreOffice path when the binary is present.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # nosec B404: only used to construct result/exception stubs in tests
+from pathlib import Path
+
+import pytest
+
+from fred_core.conversion import convert_pptx_bytes_to_pdf, convert_pptx_file_to_pdf
+
+_MODULE = "fred_core.conversion.pptx_pdf"
+
+
+@pytest.mark.asyncio
+async def test_convert_bytes_returns_pdf_on_success(monkeypatch) -> None:
+    monkeypatch.setattr(f"{_MODULE}.shutil.which", lambda _: "/usr/bin/soffice")
+
+    # Emulate soffice: write a PDF next to the input in the requested --outdir.
+    def fake_run(cmd, **kwargs):
+        outdir = Path(cmd[cmd.index("--outdir") + 1])
+        src = Path(cmd[-1])
+        (outdir / src.with_suffix(".pdf").name).write_bytes(b"%PDF-1.5 fake")
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    monkeypatch.setattr(f"{_MODULE}.subprocess.run", fake_run)
+
+    pdf = await convert_pptx_bytes_to_pdf(b"fake pptx bytes")
+
+    assert pdf is not None
+    assert pdf.startswith(b"%PDF")
+
+
+@pytest.mark.asyncio
+async def test_convert_bytes_returns_none_on_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(f"{_MODULE}.shutil.which", lambda _: "/usr/bin/soffice")
+
+    def hung_run(cmd, **kwargs):
+        # Mirror a soffice call that exceeds the deadline: to_thread surfaces the
+        # TimeoutExpired the helper is expected to swallow into a None result.
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(f"{_MODULE}.subprocess.run", hung_run)
+
+    pdf = await convert_pptx_bytes_to_pdf(b"fake pptx bytes", timeout_seconds=0.01)
+
+    assert pdf is None
+
+
+@pytest.mark.asyncio
+async def test_convert_bytes_returns_none_when_soffice_missing(monkeypatch) -> None:
+    monkeypatch.setattr(f"{_MODULE}.shutil.which", lambda _: None)
+
+    def unexpected_run(cmd, **kwargs):  # pragma: no cover - must not be reached
+        raise AssertionError("subprocess.run must not run when soffice is absent")
+
+    monkeypatch.setattr(f"{_MODULE}.subprocess.run", unexpected_run)
+
+    pdf = await convert_pptx_bytes_to_pdf(b"fake pptx bytes")
+
+    assert pdf is None
+
+
+@pytest.mark.asyncio
+async def test_convert_bytes_returns_none_when_no_pdf_produced(monkeypatch) -> None:
+    monkeypatch.setattr(f"{_MODULE}.shutil.which", lambda _: "/usr/bin/soffice")
+
+    # soffice exits 0 but writes nothing — a real failure mode worth guarding.
+    monkeypatch.setattr(
+        f"{_MODULE}.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, b"", b""),
+    )
+
+    pdf = await convert_pptx_bytes_to_pdf(b"fake pptx bytes")
+
+    assert pdf is None
+
+
+def test_convert_file_returns_none_on_called_process_error(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(f"{_MODULE}.shutil.which", lambda _: "/usr/bin/soffice")
+
+    def failing_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, stderr=b"boom")
+
+    monkeypatch.setattr(f"{_MODULE}.subprocess.run", failing_run)
+
+    src = tmp_path / "deck.pptx"
+    src.write_bytes(b"fake")
+
+    assert convert_pptx_file_to_pdf(src) is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_convert_bytes_with_real_libreoffice() -> None:
+    """End-to-end conversion via the real ``soffice`` binary (skipped when absent)."""
+    if shutil.which("soffice") is None:
+        pytest.skip("soffice not installed")
+    pytest.importorskip("pptx")
+
+    import io
+
+    from pptx import Presentation  # pyright: ignore[reportMissingImports]
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    box = slide.shapes.add_textbox(0, 0, prs.slide_width, prs.slide_height)
+    box.text_frame.text = "Hello preview"
+    buf = io.BytesIO()
+    prs.save(buf)
+
+    pdf = await convert_pptx_bytes_to_pdf(buf.getvalue())
+
+    assert pdf is not None
+    assert pdf.startswith(b"%PDF")

--- a/frontend/src/common/PdfStreamingDocumentViewer.tsx
+++ b/frontend/src/common/PdfStreamingDocumentViewer.tsx
@@ -15,24 +15,18 @@
 import CloseIcon from "@mui/icons-material/Close";
 import { AppBar, Box, CircularProgress, IconButton, Toolbar, Typography } from "@mui/material";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Document, Page, pdfjs } from "react-pdf";
+import { Document, Page } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 import { useAuthToken } from "../security/AuthContext";
+// Shared pdf.js worker plumbing: a fresh module worker per <Document> mount so remounts
+// never race a worker teardown ("the worker is being destroyed") — see pdfWorker.ts.
+import { configurePdfWorkerPort } from "./pdfWorker";
 
 type Props = {
   document: { document_uid: string; file_name?: string } | null;
   onClose: () => void;
 };
-
-// React-PDF requires workerSrc to be configured in the same module that renders
-// <Document>/<Page>; otherwise its default bare specifier can win at runtime.
-const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
-if (typeof Worker !== "undefined") {
-  pdfjs.GlobalWorkerOptions.workerPort = new Worker(pdfWorkerUrl, { type: "module" });
-} else {
-  pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
-}
 
 const PDF_SCALE = 0.8;
 
@@ -70,6 +64,11 @@ export const PdfStreamingDocumentViewer: React.FC<Props> = ({ document: doc, onC
       ? { url: pdfUrl, httpHeaders: { Authorization: token.startsWith("Bearer ") ? token : `Bearer ${token}` } }
       : { url: pdfUrl, withCredentials: true };
   }, [pdfUrl, token]);
+
+  // Provision a fresh pdf.js worker for each Document mount (keyed by reloadKey, which bumps
+  // per document). Runs during render, before <Document> reads GlobalWorkerOptions, so a
+  // reopen never reuses a port whose previous teardown is still in flight.
+  useMemo(() => configurePdfWorkerPort(), [reloadKey]);
 
   const onDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
     setNumPages(numPages);

--- a/frontend/src/common/pdfWorker.ts
+++ b/frontend/src/common/pdfWorker.ts
@@ -1,0 +1,61 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * pdfWorker
+ * ---------
+ * Shared pdf.js worker plumbing for every `react-pdf` `<Document>` in the app (the
+ * streaming PDF drawer AND the PPT preview pane).
+ *
+ * Two hard constraints shaped this:
+ *
+ * 1. The worker MUST be a real module `Worker` built from a `new URL(..., import.meta.url)`
+ *    so Vite bundles it. Setting only `GlobalWorkerOptions.workerSrc` to a string makes
+ *    pdf.js fall back to a "fake worker" that `import()`s the bare specifier
+ *    `pdf.worker.mjs`, which fails ("Setting up fake worker failed").
+ *
+ * 2. A single shared `workerPort` cannot be REUSED across `<Document>` remounts. On unmount
+ *    react-pdf calls `loadingTask.destroy()`, which marks that port `_pendingDestroy` and
+ *    evicts it from pdf.js's per-port cache. A `<Document>` mounting during that window
+ *    (open a second preview, or re-fill the open deck) calls `PDFWorker.fromPort` on the
+ *    same port and throws `PDFWorker.fromPort - the worker is being destroyed`.
+ *
+ * The fix that satisfies both: hand pdf.js a FRESH module worker per `<Document>` via
+ * `configurePdfWorkerPort()`, called right before each mount (keyed to the viewer's remount
+ * key). Each Document gets its own port, so no destroy of one can race a mount of another.
+ */
+
+import { pdfjs } from "react-pdf";
+
+// Resolved by Vite to the bundled pdf.js worker asset. Used to spawn a fresh module worker
+// per document (below). Kept as a URL — not a `workerSrc` string — on purpose (see constraint 1).
+const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
+
+/**
+ * Point pdf.js at a brand-new module worker for the NEXT `<Document>` to mount. Call this
+ * just before mounting/remounting a `<Document>` so it never shares a port with a sibling
+ * or a just-unmounted instance. No-ops (falls back to `workerSrc`) if `Worker` is missing
+ * (SSR/tests), matching pdf.js's own guard.
+ */
+export function configurePdfWorkerPort(): void {
+  if (typeof Worker === "undefined") {
+    pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
+    return;
+  }
+  pdfjs.GlobalWorkerOptions.workerPort = new Worker(pdfWorkerUrl, { type: "module" });
+}
+
+// Configure one immediately so a `<Document>` that renders before any explicit call still
+// has a worker. Viewers that remount call `configurePdfWorkerPort()` again per mount.
+configurePdfWorkerPort();

--- a/frontend/src/components/chatbot/ArtifactCard.module.css
+++ b/frontend/src/components/chatbot/ArtifactCard.module.css
@@ -1,0 +1,67 @@
+/* Copyright Thales 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin: var(--spacing-xs) 0;
+  border: 1px solid var(--outline-muted);
+  border-radius: var(--spacing-s);
+  background-color: var(--surface-container);
+  padding: var(--spacing-2xs) var(--spacing-2xs) var(--spacing-2xs) var(--spacing-s);
+  max-width: 22rem;
+}
+
+/* Clickable area that opens the artifact in its side pane. */
+.open {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: var(--spacing-xs);
+  appearance: none;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  padding: var(--spacing-2xs);
+  min-width: 0;
+  color: var(--on-surface);
+  text-align: left;
+}
+
+.icon {
+  display: flex;
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.title {
+  overflow: hidden;
+  color: var(--on-surface);
+  font: var(--font-label-large);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hint {
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}

--- a/frontend/src/components/chatbot/ArtifactCard.tsx
+++ b/frontend/src/components/chatbot/ArtifactCard.tsx
@@ -1,0 +1,64 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * ArtifactCard
+ * ------------
+ * A compact, clickable in-chat reference to a side-pane artifact: an icon, a title, a hint,
+ * and an optional trailing action (typically a download button). Clicking the main area
+ * opens/focuses the artifact in its side pane.
+ *
+ * Shared by the writable-document chip and the PPT preview card so both get the same layout,
+ * truncation, and chip styling. The *part* stays specific to each feature (rule of three) —
+ * only the card is generic.
+ *
+ * Built with the rework design system (CSS modules + shared atoms), not MUI.
+ */
+
+import Icon from "@shared/atoms/Icon/Icon.tsx";
+import type { IconType } from "@shared/utils/Type.ts";
+import styles from "./ArtifactCard.module.css";
+
+export default function ArtifactCard({
+  icon = "description",
+  title,
+  hint,
+  onOpen,
+  action,
+}: {
+  /** Leading icon (design-system outlined icon name). */
+  icon?: IconType;
+  title: string;
+  /** Sub-label under the title, e.g. "Open in editor" / "Open preview". */
+  hint: string;
+  /** Called when the user clicks the card body to open/focus the pane. */
+  onOpen?: () => void;
+  /** Optional trailing action node (e.g. a download button). */
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className={styles.chip}>
+      <button type="button" className={styles.open} onClick={() => onOpen?.()}>
+        <span className={styles.icon}>
+          <Icon category="outlined" type={icon} />
+        </span>
+        <span className={styles.text}>
+          <span className={styles.title}>{title}</span>
+          <span className={styles.hint}>{hint}</span>
+        </span>
+      </button>
+      {action}
+    </div>
+  );
+}

--- a/frontend/src/components/chatbot/ChatBot.tsx
+++ b/frontend/src/components/chatbot/ChatBot.tsx
@@ -56,6 +56,7 @@ import { useConversationOptionsController } from "./ConversationOptionsControlle
 import { toDisplayChunks } from "./messageParts.ts";
 import { UserInputContent } from "./user_input/UserInput.tsx";
 import { useWritableDocuments } from "./useWritableDocuments.ts";
+import { usePptPreview } from "./usePptPreview.ts";
 
 const HISTORY_TEXT_LIMIT = 1200;
 const LOG_GENIUS_CONTEXT_TURNS = 3;
@@ -920,6 +921,8 @@ const ChatBot = ({
 
   // Collaborative writable-documents pane state (chip clicks open/focus a document here).
   const writableDocuments = useWritableDocuments(chatSessionId, messages);
+  // Read-only PPT PDF preview pane state (fill-tool decks; card clicks open/focus a deck).
+  const pptPreview = usePptPreview(chatSessionId, messages);
 
   const [waitResponse, setWaitResponse] = useState<boolean>(false);
   const waitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1937,6 +1940,7 @@ const ChatBot = ({
         messages={messages}
         hiddenUserExchangeIds={hiddenUserExchangeIdsRef.current}
         writableDocuments={writableDocuments}
+        pptPreview={pptPreview}
         layout={layout}
         onSend={handleSend}
         onStop={stopStreaming}

--- a/frontend/src/components/chatbot/ChatBotView.tsx
+++ b/frontend/src/components/chatbot/ChatBotView.tsx
@@ -478,8 +478,8 @@ const ChatBotView = ({
                       hitlEvent={hitlEvent}
                       onHitlSubmit={onHitlSubmit}
                       onHitlCancel={onHitlCancel}
-                      onOpenWritableDocument={(documentId) => writableDocuments.openPane(documentId)}
-                      onOpenPptPreview={(previewId) => pptPreview.openPane(previewId)}
+                      onOpenWritableDocument={(documentId) => writableDocuments.togglePane(documentId)}
+                      onOpenPptPreview={(previewId) => pptPreview.togglePane(previewId)}
                     />
                     {showHistoryLoading && (
                       <Box mt={1} sx={{ display: "flex", justifyContent: "center" }}>

--- a/frontend/src/components/chatbot/ChatBotView.tsx
+++ b/frontend/src/components/chatbot/ChatBotView.tsx
@@ -48,8 +48,10 @@ import { LogConsoleTile } from "../monitoring/logs/LogConsoleTile.tsx";
 import { MessagesArea } from "./MessagesArea.tsx";
 import UserInput, { type UserInputContent } from "./user_input/UserInput.tsx";
 import type { UseWritableDocuments } from "./useWritableDocuments.ts";
+import type { UsePptPreview } from "./usePptPreview.ts";
 import WritableDocumentPane from "./WritableDocumentPane.tsx";
-import { useResizablePane } from "./useResizablePane.ts";
+import PptPreviewPane from "./PptPreviewPane.tsx";
+import { ResizablePaneShell } from "./ResizablePaneShell.tsx";
 
 type SearchRagScope = NonNullable<RuntimeContext["search_rag_scope"]>;
 
@@ -95,6 +97,7 @@ type ChatBotViewProps = {
   onHitlSubmit?: (choiceId: string, freeText?: string) => void;
   onHitlCancel?: () => void;
   writableDocuments: UseWritableDocuments;
+  pptPreview: UsePptPreview;
   layout: {
     chatWidgetRail: string;
     chatWidgetGap: string;
@@ -160,6 +163,7 @@ const ChatBotView = ({
   onHitlSubmit,
   onHitlCancel,
   writableDocuments,
+  pptPreview,
   layout,
   onSend,
   onStop,
@@ -173,49 +177,35 @@ const ChatBotView = ({
 }: ChatBotViewProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
-  const { width: paneWidth, onPointerDown: onPaneResizeStart } = useResizablePane();
+
+  // One side pane is active at a time. Opening the PDF preview swaps out the writable-doc
+  // pane and vice versa; each stays reachable from its own chat card. This keeps the
+  // single-surface layout while the shell owns the resize + open/close animation.
   const wantWritablePane = writableDocuments.isPaneOpen && writableDocuments.documents.length > 0;
+  const wantPptPreview = pptPreview.isPaneOpen && pptPreview.previews.length > 0;
 
-  // Smooth open/close: keep the pane wrapper mounted while it animates its width
-  // (0 ⇄ paneWidth). The chat is flex:1, so it grows/shrinks in lockstep — no
-  // snap. `paneRendered` keeps the element alive during the closing transition;
-  // `paneExpanded` drives the animated target width. We also suppress the width
-  // transition while the user is drag-resizing so the drag stays 1:1 with the pointer.
-  const [paneRendered, setPaneRendered] = useState(wantWritablePane);
-  const [paneExpanded, setPaneExpanded] = useState(wantWritablePane);
-  const [isPaneDragging, setIsPaneDragging] = useState(false);
+  // Enforce mutual exclusion: whichever pane opened most recently wins, and the other is
+  // asked to close. Tracking the previous "want" flags lets us detect which one just opened.
+  const prevWant = useRef({ writable: wantWritablePane, ppt: wantPptPreview });
   useEffect(() => {
-    if (wantWritablePane) {
-      // Mount at width 0, then flip to expanded. We need the width:0 frame to be
-      // painted *before* changing to the target width, otherwise the browser
-      // coalesces mount + change into one paint and skips the transition (the
-      // chat snaps). A double rAF guarantees one committed frame at width:0 first.
-      setPaneRendered(true);
-      let inner = 0;
-      const outer = requestAnimationFrame(() => {
-        inner = requestAnimationFrame(() => setPaneExpanded(true));
-      });
-      return () => {
-        cancelAnimationFrame(outer);
-        cancelAnimationFrame(inner);
-      };
+    const prev = prevWant.current;
+    if (wantPptPreview && !prev.ppt && wantWritablePane) {
+      writableDocuments.closePane();
+    } else if (wantWritablePane && !prev.writable && wantPptPreview) {
+      pptPreview.closePane();
     }
-    // Closing: collapse to width 0; unmount happens in onTransitionEnd.
-    setPaneExpanded(false);
-  }, [wantWritablePane]);
+    prevWant.current = { writable: wantWritablePane, ppt: wantPptPreview };
+  }, [wantWritablePane, wantPptPreview, writableDocuments, pptPreview]);
 
-  const onPaneResizeDown = (e: React.PointerEvent) => {
-    setIsPaneDragging(true);
-    onPaneResizeStart(e);
-  };
-  useEffect(() => {
-    if (!isPaneDragging) return;
-    const stop = () => setIsPaneDragging(false);
-    window.addEventListener("pointerup", stop);
-    return () => window.removeEventListener("pointerup", stop);
-  }, [isPaneDragging]);
+  // The active pane after applying precedence (the just-opened one wins; if both linger for
+  // a render, prefer the PPT preview — the swap effect above will close the other next tick).
+  const activePane: "writable" | "ppt" | null = wantPptPreview ? "ppt" : wantWritablePane ? "writable" : null;
 
-  const showWritablePane = paneRendered;
+  // The shell reports its animated width + drag state so the floating toolbar offsets in
+  // lockstep with the pane, exactly as before the extraction.
+  const [paneShellWidth, setPaneShellWidth] = useState(0);
+  const [isPaneDragging, setIsPaneDragging] = useState(false);
+
   const username =
     KeyCloakService.GetUserGivenName?.() ||
     KeyCloakService.GetUserFullName?.() ||
@@ -332,7 +322,7 @@ const ChatBotView = ({
         templateNameMap={templateNameMap}
         chatContextNameMap={chatContextNameMap}
         chatContextResourceMap={chatContextResourceMap}
-        rightOffsetPx={paneExpanded ? paneWidth + 6 : 0}
+        rightOffsetPx={paneShellWidth}
         rightOffsetAnimated={!isPaneDragging}
       />
       {/* ===== Conversation header status =====
@@ -489,6 +479,7 @@ const ChatBotView = ({
                       onHitlSubmit={onHitlSubmit}
                       onHitlCancel={onHitlCancel}
                       onOpenWritableDocument={(documentId) => writableDocuments.openPane(documentId)}
+                      onOpenPptPreview={(previewId) => pptPreview.openPane(previewId)}
                     />
                     {showHistoryLoading && (
                       <Box mt={1} sx={{ display: "flex", justifyContent: "center" }}>
@@ -540,63 +531,20 @@ const ChatBotView = ({
           )}
         </Box>
 
-        {/* Resizable divider + writable-document editor pane (right).
-            The wrapper animates its width 0 ⇄ (divider + paneWidth) so the chat
-            (flex:1) grows/shrinks smoothly instead of snapping. The inner row is
-            kept at its full natural width and clipped, so the pane content does
-            not reflow mid-animation — it's revealed by the expanding wrapper. */}
-        {showWritablePane && (
-          <Box
-            onTransitionEnd={(e) => {
-              // Once the collapse finishes, unmount.
-              if (e.propertyName === "width" && !paneExpanded) setPaneRendered(false);
-            }}
-            sx={{
-              flexShrink: 0,
-              minHeight: 0,
-              height: "100%",
-              overflow: "hidden",
-              // Divider net width (8 − 10 margin = -2) + pane width.
-              width: paneExpanded ? paneWidth + 6 : 0,
-              transition: isPaneDragging ? "none" : "width 0.2s ease-out",
-            }}
-          >
-            <Box sx={{ display: "flex", flexDirection: "row", height: "100%", width: paneWidth + 6 }}>
-              <Box
-                onPointerDown={onPaneResizeDown}
-                sx={{
-                  width: "8px",
-                  flexShrink: 0,
-                  cursor: "col-resize",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  // Pull the handle flush against the card's left border so it reads as the card's
-                  // edge grip, and keep it above the (transparent) pane wrapper so the grip shows.
-                  mr: "-10px",
-                  position: "relative",
-                  zIndex: 2,
-                  // The visible grip line — clearly present at idle so users discover it.
-                  "&::before": {
-                    content: '""',
-                    height: "40px",
-                    width: "4px",
-                    borderRadius: "2px",
-                    bgcolor: theme.palette.text.disabled,
-                    transition: "background-color 0.15s, height 0.15s",
-                  },
-                  "&:hover::before": {
-                    bgcolor: theme.palette.primary.main,
-                    height: "56px",
-                  },
-                }}
-              />
-              <Box sx={{ width: paneWidth, flexShrink: 0, minHeight: 0, height: "100%" }}>
-                <WritableDocumentPane sessionId={chatSessionId ?? ""} controller={writableDocuments} />
-              </Box>
-            </Box>
-          </Box>
-        )}
+        {/* One resizable side pane (right), shown for whichever surface is active.
+            The shell owns the resize divider and the open/close width animation; the chat
+            (flex:1) grows/shrinks in lockstep. Only one pane is mounted at a time. */}
+        <ResizablePaneShell
+          open={activePane !== null}
+          onWidthChange={setPaneShellWidth}
+          onDraggingChange={setIsPaneDragging}
+        >
+          {activePane === "ppt" ? (
+            <PptPreviewPane controller={pptPreview} />
+          ) : (
+            <WritableDocumentPane sessionId={chatSessionId ?? ""} controller={writableDocuments} />
+          )}
+        </ResizablePaneShell>
       </Box>
       {logsWidget?.isAdmin && (
         <>

--- a/frontend/src/components/chatbot/MessageCard.tsx
+++ b/frontend/src/components/chatbot/MessageCard.tsx
@@ -28,7 +28,13 @@ import { AgentChipMini } from "../../common/AgentChip.tsx";
 import DotsLoader from "../../common/DotsLoader.tsx";
 import { usePdfDocumentViewer } from "../../common/usePdfDocumentViewer";
 import { SimpleTooltip } from "../../shared/ui/tooltips/Tooltips.tsx";
-import type { ChartPart, GeoPart, LinkPart, WritableDocumentPart } from "../../slices/agentic/agenticOpenApi.ts";
+import type {
+  ChartPart,
+  GeoPart,
+  LinkPart,
+  PptPreviewPart,
+  WritableDocumentPart,
+} from "../../slices/agentic/agenticOpenApi.ts";
 import {
   ChatMessage,
   usePostFeedbackAgenticV1ChatbotFeedbackPostMutation,
@@ -46,6 +52,7 @@ import { tokenUsageSourceLabel } from "./tokenUsage.ts";
 import { useMessageContentPagination } from "./useMessageContentPagination.tsx";
 import { workspaceUserFileDownloader } from "./workspaceUserFileDownloader.tsx";
 import WritableDocumentChip from "./WritableDocumentChip.tsx";
+import PptPreviewCard from "./PptPreviewCard.tsx";
 
 export default function MessageCard({
   message,
@@ -61,6 +68,7 @@ export default function MessageCard({
   libraryNameById,
   chatContextNameById,
   onOpenWritableDocument,
+  onOpenPptPreview,
 }: {
   message: ChatMessage;
   agent: AnyAgent;
@@ -76,6 +84,7 @@ export default function MessageCard({
   libraryNameById?: Record<string, string>;
   chatContextNameById?: Record<string, string>;
   onOpenWritableDocument?: (documentId: string) => void;
+  onOpenPptPreview?: (previewId: string) => void;
 }) {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -137,12 +146,14 @@ export default function MessageCard({
   const isResult = isToolResult(renderMessage);
 
   // Build the message parts once (optionally filtering out text parts)
-  const { processedParts, downloadLinkPart, viewLinkPart, geoPart, writableDocumentParts, chartParts } = useMemo(() => {
+  const { processedParts, downloadLinkPart, viewLinkPart, geoPart, writableDocumentParts, pptPreviewParts, chartParts } =
+    useMemo(() => {
     const allParts = renderMessage.parts || [];
     let linkPart: LinkPart | undefined = undefined;
     let viewPart: LinkPart | undefined = undefined;
     let mapPart: GeoPart | undefined = undefined;
     const docParts: WritableDocumentPart[] = [];
+    const previewParts: PptPreviewPart[] = [];
     const diagramParts: ChartPart[] = [];
 
     const processedParts = allParts.filter((p: any) => {
@@ -176,6 +187,12 @@ export default function MessageCard({
         return false;
       }
 
+      // PPT PREVIEW part (rendered as a card; the deck lives in the preview pane)
+      if (p.type === "ppt_preview") {
+        previewParts.push(p as PptPreviewPart);
+        return false;
+      }
+
       // CHART parts — collect ALL so an agent can render several charts.
       if (p.type === "chart") {
         diagramParts.push(p as ChartPart);
@@ -192,6 +209,7 @@ export default function MessageCard({
       viewLinkPart: viewPart,
       geoPart: mapPart,
       writableDocumentParts: docParts,
+      pptPreviewParts: previewParts,
       chartParts: diagramParts,
     };
   }, [renderMessage.parts, suppressText]);
@@ -474,6 +492,11 @@ export default function MessageCard({
                       sessionId={renderMessage.session_id}
                       onOpen={onOpenWritableDocument}
                     />
+                  ))}
+
+                  {/* PPT preview cards (the filled deck is shown in the PDF preview pane) */}
+                  {pptPreviewParts.map((preview) => (
+                    <PptPreviewCard key={preview.preview_id} part={preview} onOpen={onOpenPptPreview} />
                   ))}
                 </Box>
               </Grid>

--- a/frontend/src/components/chatbot/MessagesArea.tsx
+++ b/frontend/src/components/chatbot/MessagesArea.tsx
@@ -41,6 +41,7 @@ type Props = {
   onHitlSubmit?: (choiceId?: string, freeText?: string) => void;
   onHitlCancel?: () => void;
   onOpenWritableDocument?: (documentId: string) => void;
+  onOpenPptPreview?: (previewId: string) => void;
 };
 
 function TypingIndicatorRow({ agent }: { agent: AnyAgent }) {
@@ -74,6 +75,7 @@ function Area({
   onHitlSubmit,
   onHitlCancel,
   onOpenWritableDocument,
+  onOpenPptPreview,
 }: Props) {
   // Hover highlight in Sources (syncs with [n] markers inside MessageCard)
   const [highlightUid, setHighlightUid] = React.useState<string | null>(null);
@@ -256,6 +258,7 @@ function Area({
               onCitationHover={(uid) => setHighlightUid(uid)}
               onCitationClick={(uid) => setHighlightUid(uid)}
               onOpenWritableDocument={onOpenWritableDocument}
+              onOpenPptPreview={onOpenPptPreview}
             />
           </React.Fragment>,
         );
@@ -289,6 +292,7 @@ function Area({
     onHitlSubmit,
     onHitlCancel,
     onOpenWritableDocument,
+    onOpenPptPreview,
   ]);
 
   return (

--- a/frontend/src/components/chatbot/PptPreviewCard.tsx
+++ b/frontend/src/components/chatbot/PptPreviewCard.tsx
@@ -24,10 +24,9 @@
  */
 
 import { useTranslation } from "react-i18next";
-import Icon from "@shared/atoms/Icon/Icon.tsx";
 import type { PptPreviewPart } from "../../slices/agentic/agenticOpenApi.ts";
 import ArtifactCard from "./ArtifactCard.tsx";
-import styles from "./ArtifactCard.module.css";
+import PptxDownloadButton from "./PptxDownloadButton.tsx";
 
 export default function PptPreviewCard({
   part,
@@ -39,15 +38,7 @@ export default function PptPreviewCard({
   const { t } = useTranslation();
 
   const download = part.pptx_download_url ? (
-    <a
-      className={styles.icon}
-      href={part.pptx_download_url}
-      download={part.file_name ?? undefined}
-      aria-label={t("chat.pptPreview.download", "Download .pptx")}
-      onClick={(e) => e.stopPropagation()}
-    >
-      <Icon category="outlined" type="download" />
-    </a>
+    <PptxDownloadButton href={part.pptx_download_url} fileName={part.file_name} />
   ) : undefined;
 
   return (

--- a/frontend/src/components/chatbot/PptPreviewCard.tsx
+++ b/frontend/src/components/chatbot/PptPreviewCard.tsx
@@ -1,0 +1,62 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * PptPreviewCard
+ * --------------
+ * Compact, clickable reference to a filled PowerPoint deck shown inside an assistant
+ * message. Clicking the card opens/focuses the deck's PDF preview pane; the trailing button
+ * downloads the source .pptx. The rendered deck lives in the pane, not here.
+ *
+ * A thin adapter over the shared ArtifactCard, mirroring WritableDocumentChip so both
+ * in-chat artifacts look and behave the same.
+ */
+
+import { useTranslation } from "react-i18next";
+import Icon from "@shared/atoms/Icon/Icon.tsx";
+import type { PptPreviewPart } from "../../slices/agentic/agenticOpenApi.ts";
+import ArtifactCard from "./ArtifactCard.tsx";
+import styles from "./ArtifactCard.module.css";
+
+export default function PptPreviewCard({
+  part,
+  onOpen,
+}: {
+  part: PptPreviewPart;
+  onOpen?: (previewId: string) => void;
+}) {
+  const { t } = useTranslation();
+
+  const download = part.pptx_download_url ? (
+    <a
+      className={styles.icon}
+      href={part.pptx_download_url}
+      download={part.file_name ?? undefined}
+      aria-label={t("chat.pptPreview.download", "Download .pptx")}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Icon category="outlined" type="download" />
+    </a>
+  ) : undefined;
+
+  return (
+    <ArtifactCard
+      icon="slideshow"
+      title={part.title || t("chat.pptPreview.untitled", "Presentation")}
+      hint={t("chat.pptPreview.openHint", "Open preview")}
+      onOpen={() => onOpen?.(part.preview_id)}
+      action={download}
+    />
+  );
+}

--- a/frontend/src/components/chatbot/PptPreviewPane.module.css
+++ b/frontend/src/components/chatbot/PptPreviewPane.module.css
@@ -1,0 +1,107 @@
+/* Copyright Thales 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Floating card: mirrors WritableDocumentPane so the two panes look identical. */
+.pane {
+  display: flex;
+  flex-direction: column;
+  animation: paneIn 0.3s ease-out;
+  box-sizing: border-box;
+  margin: var(--spacing-s);
+  box-shadow: var(--shadow-s);
+  border: 1px solid var(--outline-muted);
+  border-radius: var(--radius-m);
+  background-color: var(--surface-container);
+  height: calc(100% - 2 * var(--spacing-s));
+  min-height: 0;
+  overflow: hidden;
+}
+
+@keyframes paneIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pane {
+    animation: none;
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  border-bottom: 1px solid var(--outline-muted);
+  padding: var(--spacing-xs) var(--spacing-m);
+}
+
+.titleGroup {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: var(--spacing-xs);
+  min-width: 0;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--on-surface);
+  font: var(--font-title-small);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Download link styled as an icon button so it matches the header controls. */
+.download {
+  display: flex;
+  align-items: center;
+  color: var(--on-surface);
+  text-decoration: none;
+}
+
+.download:hover {
+  color: var(--primary);
+}
+
+/* Scrollable PDF body: pages stack vertically and center. */
+.body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-s);
+  padding: var(--spacing-s);
+  background-color: var(--surface-container-hight);
+}
+
+.page {
+  box-shadow: var(--shadow-s);
+}
+
+.error {
+  margin-top: var(--spacing-l);
+  color: var(--error);
+  font: var(--font-body-small);
+}

--- a/frontend/src/components/chatbot/PptPreviewPane.module.css
+++ b/frontend/src/components/chatbot/PptPreviewPane.module.css
@@ -101,6 +101,20 @@
   margin-bottom: var(--spacing-m);
 }
 
+/* Align the selectable text layer with the rendered canvas.
+ *
+ * react-pdf 10 / pdf.js 4 split a page's scale into `--scale-factor` × `--user-unit`
+ * (exposed together as `--total-scale-factor`). LibreOffice-exported PPTX→PDF decks carry a
+ * non-1 UserUnit (~0.75), so when we size a <Page> by `width`, `--scale-factor` stays 1 and
+ * the extra `--user-unit` is NOT applied to the text-layer spans — they land at full native
+ * coordinates and drift down/right of the glyphs. Scaling the whole text layer by
+ * `--total-scale-factor` puts the invisible spans back exactly over the canvas text so
+ * selection/search line up. Harmless when `--user-unit` is 1 (scale = --scale-factor). */
+.body :global(.react-pdf__Page__textContent.textLayer) {
+  transform: scale(var(--total-scale-factor));
+  transform-origin: 0 0;
+}
+
 .error {
   margin-top: var(--spacing-l);
   color: var(--error);

--- a/frontend/src/components/chatbot/PptPreviewPane.module.css
+++ b/frontend/src/components/chatbot/PptPreviewPane.module.css
@@ -70,34 +70,35 @@
   white-space: nowrap;
 }
 
-/* Download link styled as an icon button so it matches the header controls. */
-.download {
-  display: flex;
-  align-items: center;
-  color: var(--on-surface);
-  text-decoration: none;
-}
-
-.download:hover {
-  color: var(--primary);
-}
-
-/* Scrollable PDF body: pages stack vertically and center. */
+/* Scrollable PDF body: slides stack vertically, centered horizontally. `justify-content`
+ * centers a single short slide in the viewport too; once the pages overflow, the top ones
+ * stay reachable (flex-start behavior kicks in for overflow, but a lone page reads centered).
+ * Vertical gaps between pages are set on the page wrapper (`.page`) rather than `gap`, because
+ * react-pdf renders each <Page> in its own wrapper and a bare `gap` can collapse between them. */
 .body {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
   display: flex;
+  flex: 1;
   flex-direction: column;
+  justify-content: safe center;
   align-items: center;
-  gap: var(--spacing-s);
-  padding: var(--spacing-s);
   background-color: var(--surface-container-hight);
+  padding: var(--spacing-m);
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
+/* Each slide is a card with a shadow; margin (not container `gap`) guarantees the space
+ * between consecutive slides survives react-pdf's per-page wrappers. The last slide keeps
+ * its bottom margin so the deck isn't flush against the pane's bottom edge. */
 .page {
   box-shadow: var(--shadow-s);
+  border-radius: var(--radius-s);
+  overflow: hidden;
+}
+
+.page:not(:last-child) {
+  margin-bottom: var(--spacing-m);
 }
 
 .error {

--- a/frontend/src/components/chatbot/PptPreviewPane.tsx
+++ b/frontend/src/components/chatbot/PptPreviewPane.tsx
@@ -20,33 +20,30 @@
  * an editor. The PDF is fetched directly from a presigned, Range-capable URL, so the
  * backend never proxies the bytes.
  *
- * Freshness: the deck's `version` is appended to the URL (`?v=…`) AND used as the react-pdf
- * remount key. A re-fill carries a new version → a new URL → a fresh fetch and a remount, so
- * the open pane updates to the latest deck instead of showing a browser-cached stale one.
+ * Freshness: each fill mints a NEW presigned URL (fresh signature + different object) and a
+ * new `version`, which is the react-pdf remount key. A re-fill therefore fetches the latest
+ * deck instead of showing a browser-cached stale one. (The version is NOT appended to the
+ * URL — a presigned signature covers the whole query string, so an extra `?v=` would 403.)
  *
  * Built with the rework design system for the header (CSS modules + shared atoms); the PDF
  * body uses react-pdf like the existing viewer.
  */
 
 import { CircularProgress } from "@mui/material";
-import { useEffect, useRef, useState } from "react";
-import { Document, Page, pdfjs } from "react-pdf";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Document, Page } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import type { UsePptPreview } from "./usePptPreview.ts";
+import PptxDownloadButton from "./PptxDownloadButton.tsx";
+// Shared pdf.js worker plumbing: hands each <Document> a FRESH module worker so remounting
+// (opening a second preview / re-filling the open deck) never races a worker teardown and
+// throws "the worker is being destroyed" — see pdfWorker.ts for the full rationale.
+import { configurePdfWorkerPort } from "../../common/pdfWorker.ts";
 import styles from "./PptPreviewPane.module.css";
-
-// React-PDF requires workerSrc to be configured in the same module that renders
-// <Document>/<Page>; otherwise its default bare specifier can win at runtime.
-const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
-if (typeof Worker !== "undefined") {
-  pdfjs.GlobalWorkerOptions.workerPort = new Worker(pdfWorkerUrl, { type: "module" });
-} else {
-  pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
-}
 
 const PDF_SCALE = 0.95;
 
@@ -79,6 +76,12 @@ export default function PptPreviewPane({ controller }: { controller: UsePptPrevi
   const fileUrl = selected ? selected.pdf_url : null;
   const remountKey = selected ? `${selected.preview_id}:${selected.version}` : "none";
 
+  // Give this <Document> mount its own pdf.js worker. Running in useMemo (during render,
+  // before the child <Document> mounts) means the worker is in place when react-pdf reads
+  // GlobalWorkerOptions, and a new remountKey (switch deck / re-fill) provisions a fresh
+  // worker so the previous Document's teardown can't race this one's start.
+  useMemo(() => configurePdfWorkerPort(), [remountKey]);
+
   useEffect(() => {
     setNumPages(null);
     setLoadError(null);
@@ -97,13 +100,7 @@ export default function PptPreviewPane({ controller }: { controller: UsePptPrevi
           <span className={styles.title}>{selected.title || untitled}</span>
         </div>
         {selected.pptx_download_url && (
-          <a
-            className={styles.download}
-            href={selected.pptx_download_url}
-            download={selected.file_name ?? undefined}
-          >
-            <Icon category="outlined" type="download" />
-          </a>
+          <PptxDownloadButton href={selected.pptx_download_url} fileName={selected.file_name} />
         )}
         <IconButton
           color="on-surface"
@@ -122,7 +119,9 @@ export default function PptPreviewPane({ controller }: { controller: UsePptPrevi
             key={remountKey}
             file={fileUrl}
             onLoadSuccess={({ numPages }) => setNumPages(numPages)}
-            onLoadError={(err) => setLoadError(err?.message || t("chat.pptPreview.loadError", "Failed to load preview."))}
+            onLoadError={(err) =>
+              setLoadError(err?.message || t("chat.pptPreview.loadError", "Failed to load preview."))
+            }
             loading={<CircularProgress size={22} />}
             error={<div className={styles.error}>{t("chat.pptPreview.loadError", "Failed to load preview.")}</div>}
           >

--- a/frontend/src/components/chatbot/PptPreviewPane.tsx
+++ b/frontend/src/components/chatbot/PptPreviewPane.tsx
@@ -1,0 +1,144 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * PptPreviewPane
+ * --------------
+ * The read-only right-hand pane that renders a filled deck as a PDF, mirroring the
+ * writable-document pane's shell (header + scrollable body) but with react-pdf instead of
+ * an editor. The PDF is fetched directly from a presigned, Range-capable URL, so the
+ * backend never proxies the bytes.
+ *
+ * Freshness: the deck's `version` is appended to the URL (`?v=…`) AND used as the react-pdf
+ * remount key. A re-fill carries a new version → a new URL → a fresh fetch and a remount, so
+ * the open pane updates to the latest deck instead of showing a browser-cached stale one.
+ *
+ * Built with the rework design system for the header (CSS modules + shared atoms); the PDF
+ * body uses react-pdf like the existing viewer.
+ */
+
+import { CircularProgress } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import { Document, Page, pdfjs } from "react-pdf";
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+import { useTranslation } from "react-i18next";
+import Icon from "@shared/atoms/Icon/Icon.tsx";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import type { UsePptPreview } from "./usePptPreview.ts";
+import styles from "./PptPreviewPane.module.css";
+
+// React-PDF requires workerSrc to be configured in the same module that renders
+// <Document>/<Page>; otherwise its default bare specifier can win at runtime.
+const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
+if (typeof Worker !== "undefined") {
+  pdfjs.GlobalWorkerOptions.workerPort = new Worker(pdfWorkerUrl, { type: "module" });
+} else {
+  pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
+}
+
+const PDF_SCALE = 0.95;
+
+export default function PptPreviewPane({ controller }: { controller: UsePptPreview }) {
+  const { t } = useTranslation();
+  const { selected, closePane } = controller;
+
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [pageWidth, setPageWidth] = useState<number>(600);
+  useEffect(() => {
+    if (!contentRef.current) return;
+    const el = contentRef.current;
+    const measure = () => {
+      const base = Math.max(280, Math.floor(el.clientWidth - 24));
+      setPageWidth(Math.floor(base * PDF_SCALE));
+    };
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    measure();
+    return () => ro.disconnect();
+  }, []);
+
+  // Freshness comes from the presigned URL itself: each fill mints a NEW presigned URL
+  // (fresh signature/date + different object), and `version` is the react-pdf remount key
+  // so a re-fill forces a fresh <Document> fetch. We must NOT append our own query param —
+  // the presigned signature covers the whole query string, so an extra `?v=` → 403.
+  const fileUrl = selected ? selected.pdf_url : null;
+  const remountKey = selected ? `${selected.preview_id}:${selected.version}` : "none";
+
+  useEffect(() => {
+    setNumPages(null);
+    setLoadError(null);
+  }, [remountKey]);
+
+  if (!selected) return null;
+
+  const untitled = t("chat.pptPreview.untitled", "Presentation");
+  const closeLabel = t("chat.pptPreview.close", "Close preview");
+
+  return (
+    <div className={styles.pane}>
+      <div className={styles.header}>
+        <div className={styles.titleGroup}>
+          <Icon category="outlined" type="slideshow" />
+          <span className={styles.title}>{selected.title || untitled}</span>
+        </div>
+        {selected.pptx_download_url && (
+          <a
+            className={styles.download}
+            href={selected.pptx_download_url}
+            download={selected.file_name ?? undefined}
+          >
+            <Icon category="outlined" type="download" />
+          </a>
+        )}
+        <IconButton
+          color="on-surface"
+          variant="icon"
+          size="small"
+          icon={{ category: "outlined", type: "close" }}
+          onClick={closePane}
+          aria-label={closeLabel}
+        />
+      </div>
+
+      <div className={styles.body} ref={contentRef}>
+        {loadError && <div className={styles.error}>{loadError}</div>}
+        {fileUrl && !loadError && (
+          <Document
+            key={remountKey}
+            file={fileUrl}
+            onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+            onLoadError={(err) => setLoadError(err?.message || t("chat.pptPreview.loadError", "Failed to load preview."))}
+            loading={<CircularProgress size={22} />}
+            error={<div className={styles.error}>{t("chat.pptPreview.loadError", "Failed to load preview.")}</div>}
+          >
+            {Array.from({ length: numPages ?? 0 }, (_, i) => (
+              <Page
+                key={`page_${i + 1}`}
+                pageNumber={i + 1}
+                width={pageWidth}
+                renderAnnotationLayer
+                renderTextLayer={false}
+                className={styles.page}
+              />
+            ))}
+          </Document>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chatbot/PptPreviewPane.tsx
+++ b/frontend/src/components/chatbot/PptPreviewPane.tsx
@@ -166,7 +166,9 @@ export default function PptPreviewPane({ controller }: { controller: UsePptPrevi
                 pageNumber={i + 1}
                 width={pageWidth}
                 renderAnnotationLayer
-                renderTextLayer={false}
+                // Text layer on: overlays invisible positioned spans on the canvas so slide
+                // text can be selected/copied (and browser-searched). CSS is imported above.
+                renderTextLayer
                 className={styles.page}
               />
             ))}

--- a/frontend/src/components/chatbot/PptPreviewPane.tsx
+++ b/frontend/src/components/chatbot/PptPreviewPane.tsx
@@ -20,10 +20,17 @@
  * an editor. The PDF is fetched directly from a presigned, Range-capable URL, so the
  * backend never proxies the bytes.
  *
- * Freshness: each fill mints a NEW presigned URL (fresh signature + different object) and a
- * new `version`, which is the react-pdf remount key. A re-fill therefore fetches the latest
- * deck instead of showing a browser-cached stale one. (The version is NOT appended to the
- * URL — a presigned signature covers the whole query string, so an extra `?v=` would 403.)
+ * Durability (why we presign LAZILY): a presigned URL expires (~1h), but the `ppt_preview`
+ * part is persisted in the conversation. Baking a presigned URL into it means reopening the
+ * chat later hands react-pdf an expired signature → 403 ("Unexpected server response (403)
+ * while retrieving PDF"). Instead the part carries a durable KF href (`pdf_presign_url`);
+ * this pane calls it (with the bearer) each time it opens/remounts to mint a FRESH presigned
+ * URL, then points react-pdf at that. Mirrors how the `.pptx` download stays durable.
+ *
+ * Freshness: `version` is the react-pdf remount key. A re-fill (or reopen) changes the
+ * remount key → we re-presign and refetch instead of showing a browser-cached stale deck.
+ * (The version is NOT appended to the presigned URL — a presigned signature covers the whole
+ * query string, so an extra `?v=` would 403.)
  *
  * Built with the rework design system for the header (CSS modules + shared atoms); the PDF
  * body uses react-pdf like the existing viewer.
@@ -39,6 +46,7 @@ import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import type { UsePptPreview } from "./usePptPreview.ts";
 import PptxDownloadButton from "./PptxDownloadButton.tsx";
+import { useLazyPresignedHrefQuery } from "../../slices/knowledgeFlow/knowledgeFlowApi.blob.ts";
 // Shared pdf.js worker plumbing: hands each <Document> a FRESH module worker so remounting
 // (opening a second preview / re-filling the open deck) never races a worker teardown and
 // throws "the worker is being destroyed" — see pdfWorker.ts for the full rationale.
@@ -69,12 +77,39 @@ export default function PptPreviewPane({ controller }: { controller: UsePptPrevi
     return () => ro.disconnect();
   }, []);
 
-  // Freshness comes from the presigned URL itself: each fill mints a NEW presigned URL
-  // (fresh signature/date + different object), and `version` is the react-pdf remount key
-  // so a re-fill forces a fresh <Document> fetch. We must NOT append our own query param —
-  // the presigned signature covers the whole query string, so an extra `?v=` → 403.
-  const fileUrl = selected ? selected.pdf_url : null;
+  // `version` is the react-pdf remount key so a re-fill (or switching decks) forces a fresh
+  // <Document>. The URL is minted LAZILY below — the part carries a durable presign href, not
+  // a frozen presigned URL, so reopening an old chat re-presigns instead of 403-ing on an
+  // expired signature. We must NOT append our own query param to the minted URL — the
+  // presigned signature covers the whole query string, so an extra `?v=` → 403.
   const remountKey = selected ? `${selected.preview_id}:${selected.version}` : "none";
+
+  // Mint a fresh presigned PDF URL from the durable KF href each time the shown deck changes
+  // (remount key) — the persisted href never expires; the URL it returns is short-lived, so
+  // we fetch it at render time rather than trusting a stored one.
+  const [mintPresign] = useLazyPresignedHrefQuery();
+  const [fileUrl, setFileUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!selected?.pdf_presign_url) {
+      setFileUrl(null);
+      return;
+    }
+    let cancelled = false;
+    setFileUrl(null);
+    mintPresign({ href: selected.pdf_presign_url })
+      .unwrap()
+      .then((res) => {
+        if (!cancelled) setFileUrl(res.url);
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setLoadError(err?.message || t("chat.pptPreview.loadError", "Failed to load preview."));
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [remountKey]);
 
   // Give this <Document> mount its own pdf.js worker. Running in useMemo (during render,
   // before the child <Document> mounts) means the worker is in place when react-pdf reads

--- a/frontend/src/components/chatbot/PptxDownloadButton.tsx
+++ b/frontend/src/components/chatbot/PptxDownloadButton.tsx
@@ -1,0 +1,78 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * PptxDownloadButton
+ * ------------------
+ * Download icon button for a filled deck's source `.pptx`. Used by BOTH the in-chat
+ * preview card and the preview pane header so the two stay DRY and identical.
+ *
+ * Why not a plain `<a href download>`: the deck lives behind the bearer-protected
+ * Knowledge Flow `/storage/user/{key}` endpoint. A bare anchor sends no Authorization
+ * header, so the browser navigation gets a 401 and "the file wasn't available". We
+ * instead fetch the bytes WITH the bearer (RTK `downloadHrefBlob`, same path the
+ * writable-document export uses) and trigger a client-side blob download — which also
+ * guarantees the correct file name regardless of storage headers.
+ *
+ * Built with the rework design system (shared IconButton + Tooltip), not MUI.
+ */
+
+import { useTranslation } from "react-i18next";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
+import { useLazyDownloadHrefBlobQuery } from "../../slices/knowledgeFlow/knowledgeFlowApi.blob.ts";
+import { downloadFile } from "../../utils/downloadUtils.tsx";
+import { useToast } from "../ToastProvider.tsx";
+
+export default function PptxDownloadButton({
+  href,
+  fileName,
+}: {
+  /** Bearer-protected KF href for the `.pptx` (the part's `pptx_download_url`). */
+  href: string;
+  /** Suggested download file name (the part's `file_name`). */
+  fileName?: string | null;
+}) {
+  const { t } = useTranslation();
+  const { showError } = useToast();
+  const [downloadHref, { isFetching }] = useLazyDownloadHrefBlobQuery();
+
+  const label = t("chat.pptPreview.download", "Download .pptx");
+
+  const handleDownload = async () => {
+    try {
+      const blob = await downloadHref({ href }).unwrap();
+      downloadFile(blob, fileName || "presentation.pptx");
+    } catch (err: any) {
+      showError({
+        summary: t("chat.pptPreview.downloadError", "Download failed"),
+        detail: err?.message || String(err),
+      });
+    }
+  };
+
+  return (
+    <Tooltip text={label}>
+      <IconButton
+        color="on-surface"
+        variant="icon"
+        size="small"
+        icon={{ category: "outlined", type: "download" }}
+        onClick={handleDownload}
+        disabled={isFetching}
+        aria-label={label}
+      />
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/chatbot/ResizablePaneShell.tsx
+++ b/frontend/src/components/chatbot/ResizablePaneShell.tsx
@@ -1,0 +1,154 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * ResizablePaneShell
+ * ------------------
+ * The shared right-hand pane shell: a divider the user can drag to resize, plus the
+ * smooth open/close width animation (0 ⇄ paneWidth) that lets the chat (flex:1) grow and
+ * shrink in lockstep instead of snapping. It owns nothing about the pane's *content* —
+ * callers pass whatever surface they want (the writable-document editor, the PPT preview).
+ *
+ * Extracted from ChatBotView so the writable-document pane and the PPT preview pane share
+ * one implementation of resize + animation rather than each re-deriving it.
+ *
+ * Exactly one pane is shown at a time (the parent decides which `children` to pass); this
+ * shell only renders when `open` is true (kept mounted through the closing transition).
+ */
+
+import { Box, useTheme } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useResizablePane } from "./useResizablePane.ts";
+
+export function ResizablePaneShell({
+  open,
+  children,
+  onWidthChange,
+  onDraggingChange,
+}: {
+  /** Whether the pane should be visible. Toggling drives the width animation. */
+  open: boolean;
+  /** The pane surface to render (only mounted while the shell is rendered). */
+  children: React.ReactNode;
+  /**
+   * Reports the wrapper's animated target width (divider + pane, or 0 when collapsed) so
+   * the parent can offset sibling overlays (e.g. a floating toolbar) in lockstep.
+   */
+  onWidthChange?: (width: number) => void;
+  /** Reports drag start/stop so the parent can suppress its own transitions during a drag. */
+  onDraggingChange?: (dragging: boolean) => void;
+}) {
+  const theme = useTheme();
+  const { width: paneWidth, onPointerDown: onPaneResizeStart } = useResizablePane();
+
+  // Smooth open/close: keep the wrapper mounted while it animates its width (0 ⇄ paneWidth).
+  // `rendered` keeps the element alive during the closing transition; `expanded` drives the
+  // animated target width. The width transition is suppressed while dragging so the drag
+  // stays 1:1 with the pointer. (Mirrors the original ChatBotView pane machinery.)
+  const [rendered, setRendered] = useState(open);
+  const [expanded, setExpanded] = useState(open);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      // Mount at width 0, then flip to expanded. The width:0 frame must be painted before
+      // changing to the target width, otherwise the browser coalesces mount + change into
+      // one paint and skips the transition. A double rAF guarantees one committed frame first.
+      setRendered(true);
+      let inner = 0;
+      const outer = requestAnimationFrame(() => {
+        inner = requestAnimationFrame(() => setExpanded(true));
+      });
+      return () => {
+        cancelAnimationFrame(outer);
+        cancelAnimationFrame(inner);
+      };
+    }
+    setExpanded(false);
+  }, [open]);
+
+  useEffect(() => {
+    // Divider net width (8 − 10 margin = -2) + pane width; 0 when collapsed.
+    onWidthChange?.(expanded ? paneWidth + 6 : 0);
+  }, [expanded, paneWidth, onWidthChange]);
+
+  useEffect(() => {
+    onDraggingChange?.(dragging);
+  }, [dragging, onDraggingChange]);
+
+  useEffect(() => {
+    if (!dragging) return;
+    const stop = () => setDragging(false);
+    window.addEventListener("pointerup", stop);
+    return () => window.removeEventListener("pointerup", stop);
+  }, [dragging]);
+
+  const onPaneResizeDown = (e: React.PointerEvent) => {
+    setDragging(true);
+    onPaneResizeStart(e);
+  };
+
+  if (!rendered) return null;
+
+  return (
+    <Box
+      onTransitionEnd={(e) => {
+        // Once the collapse finishes, unmount.
+        if (e.propertyName === "width" && !expanded) setRendered(false);
+      }}
+      sx={{
+        flexShrink: 0,
+        minHeight: 0,
+        height: "100%",
+        overflow: "hidden",
+        width: expanded ? paneWidth + 6 : 0,
+        transition: dragging ? "none" : "width 0.2s ease-out",
+      }}
+    >
+      <Box sx={{ display: "flex", flexDirection: "row", height: "100%", width: paneWidth + 6 }}>
+        <Box
+          onPointerDown={onPaneResizeDown}
+          sx={{
+            width: "8px",
+            flexShrink: 0,
+            cursor: "col-resize",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            // Pull the handle flush against the card's left border so it reads as the card's
+            // edge grip, and keep it above the (transparent) pane wrapper so the grip shows.
+            mr: "-10px",
+            position: "relative",
+            zIndex: 2,
+            "&::before": {
+              content: '""',
+              height: "40px",
+              width: "4px",
+              borderRadius: "2px",
+              bgcolor: theme.palette.text.disabled,
+              transition: "background-color 0.15s, height 0.15s",
+            },
+            "&:hover::before": {
+              bgcolor: theme.palette.primary.main,
+              height: "56px",
+            },
+          }}
+        />
+        <Box sx={{ width: paneWidth, flexShrink: 0, minHeight: 0, height: "100%" }}>{children}</Box>
+      </Box>
+    </Box>
+  );
+}
+
+export default ResizablePaneShell;

--- a/frontend/src/components/chatbot/WritableDocumentChip.tsx
+++ b/frontend/src/components/chatbot/WritableDocumentChip.tsx
@@ -19,14 +19,13 @@
  * message. Clicking the chip opens/focuses the document in the editor pane; the Word
  * button exports it as .docx. The full document content lives in the pane, not here.
  *
- * Built with the rework design system (CSS modules + shared atoms), not MUI.
+ * A thin adapter over the shared ArtifactCard (icon + title + click-to-open + action).
  */
 
 import { useTranslation } from "react-i18next";
-import Icon from "@shared/atoms/Icon/Icon.tsx";
 import type { WritableDocumentPart } from "../../slices/agentic/agenticOpenApi.ts";
+import ArtifactCard from "./ArtifactCard.tsx";
 import DocumentDownloadButton from "./DocumentDownloadButton.tsx";
-import styles from "./WritableDocumentChip.module.css";
 
 export default function WritableDocumentChip({
   part,
@@ -40,17 +39,12 @@ export default function WritableDocumentChip({
   const { t } = useTranslation();
 
   return (
-    <div className={styles.chip}>
-      <button type="button" className={styles.open} onClick={() => onOpen?.(part.document_id)}>
-        <span className={styles.icon}>
-          <Icon category="outlined" type="description" />
-        </span>
-        <span className={styles.text}>
-          <span className={styles.title}>{part.title || t("chat.writableDocument.untitled", "Document")}</span>
-          <span className={styles.hint}>{t("chat.writableDocument.openHint", "Open in editor")}</span>
-        </span>
-      </button>
-      <DocumentDownloadButton sessionId={sessionId} documentId={part.document_id} title={part.title} />
-    </div>
+    <ArtifactCard
+      icon="description"
+      title={part.title || t("chat.writableDocument.untitled", "Document")}
+      hint={t("chat.writableDocument.openHint", "Open in editor")}
+      onOpen={() => onOpen?.(part.document_id)}
+      action={<DocumentDownloadButton sessionId={sessionId} documentId={part.document_id} title={part.title} />}
+    />
   );
 }

--- a/frontend/src/components/chatbot/usePptPreview.ts
+++ b/frontend/src/components/chatbot/usePptPreview.ts
@@ -31,7 +31,8 @@ import { ChatMessage, PptPreviewPart } from "../../slices/agentic/agenticOpenApi
 export type PptPreview = {
   preview_id: string;
   title: string;
-  pdf_url: string;
+  /** Durable KF href; the pane calls it at open time to mint a fresh presigned PDF URL. */
+  pdf_presign_url: string;
   version: string;
   pptx_download_url?: string | null;
   file_name?: string | null;
@@ -66,7 +67,7 @@ function previewsFromMessages(messages: ChatMessage[]): PptPreview[] {
       byId.set(p.preview_id, {
         preview_id: p.preview_id,
         title: p.title,
-        pdf_url: p.pdf_url,
+        pdf_presign_url: p.pdf_presign_url,
         version: p.version,
         pptx_download_url: p.pptx_download_url,
         file_name: p.file_name,

--- a/frontend/src/components/chatbot/usePptPreview.ts
+++ b/frontend/src/components/chatbot/usePptPreview.ts
@@ -45,6 +45,12 @@ export type UsePptPreview = {
   isPaneOpen: boolean;
   openPane: (previewId?: string) => void;
   closePane: () => void;
+  /**
+   * Card click: close the pane if it's already open on THIS preview, otherwise open it
+   * (switching the selection to this preview). Lets a chat card act as an on/off toggle
+   * for its own deck while still switching between decks.
+   */
+  togglePane: (previewId: string) => void;
 };
 
 /** Extract PptPreviewParts from the chat stream, keeping the latest per preview_id. */
@@ -85,6 +91,20 @@ export function usePptPreview(sessionId: string | undefined, messages: ChatMessa
 
   const closePane = useCallback(() => setIsPaneOpen(false), []);
 
+  const togglePane = useCallback(
+    (previewId: string) => {
+      // Already open on this exact preview → treat the click as "close". Otherwise open the
+      // pane on the clicked preview (which also covers switching from another deck).
+      if (isPaneOpen && selectedId === previewId) {
+        setIsPaneOpen(false);
+        return;
+      }
+      setSelectedId(previewId);
+      setIsPaneOpen(true);
+    },
+    [isPaneOpen, selectedId],
+  );
+
   // Auto-open the pane (and select the latest deck) the first time a preview appears for
   // this session, so the user sees the filled deck immediately without any click.
   const autoOpenedRef = useRef(false);
@@ -117,5 +137,5 @@ export function usePptPreview(sessionId: string | undefined, messages: ChatMessa
     [previews, selectedId],
   );
 
-  return { previews, selectedId, selected, selectPreview, isPaneOpen, openPane, closePane };
+  return { previews, selectedId, selected, selectPreview, isPaneOpen, openPane, closePane, togglePane };
 }

--- a/frontend/src/components/chatbot/usePptPreview.ts
+++ b/frontend/src/components/chatbot/usePptPreview.ts
@@ -1,0 +1,121 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * usePptPreview
+ * -------------
+ * Owns the state for the read-only PPT PDF preview pane:
+ * - the set of preview decks that arrived live in the chat stream (latest per preview_id);
+ * - the currently selected deck and whether the pane is open.
+ *
+ * Mirrors `useWritableDocuments` but is read-only: there is no list API, no autosave, and
+ * no local optimistic content. The source of truth is the `ppt_preview` message part the
+ * fill tool emits. A re-fill carries a new `version`, which downstream drives a fresh PDF
+ * fetch + react-pdf remount so the open pane updates live (the edit→preview loop).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChatMessage, PptPreviewPart } from "../../slices/agentic/agenticOpenApi";
+
+export type PptPreview = {
+  preview_id: string;
+  title: string;
+  pdf_url: string;
+  version: string;
+  pptx_download_url?: string | null;
+  file_name?: string | null;
+};
+
+export type UsePptPreview = {
+  previews: PptPreview[];
+  selectedId: string | null;
+  selected: PptPreview | null;
+  selectPreview: (previewId: string) => void;
+  isPaneOpen: boolean;
+  openPane: (previewId?: string) => void;
+  closePane: () => void;
+};
+
+/** Extract PptPreviewParts from the chat stream, keeping the latest per preview_id. */
+function previewsFromMessages(messages: ChatMessage[]): PptPreview[] {
+  const ordered = [...messages].sort((a, b) => a.rank - b.rank);
+  const byId = new Map<string, PptPreview>();
+  for (const msg of ordered) {
+    for (const part of msg.parts ?? []) {
+      if ((part as { type?: string }).type !== "ppt_preview") continue;
+      const p = part as PptPreviewPart;
+      // Later messages win (ordered by rank), so a re-fill's newer part with a fresh
+      // `version` replaces the earlier one under the same preview_id.
+      byId.set(p.preview_id, {
+        preview_id: p.preview_id,
+        title: p.title,
+        pdf_url: p.pdf_url,
+        version: p.version,
+        pptx_download_url: p.pptx_download_url,
+        file_name: p.file_name,
+      });
+    }
+  }
+  return [...byId.values()];
+}
+
+export function usePptPreview(sessionId: string | undefined, messages: ChatMessage[]): UsePptPreview {
+  const previews = useMemo(() => previewsFromMessages(messages), [messages]);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [isPaneOpen, setIsPaneOpen] = useState(false);
+
+  const selectPreview = useCallback((previewId: string) => setSelectedId(previewId), []);
+
+  const openPane = useCallback((previewId?: string) => {
+    setIsPaneOpen(true);
+    if (previewId) setSelectedId(previewId);
+  }, []);
+
+  const closePane = useCallback(() => setIsPaneOpen(false), []);
+
+  // Auto-open the pane (and select the latest deck) the first time a preview appears for
+  // this session, so the user sees the filled deck immediately without any click.
+  const autoOpenedRef = useRef(false);
+  useEffect(() => {
+    if (!autoOpenedRef.current && previews.length > 0) {
+      autoOpenedRef.current = true;
+      setIsPaneOpen(true);
+      setSelectedId((prev) => prev ?? previews[previews.length - 1].preview_id);
+    }
+  }, [previews]);
+
+  // Keep a valid selection when the preview set changes.
+  useEffect(() => {
+    if (previews.length === 0) {
+      setSelectedId(null);
+      return;
+    }
+    setSelectedId((prev) => (prev && previews.some((p) => p.preview_id === prev) ? prev : previews[0].preview_id));
+  }, [previews]);
+
+  // Reset when switching sessions.
+  useEffect(() => {
+    setSelectedId(null);
+    setIsPaneOpen(false);
+    autoOpenedRef.current = false;
+  }, [sessionId]);
+
+  const selected = useMemo(
+    () => previews.find((p) => p.preview_id === selectedId) ?? previews[0] ?? null,
+    [previews, selectedId],
+  );
+
+  return { previews, selectedId, selected, selectPreview, isPaneOpen, openPane, closePane };
+}

--- a/frontend/src/components/chatbot/useWritableDocuments.ts
+++ b/frontend/src/components/chatbot/useWritableDocuments.ts
@@ -49,6 +49,12 @@ export type UseWritableDocuments = {
   isPaneOpen: boolean;
   openPane: (documentId?: string) => void;
   closePane: () => void;
+  /**
+   * Chip click: close the pane if it's already open on THIS document, otherwise open it
+   * (switching the selected tab to this document). Lets a chat chip act as an on/off
+   * toggle for its own document while still switching between documents.
+   */
+  togglePane: (documentId: string) => void;
   /** Called by the editor on change; debounced PUT persists the user edit. */
   onEditDocument: (documentId: string, contentMd: string) => void;
   isSaving: boolean;
@@ -177,6 +183,20 @@ export function useWritableDocuments(sessionId: string | undefined, messages: Ch
 
   const closePane = useCallback(() => setIsPaneOpen(false), []);
 
+  const togglePane = useCallback(
+    (documentId: string) => {
+      // Already open on this exact document → treat the click as "close". Otherwise open the
+      // pane on the clicked document (which also covers switching from another document).
+      if (isPaneOpen && selectedId === documentId) {
+        setIsPaneOpen(false);
+        return;
+      }
+      setSelectedId(documentId);
+      setIsPaneOpen(true);
+    },
+    [isPaneOpen, selectedId],
+  );
+
   // Auto-open the pane (and select) the first time a document appears for this session.
   const autoOpenedRef = useRef(false);
   useEffect(() => {
@@ -241,6 +261,7 @@ export function useWritableDocuments(sessionId: string | undefined, messages: Ch
     isPaneOpen,
     openPane,
     closePane,
+    togglePane,
     onEditDocument,
     isSaving,
   };

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -283,6 +283,7 @@
       "untitled": "Presentation",
       "openHint": "Open preview",
       "download": "Download .pptx",
+      "downloadError": "Download failed",
       "close": "Close preview",
       "loadError": "Failed to load preview."
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -279,6 +279,13 @@
       "saving": "Saving…",
       "close": "Close panel"
     },
+    "pptPreview": {
+      "untitled": "Presentation",
+      "openHint": "Open preview",
+      "download": "Download .pptx",
+      "close": "Close preview",
+      "loadError": "Failed to load preview."
+    },
     "chart": {
       "title": "Chart",
       "type": "Chart type",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -280,6 +280,13 @@
       "saving": "Enregistrement…",
       "close": "Fermer le panneau"
     },
+    "pptPreview": {
+      "untitled": "Présentation",
+      "openHint": "Ouvrir l'aperçu",
+      "download": "Télécharger le .pptx",
+      "close": "Fermer l'aperçu",
+      "loadError": "Échec du chargement de l'aperçu."
+    },
     "chart": {
       "title": "Diagramme",
       "type": "Type de diagramme",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -284,6 +284,7 @@
       "untitled": "Présentation",
       "openHint": "Ouvrir l'aperçu",
       "download": "Télécharger le .pptx",
+      "downloadError": "Échec du téléchargement",
       "close": "Fermer l'aperçu",
       "loadError": "Échec du chargement de l'aperçu."
     },

--- a/frontend/src/rework/components/shared/utils/Type.ts
+++ b/frontend/src/rework/components/shared/utils/Type.ts
@@ -50,7 +50,8 @@ export type MaterialIconType =
   | "mail"
   | "close"
   | "download"
-  | "description";
+  | "description"
+  | "slideshow";
 
 export type CustomIconType = (typeof customIcons)[number];
 export type IconType = MaterialIconType | CustomIconType;

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -1017,7 +1017,7 @@ export type PptPreviewPart = {
   type?: "ppt_preview";
   preview_id: string;
   title: string;
-  pdf_url: string;
+  pdf_presign_url: string;
   version: string;
   pptx_download_url?: string | null;
   file_name?: string | null;

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -1013,6 +1013,15 @@ export type LinkPart = {
   document_uid?: string | null;
   file_name?: string | null;
 };
+export type PptPreviewPart = {
+  type?: "ppt_preview";
+  preview_id: string;
+  title: string;
+  pdf_url: string;
+  version: string;
+  pptx_download_url?: string | null;
+  file_name?: string | null;
+};
 export type TextPart = {
   type?: "text";
   text: string;
@@ -1142,6 +1151,9 @@ export type ChatMessage = {
     | ({
         type: "link";
       } & LinkPart)
+    | ({
+        type: "ppt_preview";
+      } & PptPreviewPart)
     | ({
         type: "text";
       } & TextPart)
@@ -1309,6 +1321,9 @@ export type EchoEnvelope = {
             type: "link";
           } & LinkPart)
         | ({
+            type: "ppt_preview";
+          } & PptPreviewPart)
+        | ({
             type: "text";
           } & TextPart)
         | ({
@@ -1448,6 +1463,9 @@ export type ChatMessage2 = {
     | ({
         type: "link";
       } & LinkPart)
+    | ({
+        type: "ppt_preview";
+      } & PptPreviewPart)
     | ({
         type: "text";
       } & TextPart)

--- a/frontend/src/slices/knowledgeFlow/knowledgeFlowApi.blob.ts
+++ b/frontend/src/slices/knowledgeFlow/knowledgeFlowApi.blob.ts
@@ -51,6 +51,15 @@ export const blobApi = api.injectEndpoints({
         responseHandler: (response) => response.blob(),
       }),
     }),
+
+    // Mint a FRESH presigned GET URL from a durable KF presign endpoint
+    // (`…/storage/user/presigned/{key}`). Used by the PPT preview: the persisted part stores
+    // the durable href (not a presigned URL, which would expire ~1h after the fill and 403 on
+    // reopen), and the pane calls this at open time to get a currently-valid, Range-capable
+    // URL to hand react-pdf. Bearer is attached by the shared baseQuery, same as downloads.
+    presignedHref: build.query<{ url: string }, { href: string }>({
+      query: ({ href }) => ({ url: href }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -64,4 +73,6 @@ export const {
   useDownloadUserAssetBlobQuery,
   useLazyDownloadHrefBlobQuery,
   useDownloadHrefBlobQuery,
+  useLazyPresignedHrefQuery,
+  usePresignedHrefQuery,
 } = blobApi;

--- a/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -299,6 +299,12 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
     }),
+    presignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGet: build.query<
+      PresignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGetApiResponse,
+      PresignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGetApiArg
+    >({
+      query: (queryArg) => ({ url: `/knowledge-flow/v1/storage/user/presigned/${queryArg.key}` }),
+    }),
     downloadUserFileKnowledgeFlowV1StorageUserKeyGet: build.query<
       DownloadUserFileKnowledgeFlowV1StorageUserKeyGetApiResponse,
       DownloadUserFileKnowledgeFlowV1StorageUserKeyGetApiArg
@@ -1392,6 +1398,11 @@ export type ListUserFilesKnowledgeFlowV1StorageUserGetApiResponse = /** status 2
 export type ListUserFilesKnowledgeFlowV1StorageUserGetApiArg = {
   prefix?: string;
 };
+export type PresignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGetApiResponse =
+  /** status 200 Successful Response */ UserStoragePresignedResponse;
+export type PresignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGetApiArg = {
+  key: string;
+};
 export type DownloadUserFileKnowledgeFlowV1StorageUserKeyGetApiResponse = /** status 200 Successful Response */ any;
 export type DownloadUserFileKnowledgeFlowV1StorageUserKeyGetApiArg = {
   key: string;
@@ -2351,6 +2362,10 @@ export type BodyUploadUserFileKnowledgeFlowV1StorageUserUploadPost = {
   /** Logical path inside the user's space */
   key?: string | null;
 };
+export type UserStoragePresignedResponse = {
+  /** Presigned GET URL. Range-capable; expires shortly. */
+  url: string;
+};
 export type BodyUploadAgentConfigFileKnowledgeFlowV1StorageAgentConfigAgentIdUploadPost = {
   /** Binary payload */
   file: Blob;
@@ -3080,6 +3095,8 @@ export const {
   useUploadUserFileKnowledgeFlowV1StorageUserUploadPostMutation,
   useListUserFilesKnowledgeFlowV1StorageUserGetQuery,
   useLazyListUserFilesKnowledgeFlowV1StorageUserGetQuery,
+  usePresignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGetQuery,
+  useLazyPresignedUserFileKnowledgeFlowV1StorageUserPresignedKeyGetQuery,
   useDownloadUserFileKnowledgeFlowV1StorageUserKeyGetQuery,
   useLazyDownloadUserFileKnowledgeFlowV1StorageUserKeyGetQuery,
   useDeleteUserFileKnowledgeFlowV1StorageUserKeyDeleteMutation,

--- a/knowledge-flow-backend/knowledge_flow_backend/application_context.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/application_context.py
@@ -1005,6 +1005,8 @@ class ApplicationContext:
                 secret_key=fs_cfg.secret_key,
                 bucket_name=fs_cfg.bucket_name,  # type: ignore
                 secure=bool(fs_cfg.secure),
+                public_endpoint=fs_cfg.public_endpoint,
+                public_secure=fs_cfg.public_secure,
             )
 
         else:

--- a/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -945,10 +945,7 @@ class MinioFilesystemConfig(BaseModel):
     secure: Optional[bool] = Field(False, description="Use TLS for the MinIO client.")
     public_endpoint: Optional[str] = Field(
         default=None,
-        description=(
-            "Public MinIO endpoint for browser-facing presigned URLs "
-            "(e.g. 'https://my.minio.ingress'). If not set, uses endpoint."
-        ),
+        description=("Public MinIO endpoint for browser-facing presigned URLs (e.g. 'https://my.minio.ingress'). If not set, uses endpoint."),
     )
     public_secure: Optional[bool] = Field(
         default=None,

--- a/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -943,6 +943,17 @@ class MinioFilesystemConfig(BaseModel):
     secret_key: str = Field(..., description="MinIO secret key.")
     bucket_name: Optional[str] = Field("filesystem", description="MinIO bucket name.")
     secure: Optional[bool] = Field(False, description="Use TLS for the MinIO client.")
+    public_endpoint: Optional[str] = Field(
+        default=None,
+        description=(
+            "Public MinIO endpoint for browser-facing presigned URLs "
+            "(e.g. 'https://my.minio.ingress'). If not set, uses endpoint."
+        ),
+    )
+    public_secure: Optional[bool] = Field(
+        default=None,
+        description="Use TLS for the public endpoint. If not set, inferred from public_endpoint scheme.",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pptx_markdown_processor/utils/pptx_slide_renderer.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pptx_markdown_processor/utils/pptx_slide_renderer.py
@@ -17,56 +17,22 @@
 from __future__ import annotations
 
 import logging
-import shutil
-import subprocess  # nosec
 from pathlib import Path
 
 import fitz
+from fred_core import convert_pptx_file_to_pdf
 
 logger = logging.getLogger(__name__)
 
 
 def convert_pptx_to_pdf(pptx_path: Path) -> Path | None:
-    """Convert a PPTX file to PDF using headless LibreOffice."""
-    pdf_path = pptx_path.with_suffix(".pdf")
-    try:
-        soffice_path = shutil.which("soffice")
-        if not soffice_path:
-            raise FileNotFoundError("LibreOffice executable 'soffice' not found in PATH. Please ensure LibreOffice is installed and available.")
+    """Convert a PPTX file to PDF using headless LibreOffice.
 
-        subprocess.run(
-            [
-                soffice_path,
-                "--headless",
-                "--nologo",
-                "--nofirststartwizard",
-                "--convert-to",
-                "pdf:writer_pdf_Export:EmbedStandardFonts=True,SelectPdfVersion=1",
-                "--outdir",
-                str(pptx_path.parent),
-                str(pptx_path),
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )  # nosec: controlled command arguments, shell=False
-
-        if pdf_path.exists():
-            logger.info("[PROCESSOR][PPTX] Converted PPTX to PDF: %s", pdf_path)
-            return pdf_path
-
-        logger.warning("[PROCESSOR][PPTX] PPTX to PDF conversion completed but PDF not found: %s", pdf_path)
-        return None
-
-    except subprocess.CalledProcessError as exc:
-        logger.error(
-            "[PROCESSOR][PPTX] LibreOffice PDF conversion failed: %s",
-            exc.stderr.decode(errors="ignore"),
-        )
-        return None
-    except FileNotFoundError:
-        logger.error("[PROCESSOR][PPTX] LibreOffice (soffice) is not installed or not in PATH.")
-        return None
+    Thin wrapper over the shared ``fred_core`` helper so the ``soffice`` invocation lives
+    in one place (see ``fred_core.conversion.pptx_pdf``). Returns the produced ``.pdf``
+    path, or ``None`` on any failure — the enricher already treats ``None`` as "skip".
+    """
+    return convert_pptx_file_to_pdf(pptx_path)
 
 
 def render_pdf_pages_to_png(pdf_path: Path, slide_numbers: list[int], out_dir: Path) -> dict[int, Path]:

--- a/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/workspace_filesystem.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/workspace_filesystem.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import posixpath
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import List, Optional
 
 from fred_core import KeycloakUser
@@ -287,6 +288,30 @@ class WorkspaceFilesystem:
         results = await self.fs.grep(pattern, full_prefix)
         return [p[len(namespace_root) :] for p in results if p.startswith(namespace_root) and p[len(namespace_root) :]]
 
-    # Placeholder for future public URL generation (HTTP controller layer)
-    def url_for(self, key: str) -> str:
-        raise NotImplementedError("UserStorage.url_for is provided by the HTTP layer")
+    def presigned_url(
+        self,
+        user: KeycloakUser,
+        key: str,
+        owner_override: str | None = None,
+        root_prefix: str | None = None,
+        expires: timedelta = timedelta(hours=1),
+    ) -> str:
+        """
+        Return a temporary, browser-reachable download URL for a scoped object.
+
+        Delegates to the backend's presigned-URL support (MinIO). Backends that cannot
+        presign (e.g. local disk) raise ``NotImplementedError`` — callers treat presigning
+        as best-effort and degrade gracefully.
+        """
+        path = self._path(user, key, owner_override, root_prefix)
+        presign = getattr(self.fs, "presigned_get_url", None)
+        if presign is None:
+            raise NotImplementedError("The configured filesystem backend does not support presigned URLs.")
+        try:
+            return presign(path, expires=expires)
+        except S3Error as e:
+            # A missing object is a 404, not a 500 — map it so the caller degrades gracefully.
+            # (The MinIO backend already maps these; this guards any other presigning backend.)
+            if e.code in {"NoSuchKey", "NoSuchObject", "NoSuchBucket"}:
+                raise FileNotFoundError(path) from e
+            raise

--- a/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/workspace_storage_controller.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/workspace_storage_controller.py
@@ -29,12 +29,19 @@ from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Request, Response, UploadFile
 from fred_core import Action, KeycloakUser, Resource, authorize_or_raise, get_current_user
+from pydantic import BaseModel, Field
 
 from knowledge_flow_backend.features.filesystem.workspace_storage_service import (
     WorkspaceStorageService,
 )
 
 logger = logging.getLogger(__name__)
+
+
+class UserStoragePresignedResponse(BaseModel):
+    """A temporary, browser-reachable download URL for a user-scoped object."""
+
+    url: str = Field(..., description="Presigned GET URL. Range-capable; expires shortly.")
 
 
 class WorkspaceStorageController:
@@ -153,6 +160,35 @@ class WorkspaceStorageController:
                 return await self.service.list_user_files(user, prefix)
             except Exception:
                 logger.exception("User storage list failed")
+                raise HTTPException(500, "Internal server error")
+
+        @router.get(
+            "/storage/user/presigned/{key:path}",
+            tags=["User Storage"],
+            summary="Get a temporary, browser-reachable presigned URL for a user-scoped file",
+        )
+        async def presigned_user_file(
+            key: str,
+            user: KeycloakUser = Depends(get_current_user),
+        ) -> UserStoragePresignedResponse:
+            # Registered BEFORE the catch-all `/storage/user/{key:path}` download route so
+            # `presigned/...` is not swallowed by it. Presigning lets the browser fetch the
+            # object (e.g. a preview PDF, with Range support) directly from object storage,
+            # keeping large-file transfer off this backend.
+            authorize_or_raise(user, Action.READ, Resource.FILES)
+            try:
+                url = self.service.presigned_user_url(user, key)
+                return UserStoragePresignedResponse(url=url)
+            except FileNotFoundError:
+                raise HTTPException(404, "File not found")
+            except NotImplementedError:
+                # Local/dev backend cannot presign. Surface a clear, non-500 signal so the
+                # caller can degrade (omit the preview) instead of erroring.
+                raise HTTPException(501, "Presigned URLs are not supported by this storage backend")
+            except ValueError as e:
+                raise HTTPException(400, str(e))
+            except Exception:
+                logger.exception("User storage presign failed")
                 raise HTTPException(500, "Internal server error")
 
         @router.get(

--- a/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/workspace_storage_service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/workspace_storage_service.py
@@ -33,6 +33,7 @@ Example
 from __future__ import annotations
 
 import mimetypes
+from datetime import timedelta
 
 from fastapi import UploadFile
 from fred_core import KeycloakUser
@@ -119,6 +120,17 @@ class WorkspaceStorageService:
         resolved = self._fmt(self.layout.user_pattern, user_id=user.uid, key=key)
         root, owner, scoped = self._split_root_owner_key(resolved)
         return await self._read_file(user, root, owner, scoped)
+
+    def presigned_user_url(self, user: KeycloakUser, key: str, expires: timedelta = timedelta(hours=1)) -> str:
+        """
+        Return a temporary, browser-reachable download URL for a user-scoped file.
+
+        Raises ``NotImplementedError`` when the backend cannot presign (local disk) and
+        ``FileNotFoundError`` when the object is missing — the caller degrades gracefully.
+        """
+        resolved = self._fmt(self.layout.user_pattern, user_id=user.uid, key=key)
+        root, owner, scoped = self._split_root_owner_key(resolved)
+        return self.storage.presigned_url(user, scoped, owner_override=owner, root_prefix=root, expires=expires)
 
     async def delete_user_file(self, user: KeycloakUser, key: str) -> None:
         resolved = self._fmt(self.layout.user_pattern, user_id=user.uid, key=key)

--- a/knowledge-flow-backend/tests/services/test_workspace_filesystem.py
+++ b/knowledge-flow-backend/tests/services/test_workspace_filesystem.py
@@ -131,3 +131,31 @@ async def test_grep_returns_namespace_relative_paths():
 
     assert fs.grep_call == ("summary", "users/u-1/reports")
     assert matches == ["reports/summary.md", "reports/archive/q1.md"]
+
+
+def test_presigned_url_delegates_to_backend_with_scoped_path():
+    fs = _FakeFilesystem()
+    captured: dict[str, object] = {}
+
+    def presign(path, expires):
+        captured["path"] = path
+        captured["expires"] = expires
+        return "https://minio.example/users/u-1/deck.pdf?sig=abc"
+
+    fs.presigned_get_url = presign  # type: ignore[attr-defined]
+    workspace = WorkspaceFilesystem(fs)
+
+    url = workspace.presigned_url(_user(), "deck.pdf")
+
+    # The scoped user path (root/owner/key) is what gets signed, not the bare key.
+    assert captured["path"] == "users/u-1/deck.pdf"
+    assert url.startswith("https://minio.example/")
+
+
+def test_presigned_url_raises_when_backend_cannot_presign():
+    # The local filesystem backend has no presigned_get_url attribute.
+    fs = _FakeFilesystem()
+    workspace = WorkspaceFilesystem(fs)
+
+    with pytest.raises(NotImplementedError):
+        workspace.presigned_url(_user(), "deck.pdf")


### PR DESCRIPTION
## Summary

Adds a PDF preview pane for the PPT Filler so the fill → review → correct loop happens inside Fred. After a fill, the deck is converted to PDF and shown read-only in a resizable side pane that **auto-opens** on first appearance and **updates in place** on re-fill, with the chat still usable beside it. The preview is **best-effort**: on conversion/presign failure the deck still comes back as a `.pptx` download with a note in chat.

Delivery uses a **MinIO presigned URL** (browser fetches the PDF straight from object storage, range-capable, keeping large-file transfer off the app server) rather than a streaming proxy. This is a deliberate change from the original RFC, which has been updated to match; the local-filesystem backend can't presign, so there the preview degrades to the download chip (accepted, known gap).

By area:
- **`fred-core`** — shared, async, timed `pptx→PDF` conversion helper (one `soffice` call for both backends); presigned-URL support on the user-storage `MinioFilesystem`, signed against the public ingress (`public_endpoint`/`public_secure`).
- **Knowledge Flow** — bearer-protected `GET /storage/user/presigned/{key}` endpoint; the vision enricher now reuses the shared conversion helper (one implementation, now bounded/timed).
- **Agentic** — new `ppt_preview` message part (in the `MessagePart`/`UiPart` unions + `hydrate_fred_parts`); the fill tool converts the filled deck, uploads the PDF beside the `.pptx` under the same session-scoped key, and emits one `ppt_preview` part (version = PDF content hash → drives react-pdf remount) with a download-chip fallback.
- **Frontend** — extracted shared `ResizablePaneShell` + `ArtifactCard` from the writable-document pane; new `usePptPreview` controller and `PptPreviewPane` (react-pdf); one active side pane at a time; en/fr strings added.

### Follow-up fixes (post-testing)

Frontend-only fixes from manual testing of the first implementation:

- **Preview crash on second deck** — opening a second preview or switching decks crashed with `PDFWorker.fromPort - the worker is being destroyed`: a single shared pdf.js `workerPort` was reused across `<Document>` remounts, so the next mount grabbed the port mid-teardown. Each `<Document>` now gets a **fresh module worker per mount** (shared `pdfWorker.ts` / `configurePdfWorkerPort`), which also de-dupes the two viewers that each minted their own worker and stomped the global.
- **`.pptx` download 401'd** ("file wasn't available") — a bare `<a download>` sends no bearer to the protected `/storage/user` endpoint. New shared `PptxDownloadButton` fetches the bytes with auth (`downloadHrefBlob`) and blob-downloads, mirroring the writable-doc export; this also fixes the download filename.
- **PDF layout** — a lone slide is now centered (`justify-content`) and multiple slides are spaced with per-page margin (container `gap` collapses across react-pdf's per-page wrappers).
- **Card polish** — the download control now reuses the design-system `IconButton` (neutral color, correct size/placement) so the card matches the writable-document chip.
- **Toggle-to-close** — clicking a card whose pane is already open on that artifact now closes it (PPT preview + writable document); clicking a different card still switches.
- **Preview 403 on reopening an old chat** — the fill tool baked a short-lived (~1h) presigned URL into the persisted `ppt_preview` part, so new fills worked but reopening a conversation later handed react-pdf an **expired** signature → 403. The part now stores a **durable** KF presign endpoint (`…/storage/user/presigned/{key}`); the pane calls it with the bearer at open time to mint a **fresh** presigned URL, mirroring how the `.pptx` download stays durable. This closes the "expired on reopen" gap noted in Risk below.

- **Preview text not selectable / misaligned** — slides rendered canvas-only (`renderTextLayer={false}`), so text couldn't be selected, copied, or searched. Enabled the text layer; LibreOffice-exported PPTX→PDF decks carry a non-1 UserUnit that react-pdf 10 / pdf.js 4 keep separate from `--scale-factor`, so the invisible text spans drifted off the glyphs — scaling the text layer by `--total-scale-factor` re-aligns them exactly over the rendered text.
Verified end-to-end in the browser (both provided repro conversations + a live fill/re-fill): crash gone, download 200s, layout correct, toggle works, reopening a filled chat re-presigns and renders (no 403).

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed (RFC updated for presigned-URL delivery).

## Validation Notes

- `fred-core`: `make test` → 30 passed, 1 integration skipped (real `soffice`, no `python-pptx` in venv). New conversion helper tests: success, timeout→None, missing-soffice→None, no-pdf→None, CalledProcessError→None.
- `knowledge-flow-backend`: `tests/services/test_workspace_filesystem.py` → 6 passed (presign delegates with scoped path; raises `NotImplementedError` when backend can't presign). `ruff` clean. OpenAPI regenerated.
- `agentic-backend`: `tests/test_ppt_filler_toolkit.py` → 26 passed, incl. the preview tests (emits `ppt_preview` carrying a **durable presign href** + uploads PDF; failed-conversion keeps `.pptx` + notes preview skipped; version changes on re-fill). `ruff` clean, `basedpyright` 0 errors. OpenAPI regenerated.
- `frontend`: `tsc --noEmit` → exit 0 (incl. the follow-up fixes). Manual browser E2E on both repro conversations + a live fill/re-fill: no console errors, `.pptx` download returns 200, single/multi-slide layout correct, deck-switch and toggle-close work. Reload of a filled conversation shows `GET …/storage/user/presigned/… → 200` then a SeaweedFS PDF fetch with a freshly-dated SigV4 signature → 200.

Pre-existing `code-quality` gap unrelated to this PR: `fred_core/sql/alembic_env.py` reports a missing `alembic` import (optional dep not installed in the local venv); present on `main`.

## Risk / Rollback

- **Main risk:** the presigned URL must be consumed exactly as signed — appending any query param breaks the SigV4 signature (a `?v=` cache-buster caused a `403` in early testing and was removed; freshness relies on a fresh presigned URL per open + the react-pdf remount key). Presigned URLs are now minted **lazily at open time** from a durable KF endpoint, so reopening an old preview card re-presigns instead of 403-ing on an expired signature. (Preview parts persisted *before* this fix use the old schema and are dropped on hydration — the `.pptx` download still works, and re-filling produces a working preview.)
- **Local/standalone caveat:** no presigning on the local filesystem backend → preview omitted, download chip shown.
- **Rollback:** revert this branch. The change is additive — no schema/params/analyze-save/agent-tool-args changes; the only chat-surface change is the produced-deck card replacing the bare download chip.

