### PR TITLE
fix(kf): stop agent from exposing document/folder ids to users

### DIFF
--- a/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
+++ b/agentic-backend/agentic_backend/integrations/kf_vector_search/kf_vector_search_tools.py
@@ -241,6 +241,13 @@ def build_kf_vector_search_tools(agent: KnowledgeFlowAgentContext) -> list[BaseT
         happens, narrow `working_directory` or switch to
         search_documents_using_vectorization instead of trying to browse
         everything.
+
+        The bracketed ids ('[tag_id]' and '[document_uid]') are internal
+        identifiers for YOUR tool calls only. NEVER show them to the user or
+        mention them in your replies — the user does not know these ids and they
+        are meaningless to them. Always refer to folders and documents by their
+        human-readable name (e.g. "the Sales folder" or "the Q3 report"), never
+        by their id.
         """
         client = KfDocumentClient(agent=agent)
         started = time.monotonic()


### PR DESCRIPTION
## Summary

When an agent uses the `list_document_tree` tool, its output renders folders and documents with bracketed internal identifiers (`[tag_id]` / `[document_uid]`). The agent sometimes echoed these ids back to the user, who has no knowledge of them — they are meaningless and confusing in a reply.

This adds an instruction to the `list_document_tree` docstring telling the agent to treat those bracketed ids as internal, for tool calls only, and to always refer to folders and documents by their human-readable name. The ids remain fully usable for downstream tool calls (search filters, summarize).

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

Docstring-only change (agent-facing prompt text); no runtime logic altered. `make code-quality` / `make test` not run for this prose-only edit.

## Risk / Rollback

Minimal risk: the change only adds guidance to a tool docstring and does not touch any code path. Rollback by reverting the single commit.
