### PR TITLE
docs: add v1.8.0 release notes

### DIFF
--- a/frontend/public/release.md
+++ b/frontend/public/release.md
@@ -1,3 +1,30 @@
+**v1.8.0** - 2026-07-06
+
+- **Features**
+
+  - PPT Filler toolkit: agents can fill PowerPoint templates by key, including text (with inline bold/italic), images, table cells and grouped shapes, plus an auto-opening resizable PDF preview pane to review filled decks without leaving Fred (#1836, #1873, #1882, #1886)
+  - Collaborative writable documents: editor pane with Word export, tables and robust inline formatting (#1791, #1809)
+  - Inline charts in chat for interactive data agents, with free-text HITL (#1788, #1812)
+  - Document tree and on-demand summarization tools for agents, working uniformly for corpus and session attachments (#1786, #1810)
+  - Accept `.txt` files as conversation attachments (#1904)
+  - Optional agent documentation help link, driven by a frontend property (#1910)
+
+- **Improvements**
+
+  - Rename agent "System prompt" field to "Instruction" (#1872)
+  - Configurable timeout and max-chars toggle for document summarization (#1803)
+  - Optional per-application hostAliases support in the chart (#1844)
+
+- **Bug Fixes**
+
+  - Retry LLM stream connection drops by default (#1813)
+  - Fix tool_loop windowing (#1807)
+  - Decode non-UTF-8 text/markdown inputs during ingestion instead of crashing (#1902)
+  - Fix duplicated chart parts in v2 runtime (#1822)
+  - Add customizable timeouts to the OpenSearch client (#1798)
+  - Stop sending `max_tokens` on summarize so strict gateways accept the request (#1808)
+  - Truncate long user names and usernames with ellipsis (#1811)
+
 **v1.7.0** - 2026-06-19
 
 - **Features**


### PR DESCRIPTION
## Summary

Add the **v1.8.0** release notes entry to `frontend/public/release.md`, summarizing the important changes shipped since the `1.7.0` tag. Fixes iterating on features that are new in this release (e.g. PPT Filler sub-fixes) are folded into their feature line rather than listed as standalone fixes.

Highlights covered:
- PPT Filler toolkit (text/image/table fill + PDF preview pane)
- Collaborative writable documents with Word export
- Inline charts in chat for interactive data agents
- Document tree + on-demand summarization tools for agents

## Mandatory Checklist

- [x] I followed [`docs/platform/DEVELOPER_CONTRACT.md`](../docs/platform/DEVELOPER_CONTRACT.md).
- [x] The change is minimal and avoids over-engineering.
- [ ] I ran `make code-quality` in every touched project. — N/A, docs-only change
- [ ] I ran `make test` in every touched project. — N/A, docs-only change
- [x] I did not introduce unit/default tests that require external services.
- [x] Any test requiring external services is marked `@pytest.mark.integration`.
- [x] I updated documentation when behavior or conventions changed.

## Validation Notes

Docs-only change to `frontend/public/release.md`. No code touched.

## Risk / Rollback

No runtime risk (release-notes markdown only). Rollback: revert the commit.
