### PR TITLE
fix(ppt-filler): install libreoffice in agentic prod runtime stage

### DIFF
--- a/agentic-backend/dockerfiles/Dockerfile-prod
+++ b/agentic-backend/dockerfiles/Dockerfile-prod
@@ -56,9 +56,12 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 ARG PRODUCTION_FASTAPI_DOCS_ENABLED=false
 
-# System deps (minimal)
+# System deps (minimal). libreoffice provides `soffice`, required at RUNTIME by the
+# PPT-filler preview (fred-core convert_pptx_bytes_to_pdf). It is installed in the build
+# stage too, but only /app/venv is copied out of that stage — so it must be reinstalled
+# here or the fill tool silently degrades to a download-only chip (no PDF preview).
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl libreoffice --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # # Install dependencies


### PR DESCRIPTION
## Summary

The PPT-filler PDF preview (added in #1886) never appeared on cluster deployments: the produced deck still rendered as the old download-only chip with no preview, while it worked fine locally.

Root cause is a Docker multi-stage gap, not the feature code:

- The preview converts the filled `.pptx` to PDF via `fred-core`'s `convert_pptx_bytes_to_pdf`, which shells out to `soffice` (LibreOffice).
- The agentic prod image installed `libreoffice` **only in the build stage**, from which just `/app/venv` is copied into the runtime stage. The runtime image therefore had no `soffice`.
- At runtime `shutil.which("soffice")` returned `None` → conversion returned `None` → the fill tool degraded (by design, best-effort) to the download chip. No preview, "like nothing changed."
- Locally `soffice` is on `PATH`, so the gap only manifested in the built image. Confirmed on integration by the log line `[PPTX2PDF] LibreOffice (soffice) is not installed or not in PATH.`

Fix: install `libreoffice` in the **runtime** stage of the agentic prod Dockerfile, matching the knowledge-flow prod image which already does this (its runtime stage installs libreoffice, which is why KF slide rendering was never affected and the RFC assumed "soffice is installed in both backend images").

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project. — N/A: Dockerfile-only change, no source code touched.
- [ ] I ran `make test` in every touched project. — N/A: Dockerfile-only change; no runtime code path altered.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed. — N/A: no behavior/convention change beyond the image dependency.

## Validation Notes

- Diagnosed from the integration agentic-backend pod log: `[PPTX2PDF] LibreOffice (soffice) is not installed or not in PATH.` emitted on every fill, followed by the download-chip fallback path in `ppt_filler/toolkit.py`.
- Confirmed the runtime stage of `agentic-backend/dockerfiles/Dockerfile-prod` previously installed only `curl`; `libreoffice` was present only in the builder stage (line 17), and only `/app/venv` is copied out of it.
- After the fix the runtime stage installs `libreoffice --no-install-recommends`, mirroring `knowledge-flow-backend/dockerfiles/Dockerfile-prod`.

## Risk / Rollback

- Risk: slightly larger agentic-backend image (LibreOffice). Same footprint the knowledge-flow image already carries, so acceptable.
- Rollback: revert this commit; the preview reverts to degrading to the download chip (no functional regression, just no preview).