### PR TITLE
fix(ingestion): decode non-UTF-8 text/markdown inputs instead of crashing

### DIFF
--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/common/base_input_processor.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/common/base_input_processor.py
@@ -246,6 +246,31 @@ class BaseInputProcessor(ABC):
         pass
 
 
+def read_text_with_fallback(file_path: Path) -> str:
+    """
+    Read a plain-text/markdown file whose encoding is not guaranteed to be UTF-8.
+
+    Many real-world inputs (e.g. emails exported from Outlook as .txt) are encoded
+    in Windows-1252 / Latin-1 and contain bytes that are invalid UTF-8, which makes
+    a hard-coded ``encoding="utf-8"`` read raise ``UnicodeDecodeError`` and crash the
+    whole ingestion workflow.
+
+    Strategy:
+    1. Try UTF-8 (with BOM handling), the overwhelmingly common case.
+    2. Fall back to cp1252 then latin-1, which cover typical Windows/Outlook exports.
+    3. As a last resort, decode as UTF-8 replacing undecodable bytes so ingestion
+       always produces a usable preview instead of failing.
+    """
+    raw = file_path.read_bytes()
+    for encoding in ("utf-8-sig", "cp1252", "latin-1"):
+        try:
+            return raw.decode(encoding)
+        except UnicodeDecodeError:
+            logger.debug("Failed to decode %s as %s, trying next encoding.", file_path, encoding)
+    logger.warning("Could not decode %s with known encodings; falling back to utf-8 with replacement.", file_path)
+    return raw.decode("utf-8", errors="replace")
+
+
 class BaseMarkdownProcessor(BaseInputProcessor):
     """For processors that convert to Markdown."""
 

--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/markdown_markdown_processor/markdown_markdown_processor.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/markdown_markdown_processor/markdown_markdown_processor.py
@@ -14,7 +14,7 @@
 
 from pathlib import Path
 
-from knowledge_flow_backend.core.processors.input.common.base_input_processor import BaseMarkdownProcessor
+from knowledge_flow_backend.core.processors.input.common.base_input_processor import BaseMarkdownProcessor, read_text_with_fallback
 
 
 class MarkdownMarkdownProcessor(BaseMarkdownProcessor):
@@ -33,6 +33,7 @@ class MarkdownMarkdownProcessor(BaseMarkdownProcessor):
     def convert_file_to_markdown(self, file_path: Path, output_dir: Path, document_uid: str | None) -> dict:
         output_dir.mkdir(parents=True, exist_ok=True)
         md_path = output_dir / "output.md"
-        with open(file_path, "r", encoding="utf-8") as f_in, open(md_path, "w", encoding="utf-8") as f_out:
-            f_out.write(f_in.read())
+        content = read_text_with_fallback(file_path)
+        with open(md_path, "w", encoding="utf-8") as f_out:
+            f_out.write(content)
         return {"doc_dir": str(output_dir), "md_file": str(md_path)}

--- a/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/text_markdown_processor/text_markdown_processor.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/text_markdown_processor/text_markdown_processor.py
@@ -16,7 +16,7 @@
 
 from pathlib import Path
 
-from knowledge_flow_backend.core.processors.input.common.base_input_processor import BaseMarkdownProcessor
+from knowledge_flow_backend.core.processors.input.common.base_input_processor import BaseMarkdownProcessor, read_text_with_fallback
 
 
 class TextMarkdownProcessor(BaseMarkdownProcessor):
@@ -40,6 +40,7 @@ class TextMarkdownProcessor(BaseMarkdownProcessor):
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         md_path = output_dir / "output.md"
-        with open(file_path, "r", encoding="utf-8") as f_in, open(md_path, "w", encoding="utf-8") as f_out:
-            f_out.write(f_in.read())
+        content = read_text_with_fallback(file_path)
+        with open(md_path, "w", encoding="utf-8") as f_out:
+            f_out.write(content)
         return {"doc_dir": str(output_dir), "md_file": str(md_path)}

--- a/knowledge-flow-backend/tests/processors/input/markdown_markdown_processor/test_markdown_markdown_processor.py
+++ b/knowledge-flow-backend/tests/processors/input/markdown_markdown_processor/test_markdown_markdown_processor.py
@@ -17,6 +17,7 @@
 import tempfile
 from pathlib import Path
 
+from knowledge_flow_backend.core.processors.input.markdown_markdown_processor.markdown_markdown_processor import MarkdownMarkdownProcessor
 from knowledge_flow_backend.core.processors.input.text_markdown_processor.text_markdown_processor import TextMarkdownProcessor
 
 
@@ -65,3 +66,24 @@ def hello_world():
         assert "# Sample Markdown Document" in content_written
         assert "```python" in content_written
         assert "> This is a blockquote." in content_written
+
+
+def test_markdown_markdown_processor_non_utf8():
+    """Regression for #1898: a non-UTF-8 (Windows-1252) .md file must not crash ingestion."""
+    processor = MarkdownMarkdownProcessor()
+    # "é" / "à" encode to bytes 0xe9 / 0xe0 which are invalid UTF-8.
+    test_content = "# Réunion\n\nDétails du café à Paris."
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        input_file = temp_path / "note.md"
+        output_dir = temp_path / "output"
+
+        input_file.write_bytes(test_content.encode("cp1252"))
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        result = processor.convert_file_to_markdown(input_file, output_dir, "uid")
+
+        content_written = Path(result["md_file"]).read_text(encoding="utf-8")
+        assert "# Réunion" in content_written
+        assert "café à Paris" in content_written

--- a/knowledge-flow-backend/tests/processors/input/text_markdown_processor/test_text_markdown_processor.py
+++ b/knowledge-flow-backend/tests/processors/input/text_markdown_processor/test_text_markdown_processor.py
@@ -43,3 +43,24 @@ def test_sample_markdown_processor_end_to_end():
         # Convert to markdown
         result = processor.convert_file_to_markdown(input_file, output_dir, metadata.document_uid)
         assert Path(result["md_file"]).exists()
+
+
+def test_text_markdown_processor_non_utf8_outlook_export():
+    """Regression for #1898: a Windows-1252 (Outlook) .txt export must not crash ingestion."""
+    processor = TextMarkdownProcessor()
+    # "Réunion à 9h — café" contains bytes (0xe9, 0xe0) that are invalid UTF-8.
+    test_content = "Réunion à 9h — café"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        input_file = temp_path / "outlook.txt"
+        output_dir = temp_path / "output"
+
+        input_file.write_bytes(test_content.encode("cp1252"))
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        result = processor.convert_file_to_markdown(input_file, output_dir, "uid")
+
+        content_written = Path(result["md_file"]).read_text(encoding="utf-8")
+        assert "Réunion à 9h" in content_written
+        assert "café" in content_written


### PR DESCRIPTION
## Summary

Ingesting a `.txt`/`.md` file that is **not UTF-8 encoded** (e.g. an email exported from Outlook as plain text, typically Windows-1252/Latin-1) crashed the ingestion pipeline with a `UnicodeDecodeError`. Temporal retried the activity to the maximum and the whole workflow failed.

Both `TextMarkdownProcessor` and `MarkdownMarkdownProcessor` read the input with a hard-coded `encoding="utf-8"`, so a byte like `0xe9` (Latin-1 "é") aborted the read.

This change:
- Adds a shared `read_text_with_fallback()` helper on the common base module: try `utf-8-sig`, then `cp1252`, then `latin-1`, then `utf-8` with `errors="replace"` as a last resort — so these files always ingest successfully instead of crashing.
- Uses it in both affected processors (DRY — one helper, two call sites).
- Adds regression tests writing genuine cp1252 bytes for both processors.

Closes #1898

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [ ] I updated documentation when behavior or conventions changed.

## Validation Notes

- `uv run pytest tests/processors/input/text_markdown_processor tests/processors/input/markdown_markdown_processor -q` → `4 passed`
- `make code-quality` → exit 0 (`0 errors, 0 warnings, 0 notes`; bandit: no issues)
- `make test` → full suite passed, coverage report generated

## Risk / Rollback

Low risk: the change only affects how plain-text/markdown inputs are decoded. UTF-8 files behave exactly as before (tried first). Rollback by reverting this commit.