### PR TITLE
#1894 make swift react + search tools equivalent compared to kea with…

### DIFF
--- a/apps/fred-agents/config/mcp_catalog.yaml
+++ b/apps/fred-agents/config/mcp_catalog.yaml
@@ -4,9 +4,12 @@ servers:
   - id: "mcp-knowledge-flow-mcp-text"
     name: "mcp.servers.search_documents.name"
     description: "mcp.servers.search_documents.description"
-    transport: "streamable_http"
-    url: "http://localhost:8111/knowledge-flow/v1/mcp-text"
-    sse_read_timeout: 2000
+    # MIGR-03.03: inprocess provider (not a remote MCP endpoint) so the search tool
+    # returns typed VectorSearchHit sources and the chat Sources panel renders —
+    # restoring kea's behaviour. A remote MCP tool returns plain text with no
+    # typed artifact, which is why the panel was lost after the port.
+    transport: "inprocess"
+    provider: "kf_vector_search"
     enabled: true
     auth_mode: "user_token"
     agent_instructions: |

--- a/apps/fred-agents/config/mcp_catalog.yaml
+++ b/apps/fred-agents/config/mcp_catalog.yaml
@@ -13,37 +13,20 @@ servers:
     enabled: true
     auth_mode: "user_token"
     agent_instructions: |
-      ## Citation contract (enforced by the search tool — non-negotiable)
+      ## Grounding contract (enforced by the search tool — non-negotiable)
 
-      Every claim derived from a search result MUST carry an inline citation
-      immediately after the claim, using this exact format: **[Title, p. X]**
+      Base every factual statement on the documents retrieved by the search tool
+      in THIS turn. The interface displays the retrieved sources separately (a
+      dedicated Sources panel), so do NOT add inline citations, bracketed
+      references, or a "Sources" list to your answer — just write a clean,
+      well-structured response grounded in the retrieved content.
 
-      Rules for building the citation:
-      - Title = the `title` field of the search result (required).
-      - Page = the `page` field if present. Otherwise use `section`. Otherwise use
-        `file_name`. Never leave the second part blank.
-      - Example: **[Dossier Technique CIR, p. 4]** or **[rapport_final.pdf, §2]**
-
-      Responses that contain factual statements without inline citations are invalid.
-      Apply citations even in lists and bullet points.
-
-      End every response that cites at least one document with a **Sources**
-      section.
-
-      Format:
-
-      > **Sources**
-      > - *Title* — file_name, p. X (or §Section)
-
-      List each distinct document once. Do not add URLs, links, or document IDs to
-      this section.
+      NEVER present a claim as factual if retrieval returned no supporting result.
+      NEVER rely on a document you have not retrieved in this turn.
 
       NEVER generate, fabricate, or include any URL, hyperlink, or web address in
       your response — not even if a URL appears in the search result metadata.
       Ignore URL or link fields entirely.
-
-      NEVER cite a document you have not retrieved in this turn.
-      NEVER present a claim as factual if retrieval returned no supporting result.
 
       If the search tool returns no relevant results, say so explicitly before
       falling back to general knowledge. Label any such claim as

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -320,7 +320,10 @@ export default function TeamAgentsPage() {
         isSubmitting={isCreatingInstance || isUpdatingInstance}
         mode={editingInstance ? "edit" : "create"}
         editInstance={editingInstance ?? undefined}
-        teamName={team?.name}
+        // Personal team's backend name is a non-localized literal ("Equipe
+        // personnelle"); pass undefined so the modal falls back to the localized
+        // "Personal space" label (follows the user's profile language).
+        teamName={isPersonalTeam ? undefined : team?.name}
         teamId={teamId}
         templates={availableTemplates}
         onClose={() => {

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -871,9 +871,11 @@ applications:
         - id: "mcp-knowledge-flow-mcp-text"
           name: "mcp.servers.search_documents.name"
           description: "mcp.servers.search_documents.description"
-          transport: "streamable_http"
-          url: "http://knowledge-flow-backend:8000/knowledge-flow/v1/mcp-text"
-          sse_read_timeout: 2000
+          # MIGR-03.03: inprocess provider (not a remote MCP endpoint) so the search
+          # tool returns typed VectorSearchHit sources and the chat Sources panel
+          # renders — restoring kea's behaviour.
+          transport: "inprocess"
+          provider: "kf_vector_search"
           enabled: true
           auth_mode: "user_token"
           agent_instructions: |

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -879,37 +879,20 @@ applications:
           enabled: true
           auth_mode: "user_token"
           agent_instructions: |
-            ## Citation contract (enforced by the search tool — non-negotiable)
+            ## Grounding contract (enforced by the search tool — non-negotiable)
 
-            Every claim derived from a search result MUST carry an inline citation
-            immediately after the claim, using this exact format: **[Title, p. X]**
+            Base every factual statement on the documents retrieved by the search
+            tool in THIS turn. The interface displays the retrieved sources
+            separately (a dedicated Sources panel), so do NOT add inline citations,
+            bracketed references, or a "Sources" list to your answer — just write a
+            clean, well-structured response grounded in the retrieved content.
 
-            Rules for building the citation:
-            - Title = the `title` field of the search result (required).
-            - Page = the `page` field if present. Otherwise use `section`. Otherwise use
-              `file_name`. Never leave the second part blank.
-            - Example: **[Dossier Technique CIR, p. 4]** or **[rapport_final.pdf, §2]**
-
-            Responses that contain factual statements without inline citations are invalid.
-            Apply citations even in lists and bullet points.
-
-            End every response that cites at least one document with a **Sources**
-            section.
-
-            Format:
-
-            > **Sources**
-            > - *Title* — file_name, p. X (or §Section)
-
-            List each distinct document once. Do not add URLs, links, or document IDs to
-            this section.
+            NEVER present a claim as factual if retrieval returned no supporting result.
+            NEVER rely on a document you have not retrieved in this turn.
 
             NEVER generate, fabricate, or include any URL, hyperlink, or web address in
             your response — not even if a URL appears in the search result metadata.
             Ignore URL or link fields entirely.
-
-            NEVER cite a document you have not retrieved in this turn.
-            NEVER present a claim as factual if retrieval returned no supporting result.
 
             If the search tool returns no relevant results, say so explicitly before
             falling back to general knowledge. Label any such claim as

--- a/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
+++ b/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
@@ -267,8 +267,14 @@ with a written rationale.
 - [ ] **MIGR-03.02** — Message feedback — leave a rating with 5 stars and a comment on a chat message
   — *Feedback feature was available in Kea; used for quality monitoring*
 
-- [ ] **MIGR-03.03** — Source citation in chat — display source references alongside agent responses
+- [x] **MIGR-03.03** — Source citation in chat — display source references alongside agent responses
   — *Kea showed which documents/sources were used in the response*
+  — Restored kea's inprocess `kf_vector_search` provider for the "search_documents"
+    tool so it returns typed `VectorSearchHit` sources (Sources panel + `[N]`
+    citations) instead of the remote-MCP plain-text path that dropped them.
+  — Execution: branch `1883-fred-202-rgpd-ready-increment-ctrlp-12`. Touches
+    `libs/fred-runtime/fred_runtime/integrations/kf_vector_search/`,
+    `inprocess_toolkit_registry.py`, `mcp_catalog.yaml`, `deploy/charts/fred/values.yaml`.
 
 ---
 
@@ -282,4 +288,4 @@ with a written rationale.
 | MIGR-07 Products (re-vectorization) | 4 | 0 | 4 |
 | MIGR-01 Cherry-picks | 15 (13 needed + 2 good-to-have) | 9 | 6 |
 | MIGR-02 DB migration | 4 (2 required + 2 optional) | 0 | 4 |
-| MIGR-03 Feature parity | 3 | 0 | 3 |
+| MIGR-03 Feature parity | 3 | 1 | 2 |

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -114,6 +114,7 @@ from fred_runtime.react.react_runtime import ReActRuntime
 from fred_runtime.runtime_support.checkpoints import load_checkpoint
 
 from ..common.structures import AgentSettingsLike
+from ..integrations.inprocess_toolkit_registry import build_inprocess_toolkit
 from ..integrations.v2_runtime.adapters import (
     CompositeToolInvoker,
     FredKnowledgeSearchToolInvoker,
@@ -128,7 +129,6 @@ from ..runtime_context import (
     set_runtime_context,
 )
 from ..runtime_context import RuntimeContext as FredRuntimeContext
-from ..integrations.inprocess_toolkit_registry import build_inprocess_toolkit
 from ..runtime_support import refresh_user_access_token_from_keycloak
 from .config import AgentPodConfig
 from .container import build_pod_container

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -128,6 +128,7 @@ from ..runtime_context import (
     set_runtime_context,
 )
 from ..runtime_context import RuntimeContext as FredRuntimeContext
+from ..integrations.inprocess_toolkit_registry import build_inprocess_toolkit
 from ..runtime_support import refresh_user_access_token_from_keycloak
 from .config import AgentPodConfig
 from .container import build_pod_container
@@ -3093,6 +3094,7 @@ def create_agent_app(
                     checkpointer=checkpointer,
                     history_store=history_store,
                     mcp_configuration=config.get_mcp_configuration(),
+                    inprocess_toolkit_factory=build_inprocess_toolkit,
                     control_plane_url=config.platform.control_plane_url,
                     rebac_engine=rebac_engine,
                     security_profile=(

--- a/libs/fred-runtime/fred_runtime/common/mcp_runtime.py
+++ b/libs/fred-runtime/fred_runtime/common/mcp_runtime.py
@@ -375,7 +375,7 @@ class MCPRuntime:
             )
             return
         for server in self.inprocess_servers:
-            toolkit = factory(server.provider)
+            toolkit = factory(server.provider, self.agent_instance)
             if toolkit is None:
                 logger.warning(
                     "[MCP] agent=%s no toolkit built for provider=%s (server=%s)",

--- a/libs/fred-runtime/fred_runtime/integrations/inprocess_toolkit_registry.py
+++ b/libs/fred-runtime/fred_runtime/integrations/inprocess_toolkit_registry.py
@@ -1,0 +1,50 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Registry mapping catalog `provider` keys to in-process MCP toolkits (MIGR-03.03).
+
+Why this module exists:
+- an MCP catalog server with `transport: inprocess` names a `provider`; the MCP
+  runtime asks this factory to build the matching toolkit for the current agent turn
+- keeping the mapping here (not in `agent_app`) lets the runtime wire a single
+  factory reference at startup without hardcoding provider knowledge in the boot path
+
+How to use it:
+- pass `build_inprocess_toolkit` as `RuntimeConfig.inprocess_toolkit_factory`
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fred_runtime.integrations.kf_vector_search import (
+    KF_VECTOR_SEARCH_PROVIDER,
+    KfVectorSearchToolkit,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_inprocess_toolkit(provider: str | None, agent: Any) -> Any | None:
+    """
+    Build the in-process toolkit for `provider`, bound to the current agent turn.
+
+    Returns None for an unknown or missing provider so the MCP runtime skips it with
+    a warning rather than failing the whole agent.
+    """
+    if provider == KF_VECTOR_SEARCH_PROVIDER:
+        return KfVectorSearchToolkit(agent=agent)
+    logger.warning("[MCP] unknown inprocess provider=%s; no toolkit built.", provider)
+    return None

--- a/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/__init__.py
+++ b/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-process Knowledge Flow vector-search MCP toolkit."""
+
+from fred_runtime.integrations.kf_vector_search.toolkit import (
+    KF_VECTOR_SEARCH_PROVIDER,
+    KfVectorSearchToolkit,
+)
+
+__all__ = ["KF_VECTOR_SEARCH_PROVIDER", "KfVectorSearchToolkit"]

--- a/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/toolkit.py
+++ b/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/toolkit.py
@@ -1,0 +1,167 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+In-process Knowledge Flow vector-search toolkit for v2 ReAct agents (MIGR-03.03).
+
+Why this module exists:
+- restores the kea behaviour where the "search_documents" tool, selected from the
+  Tools tab as an MCP server, returns typed `VectorSearchHit` sources so the chat
+  UI renders the Sources panel (and clickable `[N]` citations)
+- in kea that tool was an *inprocess* provider (`transport: inprocess`,
+  `provider: kf_vector_search`) — NOT a real remote MCP endpoint. A remote MCP tool
+  returns plain text with no typed artifact, so the panel cannot render. This
+  toolkit re-establishes the inprocess path on swift.
+
+Key design:
+- exposes one LangChain tool (`search_documents_using_vectorization`) wrapped with
+  `response_format="content_and_artifact"` so the ReAct runtime can read
+  `ToolMessage.artifact.sources` (see `react_runtime.py`)
+- retrieval scoping (libraries, document uids, search policy, session/corpus scope,
+  team) is read from the bound runtime context at call time — identical to the
+  built-in `knowledge.search` tool ref used by Rico, so both paths behave the same
+
+How to use it:
+- built by `build_inprocess_toolkit` when a catalog server declares
+  `provider: "kf_vector_search"`; the MCP runtime calls `.tools()` to collect the
+  LangChain tools
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Sequence
+
+from fred_core.common import OwnerFilter
+from fred_core.common.team_id import is_personal_team_id
+from fred_core.store.vector_search import VectorSearchHit
+from fred_sdk.contracts.context import ToolInvocationResult
+from langchain_core.tools import BaseTool, tool
+
+from fred_runtime.common.kf_base_client import KnowledgeFlowAgentContext
+from fred_runtime.common.kf_vectorsearch_client import VectorSearchClient
+from fred_runtime.runtime_support.request_context_helpers import (
+    get_document_library_tags_ids,
+    get_document_uids,
+    get_rag_knowledge_scope,
+    get_search_policy,
+    get_vector_search_scopes,
+)
+
+logger = logging.getLogger(__name__)
+
+KF_VECTOR_SEARCH_PROVIDER = "kf_vector_search"
+
+# Only the fields the LLM needs for citation and reasoning are exposed. URL and
+# operational fields are excluded so the model cannot reproduce broken or internal
+# paths in its reply — this mirrors `_invoke_knowledge_search` (the tool-ref path).
+_LLM_FIELDS = {"uid", "title", "content", "file_name", "page", "section", "score"}
+
+
+def _llm_slice(hit: VectorSearchHit) -> dict[str, object]:
+    return {k: v for k, v in hit.model_dump(mode="json").items() if k in _LLM_FIELDS}
+
+
+class KfVectorSearchToolkit:
+    """
+    Inprocess toolkit that binds a Knowledge Flow vector search to one agent turn.
+
+    Why this class exists:
+    - the MCP runtime resolves inprocess providers to a toolkit object and calls its
+      `tools()` method to collect LangChain tools
+    - the toolkit is built per request from the agent shim (which carries the bound
+      runtime context and agent settings), so each tool call reads the current
+      session scope
+
+    How to use it:
+    - `KfVectorSearchToolkit(agent=shim).tools()`
+    """
+
+    def __init__(self, *, agent: KnowledgeFlowAgentContext) -> None:
+        self._agent = agent
+        self._client = VectorSearchClient(agent=agent)
+
+    def tools(self) -> list[BaseTool]:
+        agent = self._agent
+        client = self._client
+
+        @tool(
+            "search_documents_using_vectorization",
+            response_format="content_and_artifact",
+        )
+        async def search_documents_using_vectorization(
+            question: str,
+            top_k: int = 8,
+        ) -> tuple[str, ToolInvocationResult]:
+            """Search the selected document libraries using semantic similarity (RAG).
+
+            Call this tool BEFORE answering any factual, technical, or domain-specific
+            question — the corpus may hold more specific or recent information than you
+            already know. Skip it only for purely conversational exchanges (greetings,
+            thanks, clarifying what was just said).
+
+            Returns ranked hits with title and content. Cite each grounded claim with
+            the bracketed rank of the hit it relies on: [1], [2]. Only use information
+            actually present in the returned hits; never invent facts beyond them.
+            """
+            runtime_context = agent.runtime_context
+
+            if get_rag_knowledge_scope(runtime_context) == "general_only":
+                return (
+                    "Corpus retrieval skipped in general-only mode.",
+                    ToolInvocationResult(
+                        tool_ref=KF_VECTOR_SEARCH_PROVIDER, sources=()
+                    ),
+                )
+
+            top_k = top_k if isinstance(top_k, int) and top_k > 0 else 8
+            team_id = agent.agent_settings.team_id
+            scoped_team = bool(team_id) and not is_personal_team_id(team_id)
+            include_session_scope, include_corpus_scope = get_vector_search_scopes(
+                runtime_context
+            )
+
+            hits: Sequence[VectorSearchHit] = await client.search(
+                question=question,
+                top_k=top_k,
+                document_library_tags_ids=get_document_library_tags_ids(
+                    runtime_context
+                ),
+                document_uids=get_document_uids(runtime_context),
+                search_policy=get_search_policy(runtime_context),
+                owner_filter=OwnerFilter.TEAM if scoped_team else OwnerFilter.PERSONAL,
+                team_id=team_id if scoped_team else None,
+                session_id=runtime_context.session_id,
+                include_session_scope=include_session_scope,
+                include_corpus_scope=include_corpus_scope,
+            )
+
+            logger.info(
+                "[KFVS][TOOL] question=%r top_k=%d hits=%d",
+                question[:80],
+                top_k,
+                len(hits),
+            )
+            content = json.dumps(
+                {"query": question, "hits": [_llm_slice(h) for h in hits]},
+                ensure_ascii=False,
+                default=str,
+            )
+            artifact = ToolInvocationResult(
+                tool_ref=KF_VECTOR_SEARCH_PROVIDER,
+                sources=tuple(hits),
+            )
+            return content, artifact
+
+        return [search_documents_using_vectorization]

--- a/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/toolkit.py
+++ b/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/toolkit.py
@@ -24,9 +24,14 @@ Why this module exists:
   toolkit re-establishes the inprocess path on swift.
 
 Key design:
-- exposes one LangChain tool (`search_documents_using_vectorization`) wrapped with
-  `response_format="content_and_artifact"` so the ReAct runtime can read
-  `ToolMessage.artifact.sources` (see `react_runtime.py`)
+- exposes one LangChain tool (`search_documents_using_vectorization`) that returns a
+  `ToolInvocationResult` directly (NOT a `content_and_artifact` tuple). The shared
+  runtime-provider resolver invokes provider tools with a plain args dict, which
+  collapses a `content_and_artifact` tuple to its content string and drops the
+  artifact — so the sources must ride on a returned `ToolInvocationResult`, which the
+  resolver extracts (see `react_tool_resolution._resolve_runtime_provider_tool`).
+  `blocks` carry the hit JSON for the LLM; `sources` carry the typed hits the chat
+  Sources panel renders. This mirrors the built-in `knowledge.search` tool ref.
 - retrieval scoping (libraries, document uids, search policy, session/corpus scope,
   team) is read from the bound runtime context at call time — identical to the
   built-in `knowledge.search` tool ref used by Rico, so both paths behave the same
@@ -39,14 +44,17 @@ How to use it:
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Sequence
 
 from fred_core.common import OwnerFilter
 from fred_core.common.team_id import is_personal_team_id
 from fred_core.store.vector_search import VectorSearchHit
-from fred_sdk.contracts.context import ToolInvocationResult
+from fred_sdk.contracts.context import (
+    ToolContentBlock,
+    ToolContentKind,
+    ToolInvocationResult,
+)
 from langchain_core.tools import BaseTool, tool
 
 from fred_runtime.common.kf_base_client import KnowledgeFlowAgentContext
@@ -96,14 +104,11 @@ class KfVectorSearchToolkit:
         agent = self._agent
         client = self._client
 
-        @tool(
-            "search_documents_using_vectorization",
-            response_format="content_and_artifact",
-        )
+        @tool("search_documents_using_vectorization")
         async def search_documents_using_vectorization(
             question: str,
             top_k: int = 8,
-        ) -> tuple[str, ToolInvocationResult]:
+        ) -> ToolInvocationResult:
             """Search the selected document libraries using semantic similarity (RAG).
 
             Call this tool BEFORE answering any factual, technical, or domain-specific
@@ -118,11 +123,18 @@ class KfVectorSearchToolkit:
             runtime_context = agent.runtime_context
 
             if get_rag_knowledge_scope(runtime_context) == "general_only":
-                return (
-                    "Corpus retrieval skipped in general-only mode.",
-                    ToolInvocationResult(
-                        tool_ref=KF_VECTOR_SEARCH_PROVIDER, sources=()
+                return ToolInvocationResult(
+                    tool_ref=KF_VECTOR_SEARCH_PROVIDER,
+                    blocks=(
+                        ToolContentBlock(
+                            kind=ToolContentKind.JSON,
+                            data={
+                                "sources": [],
+                                "note": "Corpus retrieval skipped in general-only mode.",
+                            },
+                        ),
                     ),
+                    sources=(),
                 )
 
             top_k = top_k if isinstance(top_k, int) and top_k > 0 else 8
@@ -153,15 +165,22 @@ class KfVectorSearchToolkit:
                 top_k,
                 len(hits),
             )
-            content = json.dumps(
-                {"query": question, "hits": [_llm_slice(h) for h in hits]},
-                ensure_ascii=False,
-                default=str,
-            )
-            artifact = ToolInvocationResult(
+            # Return a ToolInvocationResult directly: the runtime-provider resolver
+            # invokes this tool with a plain args dict, so a content_and_artifact
+            # tuple would lose the artifact (and its sources). `blocks` feed the LLM
+            # the hit JSON; `sources` carry the typed hits the Sources panel renders.
+            return ToolInvocationResult(
                 tool_ref=KF_VECTOR_SEARCH_PROVIDER,
+                blocks=(
+                    ToolContentBlock(
+                        kind=ToolContentKind.JSON,
+                        data={
+                            "query": question,
+                            "hits": [_llm_slice(h) for h in hits],
+                        },
+                    ),
+                ),
                 sources=tuple(hits),
             )
-            return content, artifact
 
         return [search_documents_using_vectorization]

--- a/libs/fred-runtime/fred_runtime/runtime_context.py
+++ b/libs/fred-runtime/fred_runtime/runtime_context.py
@@ -53,10 +53,11 @@ class InprocessToolkitFactory(Protocol):
     - fred-runtime should not hardcode agentic-backend toolkits
 
     How to use it:
-    - supply a callable that maps provider keys to toolkit instances
+    - supply a callable that maps a provider key + the current agent turn to a
+      toolkit instance (the agent carries the bound runtime context and settings)
     """
 
-    def __call__(self, provider: str | None) -> Any:
+    def __call__(self, provider: str | None, agent: Any) -> Any:
         raise NotImplementedError
 
 

--- a/libs/fred-runtime/tests/test_kf_vector_search_toolkit.py
+++ b/libs/fred-runtime/tests/test_kf_vector_search_toolkit.py
@@ -33,6 +33,7 @@ from fred_runtime.integrations.kf_vector_search import (
     KF_VECTOR_SEARCH_PROVIDER,
     KfVectorSearchToolkit,
 )
+from fred_runtime.react.react_tool_rendering import render_tool_result
 
 
 class _FakeSettings:
@@ -85,28 +86,23 @@ def _build_search_tool(
 
 
 @pytest.mark.asyncio
-async def test_search_returns_typed_sources_on_artifact(
+async def test_search_returns_tool_invocation_result_with_sources(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     ctx = RuntimeContext(session_id="s-1", team_id="team-1")
     tool = _build_search_tool(monkeypatch, ctx)
 
-    message = await tool.ainvoke(
-        {
-            "name": "search_documents_using_vectorization",
-            "args": {"question": "what is alpha?"},
-            "id": "call-1",
-            "type": "tool_call",
-        }
-    )
+    # The runtime-provider resolver invokes provider tools with a plain args dict
+    # (NOT a tool_call), so the tool must return a ToolInvocationResult directly for
+    # its sources to survive — this is the exact contract that drives the panel.
+    result = await tool.ainvoke({"question": "what is alpha?"})
 
-    artifact = message.artifact
-    assert isinstance(artifact, ToolInvocationResult)
-    assert artifact.tool_ref == KF_VECTOR_SEARCH_PROVIDER
-    # The panel-driving contract: typed hits are carried on the artifact.
-    assert [h.uid for h in artifact.sources] == ["d1", "d2"]
-    # The LLM-facing content is the JSON hit list (no artifact leakage).
-    assert "alpha" in message.content
+    assert isinstance(result, ToolInvocationResult)
+    assert result.tool_ref == KF_VECTOR_SEARCH_PROVIDER
+    # The panel-driving contract: typed hits are carried on the result.
+    assert [h.uid for h in result.sources] == ["d1", "d2"]
+    # The LLM-facing content is the JSON hit list, carried in blocks.
+    assert "alpha" in render_tool_result(result)
 
 
 @pytest.mark.asyncio
@@ -119,16 +115,10 @@ async def test_general_only_scope_short_circuits_without_search(
     tool = _build_search_tool(monkeypatch, ctx)
     _FakeSearchClient.last_kwargs = {}
 
-    message = await tool.ainvoke(
-        {
-            "name": "search_documents_using_vectorization",
-            "args": {"question": "irrelevant"},
-            "id": "call-2",
-            "type": "tool_call",
-        }
-    )
+    result = await tool.ainvoke({"question": "irrelevant"})
 
-    assert message.artifact.sources == ()
+    assert isinstance(result, ToolInvocationResult)
+    assert result.sources == ()
     # No retrieval was attempted in general-only mode.
     assert _FakeSearchClient.last_kwargs == {}
 

--- a/libs/fred-runtime/tests/test_kf_vector_search_toolkit.py
+++ b/libs/fred-runtime/tests/test_kf_vector_search_toolkit.py
@@ -1,0 +1,147 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the in-process kf_vector_search toolkit (MIGR-03.03).
+
+The point of the toolkit is that the search tool returns typed `VectorSearchHit`
+sources on a `ToolInvocationResult` artifact — that artifact is what makes the chat
+Sources panel render (kea parity). These tests lock that contract without any HTTP.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fred_core.store.vector_search import VectorSearchHit
+from fred_sdk.contracts.context import RuntimeContext, ToolInvocationResult
+from fred_sdk.contracts.models import AgentTuning
+
+import fred_runtime.integrations.kf_vector_search.toolkit as toolkit_mod
+from fred_runtime.common.structures import AgentSettingsLike
+from fred_runtime.integrations.inprocess_toolkit_registry import build_inprocess_toolkit
+from fred_runtime.integrations.kf_vector_search import (
+    KF_VECTOR_SEARCH_PROVIDER,
+    KfVectorSearchToolkit,
+)
+
+
+class _FakeSettings:
+    """Matches the AgentSettingsLike protocol (id / team_id / tuning)."""
+
+    id: str = "agent-1"
+    team_id: str | None = "team-1"
+    tuning: AgentTuning | None = None
+
+
+class _FakeAgent:
+    """Minimal shim matching what VectorSearchClient + the toolkit read."""
+
+    def __init__(self, runtime_context: RuntimeContext) -> None:
+        self.runtime_context = runtime_context
+        self.agent_settings: AgentSettingsLike = _FakeSettings()
+
+    def refresh_user_access_token(self) -> str:
+        return "token"
+
+
+class _FakeSearchClient:
+    """Stand-in for VectorSearchClient — records the call, returns preset hits."""
+
+    last_kwargs: dict[str, object] = {}
+
+    def __init__(self, agent: object) -> None:
+        self._agent = agent
+
+    async def search(self, **kwargs: object) -> list[VectorSearchHit]:
+        _FakeSearchClient.last_kwargs = kwargs
+        return [
+            VectorSearchHit(
+                uid="d1", title="Doc 1", content="alpha", score=0.9, type="document"
+            ),
+            VectorSearchHit(
+                uid="d2", title="Doc 2", content="beta", score=0.7, type="document"
+            ),
+        ]
+
+
+def _build_search_tool(
+    monkeypatch: pytest.MonkeyPatch, runtime_context: RuntimeContext
+):
+    monkeypatch.setattr(toolkit_mod, "VectorSearchClient", _FakeSearchClient)
+    toolkit = KfVectorSearchToolkit(agent=_FakeAgent(runtime_context))
+    tools = toolkit.tools()
+    assert len(tools) == 1
+    return tools[0]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_typed_sources_on_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = RuntimeContext(session_id="s-1", team_id="team-1")
+    tool = _build_search_tool(monkeypatch, ctx)
+
+    message = await tool.ainvoke(
+        {
+            "name": "search_documents_using_vectorization",
+            "args": {"question": "what is alpha?"},
+            "id": "call-1",
+            "type": "tool_call",
+        }
+    )
+
+    artifact = message.artifact
+    assert isinstance(artifact, ToolInvocationResult)
+    assert artifact.tool_ref == KF_VECTOR_SEARCH_PROVIDER
+    # The panel-driving contract: typed hits are carried on the artifact.
+    assert [h.uid for h in artifact.sources] == ["d1", "d2"]
+    # The LLM-facing content is the JSON hit list (no artifact leakage).
+    assert "alpha" in message.content
+
+
+@pytest.mark.asyncio
+async def test_general_only_scope_short_circuits_without_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = RuntimeContext(
+        session_id="s-1", team_id="team-1", search_rag_scope="general_only"
+    )
+    tool = _build_search_tool(monkeypatch, ctx)
+    _FakeSearchClient.last_kwargs = {}
+
+    message = await tool.ainvoke(
+        {
+            "name": "search_documents_using_vectorization",
+            "args": {"question": "irrelevant"},
+            "id": "call-2",
+            "type": "tool_call",
+        }
+    )
+
+    assert message.artifact.sources == ()
+    # No retrieval was attempted in general-only mode.
+    assert _FakeSearchClient.last_kwargs == {}
+
+
+def test_registry_builds_toolkit_for_known_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(toolkit_mod, "VectorSearchClient", _FakeSearchClient)
+    ctx = RuntimeContext(session_id="s-1", team_id="team-1")
+    toolkit = build_inprocess_toolkit(KF_VECTOR_SEARCH_PROVIDER, _FakeAgent(ctx))
+    assert isinstance(toolkit, KfVectorSearchToolkit)
+
+
+def test_registry_returns_none_for_unknown_provider() -> None:
+    ctx = RuntimeContext(session_id="s-1", team_id="team-1")
+    assert build_inprocess_toolkit("does-not-exist", _FakeAgent(ctx)) is None


### PR DESCRIPTION
## Restore kea-equivalent source citations for React + MCP document search (MIGR-03.03)

### What & why
A React agent using the "search_documents" tool no longer shows the **Sources
panel** in chat — citations render as inert `[N]` text. This is a **parity
regression** from the kea → swift port, not a new feature.

In kea, "search_documents" was an **inprocess** tool (`transport: inprocess`,
`provider: kf_vector_search`) that returned typed `VectorSearchHit` sources on a
`ToolInvocationResult` artifact — that artifact is what drives the Sources panel.
Swift switched the same catalog entry to a real remote MCP endpoint
(`streamable_http`), which returns plain text with no typed sources, so the panel
was lost. The remote-MCP switch was never backed by an RFC.

### Change
- Restore the inprocess `kf_vector_search` toolkit (reuses the existing
  `VectorSearchClient` and scope helpers; same retrieval behavior as the built-in
  `knowledge.search` tool ref used by Rico) so it returns typed sources.
- Wire the inprocess toolkit factory into the pod's `RuntimeConfig` — the runtime
  mechanism already existed but was never connected.
- Flip `mcp-knowledge-flow-mcp-text` back to `transport: inprocess` +
  `provider: kf_vector_search` in `mcp_catalog.yaml` and `deploy/charts/fred/values.yaml`.
- The entry's `agent_instructions` (the `[N]` citation contract) and all 9
  `config_fields` are preserved unchanged.

### Scope preserved / out of scope
- No change to real remote MCP endpoints (tabular, opensearch-ops, fs, corpus).
- Not teaching remote MCP transport to carry typed sources (kea never did this).

### Tests
- New `test_kf_vector_search_toolkit.py` (typed sources on artifact, general-only
  short-circuit, registry routing).
- Full fred-runtime suite: 396 passed. `make code-quality`: 0 errors.

Closes MIGR-03.03 (KEA-MIGRATION-BACKLOG).
