### PR TITLE
fix(ppt-filler): clear error when an image path is passed instead of a document id

### DIFF
--- a/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
+++ b/agentic-backend/agentic_backend/integrations/ppt_filler/toolkit.py
@@ -375,6 +375,22 @@ def _remove_anchor_shape(anchor) -> None:
     element.getparent().remove(element)
 
 
+def _looks_like_path_not_document_id(value: str) -> bool:
+    """True when ``value`` is clearly a file PATH rather than a document id.
+
+    An image key expects the opaque document id returned by ``list_document_tree``
+    (a UUID-style identifier that never contains a path separator). The agent sometimes
+    mistakenly passes the file's PATH instead (e.g. ``Brand/Logos/logo.png``), which then
+    fails the document fetch with an unclear "document not found" error. We detect that
+    mistake up front and hard-fail with an actionable message so the agent self-corrects.
+
+    Heuristic (deliberately CONSERVATIVE to keep false positives rare — we only flag values
+    that cannot be a valid document id): the value contains a ``/`` or ``\\`` path
+    separator. Valid document ids never contain one; any path with directory structure does.
+    """
+    return "/" in value or "\\" in value
+
+
 async def _place_images_on_slide(
     *,
     slide,
@@ -436,6 +452,20 @@ async def _place_images_on_slide(
             for anchor in key_anchors:
                 _remove_anchor_shape(anchor)
             continue
+
+        # Guard BEFORE fetching: the agent sometimes passes the file's PATH instead of its
+        # document id, which the fetch would reject with an unclear "document not found".
+        # Detect the wrong-format value up front and hard-fail with an actionable message
+        # so the agent re-picks the id (from list_document_tree) in the same turn.
+        if _looks_like_path_not_document_id(document_uid):
+            placeholder = f"{{{{{key}}}}}"
+            return (
+                f"The value '{document_uid}' you passed for the image field {placeholder} "
+                "looks like a file path, not a document id. Image fields need the document "
+                "id returned by the list_document_tree tool (an opaque id with no '/' or "
+                "'\\'), not the file's path or name. Browse the field's folder again with "
+                "list_document_tree and pass the chosen file's document id."
+            )
 
         # Provided a document id: fetch the original bytes. A fetch failure is a HARD
         # fail (the agent's correctable mistake) -> re-pick.

--- a/agentic-backend/tests/test_ppt_filler_toolkit.py
+++ b/agentic-backend/tests/test_ppt_filler_toolkit.py
@@ -935,6 +935,31 @@ async def test_image_fetch_failure_hard_fail(fake_ws, fake_doc):
 
 
 @pytest.mark.asyncio
+async def test_image_key_with_path_instead_of_id_gives_clear_error(fake_ws, fake_doc):
+    """A path-like value (e.g. 'Brand/Logos/logo.png') passed for an image key -> a clear
+    hard-fail BEFORE any fetch, telling the agent an id is required. No fetch, no upload."""
+    deck = _build_image_deck([(_IMAGE_NOTES, ["{{logo}}"])])
+    fake_ws.template_bytes = deck
+    params = PptFillerParams(schema=_image_schema(deck, slide=1, key="logo"))
+    tool = _the_tool(_FakeAgent(params=params, session_id="s"))
+
+    content, artifact = await tool.coroutine(slide_1={"logo": "Brand/Logos/logo.png"})
+
+    assert artifact.is_error is True
+    assert artifact.ui_parts == ()
+    # The message explains it looks like a path, that an id is required, and points at the
+    # tree tool; the offending value is echoed.
+    lowered = content.lower()
+    assert "path" in lowered
+    assert "document id" in lowered
+    assert "list_document_tree" in content
+    assert "Brand/Logos/logo.png" in content
+    # Detected up front: no fetch was attempted and nothing was uploaded.
+    assert fake_doc.fetch_uids == []
+    assert fake_ws.upload_calls == []
+
+
+@pytest.mark.asyncio
 async def test_webp_image_is_transcoded_and_embedded(fake_ws, fake_doc):
     """A WEBP doc id -> the toolkit transcodes it to PNG and embeds it as a picture
     instead of hard-failing. python-pptx cannot embed WEBP directly, so without the


### PR DESCRIPTION
Closes #1934

## Problem

In the PPT Filler `fill_ppt_template` tool, image keys expect the opaque **document id** returned by `list_document_tree`. When the agent mistakenly passes the file's **PATH** (e.g. `Brand/Logos/logo.png`), that value was used as a document id, the document fetch failed, and the agent got an unclear "the document could not be found" error — with no cue to fix the format.

## Fix

Guard the provided image value **before** attempting the fetch. If it clearly looks like a file path, hard-fail early (no fetch, no upload — same is_error behavior as other bad-pick failures) with an actionable message that:
- states the value looks like a file path, not a document id,
- reminds the agent the id comes from `list_document_tree`,
- echoes the offending value,

so the agent self-corrects in the same turn instead of hitting the confusing fetch error.

### Path-detection heuristic

Deliberately conservative to keep false positives rare — it only flags values that **cannot** be a valid id: the value contains a `/` or `\` path separator. Valid document ids are opaque UUID-style identifiers that never contain a separator, while any path with directory structure does. Documented inline in `_looks_like_path_not_document_id`.

## Tests added

- `test_image_key_with_path_instead_of_id_gives_clear_error` (`agentic-backend/tests/test_ppt_filler_toolkit.py`): passes `"Brand/Logos/logo.png"`, asserts `artifact.is_error is True`, that the message mentions it's a path / that a document id is required / references `list_document_tree` and echoes the offending value, and that **no fetch was attempted** (`fake_doc.fetch_uids == []`) and **nothing was uploaded** (`fake_ws.upload_calls == []`).

## Quality gates

- `make code-quality`: **PASS** (ruff/format, bandit, detect-secrets, basedpyright — 0 errors, 0 warnings)
- `make test`: **PASS** (489 passed, 1 pre-existing warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)