### PR TITLE
feat(agents): track creator and last editor of agents

### DIFF
--- a/agentic-backend/agentic_backend/common/structures.py
+++ b/agentic-backend/agentic_backend/common/structures.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
 from fred_core import (
@@ -198,6 +199,25 @@ class BaseAgent(BaseModel):
     metadata: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Optional arbitrary metadata for integrations.",
+    )
+    # Read-only audit fields, server-authoritative: always populated from the agent
+    # table columns on load; values sent by clients are ignored on create/update
+    # (the store strips them from the persisted payload).
+    created_by: Optional[str] = Field(
+        default=None,
+        description="Read-only. User id (Keycloak uid) that created the agent. NULL for system/seeded agents.",
+    )
+    updated_by: Optional[str] = Field(
+        default=None,
+        description="Read-only. User id (Keycloak uid) of the last update. NULL for system writes.",
+    )
+    created_at: Optional[datetime] = Field(
+        default=None,
+        description="Read-only. Creation time, set by the database.",
+    )
+    updated_at: Optional[datetime] = Field(
+        default=None,
+        description="Read-only. Last update time, set by the database.",
     )
     # Added for backward compatibility with older YAML files
     mcp_servers: List[MCPServerConfiguration] = Field(

--- a/agentic-backend/agentic_backend/core/agents/agent_manager.py
+++ b/agentic-backend/agentic_backend/core/agents/agent_manager.py
@@ -117,10 +117,15 @@ class AgentManager:
             return [s for s in get_mcp_configuration().servers if s.enabled]
 
     async def create_dynamic_agent(
-        self, agent_settings: AgentSettings, agent_tuning: AgentTuning
+        self,
+        agent_settings: AgentSettings,
+        agent_tuning: AgentTuning,
+        actor_uid: str | None = None,
     ) -> None:
         """
         Creates a new dynamic agent and persists it to the store.
+
+        ``actor_uid`` stamps created_by/updated_by; None for system writes.
         """
         if self.use_static_config_only:
             raise AgentUpdatesDisabled()
@@ -141,12 +146,16 @@ class AgentManager:
                 exc_info=True,
             )
 
-        await self.store.save(agent_settings, agent_tuning)
+        await self.store.save(agent_settings, agent_tuning, actor_uid=actor_uid)
         logger.info("[AGENTS] agent=%s registered as dynamic agent.", agent_settings.id)
 
-    async def update_agent(self, new_settings: AgentSettings) -> bool:
+    async def update_agent(
+        self, new_settings: AgentSettings, actor_uid: str | None = None
+    ) -> bool:
         """
         Updates an agent's settings and tuning in the persistent store.
+
+        ``actor_uid`` stamps updated_by; None for system writes (audit columns untouched).
         """
         if self.use_static_config_only:
             raise AgentUpdatesDisabled()
@@ -166,7 +175,7 @@ class AgentManager:
                 exc_info=True,
             )
         try:
-            await self.store.save(new_settings, tunings)
+            await self.store.save(new_settings, tunings, actor_uid=actor_uid)
         except Exception:
             logger.exception(
                 "Failed to persist agent '%s'.",

--- a/agentic-backend/agentic_backend/core/agents/agent_service.py
+++ b/agentic-backend/agentic_backend/core/agents/agent_service.py
@@ -497,8 +497,14 @@ class AgentService:
             tuning=default_tuning,
             chat_options=default_settings.chat_options,
             mcp_servers=[],
+            # Server-set audit stamps (echoed in the create response; the store
+            # persists them as row columns, never inside the payload blob).
+            created_by=user.uid,
+            updated_by=user.uid,
         )
-        await self.agent_manager.create_dynamic_agent(agent_settings, default_tuning)
+        await self.agent_manager.create_dynamic_agent(
+            agent_settings, default_tuning, actor_uid=user.uid
+        )
 
         # Generic toolkit-asset-processor hook. v2 create uses default tuning (no upload
         # bytes), so this is a no-op today, but it keeps create provider-agnostic and atomic:
@@ -577,9 +583,11 @@ class AgentService:
             enabled=True,
             tuning=resolved.cls.tuning,
             mcp_servers=[],
+            created_by=user.uid,
+            updated_by=user.uid,
         )
         await self.agent_manager.create_dynamic_agent(
-            agent_settings, resolved.cls.tuning
+            agent_settings, resolved.cls.tuning, actor_uid=user.uid
         )
 
         # Generic toolkit-asset-processor hook with rollback (see create_v2_agent).
@@ -712,7 +720,9 @@ class AgentService:
             folder_resolver_factory=folder_resolver_factory,
         )
 
-        await self.agent_manager.update_agent(new_settings=agent_settings)
+        await self.agent_manager.update_agent(
+            new_settings=agent_settings, actor_uid=user.uid
+        )
 
     def get_class_path_tuning(
         self,

--- a/agentic-backend/agentic_backend/core/agents/store/agent_models.py
+++ b/agentic-backend/agentic_backend/core/agents/store/agent_models.py
@@ -15,14 +15,14 @@
 from __future__ import annotations
 
 from fred_core.models.base import JsonColumn
-from fred_core.sql.mixin import TimestampMixin
+from fred_core.sql.mixin import ActorAuditMixin, TimestampMixin
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from agentic_backend.models.base import Base
 
 
-class AgentRow(Base, TimestampMixin):
+class AgentRow(Base, TimestampMixin, ActorAuditMixin):
     """ORM model for the ``agent`` table.
 
     Each row stores a serialised :class:`~agentic_backend.common.structures.AgentSettings`

--- a/agentic-backend/agentic_backend/core/agents/store/base_agent_store.py
+++ b/agentic-backend/agentic_backend/core/agents/store/base_agent_store.py
@@ -32,9 +32,14 @@ class BaseAgentStore(ABC):
         settings: AgentSettings,
         tuning: AgentTuning,
         session: AsyncSession | None = None,
+        actor_uid: str | None = None,
     ) -> None:
         """
         Persist an agent's settings.
+
+        ``actor_uid`` is the acting user's id (Keycloak uid) for audit stamping.
+        Pass ``None`` for system writes (startup/seed paths): the audit columns
+        then stay NULL on insert and are left untouched on update.
         """
         pass
 

--- a/agentic-backend/agentic_backend/core/agents/store/postgres_agent_store.py
+++ b/agentic-backend/agentic_backend/core/agents/store/postgres_agent_store.py
@@ -35,9 +35,26 @@ logger = logging.getLogger(__name__)
 
 AgentSettingsAdapter = TypeAdapter(AgentSettings)
 
+# Server-authoritative audit fields: mirrored from the agent table columns on load
+# and stripped from the persisted payload so the columns stay the single source of
+# truth (the payload is rewritten from client input on every update).
+_AUDIT_FIELDS = ("created_by", "updated_by", "created_at", "updated_at")
+
 
 def _is_legacy_leader_payload(payload_json: Any) -> bool:
     return isinstance(payload_json, dict) and payload_json.get("type") == "leader"
+
+
+def _row_to_settings(row: AgentRow) -> AgentSettings:
+    settings = AgentSettingsAdapter.validate_python(row.payload_json or {})
+    return settings.model_copy(
+        update={
+            "created_by": row.created_by,
+            "updated_by": row.updated_by,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+        }
+    )
 
 
 class PostgresAgentStore(BaseAgentStore):
@@ -54,6 +71,7 @@ class PostgresAgentStore(BaseAgentStore):
         settings: AgentSettings,
         tuning: AgentTuning,
         session: AsyncSession | None = None,
+        actor_uid: str | None = None,
     ) -> None:
         if settings.id == self._seed_marker_id:
             raise ValueError("Invalid agent id: reserved for seed marker")
@@ -61,6 +79,9 @@ class PostgresAgentStore(BaseAgentStore):
         payload = AgentSettingsAdapter.dump_python(
             settings, mode="json", exclude_none=True
         )
+        # Audit fields live in the row columns only; never in the payload blob.
+        for key in _AUDIT_FIELDS:
+            payload.pop(key, None)
         if tuning is not None and "tuning" not in payload:
             try:
                 payload["tuning"] = tuning.model_dump(exclude_none=True)
@@ -70,9 +91,24 @@ class PostgresAgentStore(BaseAgentStore):
                     settings.id,
                 )
 
-        row = AgentRow(id=settings.id, name=settings.name, payload_json=payload)
         async with use_session(self._sessions, session) as s:
-            await s.merge(row)
+            existing = await s.get(AgentRow, settings.id)
+            if existing is None:
+                s.add(
+                    AgentRow(
+                        id=settings.id,
+                        name=settings.name,
+                        payload_json=payload,
+                        created_by=actor_uid,
+                        updated_by=actor_uid,
+                    )
+                )
+            else:
+                existing.name = settings.name
+                existing.payload_json = payload
+                # System writes (actor_uid=None) never clobber the audit columns.
+                if actor_uid is not None:
+                    existing.updated_by = actor_uid
 
     async def load_all(
         self, session: AsyncSession | None = None
@@ -94,7 +130,7 @@ class PostgresAgentStore(BaseAgentStore):
                 )
                 continue
             try:
-                out.append(AgentSettingsAdapter.validate_python(row.payload_json or {}))
+                out.append(_row_to_settings(row))
             except Exception as e:
                 logger.error("[STORE][PG][AGENTS] Failed to parse AgentSettings: %s", e)
         return out
@@ -116,7 +152,7 @@ class PostgresAgentStore(BaseAgentStore):
             )
             return None
         try:
-            return AgentSettingsAdapter.validate_python(row.payload_json or {})
+            return _row_to_settings(row)
         except Exception as e:
             logger.error(
                 "[STORE][PG][AGENTS] Failed to parse AgentSettings for '%s': %s",

--- a/agentic-backend/agentic_backend/tests/test_agent_audit_fields.py
+++ b/agentic-backend/agentic_backend/tests/test_agent_audit_fields.py
@@ -1,0 +1,206 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit-field (created_by / updated_by) behavior of the agent store and service.
+
+Offline: uses in-memory async SQLite for the store and mocks for the service
+collaborators. The audit columns are server-authoritative: stamped from the
+acting user's uid, never from client-sent payload values, and never clobbered
+by system writes (startup/seed paths save without an actor).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fred_core import KeycloakUser
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from agentic_backend.common.structures import Agent
+from agentic_backend.core.agents import agent_service as agent_service_module
+from agentic_backend.core.agents.agent_service import AgentService
+from agentic_backend.core.agents.agent_spec import AgentTuning
+from agentic_backend.core.agents.store.agent_models import AgentRow
+from agentic_backend.core.agents.store.postgres_agent_store import PostgresAgentStore
+
+
+async def _make_store() -> PostgresAgentStore:
+    # Real in-memory async SQLite: exercises the actual insert/update SQL,
+    # fully offline (no Postgres).
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(AgentRow.metadata.create_all)
+    return PostgresAgentStore(engine=engine)
+
+
+def _settings(agent_id: str = "a-1", **overrides) -> Agent:
+    return Agent(id=agent_id, name="Rico", enabled=True, **overrides)
+
+
+def _tuning() -> AgentTuning:
+    return AgentTuning(role="Test role", description="Test description", fields=[])
+
+
+def test_save_with_actor_stamps_created_by_and_updated_by():
+    async def _run() -> None:
+        store = await _make_store()
+        await store.save(_settings(), _tuning(), actor_uid="u-creator")
+
+        loaded = await store.get("a-1")
+        assert loaded is not None
+        assert loaded.created_by == "u-creator"
+        assert loaded.updated_by == "u-creator"
+        # Timestamps come from the row columns (server defaults).
+        assert loaded.created_at is not None
+        assert loaded.updated_at is not None
+
+    asyncio.run(_run())
+
+
+def test_update_with_other_actor_changes_updated_by_and_preserves_created_by():
+    async def _run() -> None:
+        store = await _make_store()
+        await store.save(_settings(), _tuning(), actor_uid="u-creator")
+        await store.save(
+            _settings().model_copy(update={"name": "Rico v2"}),
+            _tuning(),
+            actor_uid="u-editor",
+        )
+
+        loaded = await store.get("a-1")
+        assert loaded is not None
+        assert loaded.name == "Rico v2"
+        assert loaded.created_by == "u-creator"
+        assert loaded.updated_by == "u-editor"
+
+    asyncio.run(_run())
+
+
+def test_save_without_actor_preserves_audit_columns():
+    async def _run() -> None:
+        store = await _make_store()
+        await store.save(_settings(), _tuning(), actor_uid="u-creator")
+        # System write (e.g. startup reconciliation): no actor.
+        await store.save(_settings().model_copy(update={"name": "Seeded"}), _tuning())
+
+        loaded = await store.get("a-1")
+        assert loaded is not None
+        assert loaded.name == "Seeded"
+        assert loaded.created_by == "u-creator"
+        assert loaded.updated_by == "u-creator"
+
+    asyncio.run(_run())
+
+
+def test_seed_insert_without_actor_leaves_audit_columns_null():
+    async def _run() -> None:
+        store = await _make_store()
+        await store.save(_settings(), _tuning())
+
+        loaded = await store.get("a-1")
+        assert loaded is not None
+        assert loaded.created_by is None
+        assert loaded.updated_by is None
+
+    asyncio.run(_run())
+
+
+def test_client_sent_audit_values_are_ignored_and_stripped_from_payload():
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite://")
+        async with engine.begin() as conn:
+            await conn.run_sync(AgentRow.metadata.create_all)
+        store = PostgresAgentStore(engine=engine)
+
+        # A client round-tripping the full agent payload could send stale/forged
+        # audit values: they must not reach the columns nor the payload blob.
+        forged = _settings(created_by="u-forged", updated_by="u-forged")
+        await store.save(forged, _tuning(), actor_uid="u-real")
+
+        loaded = await store.get("a-1")
+        assert loaded is not None
+        assert loaded.created_by == "u-real"
+        assert loaded.updated_by == "u-real"
+
+        async with engine.connect() as conn:
+            payload = (await conn.execute(select(AgentRow.payload_json))).scalar_one()
+        assert payload is not None
+        for key in ("created_by", "updated_by", "created_at", "updated_at"):
+            assert key not in payload
+
+    asyncio.run(_run())
+
+
+# ---------------- Service-level stamping ----------------
+
+
+def _build_user(uid: str = "u-1") -> KeycloakUser:
+    return KeycloakUser(
+        uid=uid,
+        username="alice",
+        roles=["user"],
+        email="alice@example.com",
+        groups=[],
+    )
+
+
+def _build_service(monkeypatch, *, store, rebac, manager) -> AgentService:
+    monkeypatch.setattr(agent_service_module, "get_agent_store", lambda: store)
+    monkeypatch.setattr(agent_service_module, "get_rebac_engine", lambda: rebac)
+    return AgentService(agent_manager=manager)
+
+
+@pytest.mark.asyncio
+async def test_create_v2_agent_stamps_actor(monkeypatch):
+    rebac = SimpleNamespace(
+        enabled=True,
+        add_user_relation=AsyncMock(),
+    )
+    manager = SimpleNamespace(create_dynamic_agent=AsyncMock())
+
+    service = _build_service(
+        monkeypatch, store=SimpleNamespace(), rebac=rebac, manager=manager
+    )
+
+    created = await service.create_v2_agent(_build_user("u-42"), "Rico")
+
+    assert created.created_by == "u-42"
+    assert created.updated_by == "u-42"
+    assert manager.create_dynamic_agent.await_args.kwargs["actor_uid"] == "u-42"
+
+
+@pytest.mark.asyncio
+async def test_update_agent_stamps_actor(monkeypatch):
+    persisted = Agent(id="a-3", name="Tessa", enabled=True)
+    rebac = SimpleNamespace(
+        enabled=True,
+        check_user_permission_or_raise=AsyncMock(),
+        lookup_subjects=AsyncMock(return_value=[]),
+    )
+    manager = SimpleNamespace(
+        get_agent_settings=AsyncMock(return_value=persisted),
+        update_agent=AsyncMock(return_value=True),
+    )
+
+    service = _build_service(
+        monkeypatch, store=SimpleNamespace(), rebac=rebac, manager=manager
+    )
+
+    await service.update_agent(_build_user("u-editor"), persisted)
+
+    assert manager.update_agent.await_args.kwargs["actor_uid"] == "u-editor"

--- a/agentic-backend/alembic/versions/c7d2a91f4e08_add_agent_created_by_updated_by.py
+++ b/agentic-backend/alembic/versions/c7d2a91f4e08_add_agent_created_by_updated_by.py
@@ -1,0 +1,34 @@
+"""add agent created_by / updated_by audit columns
+
+Revision ID: c7d2a91f4e08
+Revises: a1c4f7e92b30
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d2a91f4e08"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = (
+    "a1c4f7e92b30"  # pragma: allowlist secret
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Nullable on purpose: pre-existing agents and system/seed writes have no actor.
+    op.add_column("agent", sa.Column("created_by", sa.String(), nullable=True))
+    op.add_column("agent", sa.Column("updated_by", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("agent", "updated_by")
+    op.drop_column("agent", "created_by")

--- a/control-plane-backend/control_plane_backend/users_controller.py
+++ b/control-plane-backend/control_plane_backend/users_controller.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, FastAPI, Path, status
+from fastapi import APIRouter, Depends, FastAPI, Path, Query, status
 from fastapi.responses import JSONResponse
 from fred_core import (
     BaseUserStore,
@@ -27,6 +27,9 @@ from control_plane_backend.users_service import (
 from control_plane_backend.users_service import (
     find_user_details_by_id,
     update_gcu_validation,
+)
+from control_plane_backend.users_service import (
+    get_users_by_ids as get_users_by_ids_from_service,
 )
 from control_plane_backend.users_service import (
     list_users as list_users_from_service,
@@ -74,6 +77,26 @@ async def list_users(
     user: KeycloakUser = Depends(get_current_user),
 ) -> list[UserSummary]:
     return await list_users_from_service(user)
+
+
+@router.get(
+    "/users/by-ids",
+    response_model=list[UserSummary],
+    response_model_exclude_none=True,
+    summary="Resolve a batch of user ids to lightweight summaries.",
+)
+async def get_users_by_ids(
+    ids: Annotated[list[str], Query(min_length=1, max_length=100)],
+    user: KeycloakUser = Depends(get_current_user),
+) -> list[UserSummary]:
+    """Batch uid -> summary lookup (e.g. to display audit fields).
+
+    Deleted/unknown ids resolve to an id-only summary so callers always get one
+    entry per requested id.
+    """
+    unique_ids = sorted({user_id for user_id in ids if user_id})
+    summaries = await get_users_by_ids_from_service(unique_ids)
+    return [summaries.get(user_id, UserSummary(id=user_id)) for user_id in unique_ids]
 
 
 @router.post(

--- a/control-plane-backend/tests/test_main.py
+++ b/control-plane-backend/tests/test_main.py
@@ -61,6 +61,34 @@ async def test_list_users_returns_empty_without_keycloak_m2m() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_users_by_ids_falls_back_to_id_only_summaries() -> None:
+    """Without Keycloak M2M, every requested id resolves to an id-only summary
+    (same shape callers get for deleted users), deduplicated and sorted."""
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(
+            "/control-plane/v1/users/by-ids",
+            params=[("ids", "u-2"), ("ids", "u-1"), ("ids", "u-1")],
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": "u-1"}, {"id": "u-2"}]
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_requires_ids() -> None:
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/control-plane/v1/users/by-ids")
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_create_user_requires_keycloak_m2m() -> None:
     app = create_app()
     async with AsyncClient(

--- a/fred-core/fred_core/sql/mixin.py
+++ b/fred-core/fred_core/sql/mixin.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from typing import Any
 
 from pydantic import TypeAdapter
-from sqlalchemy import Column, Table, func, insert, select
+from sqlalchemy import Column, String, Table, func, insert, select
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -51,6 +51,16 @@ class TimestampMixin:
     updated_at: Mapped[datetime] = mapped_column(
         TimestampColumn, nullable=False, server_default=func.now(), onupdate=func.now()
     )
+
+
+class ActorAuditMixin:
+    """Adds created_by / updated_by columns storing the acting user's id (e.g. Keycloak uid).
+
+    NULL means the row was written by the system (startup/seed paths), not by a user.
+    """
+
+    created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class PydanticJsonMixin:

--- a/frontend/src/components/agentHub/AgentCreateEditForm.tsx
+++ b/frontend/src/components/agentHub/AgentCreateEditForm.tsx
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Autocomplete, Box, Divider, TextField, Typography } from "@mui/material";
+import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup.tsx";
+import TextArea from "@shared/atoms/TextArea/TextArea.tsx";
+import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
 import { Ref, useCallback, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnyAgent } from "../../common/agent.ts";
 import { useAgentUpdater } from "../../hooks/useAgentUpdater";
+import { useFrontendProperties } from "../../hooks/useFrontendProperties.ts";
 import { KeyCloakService } from "../../security/KeycloakService";
 import {
   FieldSpec,
@@ -29,19 +34,14 @@ import {
   useListToolkitAssetMetadataAgenticV1AgentsToolkitAssetMetadataGetQuery as useListToolkitAssetMetadataQuery,
   useListV2DefinitionRefsAgenticV1AgentsV2DefinitionRefsGetQuery as useListV2DefinitionRefsQuery,
 } from "../../slices/agentic/agenticOpenApi";
+import { useGetUsersByIdsQuery } from "../../slices/controlPlane/controlPlaneApiEnhancements.ts";
+import { useGetUserDetailsControlPlaneV1UserGetQuery } from "../../slices/controlPlane/controlPlaneOpenApi.ts";
+import { getUserDisplayName } from "../../utils/userDisplayName.ts";
 import { useConfirmationDialog } from "../ConfirmationDialogProvider";
 import { useToast } from "../ToastProvider";
 import { AgentPrivateResourcesManager } from "./AgentConfigWorkspaceManagerDrawer";
 import { AgentToolsSelection } from "./AgentToolsSelection";
 import { TuningForm } from "./TuningForm";
-import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup.tsx";
-import { useGetUserDetailsControlPlaneV1UserGetQuery } from "../../slices/controlPlane/controlPlaneOpenApi.ts";
-import { useGetUsersByIdsQuery } from "../../slices/controlPlane/controlPlaneApiEnhancements.ts";
-import { getUserDisplayName } from "../../utils/userDisplayName.ts";
-import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
-import TextArea from "@shared/atoms/TextArea/TextArea.tsx";
-import { AnyAgent } from "../../common/agent.ts";
-import { useFrontendProperties } from "../../hooks/useFrontendProperties.ts";
 
 type TopLevelTuningState = {
   role: string;
@@ -558,7 +558,6 @@ export function AgentCreateEditForm({
       {/* ── Audit metadata (edit mode only; lines without a recorded actor are omitted) ── */}
       {!isCreateMode && agent && (agent.created_by || agent.updated_by) && (
         <>
-          <Divider />
           <Box>
             {agent.created_by && (
               <Typography variant="caption" color="text.secondary" display="block">

--- a/frontend/src/components/agentHub/AgentCreateEditForm.tsx
+++ b/frontend/src/components/agentHub/AgentCreateEditForm.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Autocomplete, Box, Divider, TextField, Typography } from "@mui/material";
-import { Ref, useCallback, useEffect, useImperativeHandle, useState } from "react";
+import { Ref, useCallback, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAgentUpdater } from "../../hooks/useAgentUpdater";
 import { KeyCloakService } from "../../security/KeycloakService";
@@ -36,6 +36,8 @@ import { AgentToolsSelection } from "./AgentToolsSelection";
 import { TuningForm } from "./TuningForm";
 import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup.tsx";
 import { useGetUserDetailsControlPlaneV1UserGetQuery } from "../../slices/controlPlane/controlPlaneOpenApi.ts";
+import { useGetUsersByIdsQuery } from "../../slices/controlPlane/controlPlaneApiEnhancements.ts";
+import { getUserDisplayName } from "../../utils/userDisplayName.ts";
 import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
 import TextArea from "@shared/atoms/TextArea/TextArea.tsx";
 import { AnyAgent } from "../../common/agent.ts";
@@ -155,6 +157,22 @@ export function AgentCreateEditForm({
     const hasUpload = Boolean(params.template_upload_b64);
     return !hasSchema && !hasUpload;
   });
+
+  // ── Audit metadata (edit mode only): resolve created_by / updated_by uids to names ──
+  const auditUserIds = useMemo(
+    () =>
+      isCreateMode
+        ? []
+        : Array.from(new Set([agent?.created_by, agent?.updated_by].filter((uid): uid is string => Boolean(uid)))),
+    [isCreateMode, agent?.created_by, agent?.updated_by],
+  );
+  const { data: auditUsers = [] } = useGetUsersByIdsQuery({ ids: auditUserIds }, { skip: auditUserIds.length === 0 });
+  const resolveAuditUserName = (uid: string) => {
+    const user = auditUsers.find((u) => u.id === uid);
+    // Deleted/unknown users come back as id-only summaries with no usable name.
+    return (user && getUserDisplayName(user)) || t("agentEditDrawer.audit.unknownUser");
+  };
+  const formatAuditDate = (date: string | null | undefined) => (date ? new Date(date).toLocaleDateString() : "");
 
   const mergeFields = useCallback((newFields: FieldSpec[], currentFields: FieldSpec[]): FieldSpec[] => {
     const currentByKey = new Map(currentFields.map((f) => [f.key, f]));
@@ -534,6 +552,31 @@ export function AgentCreateEditForm({
           <Divider />
           <Typography variant="h6">{t("assetManager.title", { agentId: agent?.name })}</Typography>
           {agent && <AgentPrivateResourcesManager agentId={agent.id} />}
+        </>
+      )}
+
+      {/* ── Audit metadata (edit mode only; lines without a recorded actor are omitted) ── */}
+      {!isCreateMode && agent && (agent.created_by || agent.updated_by) && (
+        <>
+          <Divider />
+          <Box>
+            {agent.created_by && (
+              <Typography variant="caption" color="text.secondary" display="block">
+                {t("agentEditDrawer.audit.createdBy", {
+                  name: resolveAuditUserName(agent.created_by),
+                  date: formatAuditDate(agent.created_at),
+                })}
+              </Typography>
+            )}
+            {agent.updated_by && (
+              <Typography variant="caption" color="text.secondary" display="block">
+                {t("agentEditDrawer.audit.updatedBy", {
+                  name: resolveAuditUserName(agent.updated_by),
+                  date: formatAuditDate(agent.updated_at),
+                })}
+              </Typography>
+            )}
+          </Box>
         </>
       )}
     </>

--- a/frontend/src/components/documents/libraries/DocumentLibraryList.tsx
+++ b/frontend/src/components/documents/libraries/DocumentLibraryList.tsx
@@ -28,6 +28,7 @@ import { useLocalStorageState } from "../../../hooks/useLocalStorageState";
 import { SimpleTooltip } from "../../../shared/ui/tooltips/Tooltips";
 import { buildTree, findNode, TagNode } from "../../../shared/utils/tagTree";
 import { useListUsersQuery } from "../../../slices/controlPlane/controlPlaneApiEnhancements";
+import { getUserDisplayName } from "../../../utils/userDisplayName";
 import {
   DocumentMetadata,
   TagWithItemsId,
@@ -70,8 +71,7 @@ export default function DocumentLibraryList({ teamId, canCreateTag }: DocumentLi
   const ownerNamesById = React.useMemo(() => {
     const m: Record<string, string> = {};
     users.forEach((u) => {
-      const fullName = [u.first_name, u.last_name].filter(Boolean).join(" ").trim();
-      const name = fullName || u.username || "";
+      const name = getUserDisplayName(u);
       if (name) m[u.id] = name;
     });
     return m;

--- a/frontend/src/components/resources/ResourceLibraryList.tsx
+++ b/frontend/src/components/resources/ResourceLibraryList.tsx
@@ -27,6 +27,7 @@ import { usePermissions } from "../../security/usePermissions";
 import { SimpleTooltip } from "../../shared/ui/tooltips/Tooltips";
 import { buildTree, findNode, TagNode } from "../../shared/utils/tagTree";
 import { useListUsersQuery } from "../../slices/controlPlane/controlPlaneApiEnhancements";
+import { getUserDisplayName } from "../../utils/userDisplayName";
 import {
   Resource,
   ResourceKind,
@@ -114,8 +115,7 @@ export default function ResourceLibraryList({ kind }: Props) {
   const ownerNamesById = React.useMemo(() => {
     const m: Record<string, string> = {};
     users.forEach((u) => {
-      const fullName = [u.first_name, u.last_name].filter(Boolean).join(" ").trim();
-      const name = fullName || u.username || "";
+      const name = getUserDisplayName(u);
       if (name) m[u.id] = name;
     });
     return m;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -517,6 +517,11 @@
     "noMcpServers": "No MCP servers are currently available.",
     "headerTitle": "{{agentsNicknameSingular}} edition",
     "headerTitleCreate": "Create {{agentsNicknameSingular}}",
+    "audit": {
+      "createdBy": "Created by {{name}} on {{date}}",
+      "updatedBy": "Last modified by {{name}} on {{date}}",
+      "unknownUser": "Unknown user"
+    },
     "errors": {
       "createFailed": "Failed to create agent",
       "updateFailed": "Failed to update agent"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -518,6 +518,11 @@
     "noMcpServers": "Aucun serveur MCP disponible pour le moment.",
     "headerTitle": "Édition d'un {{agentsNicknameSingular}}",
     "headerTitleCreate": "Créer un {{agentsNicknameSingular}}",
+    "audit": {
+      "createdBy": "Créé par {{name}} le {{date}}",
+      "updatedBy": "Dernière modification par {{name}} le {{date}}",
+      "unknownUser": "Utilisateur inconnu"
+    },
     "errors": {
       "createFailed": "Échec de la création de l'agent",
       "updateFailed": "Échec de la mise à jour de l'agent"

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -823,6 +823,14 @@ export type Agent = {
   metadata?: {
     [key: string]: any;
   } | null;
+  /** Read-only. User id (Keycloak uid) that created the agent. NULL for system/seeded agents. */
+  created_by?: string | null;
+  /** Read-only. User id (Keycloak uid) of the last update. NULL for system writes. */
+  updated_by?: string | null;
+  /** Read-only. Creation time, set by the database. */
+  created_at?: string | null;
+  /** Read-only. Last update time, set by the database. */
+  updated_at?: string | null;
   /** DEPRECATED: Use the global 'mcp' catalog and the 'mcp_servers' field in AgentTuning with references instead. */
   mcp_servers?: McpServerConfiguration[];
   type?: "agent";
@@ -950,6 +958,14 @@ export type Agent2 = {
   metadata?: {
     [key: string]: any;
   } | null;
+  /** Read-only. User id (Keycloak uid) that created the agent. NULL for system/seeded agents. */
+  created_by?: string | null;
+  /** Read-only. User id (Keycloak uid) of the last update. NULL for system writes. */
+  updated_by?: string | null;
+  /** Read-only. Creation time, set by the database. */
+  created_at?: string | null;
+  /** Read-only. Last update time, set by the database. */
+  updated_at?: string | null;
   /** DEPRECATED: Use the global 'mcp' catalog and the 'mcp_servers' field in AgentTuning with references instead. */
   mcp_servers?: McpServerConfiguration[];
   type?: "agent";

--- a/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
+++ b/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
@@ -81,6 +81,7 @@ export const enhancedControlPlaneApi = api.enhanceEndpoints({
 
 export const {
   useListUsersControlPlaneV1UsersGetQuery: useListUsersQuery,
+  useGetUsersByIdsControlPlaneV1UsersByIdsGetQuery: useGetUsersByIdsQuery,
   useListTeamsControlPlaneV1TeamsGetQuery: useListTeamsQuery,
   useGetTeamControlPlaneV1TeamsTeamIdGetQuery: useGetTeamQuery,
   useUpdateTeamControlPlaneV1TeamsTeamIdPatchMutation: useUpdateTeamMutation,

--- a/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -50,6 +50,17 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({ url: `/control-plane/v1/users`, method: "POST", body: queryArg.createUserRequest }),
     }),
+    getUsersByIdsControlPlaneV1UsersByIdsGet: build.query<
+      GetUsersByIdsControlPlaneV1UsersByIdsGetApiResponse,
+      GetUsersByIdsControlPlaneV1UsersByIdsGetApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/control-plane/v1/users/by-ids`,
+        params: {
+          ids: queryArg.ids,
+        },
+      }),
+    }),
     deleteUserControlPlaneV1UsersUserIdDelete: build.mutation<
       DeleteUserControlPlaneV1UsersUserIdDeleteApiResponse,
       DeleteUserControlPlaneV1UsersUserIdDeleteApiArg
@@ -191,6 +202,10 @@ export type ListUsersControlPlaneV1UsersGetApiArg = void;
 export type CreateUserControlPlaneV1UsersPostApiResponse = /** status 201 Successful Response */ UserSummary;
 export type CreateUserControlPlaneV1UsersPostApiArg = {
   createUserRequest: CreateUserRequest;
+};
+export type GetUsersByIdsControlPlaneV1UsersByIdsGetApiResponse = /** status 200 Successful Response */ UserSummary[];
+export type GetUsersByIdsControlPlaneV1UsersByIdsGetApiArg = {
+  ids: string[];
 };
 export type DeleteUserControlPlaneV1UsersUserIdDeleteApiResponse = unknown;
 export type DeleteUserControlPlaneV1UsersUserIdDeleteApiArg = {
@@ -448,6 +463,8 @@ export const {
   useListUsersControlPlaneV1UsersGetQuery,
   useLazyListUsersControlPlaneV1UsersGetQuery,
   useCreateUserControlPlaneV1UsersPostMutation,
+  useGetUsersByIdsControlPlaneV1UsersByIdsGetQuery,
+  useLazyGetUsersByIdsControlPlaneV1UsersByIdsGetQuery,
   useDeleteUserControlPlaneV1UsersUserIdDeleteMutation,
   useGetUserDetailsControlPlaneV1UserGetQuery,
   useLazyGetUserDetailsControlPlaneV1UserGetQuery,

--- a/frontend/src/utils/userDisplayName.ts
+++ b/frontend/src/utils/userDisplayName.ts
@@ -1,0 +1,30 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Minimal structural shape shared by the control-plane and knowledge-flow UserSummary types. */
+export interface UserNameFields {
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  email?: string | null;
+}
+
+/**
+ * Resolve a user's display name: "First Last", falling back to username, then email.
+ * Returns undefined when nothing usable is set (e.g. id-only summary for a deleted user).
+ */
+export function getUserDisplayName(user: UserNameFields): string | undefined {
+  const fullName = [user.first_name, user.last_name].filter(Boolean).join(" ").trim();
+  return fullName || user.username || user.email || undefined;
+}


### PR DESCRIPTION
## Summary

Agents now record who created them and who last updated them, and the agent edit form displays this at the bottom.

- **agentic-backend**: new nullable `created_by` / `updated_by` columns on the `agent` table (Keycloak uid), stamped from the acting user in `create_v1_agent` / `create_v2_agent` / `update_agent`. Alembic migration `c7d2a91f4e08` (SQLite-compatible, nullable string columns).
- **API**: `created_by`, `updated_by`, `created_at`, `updated_at` exposed as optional read-only fields on the agent payloads (list, get and create responses).
- **control-plane-backend**: new `GET /control-plane/v1/users/by-ids?ids=...` endpoint resolving a batch of user ids to lightweight `UserSummary` objects (backed by the existing `get_users_by_ids` service used for team members). The UI uses it to resolve only the two audit uids instead of downloading the whole user directory.
- **fred-core**: small reusable `ActorAuditMixin` (`created_by` / `updated_by`) next to `TimestampMixin`.
- **frontend**: muted "Created by {name} on {date}" / "Last modified by {name} on {date}" block at the end of the agent edit form (edit mode only), EN + FR translations, dates formatted with `toLocaleDateString()` like the rest of the app. Shared `getUserDisplayName` helper (first/last name → username → email) now also used by the document/resource library owner display.

## Design: server-authoritative audit fields

The frontend round-trips the full agent payload to `PUT /agents/update`, so anything inside `payload_json` is client-writable. The audit values therefore live only in the row columns:

- On save, the store strips `created_by` / `updated_by` / `created_at` / `updated_at` from the serialized payload and stamps the columns from the `actor_uid` parameter threaded down from the service (`user.uid`), never from client-sent values.
- On load, the store mirrors the row columns back onto the returned settings, so list/get responses always reflect the database.
- System writes (startup reconciliation, static seeding, restore) pass no actor: the columns stay NULL on insert and are never clobbered on update. `created_by` is only ever set on insert.

## Deleted users / missing data

- The backend stores the uid only; the UI resolves names at display time so they never go stale. If a uid no longer resolves in Keycloak, `/users/by-ids` returns an id-only summary and the UI shows a translated "Unknown user".
- NULL audit fields (pre-existing or config-seeded agents) omit the corresponding line entirely.

## Not included

- The best-effort OpenFGA backfill of `created_by` for existing personal agents is not implemented: pre-existing agents show no creator until their next user edit stamps `updated_by`.

## Checks

- Scope kept minimal, default tests fully offline (in-memory SQLite / ASGI test client).
- `make code-quality` + `make test` run on `fred-core`, `agentic-backend` and `control-plane-backend`.
- Frontend: OpenAPI clients regenerated via `make update-agentic-api` / `make update-control-plane-api`, `tsc` and `prettier --check` clean.
- New tests: agent store audit stamping (create/update/system-write/forged-payload) and service-level actor threading in `agentic-backend`; `/users/by-ids` fallback and validation in `control-plane-backend`.

Closes #1940
