### PR TITLE
fix(frontend): improve writable document editor (tables, code blocks, images, dark theme)

### DIFF
--- a/frontend/src/components/chatbot/WritableDocumentPane.module.css
+++ b/frontend/src/components/chatbot/WritableDocumentPane.module.css
@@ -145,6 +145,44 @@
   --baseTextContrast: var(--on-surface);
 }
 
+/* MDXEditor portals every popup (block-type dropdown, table cell/column
+ * popover, link dialog) into a single `.mdxeditor-popup-container` div that it
+ * appends to <body> — a sibling of `.mdxeditor`, NOT a child. So the token
+ * mapping above (scoped to `.editorArea .mdxeditor`) never reaches the popups,
+ * and they fall back to MDXEditor's default slate scale: a white background
+ * with washed-out grey text, unreadable against our dark theme. Repeat the same
+ * mapping on the popup container so the popups follow our theme too. The rule is
+ * unscoped on purpose (the container lives outside `.editorArea`).
+ *
+ * The popup panel (`--basePageBg`) is deliberately one surface step ABOVE the
+ * pane/toolbar (which use `surface-container` / `-hight`): as a floating layer
+ * it should read as elevated, so we give it `surface-container-highest` plus a
+ * border and shadow (below) to lift it off the pane rather than blend in. */
+:global(.mdxeditor-popup-container) {
+  --basePageBg: var(--surface-container-highest);
+  --baseBase: var(--surface-container);
+  --baseBgSubtle: var(--surface-container);
+  --baseBg: var(--state-on-surface-hover);
+  --baseBgHover: var(--state-on-surface-hover);
+  --baseBgActive: var(--state-on-surface-pressed);
+  --baseLine: var(--outline-muted);
+  --baseBorder: var(--outline-muted);
+  --baseBorderHover: var(--outline);
+  --baseText: var(--on-surface);
+  --baseTextContrast: var(--on-surface);
+}
+
+/* Lift every popup panel off the pane: a crisp border + soft shadow so the
+ * elevated surface reads as a distinct floating layer. Covers the block-type
+ * dropdown, the table cell/column popover, and the link dialog. */
+:global(.mdxeditor-popup-container [class*="selectContainer"]),
+:global(.mdxeditor-popup-container [class*="PopoverContent"]),
+:global(.mdxeditor-popup-container [class*="dialogContent"]) {
+  box-shadow: var(--shadow-s);
+  border: 1px solid var(--outline-muted);
+  border-radius: var(--radius-s);
+}
+
 /* Toolbar: a fixed (non-scrolling) flex child so it always stays put. */
 .editorArea :global(.mdxeditor [role="toolbar"]) {
   position: static;

--- a/frontend/src/components/chatbot/WritableDocumentPane.module.css
+++ b/frontend/src/components/chatbot/WritableDocumentPane.module.css
@@ -209,3 +209,51 @@
   padding-right: var(--spacing-m);
   padding-left: var(--spacing-m);
 }
+
+/* Code blocks (codeBlockPlugin + codeMirrorPlugin) embed a CodeMirror editor
+ * whose generated theme hard-codes a white background and near-black text — it
+ * wins over the `--base*` token mapping above, so on our dark theme the block
+ * renders white-on-pale. Repaint CodeMirror's surfaces onto our tokens:
+ * transparent inner layers over a container-tinted editor, dimmed gutter, and a
+ * subtle active-line highlight. Syntax token hues come from CodeMirror's own
+ * highlight theme and stay readable on the dark surface. */
+.editorArea :global(.mdxeditor .cm-editor) {
+  background-color: var(--surface-container-hight);
+  color: var(--on-surface);
+}
+
+.editorArea :global(.mdxeditor .cm-editor .cm-scroller),
+.editorArea :global(.mdxeditor .cm-editor .cm-gutters),
+.editorArea :global(.mdxeditor .cm-editor .cm-content) {
+  background-color: transparent;
+}
+
+.editorArea :global(.mdxeditor .cm-editor .cm-gutters),
+.editorArea :global(.mdxeditor .cm-editor .cm-lineNumbers) {
+  color: var(--on-surface-retreat);
+}
+
+.editorArea :global(.mdxeditor .cm-editor .cm-activeLine),
+.editorArea :global(.mdxeditor .cm-editor .cm-activeLineGutter) {
+  background-color: var(--state-on-surface-hover);
+}
+
+.editorArea :global(.mdxeditor .cm-editor .cm-activeLineGutter) {
+  color: var(--on-surface);
+}
+
+.editorArea :global(.mdxeditor .cm-editor .cm-cursor),
+.editorArea :global(.mdxeditor .cm-editor .cm-cursor-primary) {
+  border-left-color: var(--on-surface);
+}
+
+/* Toolbar button tooltips (the hover bubble) portal into the same popup
+ * container as the dropdowns, but the tooltip panel carries its own hard-coded
+ * light background that the container's token mapping doesn't reach — so it
+ * renders as a pale bubble on our dark theme. Repaint it onto the elevated
+ * surface with a border to match the other popup panels. */
+:global(.mdxeditor-popup-container [class*="tooltipContent"]) {
+  border: 1px solid var(--outline-muted);
+  background-color: var(--surface-container-highest);
+  color: var(--on-surface);
+}

--- a/frontend/src/components/chatbot/WritableDocumentPane.tsx
+++ b/frontend/src/components/chatbot/WritableDocumentPane.tsx
@@ -27,6 +27,7 @@ import {
   BoldItalicUnderlineToggles,
   CreateLink,
   headingsPlugin,
+  InsertTable,
   linkDialogPlugin,
   linkPlugin,
   listsPlugin,
@@ -35,6 +36,7 @@ import {
   MDXEditor,
   quotePlugin,
   Separator,
+  tablePlugin,
   thematicBreakPlugin,
   toolbarPlugin,
   UndoRedo,
@@ -126,6 +128,7 @@ export default function WritableDocumentPane({
             linkPlugin(),
             linkDialogPlugin(),
             thematicBreakPlugin(),
+            tablePlugin(),
             markdownShortcutPlugin(),
             toolbarPlugin({
               toolbarContents: () => (
@@ -139,6 +142,8 @@ export default function WritableDocumentPane({
                   <ListsToggle />
                   <Separator />
                   <CreateLink />
+                  <Separator />
+                  <InsertTable />
                 </>
               ),
             }),

--- a/frontend/src/components/chatbot/WritableDocumentPane.tsx
+++ b/frontend/src/components/chatbot/WritableDocumentPane.tsx
@@ -147,6 +147,7 @@ export default function WritableDocumentPane({
                 js: "JavaScript",
                 json: "JSON",
                 jsx: "JSX",
+                markdown: "Markdown",
                 python: "Python",
                 sql: "SQL",
                 ts: "TypeScript",

--- a/frontend/src/components/chatbot/WritableDocumentPane.tsx
+++ b/frontend/src/components/chatbot/WritableDocumentPane.tsx
@@ -25,8 +25,14 @@
 import {
   BlockTypeSelect,
   BoldItalicUnderlineToggles,
+  ChangeCodeMirrorLanguage,
+  codeBlockPlugin,
+  codeMirrorPlugin,
+  ConditionalContents,
   CreateLink,
   headingsPlugin,
+  imagePlugin,
+  InsertCodeBlock,
   InsertTable,
   linkDialogPlugin,
   linkPlugin,
@@ -129,22 +135,54 @@ export default function WritableDocumentPane({
             linkDialogPlugin(),
             thematicBreakPlugin(),
             tablePlugin(),
+            imagePlugin(),
+            codeBlockPlugin({ defaultCodeBlockLanguage: "" }),
+            codeMirrorPlugin({
+              codeBlockLanguages: {
+                "": t("chat.writableDocument.code.plainText", "Plain text"),
+                bash: "Bash",
+                css: "CSS",
+                html: "HTML",
+                java: "Java",
+                js: "JavaScript",
+                json: "JSON",
+                jsx: "JSX",
+                python: "Python",
+                sql: "SQL",
+                ts: "TypeScript",
+                tsx: "TSX",
+                yaml: "YAML",
+              },
+            }),
             markdownShortcutPlugin(),
             toolbarPlugin({
               toolbarContents: () => (
-                <>
-                  <UndoRedo />
-                  <Separator />
-                  <BoldItalicUnderlineToggles />
-                  <Separator />
-                  <BlockTypeSelect />
-                  <Separator />
-                  <ListsToggle />
-                  <Separator />
-                  <CreateLink />
-                  <Separator />
-                  <InsertTable />
-                </>
+                <ConditionalContents
+                  options={[
+                    {
+                      when: (editor) => editor?.editorType === "codeblock",
+                      contents: () => <ChangeCodeMirrorLanguage />,
+                    },
+                    {
+                      fallback: () => (
+                        <>
+                          <UndoRedo />
+                          <Separator />
+                          <BoldItalicUnderlineToggles />
+                          <Separator />
+                          <BlockTypeSelect />
+                          <Separator />
+                          <ListsToggle />
+                          <Separator />
+                          <CreateLink />
+                          <Separator />
+                          <InsertTable />
+                          <InsertCodeBlock />
+                        </>
+                      ),
+                    },
+                  ]}
+                />
               ),
             }),
           ]}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -277,7 +277,10 @@
       "formatMarkdown": "Markdown",
       "downloadError": "Download failed",
       "saving": "Saving…",
-      "close": "Close panel"
+      "close": "Close panel",
+      "code": {
+        "plainText": "Plain text"
+      }
     },
     "pptPreview": {
       "untitled": "Presentation",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -278,7 +278,10 @@
       "formatMarkdown": "Markdown",
       "downloadError": "Échec du téléchargement",
       "saving": "Enregistrement…",
-      "close": "Fermer le panneau"
+      "close": "Fermer le panneau",
+      "code": {
+        "plainText": "Texte brut"
+      }
     },
     "pptPreview": {
       "untitled": "Présentation",


### PR DESCRIPTION
Closes #1933

## Problem
The `MDXEditor` instance used for writable documents (`frontend/src/components/chatbot/WritableDocumentPane.tsx`) was missing several plugins, so common markdown content rendered incorrectly:
- GFM tables displayed as broken raw text (no table plugin).
- Fenced code blocks had no editor support.
- Images did not render.

Additionally, several MDXEditor surfaces did not follow the app's dark theme.

## Fix
**Rendering plugins**
- Add `tablePlugin()` + the `InsertTable` toolbar control so GFM tables are parsed, rendered, and insertable.
- Add `codeBlockPlugin` + `codeMirrorPlugin` with a language dropdown, plus an `InsertCodeBlock` toolbar action. The toolbar is wrapped in `ConditionalContents` so it swaps to a `ChangeCodeMirrorLanguage` selector when the cursor is inside a code block.
- Add a render-only `imagePlugin()` (no upload handler / no insert button) so images in the markdown display.

**Dark theme**
- Map MDXEditor's internal theme variables onto our design tokens for the editor and its portalled popup container (block-type dropdown, table popover, link dialog).
- Repaint the embedded CodeMirror surfaces (editor background, gutter, line numbers, active line, cursor) — CodeMirror hard-codes a light background/text that overrode the token mapping.
- Repaint toolbar tooltips, which carried their own light background not reached by the container mapping.

**i18n**
- Add `chat.writableDocument.code.plainText` to the `en` and `fr` locales for the empty-language option in the code-block dropdown.

All new plugin exports are provided by the installed `@mdxeditor/editor` version (`^4.0.4`), so no dependency bump was needed.

## Quality gates
- `tsc` typecheck: PASS.
- `prettier --check` on touched files: PASS.
- Verified live in the browser (dark mode): tables, code blocks with syntax highlighting, and the language dropdown render correctly; code-block backgrounds and toolbar tooltips are themed.
- No lint or test scripts are defined for the `frontend` project, and there are no existing tests for `WritableDocumentPane`, so none were added.