### PR TITLE
feat(kf): add optional agent documentation help link

### DIFF
--- a/agentic-backend/agentic_backend/common/structures.py
+++ b/agentic-backend/agentic_backend/common/structures.py
@@ -388,6 +388,7 @@ class Properties(BaseModel):
     agentsNicknamePlural: str = "agents"
     agentIconName: str = "person"
     contactSupportLink: str | None = None
+    agentDocumentationLink: str | None = None
     showAgentRestoreFromConfiguration: bool = True
     showAgentDisableButton: bool = True
     showAgentCode: bool = True

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1534,7 +1534,8 @@
         "create": "Create {{agentsNicknameSingular}}",
         "firstTitle": "Create your first {{agentsNicknameSingular}} !",
         "noAgent": "No team {{agentsNicknameSingular}} configured yet. Create your first team {{agentsNicknameSingular}} to get started.",
-        "firstCreate": "Create"
+        "firstCreate": "Create",
+        "documentationHelp": "Not sure where to start?"
       },
       "formAgent": {
         "titleCreate": "Create a new {{agentsNicknameSingular}}",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1534,7 +1534,8 @@
         "create": "Créer {{agentsNicknameSingular}}",
         "firstTitle": "Créez votre premier {{agentsNicknameSingular}} !",
         "noAgent": "Aucun {{agentsNicknameSingular}} dans cette équipe !",
-        "firstCreate": "Créer"
+        "firstCreate": "Créer",
+        "documentationHelp": "Vous ne savez pas par où commencer ?"
       },
       "formAgent": {
         "titleCreate": "Créer un nouveau {{agentsNicknameSingular}}",

--- a/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentContent/TeamAgentContent.module.css
+++ b/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentContent/TeamAgentContent.module.css
@@ -1,3 +1,31 @@
+.documentationLink {
+  position: absolute;
+  top: var(--spacing-m);
+  right: var(--spacing-m);
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-m);
+  border: 1px solid var(--outline-muted);
+  border-radius: 999px;
+  color: var(--primary);
+  font: var(--font-body-medium);
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.documentationLink:hover {
+  background-color: var(--surface-container-hight);
+  border-color: var(--primary);
+}
+
+.documentationLink :global(.material-symbols-outlined) {
+  font-size: 1.125rem;
+}
+
 .title {
   display: flex;
   justify-content: center;

--- a/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentContent/TeamAgentContent.tsx
+++ b/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentContent/TeamAgentContent.tsx
@@ -1,4 +1,5 @@
 import Button from "@shared/atoms/Button/Button.tsx";
+import Icon from "@shared/atoms/Icon/Icon.tsx";
 import { Link, useParams } from "react-router-dom";
 import { useFrontendProperties } from "../../../../../hooks/useFrontendProperties.ts";
 import { useTranslation } from "react-i18next";
@@ -21,7 +22,7 @@ export default function TeamAgentContent({
   onToggleAgent,
   canUpdateAgents,
 }: TeamAgentContentProps) {
-  const { agentsNicknameSingular, agentsNicknamePlural } = useFrontendProperties();
+  const { agentsNicknameSingular, agentsNicknamePlural, agentDocumentationLink } = useFrontendProperties();
   const { t } = useTranslation();
   const { teamId } = useParams();
 
@@ -40,6 +41,17 @@ export default function TeamAgentContent({
 
   return (
     <>
+      {agentDocumentationLink && (
+        <a
+          className={styles.documentationLink}
+          href={agentDocumentationLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Icon category={"outlined"} type={"help"} />
+          {t("rework.teams.agents.documentationHelp")}
+        </a>
+      )}
       <div className={styles.title}>
         {t("rework.teams.agents.title", { agentsNicknamePlural })}
         {canUpdateAgents && (

--- a/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentEmptyState/TeamAgentEmptyState.module.css
+++ b/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentEmptyState/TeamAgentEmptyState.module.css
@@ -22,3 +22,27 @@
 
   font: var(--font-title-large);
 }
+
+.teamAgentDocumentationLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-m);
+  border: 1px solid var(--outline-muted);
+  border-radius: 999px;
+  color: var(--primary);
+  font: var(--font-body-medium);
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.teamAgentDocumentationLink:hover {
+  background-color: var(--surface-container-hight);
+  border-color: var(--primary);
+}
+
+.teamAgentDocumentationLink :global(.material-symbols-outlined) {
+  font-size: 1.125rem;
+}

--- a/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentEmptyState/TeamAgentEmptyState.tsx
+++ b/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentEmptyState/TeamAgentEmptyState.tsx
@@ -11,7 +11,7 @@ interface TeamAgentEmptyStateProps {
 }
 
 export default function TeamAgentEmptyState({ onCreateAgent, canUpdateAgents }: TeamAgentEmptyStateProps) {
-  const { agentIconName, agentsNicknameSingular } = useFrontendProperties();
+  const { agentIconName, agentsNicknameSingular, agentDocumentationLink } = useFrontendProperties();
   const { t } = useTranslation();
 
   return (
@@ -22,6 +22,17 @@ export default function TeamAgentEmptyState({ onCreateAgent, canUpdateAgents }: 
         </span>
         <span>{t("rework.teams.agents.noAgent", { agentsNicknameSingular })}</span>
       </div>
+      {agentDocumentationLink && (
+        <a
+          className={styles.teamAgentDocumentationLink}
+          href={agentDocumentationLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Icon category={"outlined"} type={"help"} />
+          {t("rework.teams.agents.documentationHelp")}
+        </a>
+      )}
       {canUpdateAgents && (
         <Button
           color={"primary"}

--- a/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -1,4 +1,5 @@
 .teamAgentContainer {
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/frontend/src/rework/components/shared/utils/Type.ts
+++ b/frontend/src/rework/components/shared/utils/Type.ts
@@ -51,7 +51,8 @@ export type MaterialIconType =
   | "close"
   | "download"
   | "description"
-  | "slideshow";
+  | "slideshow"
+  | "help";
 
 export type CustomIconType = (typeof customIcons)[number];
 export type IconType = MaterialIconType | CustomIconType;

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -1379,6 +1379,7 @@ export type Properties = {
   agentsNicknamePlural?: string;
   agentIconName?: string;
   contactSupportLink?: string | null;
+  agentDocumentationLink?: string | null;
   showAgentRestoreFromConfiguration?: boolean;
   showAgentDisableButton?: boolean;
   showAgentCode?: boolean;


### PR DESCRIPTION
## Summary

Closes #1909.

Adds an optional documentation help link on the team Agents page so users who don't know where to start can be pointed to a documentation resource (SharePoint, best-practices guide, etc.).

- New optional frontend property `agentDocumentationLink` (backend `Properties` + generated frontend type). When unset, nothing is rendered.
- **No agents**: link shown between the empty-state text and the *Create agent* button.
- **Has agents**: link pinned to the top-right corner (absolute-positioned so it stays put even when the agent list is vertically centered with only a few agents).
- Rendered as a rounded pill with a `help` icon; hover state uses existing design tokens.
- Text: EN "Not sure where to start?" / FR "Vous ne savez pas par où commencer ?"

## Mandatory Checklist

- [ ] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project.
- [ ] I ran `make test` in every touched project.
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

- `npx tsc --noEmit` — no type errors in touched files.

## Risk / Rollback

Low risk: purely additive, feature-flagged by an optional property that defaults to unset (link hidden). Rollback by reverting the commit; no data migration involved.

> Note: enabling the link in production requires setting `agentDocumentationLink` in the frontend properties config — intentionally **not** included in this PR.
