### PR TITLE
docs: add v1.8.1 release notes

### DIFF
--- a/frontend/public/release.md
+++ b/frontend/public/release.md
@@ -1,3 +1,15 @@
+**v1.8.1** - 2026-07-08
+
+- **Improvements**
+
+  - Track and display the creator and last editor of each agent (#1941)
+
+- **Bug Fixes**
+
+  - Improve the writable document editor: tables, code blocks, images and dark theme (#1935)
+  - Preserve nested list depth in Word (docx) export (#1936)
+  - PPT Filler tool: return a clear error to agent when it pass an image path instead of a document id (#1937)
+
 **v1.8.0** - 2026-07-06
 
 - **Features**


### PR DESCRIPTION
## Summary

Adds the **v1.8.1** section (2026-07-08) to the frontend release notes, covering the four merged PRs since the v1.8.0 notes:

- **Improvements**
  - Track and display the creator and last editor of each agent (#1941)
- **Bug Fixes**
  - Improve the writable document editor: tables, code blocks, images and dark theme (#1935)
  - Preserve nested list depth in Word (docx) export (#1936)
  - PPT Filler tool: return a clear error to agent when it passes an image path instead of a document id (#1937)

🤖 Generated with [Claude Code](https://claude.com/claude-code)