### PR TITLE
fix(agentic): prevent session_history rank collision on error paths

### DIFF
--- a/agentic-backend/agentic_backend/common/mcp_utils.py
+++ b/agentic-backend/agentic_backend/common/mcp_utils.py
@@ -274,7 +274,7 @@ async def get_connected_mcp_client_for_agent(
     )
 
     # Validate connections by attempting to load tools per server
-    exceptions: list[Exception] = []
+    exceptions: list[BaseException] = []
     failure_messages: list[str] = []
     total_tools = 0
     for server in mcp_servers:

--- a/agentic-backend/agentic_backend/common/mcp_utils.py
+++ b/agentic-backend/agentic_backend/common/mcp_utils.py
@@ -59,6 +59,30 @@ class MCPConnectionError(Exception):
         self.reason = message
 
 
+def _leaf_exceptions(exc: BaseException) -> List[BaseException]:
+    """Flatten an ``ExceptionGroup`` down to its meaningful leaf exceptions.
+
+    MCP connections run inside an anyio ``TaskGroup``, so a single failed server
+    surfaces as ``ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)``
+    — a message that hides the real cause (e.g. ``HTTPStatusError: 401 Unauthorized``).
+    This recurses through nested groups and returns the underlying leaves so callers
+    can report and log what actually went wrong. Returns ``[exc]`` for a plain
+    exception with no sub-exceptions.
+    """
+    sub = getattr(exc, "exceptions", None)
+    if not sub:
+        return [exc]
+    leaves: List[BaseException] = []
+    for child in sub:
+        leaves.extend(_leaf_exceptions(child))
+    return leaves
+
+
+def _format_exception(exc: BaseException) -> str:
+    """One-line ``ClassName: first message line`` label for an exception."""
+    return f"{exc.__class__.__name__}: {str(exc).splitlines()[0]}"
+
+
 def _mask_auth_value(v: str | None) -> str:
     """Return a non-sensitive label for Authorization header values."""
     if not v:
@@ -284,6 +308,11 @@ async def get_connected_mcp_client_for_agent(
             total_tools += len(tools)
         except BaseException as e:
             dur_ms = (time.perf_counter() - start) * 1000
+            # Unwrap the anyio TaskGroup ExceptionGroup so the real cause
+            # (e.g. "HTTPStatusError: 401 Unauthorized") surfaces instead of
+            # the opaque "unhandled errors in a TaskGroup (1 sub-exception)".
+            leaves = _leaf_exceptions(e)
+            leaf_summary = "; ".join(_format_exception(leaf) for leaf in leaves)
             logger.warning(
                 "[MCP][%s] connect fail name=%s url=%s err=%s dur_ms=%.0f: %s",
                 agent_id,
@@ -291,11 +320,11 @@ async def get_connected_mcp_client_for_agent(
                 url_for_log,
                 e.__class__.__name__,
                 dur_ms,
-                str(e).split("\n")[0],
+                leaf_summary,
             )
-            exceptions.extend(getattr(e, "exceptions", [e]))
+            exceptions.extend(leaves)
             failure_messages.append(
-                f"{server.id} ({transport}): {url_for_log}): {e.__class__.__name__}: {str(e).splitlines()[0]}\n"
+                f"{server.id} ({transport}): {url_for_log}): {leaf_summary}\n"
             )
 
     if exceptions:

--- a/agentic-backend/agentic_backend/core/chatbot/session_orchestrator.py
+++ b/agentic-backend/agentic_backend/core/chatbot/session_orchestrator.py
@@ -849,8 +849,11 @@ class SessionOrchestrator:
                 # Preserve everything already emitted by the transcoder.
                 agent_msgs = sae.partial_messages
                 user_msg = human_error_message(runtime_context, sae.original)
-                # Next free rank after all agent messages (base_rank consumed by user at 0).
-                safe_rank = base_rank + len(agent_msgs) + 1
+                # Next free rank: derive from next_rank_cursor, which already accounts for
+                # the user message and any injected system_notes (attachment/edited-doc).
+                # Recomputing from base_rank would ignore those and collide with a
+                # system_note rank (CardinalityViolationError on the history upsert).
+                safe_rank = next_rank_cursor + len(agent_msgs)
                 agent_msgs.append(
                     ChatMessage(
                         session_id=session.id,
@@ -880,7 +883,9 @@ class SessionOrchestrator:
                 )
             except Exception as e:
                 user_msg = human_error_message(runtime_context, e)
-                safe_rank = base_rank + len(agent_msgs) + 1
+                # See StreamAgentError handler above: use next_rank_cursor so the fallback
+                # message never collides with an injected system_note rank.
+                safe_rank = next_rank_cursor + len(agent_msgs)
                 agent_msgs.append(
                     ChatMessage(
                         session_id=session.id,

--- a/agentic-backend/agentic_backend/core/monitoring/postgres_history_store.py
+++ b/agentic-backend/agentic_backend/core/monitoring/postgres_history_store.py
@@ -129,6 +129,25 @@ class PostgresHistoryStore(BaseHistoryStore):
                 }
             )
 
+        # Guard against duplicate ranks within a single batch. A multi-row
+        # INSERT ... ON CONFLICT DO UPDATE raises CardinalityViolationError if two
+        # rows share the conflict key (session_id, user_id, rank). Collapse any
+        # duplicates to the last occurrence (same "last write wins" semantics as the
+        # upsert) so a caller-side rank bug degrades gracefully instead of losing the
+        # whole exchange.
+        by_rank: dict[int, dict] = {}
+        for v in all_values:
+            if v["rank"] in by_rank:
+                logger.warning(
+                    "[HISTORY] duplicate rank=%s in save batch session=%s user=%s; "
+                    "keeping last occurrence",
+                    v["rank"],
+                    session_id,
+                    user_id,
+                )
+            by_rank[v["rank"]] = v
+        all_values = list(by_rank.values())
+
         stmt = insert(SessionHistoryRow).values(all_values)
         upsert_stmt = stmt.on_conflict_do_update(
             index_elements=["session_id", "user_id", "rank"],

--- a/agentic-backend/tests/test_mcp_utils.py
+++ b/agentic-backend/tests/test_mcp_utils.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from agentic_backend.common.mcp_utils import (
+    _format_exception,
+    _leaf_exceptions,
+)
+
+
+def test_leaf_exceptions_plain_exception_returns_itself() -> None:
+    exc = ValueError("boom")
+    assert _leaf_exceptions(exc) == [exc]
+
+
+def test_leaf_exceptions_unwraps_single_taskgroup_leaf() -> None:
+    # Mirrors the real incident: an anyio TaskGroup wraps a single HTTP 401.
+    leaf = RuntimeError("Client error '401 Unauthorized' for url 'http://kf/mcp-tabular'")
+    group = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [leaf])
+
+    assert _leaf_exceptions(group) == [leaf]
+
+
+def test_leaf_exceptions_unwraps_multiple_leaves() -> None:
+    leaf_a = RuntimeError("a")
+    leaf_b = ValueError("b")
+    group = ExceptionGroup("group", [leaf_a, leaf_b])
+
+    assert _leaf_exceptions(group) == [leaf_a, leaf_b]
+
+
+def test_leaf_exceptions_unwraps_nested_groups() -> None:
+    leaf = RuntimeError("deep 401")
+    inner = ExceptionGroup("inner", [leaf])
+    outer = ExceptionGroup("outer", [inner])
+
+    assert _leaf_exceptions(outer) == [leaf]
+
+
+def test_format_exception_uses_first_line_only() -> None:
+    exc = RuntimeError("first line\nsecond line\nthird line")
+    assert _format_exception(exc) == "RuntimeError: first line"
+
+
+def test_format_exception_names_the_leaf_class() -> None:
+    # After unwrapping, the message names the concrete error, not "ExceptionGroup".
+    leaf = RuntimeError("Client error '401 Unauthorized'")
+    group = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [leaf])
+
+    (unwrapped,) = _leaf_exceptions(group)
+    summary = _format_exception(unwrapped)
+
+    assert summary == "RuntimeError: Client error '401 Unauthorized'"
+    assert "ExceptionGroup" not in summary
+    assert "TaskGroup" not in summary

--- a/agentic-backend/tests/test_mcp_utils.py
+++ b/agentic-backend/tests/test_mcp_utils.py
@@ -13,7 +13,9 @@ def test_leaf_exceptions_plain_exception_returns_itself() -> None:
 
 def test_leaf_exceptions_unwraps_single_taskgroup_leaf() -> None:
     # Mirrors the real incident: an anyio TaskGroup wraps a single HTTP 401.
-    leaf = RuntimeError("Client error '401 Unauthorized' for url 'http://kf/mcp-tabular'")
+    leaf = RuntimeError(
+        "Client error '401 Unauthorized' for url 'http://kf/mcp-tabular'"
+    )
     group = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [leaf])
 
     assert _leaf_exceptions(group) == [leaf]

--- a/agentic-backend/tests/test_postgres_history_store_rank_dedup.py
+++ b/agentic-backend/tests/test_postgres_history_store_rank_dedup.py
@@ -1,0 +1,128 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for PostgresHistoryStore.save rank-collision handling.
+
+A multi-row `INSERT ... ON CONFLICT (session_id, user_id, rank) DO UPDATE`
+raises Postgres CardinalityViolationError if two rows in the same batch share
+the conflict key. This happened when a system_note (attachment upload / edited
+doc) was injected and the agent run then failed: the error-fallback message was
+assigned the same rank as the system_note. `save` now collapses same-rank rows
+to the last occurrence so a stray caller-side collision degrades gracefully
+instead of losing the whole exchange.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+from agentic_backend.core.chatbot.chat_schema import (
+    Channel,
+    ChatMessage,
+    Role,
+    TextPart,
+)
+from agentic_backend.core.monitoring.postgres_history_store import PostgresHistoryStore
+
+_TS = datetime(2026, 7, 7, 16, 10, 10, tzinfo=timezone.utc)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+
+
+def _msg(rank: int, role: Role, channel: Channel, text: str) -> ChatMessage:
+    return ChatMessage(
+        session_id="sess-1",
+        exchange_id="ex-1",
+        rank=rank,
+        timestamp=_TS,
+        role=role,
+        channel=channel,
+        parts=[TextPart(text=text)],
+    )
+
+
+async def _save(messages):
+    fake_session = _FakeSession()
+    store = cast(Any, object.__new__(PostgresHistoryStore))
+    store._sessions = None  # __init__ bypassed; use_session is patched
+
+    with patch(
+        "agentic_backend.core.monitoring.postgres_history_store.use_session"
+    ) as mock_use_session:
+
+        @asynccontextmanager
+        async def _fake_use_session(factory, session=None):
+            yield fake_session
+
+        mock_use_session.side_effect = _fake_use_session
+
+        await cast(PostgresHistoryStore, store).save(
+            session_id="sess-1", messages=messages, user_id="u-1"
+        )
+    return fake_session.statement
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ranks_are_collapsed_to_last_occurrence():
+    """user(0) + system_note(1) + error-fallback(1) must not crash the upsert."""
+    messages = [
+        _msg(0, Role.user, Channel.final, "generate a user manual"),
+        _msg(1, Role.system, Channel.system_note, "The user uploaded an attachment"),
+        _msg(1, Role.assistant, Channel.final, "Agent could not start: MCP failed"),
+    ]
+
+    statement = await _save(messages)
+
+    # The compiled INSERT must carry exactly one row per rank (0 and 1), and the
+    # rank=1 row that survives is the last-written one (the assistant fallback).
+    compiled = statement.compile()
+    rank_params = sorted(
+        v for k, v in compiled.params.items() if k == "rank" or k.startswith("rank_")
+    )
+    assert rank_params == [0, 1]
+
+    role_params = [
+        v for k, v in compiled.params.items() if k == "role" or k.startswith("role_")
+    ]
+    assert "assistant" in role_params
+    # The overwritten system_note role must be gone from the batch.
+    assert "system" not in role_params
+
+
+@pytest.mark.asyncio
+async def test_distinct_ranks_are_all_preserved():
+    messages = [
+        _msg(0, Role.user, Channel.final, "hi"),
+        _msg(1, Role.system, Channel.system_note, "note"),
+        _msg(2, Role.assistant, Channel.final, "answer"),
+    ]
+
+    statement = await _save(messages)
+
+    compiled = statement.compile()
+    rank_params = sorted(
+        v for k, v in compiled.params.items() if k == "rank" or k.startswith("rank_")
+    )
+    assert rank_params == [0, 1, 2]


### PR DESCRIPTION
## What

Fixes a `CardinalityViolationError: ON CONFLICT DO UPDATE command cannot affect row a second time` that crashes a chat exchange while persisting session history.

Closes #1945

## Root cause

`session_history` has composite PK `(session_id, user_id, rank)` and `PostgresHistoryStore.save` issues one multi-row `INSERT … ON CONFLICT (session_id, user_id, rank) DO UPDATE`. Postgres rejects the statement when two rows in the same batch share the conflict key.

The two error-handling paths in `SessionOrchestrator` computed the fallback assistant-message rank as:

```python
safe_rank = base_rank + len(agent_msgs) + 1
```

This reconstructs the next free rank from `base_rank` and only counts *agent* messages — it ignores any `system_note` injected this turn (attachment upload / edited doc), which advanced the running `next_rank_cursor`, not `base_rank`. When both an attachment was uploaded **and** the agent run failed (e.g. an MCP server was unreachable — *"Some MCP connections failed"*), the fallback message collided with the system_note's rank.

Example failing batch had ranks `[0, 1, 1]`:

| rank | role | channel |
|------|------|---------|
| 0 | user | final |
| 1 | system | system_note (attachment upload) |
| 1 | assistant | final (error fallback) |

## Fix

- Both error handlers now allocate the fallback rank from `next_rank_cursor`, which already accounts for the user message and every injected system_note.
- Defensive net: `PostgresHistoryStore.save` collapses duplicate ranks within a batch to the last occurrence (same "last write wins" semantics as the upsert), so a stray caller-side collision degrades gracefully instead of losing the whole exchange. It logs a warning when it does.

## Tests

- New `tests/test_postgres_history_store_rank_dedup.py` covers the collision batch (collapsed to one row per rank, keeping the last write) and the normal distinct-rank case.
- `make -C agentic-backend code-quality` — clean.
- `make -C agentic-backend test` — 494 passed.
