### PR TITLE
fix(kf): scope list_document_tree agent tool to the agent's team

### DIFF
--- a/agentic-backend/agentic_backend/common/kf_document_client.py
+++ b/agentic-backend/agentic_backend/common/kf_document_client.py
@@ -426,9 +426,14 @@ class KfDocumentClient(KfBaseClient):
         """
         Browse the agent's document scope as a folder/document tree.
 
-        Only the library scope is resolved here (hard binding, else runtime user
-        scope) — there is no per-call document_uids concept for browsing: an agent
-        that already knows a uid has no reason to ask for it back via a listing.
+        Two scopes are resolved here, both mirroring vector search:
+          - library scope (hard binding, else runtime user scope) — there is no
+            per-call document_uids concept for browsing: an agent that already
+            knows a uid has no reason to ask for it back via a listing.
+          - owner scope — a team agent lists only its team's folders, a personal
+            agent only the user's personal folders. Without this the tree would
+            leak every folder the *user* can read (all their teams plus personal),
+            regardless of which team the agent is bound to.
         """
         kf_params = _get_kf_vector_search_params(agent_settings)
         tag_ids = resolve_library_scope(kf_params, runtime_context, None)
@@ -436,6 +441,10 @@ class KfDocumentClient(KfBaseClient):
             working_directory=working_directory,
             tag_ids=list(tag_ids) if tag_ids else None,
             max_chars=max_chars,
+            owner_filter=OwnerFilter.TEAM
+            if agent_settings.team_id
+            else OwnerFilter.PERSONAL,
+            team_id=agent_settings.team_id,
         )
 
     async def tree(
@@ -444,6 +453,8 @@ class KfDocumentClient(KfBaseClient):
         working_directory: Optional[str] = None,
         tag_ids: Optional[Collection[str]] = None,
         max_chars: int = 6000,
+        owner_filter: Optional[OwnerFilter] = None,
+        team_id: Optional[str] = None,
     ) -> DocumentTreeResult:
         """
         Wire format (matches controller):
@@ -451,7 +462,9 @@ class KfDocumentClient(KfBaseClient):
           {
             "working_directory": str?,
             "tag_ids": [str]?,
-            "max_chars": int
+            "max_chars": int,
+            "owner_filter": str?,
+            "team_id": str?
           }
         """
         payload: Dict[str, Any] = {"max_chars": max_chars}
@@ -459,6 +472,10 @@ class KfDocumentClient(KfBaseClient):
             payload["working_directory"] = working_directory
         if tag_ids:
             payload["tag_ids"] = list(tag_ids)
+        if owner_filter:
+            payload["owner_filter"] = owner_filter.value
+        if team_id:
+            payload["team_id"] = team_id
 
         r = await self._request_with_token_refresh(
             method="POST",

--- a/agentic-backend/tests/test_kf_vector_search_tools.py
+++ b/agentic-backend/tests/test_kf_vector_search_tools.py
@@ -94,6 +94,60 @@ async def test_list_document_tree_returns_rendered_tree_text(
 
 
 @pytest.mark.asyncio
+async def test_list_document_tree_scopes_to_agent_team(monkeypatch):
+    """A team-bound agent must list only its own team's folders: the tree call
+    sends owner_filter=team and the agent's team_id, mirroring vector search.
+    Without this the tree leaks every folder the user can read across all their
+    teams and personal space (see issue #1899)."""
+    captured: dict = {}
+
+    async def fake_request(self, *, method, path, phase_name, **kwargs):
+        captured["path"] = path
+        captured["json"] = kwargs.get("json")
+        return _response({"tree": "Sales/\n", "truncated": False})
+
+    monkeypatch.setattr(KfDocumentClient, "_request_with_token_refresh", fake_request)
+
+    agent = _FakeAgent(
+        agent_settings=AgentSettings(id="a-1", name="Agent", team_id="team-42"),
+        runtime_context=RuntimeContext(),
+    )
+    tools = build_kf_vector_search_tools(agent)
+    list_document_tree = _tool_by_name(tools, "list_document_tree")
+
+    await list_document_tree.coroutine()
+
+    assert captured["path"] == "/documents/tree"
+    assert captured["json"]["owner_filter"] == "team"
+    assert captured["json"]["team_id"] == "team-42"
+
+
+@pytest.mark.asyncio
+async def test_list_document_tree_scopes_to_personal_when_no_team(monkeypatch):
+    """A personal (team-less) agent lists only the user's personal folders:
+    owner_filter=personal and no team_id."""
+    captured: dict = {}
+
+    async def fake_request(self, *, method, path, phase_name, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return _response({"tree": "Personal/\n", "truncated": False})
+
+    monkeypatch.setattr(KfDocumentClient, "_request_with_token_refresh", fake_request)
+
+    agent = _FakeAgent(
+        agent_settings=AgentSettings(id="a-1", name="Agent"),
+        runtime_context=RuntimeContext(),
+    )
+    tools = build_kf_vector_search_tools(agent)
+    list_document_tree = _tool_by_name(tools, "list_document_tree")
+
+    await list_document_tree.coroutine()
+
+    assert captured["json"]["owner_filter"] == "personal"
+    assert "team_id" not in captured["json"]
+
+
+@pytest.mark.asyncio
 async def test_list_document_tree_appends_session_attachments(
     monkeypatch, _stub_request_with_token_refresh
 ):

--- a/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -2507,6 +2507,10 @@ export type DocumentTreeRequest = {
   working_directory?: string | null;
   /** Restrict the listing to these folder tag ids (and their descendants), when set. */
   tag_ids?: string[] | null;
+  /** Restrict the listing by ownership. None lists every folder the user can read (all their teams plus personal); PERSONAL restricts to the user's personal folders; TEAM restricts to a single team (requires team_id). */
+  owner_filter?: OwnerFilter | null;
+  /** Team whose folders to list. Required when owner_filter is TEAM. */
+  team_id?: string | null;
   /** Render budget for the returned tree text. Oversized trees are pruned, deepest branches first. */
   max_chars?: number;
 };

--- a/knowledge-flow-backend/knowledge_flow_backend/features/tree/service.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/tree/service.py
@@ -55,6 +55,8 @@ class TreeService:
             tag_type=TagType.DOCUMENT,
             path_prefix=request.working_directory,
             limit=_MAX_FOLDERS,
+            owner_filter=request.owner_filter,
+            team_id=request.team_id,
         )
 
         if request.tag_ids:

--- a/knowledge-flow-backend/knowledge_flow_backend/features/tree/structure.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/tree/structure.py
@@ -14,6 +14,7 @@
 
 from typing import List, Optional
 
+from fred_core.common import OwnerFilter
 from pydantic import BaseModel, Field
 
 
@@ -25,6 +26,19 @@ class DocumentTreeRequest(BaseModel):
     tag_ids: Optional[List[str]] = Field(
         default=None,
         description="Restrict the listing to these folder tag ids (and their descendants), when set.",
+    )
+    owner_filter: Optional[OwnerFilter] = Field(
+        default=None,
+        description=(
+            "Restrict the listing by ownership. None lists every folder the user "
+            "can read (all their teams plus personal); PERSONAL restricts to the "
+            "user's personal folders; TEAM restricts to a single team (requires "
+            "team_id)."
+        ),
+    )
+    team_id: Optional[str] = Field(
+        default=None,
+        description="Team whose folders to list. Required when owner_filter is TEAM.",
     )
     max_chars: int = Field(
         default=6000,

--- a/knowledge-flow-backend/tests/services/test_tree_service.py
+++ b/knowledge-flow-backend/tests/services/test_tree_service.py
@@ -14,6 +14,7 @@
 
 import pytest
 from fred_core import KeycloakUser
+from fred_core.common import OwnerFilter
 
 from knowledge_flow_backend.common.document_structures import (
     DocumentMetadata,
@@ -61,9 +62,15 @@ def _library(*, tag_id: str, name: str, path: str | None = None, item_ids: list[
 class _TagServiceStub:
     def __init__(self, tags: list[TagWithItemsId]) -> None:
         self._tags = tags
+        # Records the owner scope the last call was made with, so tests can assert
+        # get_tree forwards owner_filter/team_id from the request (issue #1899).
+        self.last_owner_filter = None
+        self.last_team_id = None
 
-    async def list_all_tags_for_user(self, user, tag_type=None, path_prefix=None, limit=10000, offset=0):
+    async def list_all_tags_for_user(self, user, tag_type=None, path_prefix=None, limit=10000, offset=0, owner_filter=None, team_id=None):
         del user, tag_type, limit, offset
+        self.last_owner_filter = owner_filter
+        self.last_team_id = team_id
         if not path_prefix:
             return list(self._tags)
         return [t for t in self._tags if t.full_path == path_prefix or t.full_path.startswith(path_prefix + "/")]
@@ -141,3 +148,19 @@ async def test_unknown_working_directory_yields_empty_tree():
 
     assert result.tree == "(empty)"
     assert not result.truncated
+
+
+@pytest.mark.asyncio
+async def test_owner_scope_is_forwarded_to_tag_service():
+    """get_tree must pass the request's owner_filter/team_id down to the tag
+    service so a team-bound agent lists only that team's folders, not every
+    folder the user can read across all their teams and personal space (#1899)."""
+    service = _tree_service(tags=[], docs=[])
+
+    await service.get_tree(
+        _user(),
+        DocumentTreeRequest(owner_filter=OwnerFilter.TEAM, team_id="team-42"),
+    )
+
+    assert service.tag_service.last_owner_filter == OwnerFilter.TEAM
+    assert service.tag_service.last_team_id == "team-42"


### PR DESCRIPTION
## Summary

Fixes #1899.

The `list_document_tree` agent tool leaked documents across team boundaries. An agent bound to **team A** listed folders and documents from every other team the user belongs to, plus the user's **personal space** — a cross-team confidentiality leak (folder names, structure, and document uids).

Vector search already scopes to the agent's team via `owner_filter`/`team_id`, but the tree path never propagated any owner scope: `agent_tree` → `tree()` forwarded only `working_directory`/`tag_ids`/`max_chars`, so KF's `get_tree` listed every tag the *user* could read.

This threads the agent's team scope through the tree call the same way search does:

- **agentic-backend** — `agent_tree` derives `owner_filter` (`TEAM` when the agent has a `team_id`, else `PERSONAL`) and passes `team_id`; `tree()` sends both in the `/documents/tree` payload.
- **knowledge-flow-backend** — `DocumentTreeRequest` gains `owner_filter`/`team_id`; `get_tree` forwards them into `list_all_tags_for_user`, which already supports them (no new RBAC logic).

Leaf name resolution (`get_documents_metadata`) already receives only the now team-scoped uid list, so no cross-team names leak there.

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project. *(Ran the affected test suites only — see Validation Notes.)*
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed. *(N/A — no doc-facing behavior/convention change.)*

## Validation Notes

`make code-quality` — both projects clean:
- `agentic-backend`: `All checks passed!` / `361 files already formatted`
- `knowledge-flow-backend`: `All checks passed!` / `307 files already formatted`

Affected test suites:
- `agentic-backend`: `pytest tests/test_kf_vector_search_tools.py` → 21 passed (incl. new `test_list_document_tree_scopes_to_agent_team` and `..._scopes_to_personal_when_no_team`)
- `knowledge-flow-backend`: `pytest tests/services/test_tree_service.py` → 5 passed (incl. new `test_owner_scope_is_forwarded_to_tag_service`)

## Risk / Rollback

Low risk. The change only narrows the tree listing to the scope the agent was already meant to have; the `owner_filter`/`team_id` request fields are optional and default to `None` (previous behavior) for any other caller. Rollback: revert this commit — no migrations or data changes.
