### PR TITLE
fix(writable-documents): preserve nested list depth in docx export

### DIFF
--- a/agentic-backend/agentic_backend/core/writable_documents/docx_export.py
+++ b/agentic-backend/agentic_backend/core/writable_documents/docx_export.py
@@ -32,9 +32,27 @@ from docx.text.paragraph import Paragraph
 from agentic_backend.core.markdown.inline import parse_inline_markdown
 
 _HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.*)$")
-_BULLET_RE = re.compile(r"^\s*[-*+]\s+(?P<text>.*)$")
-_ORDERED_RE = re.compile(r"^\s*\d+[.)]\s+(?P<text>.*)$")
+_BULLET_RE = re.compile(r"^(?P<indent>\s*)[-*+]\s+(?P<text>.*)$")
+_ORDERED_RE = re.compile(r"^(?P<indent>\s*)\d+[.)]\s+(?P<text>.*)$")
 _FENCE_RE = re.compile(r"^\s*```")
+
+# List nesting: every 2 columns of leading whitespace is one indent level (a tab
+# counts as 2 columns). python-docx ships styles up to level 3 ("List Bullet",
+# "List Bullet 2", "List Bullet 3"); deeper nesting is capped at level 3.
+_LIST_INDENT_WIDTH = 2
+_MAX_LIST_LEVEL = 3
+
+
+def _list_style(base: str, indent: str) -> str:
+    """Map a list item's leading whitespace to a python-docx list style name.
+
+    ``base`` is ``"List Bullet"`` or ``"List Number"``. Level 1 keeps the base
+    name; levels 2..3 append the number (e.g. ``"List Bullet 2"``).
+    """
+    columns = indent.replace("\t", " " * _LIST_INDENT_WIDTH).count(" ")
+    level = min(columns // _LIST_INDENT_WIDTH + 1, _MAX_LIST_LEVEL)
+    return base if level == 1 else f"{base} {level}"
+
 
 # A table row contains at least one (unescaped) pipe. The separator line that
 # follows the header is made only of pipes, dashes, colons and whitespace, with
@@ -157,14 +175,16 @@ def markdown_to_docx_bytes(content_md: str, *, title: str | None = None) -> byte
 
         bullet = _BULLET_RE.match(line)
         if bullet:
-            paragraph = document.add_paragraph(style="List Bullet")
+            style = _list_style("List Bullet", bullet.group("indent"))
+            paragraph = document.add_paragraph(style=style)
             _add_inline_runs(paragraph, bullet.group("text").strip())
             i += 1
             continue
 
         ordered = _ORDERED_RE.match(line)
         if ordered:
-            paragraph = document.add_paragraph(style="List Number")
+            style = _list_style("List Number", ordered.group("indent"))
+            paragraph = document.add_paragraph(style=style)
             _add_inline_runs(paragraph, ordered.group("text").strip())
             i += 1
             continue

--- a/agentic-backend/agentic_backend/tests/test_writable_document_docx_export.py
+++ b/agentic-backend/agentic_backend/tests/test_writable_document_docx_export.py
@@ -187,3 +187,39 @@ def test_pipe_without_separator_is_not_a_table():
     doc = Document(io.BytesIO(markdown_to_docx_bytes(md)))
     assert not doc.tables
     assert any("has a pipe" in p.text for p in doc.paragraphs)
+
+
+def test_nested_bullets_get_per_level_styles():
+    # 2 spaces per level (a tab counts as 2). Depth is preserved instead of
+    # every item flattening to the base "List Bullet".
+    md = "- top\n  - level two\n    - level three\n      - level four (capped at 3)\n"
+    paras = _read_paragraphs(markdown_to_docx_bytes(md))
+    styled = [(s, t) for s, t in paras if s.startswith("List Bullet")]
+    assert styled == [
+        ("List Bullet", "top"),
+        ("List Bullet 2", "level two"),
+        ("List Bullet 3", "level three"),
+        ("List Bullet 3", "level four (capped at 3)"),
+    ]
+
+
+def test_nested_ordered_lists_get_per_level_styles():
+    md = "1. top\n  2. level two\n    3. level three\n"
+    paras = _read_paragraphs(markdown_to_docx_bytes(md))
+    styled = [(s, t) for s, t in paras if s.startswith("List Number")]
+    assert styled == [
+        ("List Number", "top"),
+        ("List Number 2", "level two"),
+        ("List Number 3", "level three"),
+    ]
+
+
+def test_tab_indented_bullet_is_one_level():
+    # A single tab equals one indent level (2 columns).
+    md = "- top\n\t- child\n"
+    paras = _read_paragraphs(markdown_to_docx_bytes(md))
+    styled = [(s, t) for s, t in paras if s.startswith("List Bullet")]
+    assert styled == [
+        ("List Bullet", "top"),
+        ("List Bullet 2", "child"),
+    ]


### PR DESCRIPTION
Closes #1932

## Problem
Exporting a writable document with **nested** bullet points to Word (.docx) flattened all items to the base indentation: `_BULLET_RE`/`_ORDERED_RE` discarded the leading whitespace, and the bullet/ordered branches always applied the base `List Bullet` / `List Number` style regardless of depth.

## Fix
- The bullet and ordered regexes now capture the leading whitespace (`indent` group).
- A small `_list_style(base, indent)` helper maps that indent to the matching python-docx built-in list style.

### Nesting-depth rule
Every **2 columns** of leading whitespace is one indent level; a **tab counts as 2 columns**. So:
- 0 spaces -> `List Bullet` / `List Number`
- 2 spaces (or 1 tab) -> `List Bullet 2` / `List Number 2`
- 4 spaces -> `List Bullet 3` / `List Number 3`

python-docx only ships built-in list styles up to level 3, so deeper nesting is **capped at level 3** (graceful fallback rather than an error).

## Tests added (offline, no external deps)
`agentic-backend/agentic_backend/tests/test_writable_document_docx_export.py`:
- `test_nested_bullets_get_per_level_styles` — 4 levels of bullets map to `List Bullet` / `2` / `3` / `3` (capped).
- `test_nested_ordered_lists_get_per_level_styles` — same for ordered lists / `List Number`.
- `test_tab_indented_bullet_is_one_level` — a single tab yields `List Bullet 2`.

## Quality gates (in `agentic-backend`)
- `make code-quality` — **PASS** (ruff lint + format, detect-secrets, basedpyright: 0 errors/warnings)
- `make test` — **PASS** (491 passed, 1 pre-existing pydantic deprecation warning unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)