### PR TITLE
feat(kf): accept .txt files as conversation attachments (#1900)

### DIFF
--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -204,6 +204,10 @@ x-profile-rich-worker: &profile-rich-worker
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_pptx_processor.FastLitePptxProcessor
 #   - suffix: ".csv"
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_csv_processor.FastLiteCsvProcessor
+#   - suffix: ".md"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
+#   - suffix: ".txt"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
 
 # ── Shared knowledge-flow configuration (backend + worker) ──────────────────────────
 

--- a/knowledge-flow-backend/config/configuration.yaml
+++ b/knowledge-flow-backend/config/configuration.yaml
@@ -192,6 +192,10 @@ processing:
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_pptx_processor.FastLitePptxProcessor
 #   - suffix: ".csv"
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_csv_processor.FastLiteCsvProcessor
+#   - suffix: ".md"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
+#   - suffix: ".txt"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
 security:
   m2m:
     enabled: false

--- a/knowledge-flow-backend/config/configuration_gcp.yaml
+++ b/knowledge-flow-backend/config/configuration_gcp.yaml
@@ -213,6 +213,10 @@ processing:
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_pptx_processor.FastLitePptxProcessor
 #   - suffix: ".csv"
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_csv_processor.FastLiteCsvProcessor
+#   - suffix: ".md"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
+#   - suffix: ".txt"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
 
 security:
   m2m:

--- a/knowledge-flow-backend/config/configuration_test.yaml
+++ b/knowledge-flow-backend/config/configuration_test.yaml
@@ -192,6 +192,10 @@ processing:
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_pptx_processor.FastLitePptxProcessor
 #   - suffix: ".csv"
 #     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_csv_processor.FastLiteCsvProcessor
+#   - suffix: ".md"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
+#   - suffix: ".txt"
+#     class_path: knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor.FastLiteMarkdownProcessor
 
 # Use a no-op output processor for markdown-quality profile tests.
 # This avoids embedding/vectorization calls so tests can focus only on

--- a/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
+++ b/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
@@ -251,6 +251,7 @@ class IngestionController:
             registry[".pptx"] = FastLitePptxProcessor
             registry[".csv"] = FastLiteCsvProcessor
             registry[".md"] = FastLiteMarkdownProcessor
+            registry[".txt"] = FastLiteMarkdownProcessor
         logger.info(f"[INGESTION][FAST TEXT] Fast text processor registry: {registry}")
         return registry
 

--- a/knowledge-flow-backend/tests/features/ingestion/test_fast_text_registry_txt.py
+++ b/knowledge-flow-backend/tests/features/ingestion/test_fast_text_registry_txt.py
@@ -1,0 +1,62 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for `.txt` support as a conversation/session attachment (issue #1900).
+
+Why this exists:
+- Uploading a `.txt` attachment previously failed with
+  `HTTPException(400, "No fast text processor configured for '.txt'")` because the
+  default fast-text processor registry did not include `.txt`.
+- These tests pin `.txt` (case-insensitive) to `FastLiteMarkdownProcessor` and verify
+  that a plain-text file extracts its content, mirroring what `/fast/ingest` does with
+  an uploaded attachment.
+"""
+
+import pytest
+
+from knowledge_flow_backend.core.processors.input.fast_text_processor.fast_lite_markdown_processor import (
+    FastLiteMarkdownProcessor,
+)
+from knowledge_flow_backend.features.ingestion.ingestion_controller import IngestionController
+
+
+@pytest.fixture
+def controller() -> IngestionController:
+    """Build a controller with only the fast-text registry wired up.
+
+    The default registry is used because the test `Configuration` leaves
+    `attachment_processors` unset (see conftest `app_context`).
+    """
+    ctrl = IngestionController.__new__(IngestionController)
+    ctrl._fast_text_registry = ctrl._build_fast_text_registry()
+    ctrl._fast_text_instances = {}
+    return ctrl
+
+
+@pytest.mark.parametrize("filename", ["notes.txt", "NOTES.TXT", "Notes.Txt"])
+def test_txt_resolves_to_markdown_processor(controller: IngestionController, filename: str):
+    processor = controller._get_fast_text_processor(filename)
+    assert isinstance(processor, FastLiteMarkdownProcessor)
+
+
+def test_txt_extraction_returns_plain_text(controller: IngestionController, tmp_path):
+    txt_file = tmp_path / "hello.txt"
+    txt_file.write_text("Hello, world.\nSecond line.\n", encoding="utf-8")
+
+    processor = controller._get_fast_text_processor(txt_file.name)
+    result = processor.extract(txt_file)
+
+    assert "Hello, world." in result.text
+    assert "Second line." in result.text


### PR DESCRIPTION
## Summary

Uploading a `.txt` file as a session (conversation) attachment failed with `HTTPException(400, "No fast text processor configured for '.txt'")`. The frontend already accepts `.txt`; the gap was entirely backend — the fast-text processor registry that gates accepted attachment types had no `.txt` entry.

- Register `.txt` → the existing `FastLiteMarkdownProcessor` (already a plain-text reader) in `IngestionController._build_fast_text_registry()`. No new processor class.
- Add commented `.md`/`.txt` examples to the `attachment_processors` blocks in `configuration.yaml`, `configuration_gcp.yaml`, `configuration_test.yaml`, and the Helm chart `deploy/charts/fred/values.yaml`, so admins overriding the registry don't silently drop plain-text support (the examples previously stopped at `.csv`).
- Add an offline unit test asserting `.txt`/`.TXT`/`.Txt` resolve to `FastLiteMarkdownProcessor` and that a real `.txt` extracts its content.

**Scope:** Encoding handling for non-UTF-8 `.txt` (Outlook/latin-1 exports) is intentionally left to #1898. Because this reuses `FastLiteMarkdownProcessor`, any encoding fix made there applies to `.txt` automatically.

> Note: `configuration_prod.yaml` and `configuration_worker.yaml` carry the git `skip-worktree` flag in this repo, so their (equivalent) example edits are intentionally not part of this commit.

Closes #1900

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [x] I ran `make code-quality` in every touched project.
- [x] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

Run in `knowledge-flow-backend/`:

- `make test-one TEST=tests/features/ingestion/test_fast_text_registry_txt.py` → **4 passed**
- `make code-quality` → **0 errors, 0 warnings**; bandit: *No issues identified*
- `make test` → **222 passed, 2 deselected**

## Risk / Rollback

Low risk: one registry entry pointing `.txt` at an existing plain-text reader, plus commented config examples. Rollback by reverting the commit — no data migration or schema change.
