### PR TITLE
#1992 make the swift import production ready yet simple

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/import_export/agent_map.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/agent_map.py
@@ -1,7 +1,9 @@
 """Kea→Swift agent template mapping (MIGR-05).
 
 Maps a kea-exported agent to its swift template, so the import can create the
-equivalent managed `agent_instance`. See docs/swift/rfc/PLATFORM-IMPORT-RFC.md §7.
+equivalent managed `agent_instance`. Kea-import-path only (§8 of
+docs/swift/rfc/PLATFORM-IMPORT-RFC.md) — swift-native imports carry
+`agent_instance` rows directly and never go through this mapping.
 
 The mapping table is the single control point. Every exported agent is classified
 into exactly one outcome:

--- a/apps/control-plane-backend/control_plane_backend/import_export/bundle.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/bundle.py
@@ -6,21 +6,44 @@ import io
 import json
 import zipfile
 from collections.abc import Iterator
-from dataclasses import dataclass
 from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane_backend.import_export.schemas import BundleUserEntry
 
+# Canonical contract — swift-native baseline (PLATFORM-IMPORT-RFC.md). Two
+# independent version numbers because they change at different rates:
+# format_version is the container's own shape (which top-level files/tables
+# exist); users_schema_version is BundleUserEntry's field set, which already
+# grew once (identity fields) without a container version bump.
+SUPPORTED_FORMAT_VERSIONS: frozenset[int] = frozenset({1})
+SUPPORTED_USERS_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
 
-@dataclass(frozen=True)
-class SnapshotManifest:
+
+class UnsupportedBundleFormatError(ValueError):
+    """manifest.json declares a format/schema version this importer doesn't understand."""
+
+
+class SnapshotManifest(BaseModel):
+    """Typed, validated `manifest.json` — parity with `BundleUserEntry`.
+
+    Replaces the previous hand-built `@dataclass` populated via
+    `raw.get(key, default)`, which accepted any JSON shape silently.
+    `format_version`/`users_schema_version` are checked against the supported
+    sets in `open_bundle()` — no other field changes behavior.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
     format_version: int
-    source_platform: str
-    created_at: str
-    tables: dict[str, int]
-    tuple_count: int
-    realm_exported: bool
-    content_keys: list[str]
+    users_schema_version: int = 1
+    source_platform: str = "kea"
+    created_at: str = ""
+    tables: dict[str, int] = Field(default_factory=dict)
+    tuple_count: int = 0
+    realm_exported: bool = False
+    content_keys: list[str] = Field(default_factory=list)
 
 
 class KBundle:
@@ -59,7 +82,7 @@ class KBundle:
     def demo_users(self) -> list[BundleUserEntry]:
         """Return the typed users.json provisioning list, empty list if absent.
 
-        AUTHZ-07 Part 8 §40.2 / PLATFORM-IMPORT-RFC.md §10: declarative platform
+        AUTHZ-07 Part 8 §40.2 / PLATFORM-IMPORT-RFC.md §6: declarative platform
         provisioning for identities/teams/roles/users. Unlike `postgres/<table>.jsonl`
         rows, these entries are not Postgres rows — each one describes an optional
         Keycloak identity to create (email/first_name/last_name/password) plus the
@@ -78,16 +101,23 @@ class KBundle:
 
 
 def open_bundle(data: bytes) -> KBundle:
-    """Open a kea snapshot zip from raw bytes and parse its manifest."""
+    """Open a snapshot zip from raw bytes, parse and validate its manifest.
+
+    Rejects a bundle whose `format_version`/`users_schema_version` isn't in
+    the supported set — no silent default when the key is absent or wrong,
+    per the canonical contract in `PLATFORM-IMPORT-RFC.md`.
+    """
     zf = zipfile.ZipFile(io.BytesIO(data))
     raw = json.loads(zf.read("manifest.json"))
-    manifest = SnapshotManifest(
-        format_version=raw.get("format_version", 1),
-        source_platform=raw.get("source_platform", "kea"),
-        created_at=raw.get("created_at", ""),
-        tables=raw.get("tables", {}),
-        tuple_count=raw.get("tuple_count", 0),
-        realm_exported=raw.get("realm_exported", False),
-        content_keys=raw.get("content_keys", []),
-    )
+    manifest = SnapshotManifest.model_validate(raw)
+    if manifest.format_version not in SUPPORTED_FORMAT_VERSIONS:
+        raise UnsupportedBundleFormatError(
+            f"Unsupported bundle format_version {manifest.format_version}; "
+            f"this importer understands {sorted(SUPPORTED_FORMAT_VERSIONS)}"
+        )
+    if manifest.users_schema_version not in SUPPORTED_USERS_SCHEMA_VERSIONS:
+        raise UnsupportedBundleFormatError(
+            f"Unsupported users.json schema version {manifest.users_schema_version}; "
+            f"this importer understands {sorted(SUPPORTED_USERS_SCHEMA_VERSIONS)}"
+        )
     return KBundle(zf, manifest)

--- a/apps/control-plane-backend/control_plane_backend/import_export/bundle.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/bundle.py
@@ -37,7 +37,7 @@ class SnapshotManifest(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     format_version: int
-    users_schema_version: int = 1
+    users_schema_version: int
     source_platform: str = "kea"
     created_at: str = ""
     tables: dict[str, int] = Field(default_factory=dict)

--- a/apps/control-plane-backend/control_plane_backend/import_export/exporter.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/exporter.py
@@ -146,7 +146,10 @@ async def run_export(engine: AsyncEngine) -> bytes:
         },
         "tuple_count": 0,
         "realm_exported": False,
-        "content_keys": [],
+        # Every exported document's binary is expected to already be mirrored
+        # into the target's object store (MIGR-06) — this import never
+        # transports content, only declares what it assumes is there.
+        "content_keys": [m["document_uid"] for m in metadata],
     }
 
     buffer = io.BytesIO()

--- a/apps/control-plane-backend/control_plane_backend/import_export/exporter.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/exporter.py
@@ -39,6 +39,10 @@ from control_plane_backend.models.agent_instance_models import AgentInstanceRow
 logger = logging.getLogger(__name__)
 
 FORMAT_VERSION = 1
+# This export never writes users.json, but manifest.json's users_schema_version
+# is required on every bundle regardless (bundle.py::SnapshotManifest) — declare
+# it so a re-import of this exact export never fails on a missing field.
+USERS_SCHEMA_VERSION = 1
 SOURCE_PLATFORM = "swift"
 
 
@@ -136,6 +140,7 @@ async def run_export(engine: AsyncEngine) -> bytes:
 
     manifest = {
         "format_version": FORMAT_VERSION,
+        "users_schema_version": USERS_SCHEMA_VERSION,
         "source_platform": SOURCE_PLATFORM,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "tables": {

--- a/apps/control-plane-backend/control_plane_backend/import_export/importer.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/importer.py
@@ -15,7 +15,7 @@ Scope (current snapshot):
 - Team metadata → team_metadata rows (branding + per-team retention, CTRLP-12;
              swift-native snapshots only, idempotent skip-if-present)
 - Users    → two-phase declarative provisioning (AUTHZ-07 Part 8 §40.2,
-             `PLATFORM-IMPORT-RFC.md` §10, reconciliation fix AUTHZ-07 Step 2)
+             `PLATFORM-IMPORT-RFC.md` §6, reconciliation fix AUTHZ-07 Step 2)
              from the top-level `users.json` bundle entry, run outside the DB
              transaction above (after it, so role grants may reference teams
              the same bundle just created).
@@ -78,6 +78,7 @@ from fred_core import (
 )
 from fred_core.common import TeamId
 from fred_core.documents.document_models import DocumentMetadataRow
+from fred_core.documents.document_structures import ProcessingStage, ProcessingStatus
 from fred_core.documents.tag_models import TagRow
 from fred_core.sql.async_session import make_session_factory
 from fred_core.tasks.models import (
@@ -124,12 +125,37 @@ _PLATFORM_ROLE_RELATIONS: dict[str, RelationType] = {
     "observer": RelationType.PLATFORM_OBSERVER,
 }
 
+# Canonical contract — swift-native baseline (PLATFORM-IMPORT-RFC.md):
+# vectors/SQL indexes are never transported by this import (products are
+# rebuilt on the target, MIGR-07), so a restored document must not carry
+# forward the source's stale DONE claim for them. PREVIEW_READY is left
+# alone — the data-before-metadata ordering (MIGR-06 before MIGR-05) is a
+# documented precondition, so preview content is trusted to already be there.
+_STAGES_RESET_ON_IMPORT = (
+    ProcessingStage.VECTORIZED.value,
+    ProcessingStage.SQL_INDEXED.value,
+)
+
+
+def _reset_transported_stages(doc: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Reset VECTORIZED/SQL_INDEXED to NOT_STARTED on a restored metadata `doc`
+    blob so the platform never reports a document as searchable when its
+    embeddings/index were never restored."""
+    if not doc:
+        return doc
+    stages = (doc.get("processing") or {}).get("stages")
+    if isinstance(stages, dict):
+        for stage in _STAGES_RESET_ON_IMPORT:
+            if stage in stages:
+                stages[stage] = ProcessingStatus.NOT_STARTED.value
+    return doc
+
 
 class BundleProvisioningError(Exception):
     """A `users.json` bundle cannot be fully reconciled (AUTHZ-07 Step 2).
 
     Why this type exists:
-    - `PLATFORM-IMPORT-RFC.md` §10's fail-closed rule: a declared-valid
+    - `PLATFORM-IMPORT-RFC.md` §6's fail-closed rule: a declared-valid
       bundle must never produce a silently incomplete `succeeded` import.
       Every one of the conditions below now aborts the whole users phase
       (and thus the import — `import_export/api.py`'s background-task
@@ -533,7 +559,7 @@ def _effective_team_relations(
     entry: BundleUserEntry,
 ) -> dict[str, set[UserTeamRelation]]:
     """Resolve the exact set of direct team-role tuples one bundle entry
-    requests (AUTHZ-07 Step 2 / `PLATFORM-IMPORT-RFC.md` §10 `teams`/
+    requests (AUTHZ-07 Step 2 / `PLATFORM-IMPORT-RFC.md` §6 `teams`/
     `team_roles` semantics).
 
     - A team name in `entry.team_roles` requests exactly the named
@@ -940,7 +966,7 @@ async def run_import(
                         source_tag=row.get("source_tag"),
                         date_added_to_kb=_coerce_dt(row.get("date_added_to_kb")),
                         tag_ids=row.get("tag_ids") or [],
-                        doc=row.get("doc"),
+                        doc=_reset_transported_stages(row.get("doc")),
                     )
                 )
                 return True
@@ -953,6 +979,18 @@ async def run_import(
                 import_fn=_import_metadata,
                 session=session,
             )
+            if bundle.manifest.content_keys:
+                # Canonical contract — track, don't embed: this import never
+                # carries document binaries, only declares what it assumes is
+                # already mirrored (MIGR-06). Not verified here (no
+                # cross-backend content-store probe) — surfaced so the
+                # operator can check, same as any other partial-reconciliation
+                # warning (RFC §11's "with warnings" tell).
+                report.warnings.append(
+                    f"{len(bundle.manifest.content_keys)} document(s) expect content "
+                    "already present in the target's object store (mirrored via "
+                    "MIGR-06) — not verified by this import"
+                )
 
             # --- team metadata (branding + retention) ---
             async def _import_team_metadata(

--- a/apps/control-plane-backend/control_plane_backend/import_export/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/schemas.py
@@ -14,7 +14,7 @@
 
 """Typed bundle schemas for declarative platform provisioning.
 
-AUTHZ-07 Part 8 §40.2 / `docs/swift/rfc/PLATFORM-IMPORT-RFC.md` §10. `BundleUserEntry`
+AUTHZ-07 Part 8 §40.2 / `docs/swift/rfc/PLATFORM-IMPORT-RFC.md` §6. `BundleUserEntry`
 is the typed shape of each `users.json` bundle entry — it carries both the
 identity-creation fields consumed by `importer.py::_provision_bundle_identities`
 (email/first_name/last_name/password, all optional) and the authorization
@@ -54,7 +54,7 @@ class BundleUserEntry(BaseModel):
     last_name: str | None = None
     password: str | None = None
     # Role phase (`_resolve_bundle_usernames` / `_apply_bundle_user_roles`) —
-    # unchanged from the shape documented in `PLATFORM-IMPORT-RFC.md` §10.
+    # unchanged from the shape documented in `PLATFORM-IMPORT-RFC.md` §6.
     teams: list[str] = Field(default_factory=list)
     team_roles: dict[str, list[str]] = Field(default_factory=dict)
     platform_roles: list[str] = Field(default_factory=list)

--- a/apps/control-plane-backend/tests/fixtures/import_export/demo_provisioning/manifest.json
+++ b/apps/control-plane-backend/tests/fixtures/import_export/demo_provisioning/manifest.json
@@ -1,5 +1,6 @@
 {
   "format_version": 1,
+  "users_schema_version": 1,
   "source_platform": "swift",
   "created_at": "2026-07-14T00:00:00Z",
   "tables": {},

--- a/apps/control-plane-backend/tests/test_import_export_manifest.py
+++ b/apps/control-plane-backend/tests/test_import_export_manifest.py
@@ -1,0 +1,172 @@
+"""MIGR-05.13 — swift-native baseline hardening.
+
+Covers the "Canonical contract — swift-native baseline" section of
+`PLATFORM-IMPORT-RFC.md`: `SnapshotManifest` is now validated (Pydantic,
+`format_version`/`users_schema_version` enforced against a supported set —
+no silent default), and the bundle is honest about what it does NOT
+transport (`content_keys` populated on export + surfaced as a warning on
+import; `VECTORIZED`/`SQL_INDEXED` reset to `NOT_STARTED` on import so a
+restored document never claims to be searchable when its embeddings/index
+were never restored).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from control_plane_backend.agent_instances.store import AgentInstanceStore
+from control_plane_backend.import_export.bundle import (
+    UnsupportedBundleFormatError,
+    open_bundle,
+)
+from control_plane_backend.import_export.exporter import run_export
+from control_plane_backend.import_export.importer import MigrationReport, run_import
+from control_plane_backend.models.base import Base as CPBase
+from fred_core.documents.document_models import DocumentMetadataRow
+from fred_core.models import Base as CoreBase
+from fred_core.scheduler import SchedulerBackend
+from fred_core.sql.async_session import make_session_factory
+from fred_core.tasks.models import StartMigrationRequest
+from fred_core.tasks.service import TaskService
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+
+def _minimal_bundle_bytes(manifest: dict) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+    return buf.getvalue()
+
+
+def test_open_bundle_rejects_unsupported_format_version() -> None:
+    data = _minimal_bundle_bytes({"format_version": 999, "source_platform": "swift"})
+    with pytest.raises(UnsupportedBundleFormatError):
+        open_bundle(data)
+
+
+def test_open_bundle_rejects_missing_format_version() -> None:
+    data = _minimal_bundle_bytes({"source_platform": "swift"})
+    with pytest.raises(ValidationError):
+        open_bundle(data)
+
+
+def test_open_bundle_rejects_unsupported_users_schema_version() -> None:
+    data = _minimal_bundle_bytes(
+        {"format_version": 1, "users_schema_version": 999, "source_platform": "swift"}
+    )
+    with pytest.raises(UnsupportedBundleFormatError):
+        open_bundle(data)
+
+
+def test_open_bundle_accepts_a_conformant_manifest() -> None:
+    data = _minimal_bundle_bytes(
+        {
+            "format_version": 1,
+            "source_platform": "swift",
+            "created_at": "2026-07-16T00:00:00Z",
+            "tables": {},
+            "tuple_count": 0,
+            "realm_exported": False,
+            "content_keys": [],
+        }
+    )
+    bundle = open_bundle(data)
+    assert bundle.manifest.format_version == 1
+    assert bundle.manifest.source_platform == "swift"
+    assert bundle.manifest.users_schema_version == 1
+
+
+async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
+    # DocumentMetadataRow's table is registered on import via importer.py's own
+    # import chain (imported above), so it is present on CoreBase.metadata by
+    # the time create_all runs below.
+    import control_plane_backend.models.agent_instance_models  # noqa: F401
+    import fred_core.tasks.orm_models  # noqa: F401
+
+    db_path = tmp_path / name
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(CPBase.metadata.create_all)
+    return engine
+
+
+async def _seed_metadata(engine: AsyncEngine, row: DocumentMetadataRow) -> None:
+    session_factory = make_session_factory(engine)
+    async with session_factory() as session:
+        async with session.begin():
+            session.add(row)
+
+
+async def _import(bundle_bytes: bytes, engine: AsyncEngine) -> MigrationReport:
+    task_service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+    start = await task_service.start(StartMigrationRequest(), created_by="tester")
+    bundle = open_bundle(bundle_bytes)
+    return await run_import(
+        bundle=bundle,
+        import_id="imp-1",
+        task_id=start.task_id,
+        task_service=task_service,
+        engine=engine,
+        agent_instance_store=AgentInstanceStore(engine),
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_populates_content_keys_and_import_resets_transported_stages(
+    tmp_path: Path,
+) -> None:
+    source = await _make_engine(tmp_path, "source.sqlite3")
+    dest = await _make_engine(tmp_path, "dest.sqlite3")
+    try:
+        await _seed_metadata(
+            source,
+            DocumentMetadataRow(
+                document_uid="doc-1",
+                source_tag="uploads",
+                date_added_to_kb=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                tag_ids=[],
+                doc={
+                    "processing": {
+                        "stages": {"preview": "done", "vector": "done", "sql": "done"},
+                        "errors": {},
+                    }
+                },
+            ),
+        )
+
+        snapshot = await run_export(source)
+        manifest = json.loads(
+            zipfile.ZipFile(io.BytesIO(snapshot)).read("manifest.json")
+        )
+        assert manifest["content_keys"] == ["doc-1"]
+
+        report = await _import(snapshot, dest)
+
+        assert report.docs_imported == 1
+        assert any("1 document(s) expect content" in w for w in report.warnings)
+
+        async with make_session_factory(dest)() as session:
+            imported = (
+                await session.execute(
+                    select(DocumentMetadataRow).where(
+                        DocumentMetadataRow.document_uid == "doc-1"
+                    )
+                )
+            ).scalar_one()
+
+        assert imported.doc is not None
+        stages = imported.doc["processing"]["stages"]
+        assert stages["vector"] == "not_started"
+        assert stages["sql"] == "not_started"
+        assert stages["preview"] == "done"
+    finally:
+        await source.dispose()
+        await dest.dispose()

--- a/apps/control-plane-backend/tests/test_import_export_manifest.py
+++ b/apps/control-plane-backend/tests/test_import_export_manifest.py
@@ -46,13 +46,26 @@ def _minimal_bundle_bytes(manifest: dict) -> bytes:
 
 
 def test_open_bundle_rejects_unsupported_format_version() -> None:
-    data = _minimal_bundle_bytes({"format_version": 999, "source_platform": "swift"})
+    data = _minimal_bundle_bytes(
+        {"format_version": 999, "users_schema_version": 1, "source_platform": "swift"}
+    )
     with pytest.raises(UnsupportedBundleFormatError):
         open_bundle(data)
 
 
 def test_open_bundle_rejects_missing_format_version() -> None:
-    data = _minimal_bundle_bytes({"source_platform": "swift"})
+    data = _minimal_bundle_bytes(
+        {"users_schema_version": 1, "source_platform": "swift"}
+    )
+    with pytest.raises(ValidationError):
+        open_bundle(data)
+
+
+def test_open_bundle_rejects_missing_users_schema_version() -> None:
+    """No silent default — a bundle producer that forgets this field must fail
+    loudly, not be silently treated as schema v1 (the gap a Codex review found
+    on PR #1993: users_schema_version used to default to 1 when absent)."""
+    data = _minimal_bundle_bytes({"format_version": 1, "source_platform": "swift"})
     with pytest.raises(ValidationError):
         open_bundle(data)
 
@@ -69,6 +82,7 @@ def test_open_bundle_accepts_a_conformant_manifest() -> None:
     data = _minimal_bundle_bytes(
         {
             "format_version": 1,
+            "users_schema_version": 1,
             "source_platform": "swift",
             "created_at": "2026-07-16T00:00:00Z",
             "tables": {},

--- a/apps/control-plane-backend/tests/test_import_export_users.py
+++ b/apps/control-plane-backend/tests/test_import_export_users.py
@@ -359,6 +359,7 @@ def _build_bundle_bytes(users: list[dict[str, Any]]) -> bytes:
             json.dumps(
                 {
                     "format_version": 1,
+                    "users_schema_version": 1,
                     "source_platform": "swift",
                     "created_at": "2026-07-14T00:00:00Z",
                     "tables": {},

--- a/docs/swift/RELEASE-STRATEGY.md
+++ b/docs/swift/RELEASE-STRATEGY.md
@@ -170,5 +170,5 @@ or expected.
 
 | Branch  | Status                    | Latest tag                        | Doc tree               |
 | ------- | ------------------------- | ---------------------------------- | ---------------------- |
-| `swift` | Active — v2.x development | `code/v2.1.1` + `chart/v2.1.1` (2026-07-15) | `docs/swift/`          |
+| `swift` | Active — v2.x development | `code/v2.1.2` + `chart/v2.1.2` (2026-07-16) | `docs/swift/`          |
 | `eagle` | Not yet created           | —                                  | `docs/eagle/` (future) |

--- a/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
+++ b/docs/swift/backlog/KEA-MIGRATION-BACKLOG.md
@@ -91,19 +91,8 @@ OpenFGA tuples) is imported into a target environment. Owned by platform/ops.
 
 ## §0bis Platform import service (MIGR-05)
 
-Rock-solid swift-side **import** counterpart to kea's throwaway export. Temporal-backed,
-observable via the task/event stream, with an admin progress UI. Scope confirmed:
-**config graph only** (agents, prompts/resources, tags, document metadata, MCP, team/users,
-OpenFGA tuples), **fresh target only** (refuse if populated). Document blobs/vectors and
-conversations are out of scope (re-ingest separately). RFC: [`PLATFORM-IMPORT-RFC`](../rfc/PLATFORM-IMPORT-RFC.md).
-
-> **Status (2026-06-27): core import shipped, reviewed + live-tested.** Architecture deviated from the
-> Temporal design — see RFC §0 "Implementation note". The importer is an **atomic SQLAlchemy
-> transaction in a FastAPI BackgroundTask**: agents + tags + document metadata commit together or roll
-> back together, idempotent by primary key. Module is `import_export/` (not `migration/`); endpoints are
-> `import` / `export` / `reset` / `stats` under `/control-plane/v1/import-export/`. Validation path:
-> **export from kea first, then import with swift.** Governing principle: **dumb export / smart import**.
-> Next gap to close: **agent prompt transfer (05.11)**.
+Full contract: [`PLATFORM-IMPORT-RFC.md`](../rfc/PLATFORM-IMPORT-RFC.md) — swift-native path
+shipped + hardened; kea-import path (this checklist's `[ ]` items) deferred, tracked below.
 
 - [x] **MIGR-05.01** — Bundle reader + manifest parse (`format_version 1`, kea + swift formats) — `import_export/bundle.py`
 - [x] **MIGR-05.02** — Atomic import service (FastAPI `BackgroundTask` + single SQLAlchemy transaction; **not** Temporal): validate manifest → import agents → tags → metadata, all-or-nothing rollback, idempotent by PK — `import_export/importer.py` + `api.py`. *(Temporal design preserved in RFC §5 for future scale; fresh-target preflight + verify superseded by idempotent-by-PK + reset.)*
@@ -111,11 +100,12 @@ conversations are out of scope (re-ingest separately). RFC: [`PLATFORM-IMPORT-RF
 - [ ] **MIGR-05.04** — OpenFGA tuple restore with identity/team validation + personal-team reconciliation. *Deferred: handled by ops bulk-copy at cutover (Option A); `reset` leaves tuples intact so ownership survives re-test.*
 - [x] **MIGR-05.05** — `MigrationTaskEvent` populated (`step`/`progress`/`MigrationDetail`) + control-plane wired into frontend task rehydration & SSE sources (tasks survive reload)
 - [x] **MIGR-05.06** — Admin UI import page (upload zip → launch → task-atom progress, admin-only) — *fully wired to the live backend; page renamed **Platform data***
-- [ ] **MIGR-05.07** — Stage reconciliation (dumb-export/smart-import): on restore, reset each doc's
-  `VECTORIZED`/`SQL_INDEXED` → `NOT_STARTED`, conditionally reset `PREVIEW_READY`; consumed by MIGR-07
-  re-vectorize. *Inert without the MIGR-07 trigger — two ends of one flow.*
-  — RFC: [`PLATFORM-IMPORT-RFC`](../rfc/PLATFORM-IMPORT-RFC.md) "Canonical contract"
-  — depends on: MIGR-04 (identity bootstrap), reuses TASK-EVENT-STREAM task/event infra
+- [x] **MIGR-05.07** — Stage reconciliation: reset each restored document's `VECTORIZED`/
+  `SQL_INDEXED` → `NOT_STARTED` (never transported), `PREVIEW_READY` untouched. Closed by
+  MIGR-05.13 (`importer.py::_reset_transported_stages`) — the metadata-import phase is shared code,
+  not swift-only, so this applies to both the swift-native and kea-import paths. *Still inert until
+  MIGR-07's re-vectorize trigger actually consumes the reset — two ends of one flow.*
+  — RFC: [`PLATFORM-IMPORT-RFC`](../rfc/PLATFORM-IMPORT-RFC.md) §5
 - [x] **MIGR-05.08** — Tags + document-metadata import phases (atomic, shared generic loop) — `import_export/importer.py`; new `fred_core/documents/tag_models.py` `TagRow`
 - [x] **MIGR-05.09** — Swift-native **export** (`GET /import-export/export`) + re-import branch (`source_platform=swift`, bypasses `agent_map`) — `import_export/exporter.py`
 - [x] **MIGR-05.10** — Atomic **reset** (`POST /import-export/reset`) — wipes agents+tags+metadata in one transaction; enables export → reset → import test cycles (object store / Keycloak / OpenFGA untouched)
@@ -128,6 +118,14 @@ conversations are out of scope (re-ingest separately). RFC: [`PLATFORM-IMPORT-RF
   imported agents. — RFC: [`PLATFORM-IMPORT-RFC`](../rfc/PLATFORM-IMPORT-RFC.md) §8
 - [x] **MIGR-05.12** — Platform-data stats dashboard (`GET /import-export/stats`): teams, members by
   role, agents, prompts; personal spaces (`personal-*`) aggregated into one row — `import_export/stats.py`
+- [x] **MIGR-05.13** — Manifest contract hardening: `SnapshotManifest` → Pydantic + enforced
+  `format_version`/`users_schema_version` (reject unknown, no silent default) — `bundle.py`; honest
+  `content_keys` (populated on export, surfaced as a single count-warning on import — not a
+  per-document content-store probe, that's a future MIGR-06-side improvement) instead of an
+  always-`[]` placeholder — `exporter.py`/`importer.py`. Also closed MIGR-05.07 (stage
+  reconciliation) as a side effect, since it touched the same shared metadata-import phase. Tests:
+  `tests/test_import_export_manifest.py` (5 new). — RFC:
+  [`PLATFORM-IMPORT-RFC`](../rfc/PLATFORM-IMPORT-RFC.md) §4–§5
 
 ---
 

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -1873,15 +1873,15 @@ items:
       backlog: "docs/swift/backlog/KEA-MIGRATION-BACKLOG.md §0bis"
       rfc: "docs/swift/rfc/PLATFORM-IMPORT-RFC.md"
     notes: >
-      The 'metadata' topic — swift-side import counterpart to kea's throwaway export. SHIPPED
-      (reviewed + live-tested): atomic import of agents+tags+document-metadata (single SQLAlchemy
-      transaction in a FastAPI BackgroundTask — NOT Temporal; idempotent by PK), swift-native export
-      (re-importable), atomic reset (test cycle), and a Platform-data stats dashboard. Module is
-      import_export/ under /control-plane/v1/import-export/ (import|export|reset|stats). DEFERRED:
-      agent prompt transfer (05.11 — next gap; agents land with default tuning, no prompt content),
-      OpenFGA tuple restore (05.04 — ops bulk-copy Option A), stage reconciliation (05.07 → MIGR-07).
-      Document binaries move via MIGR-06; embeddings rebuilt by MIGR-07; conversations out of scope.
-      Architecture deviation from the Temporal design recorded in PLATFORM-IMPORT-RFC §0.
+      The 'metadata' topic — swift-side import counterpart to kea's throwaway export. Full current
+      contract: PLATFORM-IMPORT-RFC.md (rewritten 2026-07-16 to state the current contract only —
+      history is in git log, not inline). SHIPPED: atomic import of agents+tags+document-metadata+
+      team-metadata (single SQLAlchemy transaction in a FastAPI BackgroundTask, idempotent by PK),
+      swift-native export/reset, Platform-data stats dashboard, declarative users.json team/platform
+      role provisioning (fail-closed), validated+versioned manifest, honest content_keys + stage
+      reconciliation (05.13). DEFERRED (kea-import path only): OpenFGA tuple restore (05.04 — ops
+      bulk-copy Option A), agent prompt transfer (05.11). Document binaries move via MIGR-06;
+      embeddings rebuilt by MIGR-07 (re-vectorize trigger after import not yet wired).
 
   - id: MIGR-06
     title: "Data — document binaries MinIO mc mirror (key-for-key, laptop bridge)"

--- a/docs/swift/rfc/PLATFORM-IMPORT-RFC.md
+++ b/docs/swift/rfc/PLATFORM-IMPORT-RFC.md
@@ -1,571 +1,171 @@
-# RFC — Platform Import service (kea→swift configuration restore)
+# RFC — Platform Import/Export (swift-native contract)
 
-**ID:** MIGR-05 · **Status:** partially implemented — agents + tags + document metadata land atomically; export / reset / stats shipped; prompts, OpenFGA tuples, stage-reconciliation deferred
-**Owner:** Dimitri · **Surface:** control-plane-backend + frontend
-**Extends:** [`TASK-EVENT-STREAM-RFC.md`](TASK-EVENT-STREAM-RFC.md) (task/event infra),
-[`KEA-MIGRATION-BACKLOG.md`](../backlog/KEA-MIGRATION-BACKLOG.md) §0bis (MIGR-05).
-**Depends on:** [`ops/KEYCLOAK-IDENTITY-BOOTSTRAP-S3NS.md`](../ops/KEYCLOAK-IDENTITY-BOOTSTRAP-S3NS.md) (MIGR-04 — identity must exist first).
-**Operational model:** [`ops/KEA_SWIFT_CUTOVER.md`](../ops/KEA_SWIFT_CUTOVER.md).
-
-**Migration topic:** this RFC is the **metadata** topic — one of the four migration topics
-(**identity → data → metadata → products**). It runs **after** identity (MIGR-04) and **data**
-(MIGR-06, the `mc mirror` of document binaries) and **before** products (MIGR-07, re-vectorize).
-Vocabulary and order: [`KEA-MIGRATION-BACKLOG.md` → "Migration model"](../backlog/KEA-MIGRATION-BACKLOG.md).
-
----
-
-## 0. Status & team handoff (read before branching)
-
-This feature is documented here on the swift side because **all import/export RFCs live on swift**
-(kea is being retired). The validation path is: **first produce an export from kea, then import it
-with swift.**
-
-### Implementation note — architecture deviation from §5 (2026-06-27)
-
-The shipped implementation **does not use Temporal** (§5 below remains the future design if payloads
-grow). For a config-sized payload (one shared `fred` Postgres DB, sub-megabyte zip), a single
-**atomic SQLAlchemy transaction inside a FastAPI `BackgroundTask`** is simpler and gives a stronger
-guarantee than per-activity retries: **all writes (agents + tags + metadata) commit together or roll
-back together — no partial state**. Progress still streams through the fred-core task/event API
-(`MigrationTaskEvent`), so the frontend task atoms render it unchanged. If/when binaries or
-large multi-store restores enter scope, revisit the Temporal design in §5.
-
-- **Module:** `control_plane_backend/import_export/` (not `migration/`).
-- **Endpoints** (all `require_admin`, prefix `/control-plane/v1`):
-  - `POST /import-export/import` — multipart zip → async task; atomic import.
-  - `GET  /import-export/export` — download a **swift-native** snapshot (`source_platform=swift`),
-    re-importable through the same importer (a native branch skips the kea `agent_map` translation).
-  - `POST /import-export/reset` — atomic wipe of agents + tags + metadata (enables
-    export → reset → import test cycles; Keycloak / OpenFGA / object store untouched).
-  - `GET  /import-export/stats` — relational platform overview (teams, members by role, agents,
-    prompts; personal spaces aggregated). Powers the **Platform data** admin page.
-
-**Done (on the current branch, reviewed + live-tested):**
-- `import_export/agent_map.py` (+ `tests/test_agent_map.py`) — kea→swift agent classification (§7).
-- `import_export/bundle.py` — bundle reader + manifest parse (kea + swift formats).
-- `import_export/importer.py` — atomic import of **agents** (mapped; IGNORED skipped; GAP warned),
-  **tags**, **document metadata**, in one transaction; idempotent by primary key (safe re-run).
-- `import_export/exporter.py` — swift-native snapshot writer.
-- `import_export/stats.py` — platform summary aggregation.
-- `MigrationTaskEvent` populated with `step` + `progress`; control-plane added to frontend task
-  rehydration + SSE sources, so migration tasks survive reload.
-- Admin page (renamed **Platform data**) — import / export / reset + the live stats dashboard.
-- `import_export/importer.py::_run_users_phase` (+ `bundle.py::demo_users`,
-  `users/service.py::find_user_sub_by_username`) — declarative team/platform role provisioning from
-  the new `users.json` bundle entry (§10, AUTHZ-07 Part 8 §40.2), **team-role reconciliation fixed
-  2026-07-14 (AUTHZ-07 Step 2 — see §10's "Team-scoped roles" subsection)** after the first pass's live
-  validation run surfaced a design gap: non-admin team-scoped grants were unconditionally refused by the
-  `team_admin`-gated ordinary API and downgraded to warnings while the import still reported
-  `succeeded`. **Live-validated 2026-07-14**: re-imported the same demo bundle onto the
-  already-partially-provisioned live stack, then re-ran root `make validation-report` —
-  **225 passed, 0 failed, 0 errors, 2 skipped (expected)**, confirming the fix closes the gap end to end,
-  not just offline.
-- `import_export/api.py` (§11, AUTHZ-07 Step 3) — the import task now carries a canonical, durable
-  `TaskTarget` and its terminal `succeeded` event carries the full structured `MigrationReport` (via
-  `fred_core.tasks.models.MigrationDetail.result`), so a partial reconciliation (warnings) is never
-  indistinguishable from full success after a reload. See §11.
-
-**Deferred (not done — tracked in backlog §0bis):**
-- **Prompts/resources** — agents import with default tuning only; kea agent prompt → swift agent
-  instance prompt is **not** transferred yet (MIGR-05.11, the explicit next gap).
-- **OpenFGA tuple restore** (MIGR-05.04) — handled out-of-band by ops bulk-copy (cutover Option A);
-  `reset` deliberately leaves tuples intact so team ownership survives a re-test.
-- **Stage reconciliation** (MIGR-05.07) + **re-vectorize trigger** (MIGR-07).
-- ~~**users / MCP** restore — re-seeded by deployment / identity bootstrap (MIGR-04)~~ **partially
-  superseded (2026-07-14, §10):** this line meant the kea `postgres/users.jsonl` table (Keycloak
-  identity rows) — still correctly out of scope, identity stays MIGR-04's job. A *different*,
-  top-level `users.json` bundle entry (not a `postgres/` table) now exists for a separate concern:
-  declarative Fred-side authorization provisioning (team roles, platform roles) for identities that
-  already exist. See §10. **MCP** restore is still fully deferred (unchanged).
-- ~~**teammetadata** restore — re-seeded by deployment / identity bootstrap~~ **superseded
-  (2026-07-10):** this assumed team metadata was Keycloak-identity-derived, which was true only
-  while teams were Keycloak groups. AUTHZ-05 review item 9 decoupled teams from Keycloak entirely
-  — `import_export/importer.py::_import_team_metadata` already restores `teammetadata` rows
-  (including the now-required `name` column, with an id-fallback for older bundles) as part of
-  the same import transaction as agents/tags/document metadata, not a separate identity-bootstrap
-  step. Update this line's status if that changed since.
-- **Fresh-target preflight guard / verify step** — superseded by idempotent-by-PK import + `reset`.
-
-**Known incompleteness on the kea side:** verify the real bundle against §3 (an early test bundle had
-`users: 0`, `teammetadata: 0`, `realm_exported: false`, `content_keys: []`). Treat §3 as the target;
-**export gaps are kea's to fix; the import is designed to the §3 contract.**
+**ID:** MIGR-05 · **Status:** in progress — swift-native path shipped + hardened (baseline 2026-07-16);
+kea-import path deferred, see §8.
+**Owner:** Dimitri · **Surface:** control-plane-backend (`import_export/`)
+**Extends:** [`TASK-EVENT-STREAM-RFC.md`](TASK-EVENT-STREAM-RFC.md) (task/event infra).
+**Backlog:** [`KEA-MIGRATION-BACKLOG.md`](../backlog/KEA-MIGRATION-BACKLOG.md) §0bis — migration
+vocabulary (identity/data/metadata/products topics) is defined there; this RFC is the **metadata**
+topic.
+**History:** this file states the current contract only. Full design/implementation history
+(architecture deviations, live-validation evidence, review threads) is in
+`git log -p -- docs/swift/rfc/PLATFORM-IMPORT-RFC.md`, not inline here.
 
 ---
 
-## Canonical contract — dumb export, smart import
+## 1. What this is
 
-This is the governing principle for **every** import/export path (kea→kea and kea→swift):
+An admin-only, atomic export/import of a swift instance's configuration graph — agent instances,
+tags, document metadata, team metadata, and (via a separate `users.json` bundle entry) declarative
+team/platform role provisioning. Used to clone/restore an instance's configuration, and as the
+swift side of the Kea→Swift migration's metadata step.
 
-- **Export is dumb.** It dumps the source verbatim — all rows, all tuples, **all status flags** —
-  with no reconciliation and no assumptions about the target. The bundle is a truthful snapshot of
-  the source. (Today: metadata + OpenFGA tuples + banners; **not** document binaries, **not** vectors.)
-- **Import is smart.** Only the importer knows *what it actually restored*, so it reconciles the
-  target's metadata to reality. The same dumb bundle can yield different target states under
-  different importers (kea-import vs swift-import).
+**Endpoints** (`/control-plane/v1/import-export/`, all `require_admin` + `CAN_MANAGE_PLATFORM`):
+- `POST /import` — multipart zip → async task; atomic import.
+- `GET /export` — download a swift-native snapshot (`source_platform=swift`), re-importable
+  through the same endpoint.
+- `POST /reset` — atomic wipe of agents+tags+metadata (enables export → reset → import test
+  cycles; Keycloak / OpenFGA / object store untouched).
+- `GET /stats` — platform overview (teams, members by role, agents, prompts) — powers the
+  **Platform data** admin page.
 
-### Stage reconciliation (import-side, mandatory)
+**Module:** `control_plane_backend/import_export/{bundle,exporter,importer,agent_map,stats,schemas,api}.py`.
 
-Documents carry per-stage processing flags. Swift's model is `ProcessingStage` in
-[`document_structures.py:32`](../../../apps/knowledge-flow-backend/knowledge_flow_backend/common/document_structures.py)
-— `PREVIEW_READY="preview"`, `VECTORIZED="vector"`, `SQL_INDEXED="sql"` — held on
-`DocumentMetadata.processing`, mutated via `set_status(stage, status)` / `mark_stage_done(stage)`
-(status set: DONE / IN_PROGRESS / NOT_STARTED / ERROR). This is the same model as kea's
-`metadata.processing.stages` / `ProcessingStage`.
+**Architecture:** a single atomic SQLAlchemy transaction inside a FastAPI `BackgroundTask` — not
+Temporal. For a config-sized payload (one shared Postgres DB, sub-megabyte zip), this is simpler
+and gives a stronger guarantee than per-activity retries: agents + tags + metadata commit together
+or roll back together, idempotent by primary key. Revisit a Temporal-workflow design only if
+binaries/embeddings ever enter this bundle (they currently never do — see §2).
 
-A dumb export typically carries `VECTORIZED: DONE`. But **vectors are never transported** — they are
-rebuilt on the target. So the importer **must rewrite stage flags to reflect what it actually put in
-place**, not what the source claimed; otherwise the metadata lies and the platform audit (correctly)
-reports `missing_vectors` while the index is empty.
+## 2. Scope
 
-Rule the swift importer applies after restoring each document's metadata row:
-- **`VECTORIZED` and `SQL_INDEXED` → reset to `NOT_STARTED`** (never in the bundle; rebuilt by MIGR-07).
-- **`PREVIEW_READY`:** keep `DONE` **only if** the document's `output/` artifacts (markdown, media)
-  are present in the target content store; otherwise reset to `NOT_STARTED` and let the target
-  regenerate them.
+**In scope — the config graph only:** agent instances, tags, document metadata, team metadata,
+declarative team/platform role provisioning (`users.json`). OpenFGA tuple restore exists only on
+the kea-import path today (§8).
 
-Net state of a migrated document: **visible and previewable/downloadable, but "search pending"**
-until re-vectorization completes — and the audit reports the truth.
+**Conflict policy:** fresh-target only for Postgres rows — no upsert, no merge. Idempotent by
+primary key (re-running a bundle over already-imported rows skips them). `users.json` role grants
+are separately idempotent (`RebacEngine.add_relation(on_duplicate_writes=IGNORE)`).
 
-### Ordering decision (data-mirror vs import)
-
-The fixed migration order is **data (MIGR-06) before metadata (MIGR-05)** — the `mc mirror` of
-`input/` **and** `output/` runs before the import. **Decision: the importer trusts content presence**
-on that guarantee, so it keeps `PREVIEW_READY: DONE` and only resets the vector/sql stages.
-Defensive belt-and-braces: the importer *may* still probe the content store for `output/<uid>/` and
-fall back to resetting `PREVIEW_READY` if absent — cheap and removes the ordering dependency. The
-runbook ([MIGRATION-CASTLE-TO-S3NS](../ops/MIGRATION-CASTLE-TO-S3NS.html)) must state the ordering
-guarantee explicitly.
-
-### Hard dependency — the re-vectorize trigger
-
-Resetting a stage to `NOT_STARTED` is **inert unless something re-processes those documents**. That
-"something" is the post-import re-vectorization ([`CORPUS-REVECTORIZE-RFC.md`](CORPUS-REVECTORIZE-RFC.md),
-MIGR-07): the migration's final step triggers re-vectorize over the migrated scope, which consumes the
-`NOT_STARTED` vector stages and flips them to `DONE`. The stage reset and the re-vectorize trigger are
-**two ends of one flow** — neither is complete without the other.
-
----
-
-## 1. Problem
-
-Kea ships a minimal **export** that bundles durable platform configuration into a timestamped
-`.zip` (postgres rows + OpenFGA tuples + manifest). Swift needs the **import** counterpart: a
-platform admin uploads the zip and schedules an import task that repopulates an *empty* swift
-instance with an equivalent configuration graph. The kea export code is throwaway; the swift
-import must be **rock-solid**, observable (Temporal + task/event stream), and surfaced through a
-clear progress UI built from the existing task atoms/molecules.
-
-## 2. Scope (confirmed)
-
-**In scope — restore the configuration + authorization graph only:**
-agents, prompts/chat-contexts (`resource`), tags, document **metadata**, MCP servers,
-team metadata, users, and OpenFGA tuples.
-
-**Conflict policy — fresh target only:** the import refuses to run if the target tables / OpenFGA
-store already contain relevant data. No upsert, no overwrite, no merge.
-
-**Explicitly out of scope (handled by sibling topics, not this RFC):**
-- **data** — document **binaries** (the bundle's `content_keys` is empty). They are **not**
-  re-ingested; they arrive via the **`mc mirror`** of the MinIO buckets, key-for-key, joined back
-  to metadata by `document_uid` (MIGR-06). This import only restores their **metadata rows**.
-- **products** — **vector embeddings** (OpenSearch) are **rebuilt on the target** by re-vectorize
-  (MIGR-07), not transported.
-- **identity** — the **Keycloak realm** is bootstrapped first with identical users,
-  **IDs preserved** (MIGR-04). This import **validates** referenced identities exist; it does not
-  create them. Team membership is **not** derived from Keycloak groups (AUTHZ-05 review item 9,
-  `FRED-AUTHORIZATION-TARGET-MODEL-RFC.md` Part 6) — a team is a `team_metadata` row (which this
-  import already restores, including the now-required `name` column) plus explicit OpenFGA
-  membership tuples (`team_admin`/`team_editor`/`team_analyst`/`team_member`), which **are** part
-  of the imported tuple set like any other relation.
+**Explicitly and permanently out of scope — never transported by this bundle:**
+- **Document binaries** (MinIO/S3) — moved separately, key-for-key, via `mc mirror` (MIGR-06).
+- **Vector embeddings** (OpenSearch) — rebuilt on the target via re-vectorize (MIGR-07), never
+  transported.
 - **Conversations / sessions / message history.**
+- **MCP server rows** — re-seeded by deployment, not carried in the bundle.
 
-## 3. Bundle contract (observed from `kea-snapshot-*.zip`, format_version 1)
+## 3. Bundle format (swift-native)
 
 ```
-manifest.json            # format_version, source_platform, created_at, tables{...},
-                         #   tuple_count, realm_exported(bool), content_keys[]
+manifest.json                        # see §4
 postgres/
-  tag.jsonl              # tag_id,name,owner_id,path,description,type,doc,created_at,updated_at
-  metadata.jsonl         # document_uid,source_tag,date_added_to_kb,tag_ids[],doc,created_at,updated_at
-  resource.jsonl         # resource_id,resource_name,resource_type,author,doc,created_at,updated_at
-  mcp-server.jsonl       # server_id,payload_json,created_at,updated_at
-  agent.jsonl            # id,name,payload_json{...,definition_ref,class_path,...},created_at,updated_at
-  teammetadata.jsonl     # (may be empty)
-  users.jsonl            # (may be empty)
-openfga/
-  tuples.json            # [{user,relation,object}]  — store "kea"
-```
-One JSON object per line; last line may lack a trailing newline (manifest counts are authoritative).
-
-## 4. Target mapping & transforms
-
-| Bundle table | Swift target (file) | Transform |
-|---|---|---|
-| `tag` | `tag` — `knowledge-flow-backend/.../tags/tag_models.py` | 1:1 |
-| `resource` | `resource` — `.../resources/resource_models.py` | drop/fold `created_at`/`updated_at` (no such cols in swift); covers prompts/chat-contexts |
-| `metadata` | `metadata` — `.../metadata/metadata_models.py` | same timestamp note |
-| `agent` | **`agent_instance`** — `control-plane-backend/.../models/agent_instance_models.py` | **decompose** `payload_json` → `template_id`, `source_runtime_id`, `source_agent_id`, `tuning_json`, `prompt_refs_json`; inject `team_id`, `created_by`; map kea `class_path`/`definition_ref` via an **agent catalog mapping** (see §7 risk) |
-| `mcp-server` | none (MCP refs live inline in agent tuning) | fold into agent restore / dedupe; no standalone table |
-| `teammetadata` | `teammetadata` — `fred-core/.../team_metatada_models.py` | map; default swift-only cols (`is_private`, storage sizes, banner); `name` is now required (AUTHZ-05 review item 9) — fall back to the id if the source bundle predates it |
-| `users` | `users` — `fred-core/.../users/user_models.py` | map `id`; default GCU/storage |
-| `openfga/tuples.json` | swift `fred` OpenFGA store | write tuples; **validate** user/team/object existence; conform to `schema.fga`; reconcile `team:personal*` with `personal_team_id(uid)` |
-
-Both backends share one Postgres DB (`fred`); the import (in control-plane) writes knowledge-flow
-tables directly or via a thin knowledge-flow restore call — to be decided in §7.
-
-## 5. Architecture — mirror the ingestion pipeline (Temporal + fred-core task/event)
-
-The import is implemented as a **Temporal workflow in control-plane** that drives progress through
-the **fred-core task/event API**, so the existing frontend task atoms render it with zero new event
-plumbing. It deliberately mirrors the knowledge-flow **ingestion** pipeline so the team reuses one
-pattern. Reference implementation to copy:
-
-| Ingestion (reference) | Import (this RFC) |
-|---|---|
-| `features/scheduler/workflow.py` `ProcessPullFile.run` (emit → stages → emit) | `migration/workflow.py` `PlatformImportWorkflow.run` |
-| `features/scheduler/activities.py` `output_process` etc. | `migration/activities.py` (`validate_bundle`, `preflight`, `restore_relational`, `restore_agents`, `restore_openfga`, `verify`) |
-| `activities.py:122` `emit_ingestion_task_event` → `task_service.record(IngestionTaskEvent(IngestionDetail))` | `emit_migration_task_event` → `task_service.record(MigrationTaskEvent(MigrationDetail))` |
-| `ingestion_controller.py:511` `task_service.start(...)` then `client.start_workflow(..., task_queue="ingestion")` | `migration/api.py` `task_service.start(kind="migration")` then `client.start_workflow("PlatformImportWorkflow", task_queue="control-plane-lifecycle")` |
-| `scheduler/worker.py` registers workflows + activities | register `PlatformImportWorkflow` + activities in control-plane `scheduler/temporal/worker.py` |
-
-**1. Upload + start** (`migration/api.py`, admin-only via `require_admin`):
-`POST /control-plane/v1/migration/import` (multipart zip) → stash zip in object storage
-(`migration-imports/{import_id}.zip`) → `task = task_service.start(StartTaskRequest(kind="migration",
-target=TaskTarget(type="platform", id=import_id)), created_by=user.uid)` → `client.start_workflow(
-"PlatformImportWorkflow", {task_id, zip_key}, id="import-{import_id}", task_queue="control-plane-lifecycle")`
-→ return `202 {task_id, import_id}`.
-
-**2. Workflow** (`migration/workflow.py`) — ordered, retryable activities, each bracketed by an emit,
-exactly like `ProcessPullFile`:
-```
-validate_bundle (manifest format_version, counts)   emit step=validate      progress .0
-preflight (FRESH-TARGET guard + identity exists)    emit step=preflight     progress .1
-restore_relational (tag/metadata/resource/team/users) emit step=relational  progress .2
-restore_agents (agent → agent_instance via map)     emit step=agents        progress .5
-restore_openfga (tuples; validate; personal-team)   emit step=openfga       progress .75
-verify (counts vs manifest, dangling refs)          emit step=verify        progress .9
-                                                    emit state=succeeded     progress 1.0
-on exception: emit state=failed, error=...
+  agent_instance.jsonl
+  tag.jsonl
+  metadata.jsonl
+  team_metadata.jsonl
+users.json                           # optional, top-level, sibling of manifest.json — see §6
 ```
 
-**3. Event model** — add `MigrationDetail {step_id, processed, total, failed}` to
-`fred-core/tasks/models.py` (sibling of `IngestionDetail`). The frontend already declares the matching
-`MigrationTaskEvent` type (`features/tasks/taskTypes.ts`) and a `migration` task kind — so the UI side
-is mostly wiring, not new types.
+(The kea-import path reads a different, wider set of `postgres/*.jsonl` tables plus
+`openfga/tuples.json` — §8.)
 
-**4. Cross-backend (resolves §4's open question — recommended).** `restore_relational` writes the
-knowledge-flow-owned tables (`tag`, `metadata`, `resource`) by calling a **thin synchronous KF admin
-endpoint** (`POST /knowledge-flow/v1/admin/import/relational`) over httpx (pattern at
-`product/service.py:1021`), keeping each backend the owner of its tables. Control-plane writes its own
-domain directly: `agent_instance` (via `enroll_agent_instance`), `users`/`teammetadata` (fred-core),
-and the OpenFGA tuples. `mcp-server` is **skipped** (re-seeded by deployment).
+## 4. Manifest contract — versioned, validated
 
-**5. UI** — `/admin/migration` page: drop zip → POST → `taskRegistered({kind:'migration'})` → live
-progress via the task SSE → 6 step cards (`TaskCard`/`BatchStepCard`) → pass/fail. Admin-only. (See
-frontend plan; most types/atoms already exist.) **Note:** `useTaskSseManager` currently hardcodes the
-knowledge-flow task-events URL; it must resolve the events base per task kind (control-plane for
-`migration`).
+`manifest.json` is parsed into `bundle.py::SnapshotManifest`, a Pydantic model.
+`open_bundle()` **rejects** any bundle whose `format_version` or `users_schema_version` isn't in
+the set this importer understands (today: `{1}` for both) — no silent default when a key is
+absent or unrecognised.
 
-**6. SSE source.** The import task lives in control-plane, so events stream from control-plane
-`tasks/api.py:/tasks/{id}/events`. The KF relational sub-call is synchronous (small data) and reports
-into the same control-plane task via the activity's emit — one task_id, one progress stream.
+Two version numbers, tracked independently because they evolve at different rates:
+- **`format_version`** — the container's own shape: which top-level files/tables exist.
+- **`users_schema_version`** — `BundleUserEntry`'s field set (`schemas.py`), which has already
+  grown once (identity fields, §6) independent of any container change.
 
-**7. Idempotency / robustness** — `preflight` fresh-target guard refuses a populated target; Temporal
-gives retries + restart-safety per activity. No merge into populated tables (per §2 scope).
+Fields: `format_version: int` (required) · `users_schema_version: int = 1` ·
+`source_platform: str = "kea"` · `created_at: str` · `tables: dict[str, int]` ·
+`tuple_count: int` · `realm_exported: bool` · `content_keys: list[str]`.
 
-## 6. Products phase — post-import re-vectorization (MIGR-07)
+`source_platform` is the live discriminator: `"swift"` takes the swift-native branch (this
+document); anything else takes the kea-import branch (§8).
 
-A config-only import restores agents/prompts/metadata + the document **metadata** rows, and the
-document **binaries** arrive via the data mirror — but **embeddings are not migrated** (products are
-rebuilt). The final migration phase rebuilds them. This is designed in
-[`CORPUS-REVECTORIZE-RFC.md`](CORPUS-REVECTORIZE-RFC.md): a knowledge-flow Temporal workflow that
-re-runs the existing `output_process` activity over the migrated documents, streaming progress on the
-same task/event infra. The migration UI surfaces it as the last step ("Rebuild embeddings"),
-reusing the same atoms.
+## 5. Content honesty — track binaries/embeddings, never embed them
 
-Other out-of-scope follow-ups (not built here): extending the kea export to bundle binaries;
-conversation/session restore.
+The bundle never carries document binaries or vector embeddings (§2) — but it must not silently
+imply they're already handled on the target:
 
-## 7. Agent mapping — consolidated spec (resolves the crux)
+- **`content_keys`** — every exported document's `document_uid` (`exporter.py::run_export`). On
+  import, a non-empty `content_keys` adds one `report.warnings` entry naming the count — a
+  reminder that these documents need their binaries mirrored separately (MIGR-06), **not** a
+  per-document presence check (there is no cross-backend call from control-plane into
+  knowledge-flow's content store).
+- **Stage reconciliation** — `importer.py::_reset_transported_stages` resets `VECTORIZED` and
+  `SQL_INDEXED` to `NOT_STARTED` on every restored `metadata` row, since embeddings/SQL indexes
+  are never transported. `PREVIEW_READY` is left untouched — trusted present, given the
+  MIGR-06-before-MIGR-05 ordering guarantee. A re-vectorize pass (MIGR-07) is required after
+  import to make search work again; it is not yet auto-triggered.
 
-Scope is **user-created agent instances only**; kea built-in samples are not migrated. A kea agent's
-template identity is its v2 `definition_ref` (e.g. `v2.react.basic`) or, for legacy agents, its v1
-top-level `class_path`. The transform maps that identity to a swift template id in
-`{source_runtime_id}:{source_agent_id}` form, validated at import against the live fred-agents
-`/agents/templates` catalog. Implemented in `migration/agent_map.py` (+ `tests/test_agent_map.py`).
+## 6. `users.json` — declarative team/platform role provisioning
 
-**Three-state classification** (the mapping table is the single control point):
-
-| Outcome | Meaning | Action |
-|---|---|---|
-| **mapped** | template is in `KEA_TO_SWIFT_TEMPLATE` | create the `agent_instance` |
-| **ignored** | a known kea sample/demo (`v2.sample.*`, `v2.deep.*`, dva validators…) | skip — not user data |
-| **gap** | anything else (incl. unresolvable template) | **build the equivalent in fred-agents**, add the mapping, re-run |
-
-Mappings (real swift ids):
-
-| kea template | swift template id |
-|---|---|
-| `v2.react.basic` | `fred-agents:fred.github.assistant` |
-| `v2.production.sql_analyst` | `fred-agents:fred.github.sql_expert` |
-| `…prometheus_expert.Spot` | `fred-agents:fred.github.sentinel` |
-| `…rag_expert.Rico` | `fred-agents:fred.github.rag_expert` |
-| `…tabular_expert.Tessa` | `fred-agents:fred.github.sql_expert` |
-
-**Gap policy is "fill, not skip":** `preflight` classifies every agent and emits the gap list; a real
-cutover requires **zero gaps**. This converts the former correctness risk into an enforced, visible
-checklist. (`preflight` may run report-only during iteration; it blocks at cutover.)
-
-## 8. Remaining open items
-- **Agent prompt transfer (MIGR-05.11) — the next gap.** Imported agents currently land with default
-  tuning only (`role`/`description` = display name) and **no prompt content**. Kea agents carry their
-  prompt(s) in `agent.payload_json` (system/tuning prompt text); swift agent instances reference
-  prompts via `prompt_refs_json` → team-scoped `prompt` rows (`PromptRow`, unique on `(team_id, name)`).
-  The importer must, per mapped agent: create/locate a `prompt` row owned by the agent's `team_id`
-  holding the kea prompt text, and wire the new `agent_instance.prompt_refs_json` to it. Until then the
-  **Prompts** column in the Platform-data stats stays at 0 for imported agents.
-- **Stage reconciliation API** — `restore_relational` must call `set_status(VECTORIZED, NOT_STARTED)`
-  (and `SQL_INDEXED`) per migrated document, and conditionally reset `PREVIEW_READY` (see the
-  canonical-contract section). Confirm the exact write path through `DocumentMetadata.processing`.
-- **Re-vectorize trigger** — MIGR-07 must actually consume the reset stages (the inert-flag risk).
-  Specify the trigger (migration final step → `/corpus/revectorize` over the migrated scope).
-- **Data-vs-import ordering** — document the "data mirrored before import" guarantee in the runbook,
-  or have the importer probe the content store defensively (decision recorded above: trust + optional probe).
-- **Personal-team tuples**: bundle references `team:personal*`; swift derives personal teams via
-  `personal_team_id(uid)` — restore must reconcile, not blindly insert.
-- `metadata`/`resource` timestamp columns absent in swift — confirm fold-into-`doc` vs add-columns.
-- **Kea export completeness** — reconcile §3 contract with the real kea export as it matures (export
-  gaps are kea's to fix).
-
-## 9. Decision requested
-Approve scope (§2) + architecture (§5) + agent mapping (§7) + the dumb-export/smart-import contract
-(stage reconciliation) so this can become MIGR-05 implementation work (control-plane import service +
-Temporal workflow + admin UI), tracked in `KEA-MIGRATION-BACKLOG.md`.
-
-## 10. Declarative team/platform role provisioning — `users.json` (2026-07-14)
-
-This is the confirmation/implementation `FRED-AUTHORIZATION-TARGET-MODEL-RFC.md` Part 8 §40.2
-("Platform provisioning") asked for: *"the likely right move is to harden and generalize
-[`PLATFORM-IMPORT-RFC.md`]'s input contract... to be confirmed with whoever owns that RFC before any
-implementation."* Part (2) of `AUTHZ-07`'s original scope (declarative platform provisioning for
-teams/roles/users, tracked open in `AUTHZ-MIGRATION-BACKLOG.md`'s AUTHZ-07 rows) is closed by this
-section.
-
-**Bundle addition.** A new top-level `users.json` entry (sibling of `manifest.json`/`openfga/`, **not**
-under `postgres/` — these are not Postgres rows, they are a typed (`import_export/schemas.py::BundleUserEntry`)
-description of the Keycloak identity and the Fred-side authorization state a user should end up with):
+A top-level `users.json` (sibling of `manifest.json`), a JSON array with one entry per identity
+(`schemas.py::BundleUserEntry`):
 
 ```json
-[
-  {"username": "alice", "email": "alice@app.com", "first_name": "Alice", "last_name": "Watson",
-   "password": "Azerty123_", "teams": [], "team_roles": {"team_admin": ["fredlab"]}, "platform_roles": ["admin"]},
-  {"username": "bob", "teams": ["fredlab"], "team_roles": {"team_editor": ["fredlab"]}, "platform_roles": []}
-]
+[{"username": "alice", "email": "alice@app.com", "first_name": "Alice", "last_name": "Watson",
+  "password": "Azerty123_", "teams": [], "team_roles": {"team_admin": ["fredlab"]},
+  "platform_roles": ["admin"]}]
 ```
 
-`BundleUserEntry`'s full shape: `username: str` (required); `email`/`first_name`/`last_name`/`password:
-str | None = None` (identity-phase fields, all optional — see the 2026-07-14 addendum below);
-`teams: list[str] = []`, `team_roles: dict[str, list[str]] = {}`, `platform_roles: list[str] = []`
-(role-phase fields, unchanged). One format, because it's one file: each phase reads what it needs from
-the same entry and ignores the rest — `bob` above has no identity fields and is treated exactly as
-before (assumed to already exist). `KBundle.demo_users()` reads and validates it
-(`BundleUserEntry.model_validate` per entry), mirroring `openfga_tuples()`'s try/except-`KeyError`-
-return-`[]` pattern around the zip read itself (`bundle.py`). `teams` names every team a user should be
-provisioned into; `team_roles` maps a relation (`team_admin`/`team_editor`/`team_analyst`/`team_member`)
-to the team names it should be granted on; `platform_roles` (`"admin"` → `platform_admin`, `"observer"`
-→ `platform_observer`) grants org-level roles.
+- `username: str` required.
+- `email` / `first_name` / `last_name` / `password: str | None = None` — identity-phase fields,
+  all optional.
+- `teams: list[str]` / `team_roles: dict[str, list[str]]` / `platform_roles: list[str]` —
+  role-phase fields.
 
-**Design principle — the role phase never creates an identity; the identity phase creates one only when
-explicitly asked.** Consistent with AUTHZ-05's Keycloak-is-identity-only model, the role phase resolves
-`username` → Keycloak `sub` via **read-only** `users/service.py::find_user_sub_by_username` (the same
-read-only admin client `list_users`/`get_users_by_ids` already use — never the write-gated M2M path
-`create_user` requires). A username still unresolved after the identity phase (below) is **skipped and
-reported** (`report.users_skipped`, `report.warnings`), never created by this phase and never failing
-the rest of the import.
+**Two phases** (`importer.py::_run_users_phase`), always in this order:
 
-**The new capability — granting a platform role to a third party.** Before this change, the only path
-to `platform_admin`/`platform_observer` was `bootstrap/service.py::bootstrap_platform_admin`'s
-self-promotion-only endpoint (RFC Part 8 §42.2: "the grant always targets the calling JWT's own
-`sub`"). `users.json`'s `platform_roles` is the first path that can name a **third party**. It is
-deliberately **not** a new public service function or endpoint: `importer.py::_grant_platform_role` is
-a small private helper, reachable only through `POST /import-export/import`, which already requires
-`OrganizationPermission.CAN_MANAGE_PLATFORM` as the first line of the route handler (`api.py`,
-unchanged by this work — the new phase rides the same existing gate, no second check added). This is
-not a privilege-escalation path: granting `platform_admin` to someone else already requires being a
-`platform_admin` yourself, exactly the same shape as any other admin capability in this system. The
-call mirrors `bootstrap_platform_admin`'s own direct `rebac.add_relation(...)` — `add_relation` is
-idempotent (`on_duplicate_writes=IGNORE`), so re-running the same bundle never errors on an
-already-granted role.
+1. **Identity** (`_provision_bundle_identities`) — creates a Keycloak user via the existing
+   `users/service.py::create_user` only if **both** hold: no existing identity resolves by
+   username, **and** the entry carries a `password`. No `password` → assumed to already exist,
+   never force-created. Requires Keycloak Admin M2M credentials configured; if not configured,
+   fails loudly (no silent skip) for any entry that needs one.
+2. **Role** — resolves `username` → Keycloak `sub` (read-only lookup), then grants:
+   - **`platform_roles`** (`"admin"` → `platform_admin`, `"observer"` → `platform_observer`) via a
+     private `_grant_platform_role` helper — the only path that can grant a platform role to a
+     **third party** (every other path is self-promotion-only). Gated solely by the route's
+     existing `CAN_MANAGE_PLATFORM` check; no second authorization check added.
+   - **`team_roles`/`teams`** via `_grant_team_role_via_import`, a private reconciliation
+     primitive (direct `RebacEngine.add_relation`) — deliberately bypasses the ordinary,
+     `team_admin`-gated `grant_team_member_role` API, since the importer is never expected to
+     already hold `team_admin` on every team a bundle touches. A brand-new team's *initial*
+     `team_admin`(s) are instead seeded at `create_team` time. The ordinary team-membership APIs
+     are unchanged and still `team_admin`-gated (regression-tested against this importer identity).
+   - Semantics: multiple roles on the same team are cumulative (all persisted as direct tuples). A
+     team with any explicit role never also gets a redundant direct `team_member` tuple —
+     `schema.fga` already derives `team_member` as a union over the explicit roles.
 
-**Team-scoped roles — bounded by the existing permission model, not bypassed. Revised 2026-07-14
-(AUTHZ-07 Step 2 — reconciliation fix).** `schema.fga`'s `type team` comment is still explicit and was
-tested in review (§24.2/§24.7): team-scoped relations (`team_admin`/`team_editor`/`team_analyst`/
-`team_member`) are **never** derived from a platform role — "a `platform_admin from organization`
-exception was tried for team bootstrap and reverted the same day." This importer does not reopen that
-door; `schema.fga` is untouched by this fix. Two consequences, both implemented and covered by
-`tests/test_import_export_users.py`:
-- A **brand-new** team's initial `team_admin`(s) is seeded at creation time
-  (`teams.service.create_team`'s own one-shot, `CAN_CREATE_TEAM`-gated bootstrap capability —
-  `CreateTeamRequest.initial_team_admin_ids`), by collecting every `team_admin` the bundle declares for
-  that team before creating it. `CAN_CREATE_TEAM` is org-wide (`platform_admin`), so this needs no
-  team-scoped permission from the importing caller.
-- **Every other team-scoped grant** — `team_editor`/`team_analyst`/`team_member` on any team, or any
-  role at all on a team that already existed before this import — is now written through
-  `importer.py::_grant_team_role_via_import`, a **private, import-only reconciliation primitive** that
-  calls `RebacEngine.add_relation` directly, mirroring `_grant_platform_role`'s own direct-write shape.
-  This is the fix: the first implementation (2026-07-14, superseded by this revision the same day) routed
-  every such grant through the existing `teams.service.grant_team_member_role`, which requires the
-  importing `platform_admin` to already hold `team_admin` on that specific team — a condition the
-  importer deliberately never satisfies (RFC Part 8 §24.2/§24.7, "zero implicit access"). That made
-  every non-admin team-scoped grant in a real bundle unconditionally refused and downgraded to a
-  warning while the import still reported `succeeded` — confirmed live: importing the 15-identity demo
-  bundle produced exactly 10 skipped grants (bob/phil/zoe/liam/elena/derek/priya's non-`team_admin`
-  roles) out of 14 declared, which then cascaded into 227 setup errors in `validation/report.md` (every
-  scenario's fixture setup depends on the full role matrix being present). `_grant_team_role_via_import`
-  closes this without weakening the *ordinary* permission model: `grant_team_member_role`/
-  `add_team_member`/etc. are completely unchanged and still require `team_admin`, proven by a dedicated
-  regression test (`test_grant_team_member_role_still_requires_team_admin_for_the_importer`) that calls
-  the ordinary API with the same importer identity and asserts it still raises `AuthorizationError`. The
-  new primitive is reachable only from `POST /import-export/import` (already `CAN_MANAGE_PLATFORM`-gated,
-  no second check added) and is never exposed as a second public team-membership service — same shape
-  and same safety argument as `_grant_platform_role`.
+**Fail-closed, not warn-and-succeed.** `BundleProvisioningError` aborts the whole users phase
+(→ the import task fails, never a silently-partial `succeeded`) for: ReBAC disabled; an unknown
+`team_roles`/`platform_roles` value; a username still unresolved after the identity phase; a team
+referenced by the bundle that has no `team_admin` declared for it anywhere in the same bundle (so
+it cannot be created). Idempotent: re-running an already-reconciled bundle re-writes the same
+tuples with no error and no duplicate.
 
-**`teams`/`team_roles` semantics (`importer.py::_effective_team_relations`, formalized 2026-07-14).**
-Per bundle entry, per team: if the team name is a value anywhere in that entry's `team_roles`, the
-requested state is **exactly** the named relation(s) on that team — multiple roles on the same team are
-**cumulative** (e.g. priya: `team_admin` + `team_editor` + `team_analyst` on `fredlab`, all three
-persisted as direct tuples). If the team name appears in `entry.teams` but is **never** a `team_roles`
-value for that same entry, the requested state is a single direct `team_member` tuple — the only
-fallback. A team with an explicit role never *also* gets the direct `team_member` tuple: `schema.fga`
-already derives `team_member` as a union over `team_admin`/`team_editor`/`team_analyst`, so writing it
-directly on top would be redundant, not additive.
+## 7. Observability
 
-**Fail-closed, not warn-and-succeed (AUTHZ-07 Step 2).** A declared-valid bundle must never produce a
-silently incomplete `succeeded` import. `importer.py::BundleProvisioningError` is raised — aborting the
-whole users phase, which `import_export/api.py`'s background-task wrapper turns into
-`task_service.fail_task` — for every one of: **ReBAC disabled** (checked first, before anything else in
-`_run_users_phase` — see below); an unknown `team_roles` key or `platform_roles` value (validated upfront,
-before any write); a username still unresolved after the identity phase; a team referenced by the bundle
-(via `teams` or `team_roles`) that does not already exist and has no `team_admin` declared for it anywhere
-in the bundle (so `create_team` cannot seed it). None of these are downgraded to a warning anymore.
-**Idempotence is preserved**: `add_relation`'s `on_duplicate_writes=IGNORE` means re-running an
-already-fully-reconciled bundle re-writes the same tuples with no error and no duplicate —
-`report.team_roles_granted` counts every declared grant on every run, whether or not the underlying write
-was a no-op.
+The terminal task event carries a structured `MigrationResult`
+(`fred_core.tasks.models`, populated via `importer.py::to_migration_result`) — every counter
+(`agents_imported`, `docs_imported`, `teams_provisioned`, `team_roles_granted`,
+`platform_roles_granted`, …) plus `warnings`. A `succeeded` task with non-empty `warnings` is a
+partial reconciliation, distinguishable from a clean success — durable across reload
+(`GET /tasks` returns the same structured `detail`), not just visible on the terminal event.
 
-**Precondition — ReBAC must be enabled (2026-07-15, PR #1987 review r3585102660).** A bundle that contains
-`users.json` requires ReBAC to be enabled. With ReBAC disabled, `team_deps.rebac` is `NoopRebacEngine` —
-every `add_relation` call it makes is a silent no-op — so, without this guard, `_apply_bundle_user_roles`
-would still increment `team_roles_granted`/`platform_roles_granted` and the import could report `succeeded`
-with no authorization tuple ever written, exactly the gap the fail-closed rule above exists to prevent.
-`_run_users_phase` therefore checks `team_deps.rebac.enabled` as its very first step, before role-name
-validation, Keycloak identity creation, username resolution, team creation, or any relation write or
-counter increment — raising `BundleProvisioningError` immediately if it is false. A bundle whose
-`users.json` is absent or empty never invokes `_run_users_phase` at all, so this guard has no effect on an
-ordinary agents/tags/metadata-only import.
+## 8. Deferred — tracked separately, not part of this contract
 
-**Report fields** (`importer.py::MigrationReport`, folded into the existing task-event summary string,
-same as every other phase — no new HTTP response field, since the report was never returned over HTTP
-to begin with, only surfaced via the `MigrationTaskEvent.step` string and server logs):
-`identities_created` (see the addendum below), `users_processed`, `users_skipped` (list of unresolved
-usernames — now vestigial, always `[]` on a report that made it back to the caller, since an unresolved
-username raises instead; kept on the dataclass for API stability and for AUTHZ-07 Step 3), `teams_provisioned`
-(distinct name from the pre-existing `teams_imported`/`teams_skipped`, which count `team_metadata`
-Postgres rows, not teams created via this phase), `team_roles_granted`, `team_roles_skipped` (same
-vestigial note as `users_skipped` — always `0` now), `platform_roles_granted`.
-
-### 10.1 Identity phase — bundle-driven Keycloak user creation (2026-07-14)
-
-Closes the remaining part of the `fred`/`fred-deployment-factory` boundary split: `fred`
-(`control_plane_backend/import_export/`) is now the sole, complete owner of platform provisioning — both
-the Keycloak identities and the Fred authorization state — in the one typed, versioned, git-committed
-`users.json` format described above. `fred-deployment-factory` carries no user/team data of its own.
-
-**What runs, and in what order** (`importer.py::_run_users_phase`): phase 1
-(`_provision_bundle_identities`) runs first, then phase 2 is the role-provisioning logic described
-above, unchanged. For each bundle entry, phase 1 creates a Keycloak user via the existing
-`users/service.py::create_user` (already Keycloak-Admin-M2M-gated — no new Keycloak capability, just a
-new caller) **only if both** conditions hold: (a) `find_user_sub_by_username` finds no existing match,
-and (b) the entry carries a `password`. An entry with no `password` is assumed to already exist and is
-never force-created — it falls through to phase 2's read-only resolution exactly as before, and is
-skipped/reported there if it still doesn't resolve. Phase 1 never overwrites an already-existing
-identity. Running phase 1 before phase 2 means a bundle that creates *and* grants roles to the same
-identity, in the same entry, works in a single import call — not two separate uploads.
-
-**Precondition.** Any bundle that creates identities requires Keycloak Admin M2M credentials to be
-configured (the same precondition `create_user`/`delete_user` already have via
-`_get_keycloak_admin_for_user_operations`). If they are not configured, `create_user` raises
-`KeycloakM2MUserOperationDisabledError`, which this phase lets propagate rather than swallowing — the
-import fails loudly with a clear cause instead of silently skipping every identity-creation entry. A
-bundle whose entries carry no `password` (already-existing identities only) has no such precondition —
-phase 1 is then a no-op for every entry, same as before this addendum.
-
-**Report field.** `report.identities_created` counts Keycloak users created by phase 1, folded into the
-same task-event summary string as every other phase field.
-
-**The fixture.** `apps/control-plane-backend/tests/fixtures/import_export/demo_provisioning/`
-(`manifest.json` + `users.json`) is the single, checked-in, git-committed source of truth for every demo
-identity *and* every team/platform role — the data that used to live in
-`fred-deployment-factory/config/configuration.yaml`'s `users:` list now lives here exclusively, typed
-through `BundleUserEntry`. `make build-demo-bundle` (`apps/control-plane-backend/Makefile`) zips the two
-fixture files into `target/demo-provisioning-bundle.zip` for upload via Admin → Migration. No top-level
-`teams:` list is needed in the fixture — every team name is derivable by unioning `entry.teams` and
-`entry.team_roles.values()` across all entries.
-
-## 11. Observable, durable, truthful import outcome (AUTHZ-07 Step 3, 2026-07-14)
-
-Step 2 (§10, above) made reconciliation *complete* — a declared-valid bundle either fully provisions or
-fails closed. It did not make the result *observable*: `import_export/api.py` discarded the
-`MigrationReport` `run_import()` returned and emitted an empty terminal `succeeded` event with no target
-beyond the raw `import_id` UUID. A live import (Step 1's evidence, §"Step 1" above) showed the operator
-only a bare UUID and the word "Terminé" — a partial reconciliation (silently-skipped grants, before the
-Step 2 fix) was indistinguishable from full success once the task list reloaded.
-
-**Truth rule.** A `succeeded` platform-import task is not always a *clean* success — it may have produced
-warnings during a phase that does not itself fail closed (e.g. an agent classified `GAP`, §7). The
-terminal event and `GET /tasks` must let an admin tell the two apart without guessing. **No new
-`TaskState` is introduced** (`succeeded` stays `succeeded`, matching `TASK-EVENT-STREAM-RFC.md`'s state
-machine) — the tell is a non-empty `result.warnings` list in the structured detail below, which the UI
-renders as an explicit "with warnings" flag distinct from a silent success.
-
-**Canonical target.** `import_export/api.py::_import_target` builds the task's `TaskTarget` once, at
-launch, before the background import runs: `type="platform_import"`, `id=import_id`, `label=` the
-operator-supplied label (trimmed) if non-empty, else the uploaded file's name, else a safe fallback
-(`"Platform import"`). This is passed to `task_service.start(..., target=...)`, so it is durable from the
-first `GET /tasks` — including if the import fails before any progress event is ever emitted.
-`ImportLaunchResponse` also returns this exact `target` (2026-07-14 close-out amendment,
-`CONTROL-PLANE-PRODUCT-CONTRACT.md` §16): the frontend's optimistic registration
-(`launchPlatformImport.ts` → `MigrationPage.tsx::handleLaunch`) registers the backend's own returned
-value directly, rather than reconstructing the same precedence rules a second time — one canonical
-target, not two independently-built ones.
-
-**Structured terminal result.** `fred_core.tasks.models.MigrationResult` (a new Pydantic model, sibling of
-`MigrationDetail`) is a typed public projection of the internal `MigrationReport`
-(`import_export/importer.py`), converted field-for-field by `importer.py::to_migration_result` — the
-report's own field computation is not duplicated, only mapped. `MigrationDetail` gained an optional
-`result: MigrationResult | None` field (`None` on every intermediate progress event, exactly as before;
-populated only on the terminal `succeeded` event). Carries: `import_id`, `source_platform`,
-`identities_created`, `users_processed`, `users_skipped`, `teams_imported`/`teams_skipped`,
-`teams_provisioned`, `team_roles_granted`/`team_roles_skipped`, `platform_roles_granted`,
-`agents_imported`/`agents_skipped`/`agents_gap`, `tags_imported`/`tags_skipped`,
-`docs_imported`/`docs_skipped`, `warnings`. Same content-boundary rule as every other task detail
-(`TASK-EVENT-STREAM-RFC.md` §3.3): operational counters and warning strings only, never bundle content.
-
-**Durable across reload.** `TaskSummary` (the `GET /tasks` response shape) gained an optional `detail`
-field, typed per `kind` exactly like `TaskEvent.detail` (a plain, non-discriminated union of the existing
-per-kind Detail models — the frontend narrows on the sibling `kind` field, the same pattern already used
-for `TaskEvent`). `TaskStore.list_tasks` projects the last-persisted `TaskRunRow.detail` (already written
-by the pre-existing `record_event` "keep the last non-null detail" rule) into the correctly-typed model
-for the row's `kind`. Backward compatible: a task with no persisted detail (every kind before this change,
-and `log`, which has no summary detail model) reads back `detail: null`.
-
-**Honest failure, unchanged path.** An exception during `run_import()` still drives the task `failed` via
-the pre-existing `task_service.fail_task`, unchanged by this step — it already reads the canonical target
-from `TaskRunRow.target` (set at creation, per above), so the failure event carries the same target and a
-usable `error` message. Never `succeeded` on an exception.
-
-**No parallel model.** This is presentation of the existing canonical pipeline, not a new one:
-`MigrationReport` → (`to_migration_result`) → `MigrationTaskEvent.detail.result` → `TaskStore`
-("keep the last detail") → `TaskSummary.detail` → the shared `TaskActivity` component. No new table, no
-new endpoint, no new Redux store, no import-specific activity page — `GET /tasks` and the existing task
-system remain the single source of truth (`TASK-EVENT-STREAM-RFC.md` §3.4).
+- **Kea-import path** (`source_platform=kea`) — reads a wider `postgres/*.jsonl` set plus
+  `openfga/tuples.json`, transforms kea agents via `agent_map.py`. OpenFGA tuple restore
+  (**MIGR-05.04**) and agent prompt transfer (**MIGR-05.11**) remain open. Tracked in
+  [`KEA-MIGRATION-BACKLOG.md` §0bis](../backlog/KEA-MIGRATION-BACKLOG.md).
+- **Re-vectorize auto-trigger after import** (MIGR-07) — the stage reset in §5 is inert until
+  something consumes it.
+- **Per-document content-store presence verification** (§5) — currently a count-only reminder,
+  not a real check.

--- a/docs/swift/rfc/PLATFORM-IMPORT-RFC.md
+++ b/docs/swift/rfc/PLATFORM-IMPORT-RFC.md
@@ -81,9 +81,11 @@ Two version numbers, tracked independently because they evolve at different rate
 - **`users_schema_version`** — `BundleUserEntry`'s field set (`schemas.py`), which has already
   grown once (identity fields, §6) independent of any container change.
 
-Fields: `format_version: int` (required) · `users_schema_version: int = 1` ·
+Fields: `format_version: int` (required) · `users_schema_version: int` (required) ·
 `source_platform: str = "kea"` · `created_at: str` · `tables: dict[str, int]` ·
-`tuple_count: int` · `realm_exported: bool` · `content_keys: list[str]`.
+`tuple_count: int` · `realm_exported: bool` · `content_keys: list[str]`. Both version fields are
+required on **every** bundle, whether or not it carries a `users.json` — a bundle producer that
+omits either fails loudly at `open_bundle()`, never silently assumed to be `v1`.
 
 `source_platform` is the live discriminator: `"swift"` takes the swift-native branch (this
 document); anything else takes the kea-import branch (§8).


### PR DESCRIPTION
This PR is meant to make first production GKE deployement clean and safe even if we keep improving our swift to swift export import features. 