### PR TITLE
feat(CAPAB-01): resting capability health + revoke-impact preview, fix grant-side revive

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/capabilities/api.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/api.py
@@ -38,6 +38,7 @@ from control_plane_backend.capabilities.enablement import (
 from control_plane_backend.capabilities.schemas import (
     CapabilityDefaultOnResult,
     CapabilityEnablementList,
+    CapabilityImpactPreview,
     EnableTeamCapabilityRequest,
     SetCapabilityDefaultOnRequest,
     TeamCapabilityEnablementResult,
@@ -74,6 +75,36 @@ async def get_admin_capabilities(
 ) -> CapabilityEnablementList:
     try:
         return await capability_service.list_capability_enablement(user=user, deps=deps)
+    except (AuthorizationError, CapabilityNotFound) as exc:
+        raise _map_error(exc) from exc
+
+
+@router.get(
+    "/admin/capabilities/{capability_id}/revoke-impact",
+    response_model=CapabilityImpactPreview,
+    summary="Preview which agents revoking a capability would suspend.",
+)
+async def get_capability_revoke_impact(
+    capability_id: Annotated[str, Path(min_length=1)],
+    deps: ProductDependencies,
+    team_id: Annotated[
+        TeamId | None,
+        Query(
+            description=(
+                "Preview one team's disable. Omit for a platform-wide "
+                "default-off preview."
+            )
+        ),
+    ] = None,
+    user: KeycloakUser = Depends(get_current_user),
+) -> CapabilityImpactPreview:
+    try:
+        return await capability_service.preview_capability_revoke(
+            user=user,
+            capability_id=capability_id,
+            team_id=team_id,
+            deps=deps,
+        )
     except (AuthorizationError, CapabilityNotFound) as exc:
         raise _map_error(exc) from exc
 

--- a/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
@@ -181,6 +181,11 @@ async def enable_capability_for_team(
     Write ordering: the settings row is persisted FIRST, then the `enabled`
     tuple — so a crash between the two leaves the capability disabled, never
     enabled-without-settings.
+
+    Reviving the instances this grant unblocks is the CALLER's second step (see
+    `revive_dependent_instances`): it needs the live ReBAC + pod facts, which
+    this module deliberately does not fetch, and it must run AFTER the tuple
+    write below so the `can_use` lookup observes the new grant.
     """
 
     validated = validate_team_settings(
@@ -337,6 +342,82 @@ async def suspend_dependent_instances(
         if reason is not None:
             suspended += 1
     return suspended
+
+
+async def revive_dependent_instances(
+    *,
+    agent_instance_store: AgentInstanceStore,
+    capability_id: str,
+    usable_capability_ids: set[str] | None,
+    available_by_source: Mapping[str, frozenset[str] | None],
+    team_id: TeamId | None = None,
+    kpi_writer: BaseKPIWriter | None = None,
+) -> int:
+    """Clear the suspensions a capability GRANT resolves — the inverse of
+    `suspend_dependent_instances` (the missing half of the #1980 → #1975 seam).
+
+    Why this cannot mirror the revoke path's shortcut: `suspend_dependent_
+    instances` fakes the available set as `selected - {capability_id}` because a
+    revoke knows exactly what it removed. A grant knows only what it ADDED — it
+    cannot conclude the instance is healthy, because a SECOND capability may
+    still be revoked or missing from the pod. So the caller must supply the real
+    availability facts and let `reconcile_instance_suspension` decide: it clears
+    only when NOTHING is missing, and re-suspends otherwise.
+
+    Safe on the reasons it must not touch: the reconcile clears only
+    `AVAILABILITY_REASONS`, so a `capability_config_invalid` suspension survives
+    untouched — only a successful save clears that (RFC §3.9). Passing the real
+    sets rather than a synthetic one is what makes that guarantee hold here.
+
+    `usable_capability_ids=None` means ReBAC is disabled (no scoping). An
+    instance whose runtime is absent from `available_by_source` (or maps to
+    None) has an unreachable pod and is SKIPPED rather than revived — the same
+    fail-to-unknown rule the reconciliation sweep applies (#1975). Returns the
+    number of instances whose suspension was cleared.
+    """
+
+    instances = (
+        await agent_instance_store.list_by_team(team_id)
+        if team_id is not None
+        else await agent_instance_store.list_all()
+    )
+    revived = 0
+    for instance in instances:
+        selected = set(instance.tuning.selected_capability_ids or [])
+        # Only instances that selected the granted capability can be revived by
+        # this grant; an unrelated suspension is never touched.
+        if capability_id not in selected:
+            continue
+        if not instance.is_suspended:
+            continue
+        available_ids = available_by_source.get(instance.source_runtime_id)
+        if available_ids is None:
+            continue
+        # The real available set: what the team may use AND the pod ships. The
+        # reconcile clears only if EVERY selected capability is in it.
+        effective = (
+            selected & available_ids
+            if usable_capability_ids is None
+            else selected & usable_capability_ids & available_ids
+        )
+        updated = await reconcile_instance_suspension(
+            instance=instance,
+            store=agent_instance_store,
+            available_capability_ids=effective,
+            revoked_reason=SuspensionReason.CAPABILITY_ACCESS_REVOKED,
+            kpi_writer=kpi_writer,
+        )
+        # A None return means "no AVAILABILITY reason" — NOT necessarily
+        # cleared: a `capability_config_invalid` instance also returns None
+        # while `clear_suspension` deliberately leaves its reason intact
+        # (RFC §3.9). Re-read the record and count only a real transition to
+        # unsuspended, so config-invalid instances are never miscounted.
+        if updated is not None:
+            continue
+        fresh = await agent_instance_store.get(instance.agent_instance_id)
+        if fresh is not None and not fresh.is_suspended:
+            revived += 1
+    return revived
 
 
 async def set_capability_default_on(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/impact.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/impact.py
@@ -1,0 +1,293 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Resting capability impact — who is broken RIGHT NOW, and by what (CAPAB-01).
+
+Why this module exists:
+- `agent_instance.suspension_reason` records WHY an instance is suspended, never
+  WHICH capability did it. An instance broken by `capa1` while also selecting
+  `capa2` would be miscounted against `capa2` by any `suspension_reason IS NOT
+  NULL AND capa2 IN selected` query. Attribution is therefore DERIVED, never
+  stored: `selected_capability_ids` minus what the instance's space may
+  currently use, minus what its pod currently advertises.
+- the same derivation answers two questions the admin surface asks, so it lives
+  in exactly one place (both callers below):
+    1. resting health  — "how many instances does capability X break today?"
+    2. impact preview  — "how many WOULD X break if I revoked it now?"
+
+Why not reuse the write path's shortcut: `suspend_dependent_instances` fakes the
+available set as `selected - {capability_id}` because a revoke KNOWS what it
+just took away. A resting read has no such luxury — it must ask ReBAC and the
+pods what is true now. That asymmetry is exactly why this module exists.
+
+Availability is the CONJUNCTION of two independent facts (both required):
+- ReBAC `can_use` — the space is authorized for the capability
+- pod manifest — the capability is actually shipped by the instance's runtime
+
+Unreachable pod = UNKNOWN, never "broken": the reconciliation sweep skips such
+instances (`skipped_unreachable`) rather than suspending them on a transient
+outage (#1975, RFC §3.9), and this read reports the same way. Telling an admin
+"12 agents broken" because a pod is restarting would be a lie with consequences.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from fred_core.common import TeamId
+
+from control_plane_backend.agent_instances.store import (
+    AgentInstanceRecord,
+    AgentInstanceStore,
+)
+from control_plane_backend.capabilities.authz import usable_capability_ids
+from control_plane_backend.product.dependencies import ProductServiceDependencies
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ImpactedInstance:
+    """One agent instance a capability currently breaks (or would break)."""
+
+    agent_instance_id: str
+    team_id: str
+    display_name: str
+
+
+@dataclass
+class CapabilityImpact:
+    """Per-capability resting impact across every team."""
+
+    suspended_instances: int = 0
+    instances: list[ImpactedInstance] = field(default_factory=list)
+    #: Instances skipped because their pod was unreachable — impact UNKNOWN for
+    #: them, deliberately not folded into `suspended_instances`.
+    skipped_unreachable: int = 0
+
+
+async def _usable_ids_by_team(
+    deps: ProductServiceDependencies,
+    team_ids: set[TeamId],
+) -> dict[TeamId, set[str] | None]:
+    """`can_use` capability ids per team — ONE `ListObjects` per team.
+
+    `can_use` is a TEAM-subject check (RFC §8.1), so authorization is a property
+    of (capability, space) and never fans out per agent instance: a team with 50
+    agents still costs one lookup. `None` means ReBAC is disabled — "no scoping",
+    every capability usable (matching `usable_capability_ids`).
+    """
+
+    rebac = deps.team_dependencies.rebac
+    return {
+        team_id: await usable_capability_ids(rebac, team_id) for team_id in team_ids
+    }
+
+
+def _broken_capability_ids(
+    instance: AgentInstanceRecord,
+    usable_ids: set[str] | None,
+    available_ids: frozenset[str] | None,
+) -> list[str]:
+    """The instance's selected capabilities that are NOT currently usable.
+
+    A capability is broken for this instance when the team lacks `can_use` on it
+    OR its pod no longer advertises it — the two independent failure modes
+    behind `capability_access_revoked` and `capability_unavailable`.
+
+    `usable_ids=None` (ReBAC disabled) skips the authorization half;
+    `available_ids=None` (unreachable pod) must be handled by the CALLER, which
+    reports the instance as unknown rather than broken — this function is only
+    reached with a known pod set.
+    """
+
+    selected = instance.tuning.selected_capability_ids or []
+    broken: list[str] = []
+    for cap_id in selected:
+        denied = usable_ids is not None and cap_id not in usable_ids
+        missing = available_ids is not None and cap_id not in available_ids
+        if denied or missing:
+            broken.append(cap_id)
+    return broken
+
+
+async def compute_capability_impact(
+    deps: ProductServiceDependencies,
+    *,
+    store: AgentInstanceStore | None = None,
+    collect_instances: bool = False,
+) -> dict[str, CapabilityImpact]:
+    """Resting impact for EVERY capability, keyed by capability id (CAPAB-01).
+
+    The number an admin sees in the dashboard's health column: how many agent
+    instances each capability breaks at rest. Derived, never read from
+    `suspension_reason` — see the module docstring for why that column cannot
+    answer this.
+
+    Cost is bounded by design: one `ListObjects` per team with instances (NOT
+    per instance) plus one template fetch per runtime pod. With the handful of
+    pods this platform runs, that is a few round-trips for an admin-only screen.
+
+    `collect_instances=True` additionally names the impacted instances (the
+    drill-down "which agents, in which space"); the count alone skips that work.
+    """
+
+    # Lazy import: `product.service` imports the capabilities package, so a
+    # module-level import here would close the cycle (same reason
+    # `catalog.py` defers its pod-fetch imports).
+    from control_plane_backend.product.service import (
+        _available_capability_ids_by_source,
+    )
+
+    instance_store = store or deps.get_agent_instance_store()
+    instances = await instance_store.list_all()
+    if not instances:
+        return {}
+
+    available_by_source = await _available_capability_ids_by_source(deps)
+    usable_by_team = await _usable_ids_by_team(
+        deps, {instance.team_id for instance in instances}
+    )
+
+    impact: dict[str, CapabilityImpact] = {}
+    for instance in instances:
+        available_ids = available_by_source.get(instance.source_runtime_id)
+        if available_ids is None:
+            # Pod unreachable — the sweep would skip this instance rather than
+            # suspend it, so its impact is UNKNOWN. Attribute the skip to each
+            # selected capability so the caller can say "unknown", not "fine".
+            for cap_id in instance.tuning.selected_capability_ids or []:
+                impact.setdefault(cap_id, CapabilityImpact()).skipped_unreachable += 1
+            continue
+
+        broken = _broken_capability_ids(
+            instance, usable_by_team.get(instance.team_id), available_ids
+        )
+        for cap_id in broken:
+            entry = impact.setdefault(cap_id, CapabilityImpact())
+            entry.suspended_instances += 1
+            if collect_instances:
+                entry.instances.append(
+                    ImpactedInstance(
+                        agent_instance_id=instance.agent_instance_id,
+                        team_id=str(instance.team_id),
+                        display_name=instance.display_name,
+                    )
+                )
+    return impact
+
+
+async def resolve_availability_for_team(
+    deps: ProductServiceDependencies,
+    *,
+    team_id: TeamId,
+    source_runtime_ids: set[str],
+) -> tuple[set[str] | None, dict[str, frozenset[str] | None]]:
+    """The real availability facts a GRANT needs to revive instances.
+
+    Returns `(usable_ids, available_by_source)` — the team's `can_use` set (None
+    when ReBAC is disabled) and each runtime's advertised capability set (None
+    per source when that pod is unreachable). The revoke path can synthesize
+    `selected - {id}` instead; a grant cannot, because it does not know whether
+    the instance's OTHER capabilities are healthy. See
+    `revive_dependent_instances`.
+    """
+
+    from control_plane_backend.product.service import (
+        _available_capability_ids_by_source,
+    )
+
+    usable_ids = await usable_capability_ids(deps.team_dependencies.rebac, team_id)
+    available_by_source = await _available_capability_ids_by_source(deps)
+    return usable_ids, {
+        runtime_id: available_by_source.get(runtime_id)
+        for runtime_id in source_runtime_ids
+    }
+
+
+async def preview_revoke_impact(
+    deps: ProductServiceDependencies,
+    *,
+    capability_id: str,
+    team_id: TeamId | None = None,
+    store: AgentInstanceStore | None = None,
+) -> CapabilityImpact:
+    """What revoking `capability_id` WOULD break — the pre-disable preview.
+
+    Forward-looking, so it cannot read the world as-is: it counts instances that
+    select the capability and are NOT ALREADY broken by it. An instance already
+    suspended for this capability is not "newly suspended" by revoking it again,
+    which keeps the dialog's number honest ("this will suspend N agents" means N
+    agents that work today will stop working).
+
+    `team_id=None` previews a platform-wide default-off; a team id previews that
+    one team's disable. Instances whose pod is unreachable are reported via
+    `skipped_unreachable` rather than counted — same fail-open-to-unknown rule
+    as `compute_capability_impact`.
+    """
+
+    from control_plane_backend.product.service import (
+        _available_capability_ids_by_source,
+    )
+
+    instance_store = store or deps.get_agent_instance_store()
+    instances = (
+        await instance_store.list_by_team(team_id)
+        if team_id is not None
+        else await instance_store.list_all()
+    )
+    # Only instances that actually selected the capability can be affected.
+    instances = [
+        instance
+        for instance in instances
+        if capability_id in (instance.tuning.selected_capability_ids or [])
+    ]
+    if not instances:
+        return CapabilityImpact()
+
+    available_by_source = await _available_capability_ids_by_source(deps)
+    usable_by_team = await _usable_ids_by_team(
+        deps, {instance.team_id for instance in instances}
+    )
+
+    result = CapabilityImpact()
+    for instance in instances:
+        available_ids = available_by_source.get(instance.source_runtime_id)
+        if available_ids is None:
+            result.skipped_unreachable += 1
+            continue
+        already_broken = capability_id in _broken_capability_ids(
+            instance, usable_by_team.get(instance.team_id), available_ids
+        )
+        if already_broken:
+            continue
+        result.suspended_instances += 1
+        result.instances.append(
+            ImpactedInstance(
+                agent_instance_id=instance.agent_instance_id,
+                team_id=str(instance.team_id),
+                display_name=instance.display_name,
+            )
+        )
+    return result
+
+
+__all__ = [
+    "CapabilityImpact",
+    "ImpactedInstance",
+    "compute_capability_impact",
+    "preview_revoke_impact",
+]

--- a/apps/control-plane-backend/control_plane_backend/capabilities/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/schemas.py
@@ -23,6 +23,14 @@ from fred_sdk.contracts.models import FieldSpec
 from pydantic import BaseModel, Field
 
 
+class ImpactedInstanceSummary(BaseModel):
+    """One agent instance affected by a capability change (admin drill-down)."""
+
+    agent_instance_id: str
+    team_id: str
+    display_name: str
+
+
 class CapabilityEnablementItem(BaseModel):
     """One capability's admin-facing scope + enablement state (RFC §8.5)."""
 
@@ -67,6 +75,28 @@ class CapabilityEnablementItem(BaseModel):
             " explicit admin grant, exactly like a tool."
         ),
     )
+    suspended_instances: int = Field(
+        default=0,
+        description=(
+            "Agent instances this capability breaks AT REST, across every team "
+            "(#1975 health). DERIVED per request — `suspension_reason` records "
+            "why an instance is suspended, never which capability did it, so an "
+            "instance broken by capa1 while also selecting capa2 must not count "
+            "against capa2. An instance is counted when it selects this "
+            "capability AND its team lacks `can_use` on it OR its pod no longer "
+            "advertises it."
+        ),
+    )
+    health_unknown_instances: int = Field(
+        default=0,
+        description=(
+            "Instances selecting this capability whose runtime pod was "
+            "unreachable, so their health is UNKNOWN rather than broken. Kept "
+            "separate from `suspended_instances`: the reconciliation sweep skips "
+            "an unreachable pod rather than suspending on a transient outage "
+            "(#1975, RFC §3.9), and this count reports the same way."
+        ),
+    )
 
 
 class CapabilityEnablementList(BaseModel):
@@ -92,9 +122,44 @@ class TeamCapabilityEnablementResult(BaseModel):
         default=0,
         description="Dependent agent instances suspended by this change (#1975).",
     )
+    revived_instances: int = Field(
+        default=0,
+        description=(
+            "Dependent agent instances whose suspension this GRANT cleared "
+            "(#1975). Only availability suspensions are cleared; an instance "
+            "still missing another capability stays suspended, and a "
+            "`capability_config_invalid` one is never touched here (RFC §3.9)."
+        ),
+    )
 
 
 class CapabilityDefaultOnResult(BaseModel):
     capability_id: str
     default_on: bool
     suspended_instances: int = 0
+    revived_instances: int = Field(
+        default=0,
+        description="Dependent instances revived by turning default-on ON (#1975).",
+    )
+
+
+class CapabilityImpactPreview(BaseModel):
+    """What a pending revoke WOULD break — the pre-disable dialog (#1975)."""
+
+    capability_id: str
+    suspended_instances: int = Field(
+        default=0,
+        description=(
+            "Agents that work today and would be suspended by this change. "
+            "Excludes agents already broken by this capability — revoking it "
+            "again does not newly break them."
+        ),
+    )
+    health_unknown_instances: int = Field(
+        default=0,
+        description="Selecting instances whose pod is unreachable (impact unknown).",
+    )
+    instances: list[ImpactedInstanceSummary] = Field(
+        default_factory=list,
+        description="The affected agents, for the admin drill-down.",
+    )

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -40,12 +40,20 @@ from control_plane_backend.capabilities.enablement import (
     enable_capability_for_team,
     ensure_capability_anchor,
     reset_capability_for_team,
+    revive_dependent_instances,
     set_capability_default_on,
+)
+from control_plane_backend.capabilities.impact import (
+    compute_capability_impact,
+    preview_revoke_impact,
+    resolve_availability_for_team,
 )
 from control_plane_backend.capabilities.schemas import (
     CapabilityDefaultOnResult,
     CapabilityEnablementItem,
     CapabilityEnablementList,
+    CapabilityImpactPreview,
+    ImpactedInstanceSummary,
     TeamCapabilityEnablementResult,
 )
 from control_plane_backend.product.dependencies import ProductServiceDependencies
@@ -120,6 +128,11 @@ async def list_capability_enablement(
     # Platform-wide denominator for default-on inheritance (§8.5). Fetched once
     # for the whole list — it is the same for every capability.
     total_team_count = await count_all_collaborative_teams(deps.team_dependencies)
+    # Resting health for the WHOLE catalog in one pass (#1975): one ReBAC
+    # `ListObjects` per team holding instances plus one template fetch per pod,
+    # rather than a lookup per row. Admin-only screen, so the extra round-trips
+    # buy the most accurate answer available.
+    impact = await compute_capability_impact(deps)
     items: list[CapabilityEnablementItem] = []
     for entry in catalog.values():
         items.append(
@@ -139,6 +152,12 @@ async def list_capability_enablement(
                 total_team_count=total_team_count,
                 team_settings_fields=list(entry.team_settings_fields),
                 kind=entry.kind,
+                suspended_instances=(
+                    impact[entry.id].suspended_instances if entry.id in impact else 0
+                ),
+                health_unknown_instances=(
+                    impact[entry.id].skipped_unreachable if entry.id in impact else 0
+                ),
             )
         )
     items.sort(key=lambda item: item.id)
@@ -153,6 +172,39 @@ async def _require_manage_any(rebac: RebacEngine, user: KeycloakUser) -> None:
 
     await rebac.check_user_permission_or_raise(
         user, OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID
+    )
+
+
+async def _revive_after_grant(
+    *,
+    capability_id: str,
+    team_id: TeamId,
+    deps: ProductServiceDependencies,
+) -> int:
+    """Clear the suspensions a fresh grant resolves (the #1980 → #1975 seam).
+
+    Runs AFTER the enabling tuple write so the `can_use` lookup observes the new
+    grant. Every grant path funnels through here: without it a revoked-then-
+    re-enabled capability leaves its agents suspended forever, because the only
+    other clear path is the reconciliation sweep — which has no scheduled host
+    yet (#1975 names the Temporal lifecycle queue as the intended one).
+    """
+
+    agent_instance_store = deps.get_agent_instance_store()
+    instances = await agent_instance_store.list_by_team(team_id)
+    source_runtime_ids = {instance.source_runtime_id for instance in instances}
+    if not source_runtime_ids:
+        return 0
+    usable_ids, available_by_source = await resolve_availability_for_team(
+        deps, team_id=team_id, source_runtime_ids=source_runtime_ids
+    )
+    return await revive_dependent_instances(
+        agent_instance_store=agent_instance_store,
+        capability_id=capability_id,
+        usable_capability_ids=usable_ids,
+        available_by_source=available_by_source,
+        team_id=team_id,
+        kpi_writer=deps.get_kpi_writer(),
     )
 
 
@@ -176,11 +228,15 @@ async def enable_team_capability(
         settings=settings,
         updated_by=user.uid,
     )
+    revived = await _revive_after_grant(
+        capability_id=capability_id, team_id=team_id, deps=deps
+    )
     return TeamCapabilityEnablementResult(
         capability_id=capability_id,
         team_id=str(team_id),
         enabled=True,
         settings=validated,
+        revived_instances=revived,
     )
 
 
@@ -234,11 +290,22 @@ async def reset_team_capability(
         default_on=default_on,
         kpi_writer=deps.get_kpi_writer(),
     )
+    # Reset onto a default-ON platform is a GRANT (the team keeps access by
+    # inheritance), so it must revive exactly like an explicit enable — the
+    # reset path previously bare-returned 0 here and stranded its dependents.
+    revived = (
+        await _revive_after_grant(
+            capability_id=capability_id, team_id=team_id, deps=deps
+        )
+        if default_on
+        else 0
+    )
     return TeamCapabilityEnablementResult(
         capability_id=capability_id,
         team_id=str(team_id),
         enabled=default_on,
         suspended_instances=suspended,
+        revived_instances=revived,
     )
 
 
@@ -260,10 +327,63 @@ async def set_default_on(
         on=default_on,
         kpi_writer=deps.get_kpi_writer(),
     )
+    # Turning default-on ON grants inherited access platform-wide, so it revives
+    # across EVERY team holding dependents — not one team like the enable path.
+    # Teams with an explicit `disabled` opt-out keep their suspension: the
+    # per-team `can_use` lookup below still answers False for them, so the
+    # reconcile re-suspends rather than clears. That is the tri-state working,
+    # not a special case.
+    revived = 0
+    if default_on:
+        agent_instance_store = deps.get_agent_instance_store()
+        team_ids = {
+            instance.team_id
+            for instance in await agent_instance_store.list_all()
+            if capability_id in (instance.tuning.selected_capability_ids or [])
+        }
+        for team_id in team_ids:
+            revived += await _revive_after_grant(
+                capability_id=capability_id, team_id=team_id, deps=deps
+            )
     return CapabilityDefaultOnResult(
         capability_id=capability_id,
         default_on=default_on,
         suspended_instances=suspended,
+        revived_instances=revived,
+    )
+
+
+async def preview_capability_revoke(
+    *,
+    user: KeycloakUser,
+    capability_id: str,
+    team_id: TeamId | None,
+    deps: ProductServiceDependencies,
+) -> CapabilityImpactPreview:
+    """Preview what revoking a capability would break (the confirm dialog).
+
+    `team_id=None` previews a platform-wide default-off; a team id previews that
+    one team's disable. Read-only — same `can_manage` gate as the mutation it
+    precedes, so the preview never reveals more than the admin may already do.
+    """
+
+    rebac = _rebac(deps)
+    await _require_can_manage(rebac, user, capability_id)
+    impact = await preview_revoke_impact(
+        deps, capability_id=capability_id, team_id=team_id
+    )
+    return CapabilityImpactPreview(
+        capability_id=capability_id,
+        suspended_instances=impact.suspended_instances,
+        health_unknown_instances=impact.skipped_unreachable,
+        instances=[
+            ImpactedInstanceSummary(
+                agent_instance_id=item.agent_instance_id,
+                team_id=item.team_id,
+                display_name=item.display_name,
+            )
+            for item in impact.instances
+        ],
     )
 
 
@@ -275,5 +395,6 @@ __all__ = [
     "enable_team_capability",
     "disable_team_capability",
     "reset_team_capability",
+    "preview_capability_revoke",
     "set_default_on",
 ]

--- a/apps/control-plane-backend/tests/test_capability_enablement_1980.py
+++ b/apps/control-plane-backend/tests/test_capability_enablement_1980.py
@@ -1029,7 +1029,12 @@ async def test_aggregate_list_exposes_optouts_and_platform_team_count(
         capability_service, "count_all_collaborative_teams", _fake_count
     )
 
-    deps = SimpleNamespace(team_dependencies=SimpleNamespace(rebac=rebac))
+    # No instances enrolled → the resting-health pass returns nothing and the
+    # list still renders (an empty store short-circuits before any pod fetch).
+    deps = SimpleNamespace(
+        team_dependencies=SimpleNamespace(rebac=rebac),
+        get_agent_instance_store=lambda: _FakeAgentInstanceStore([]),
+    )
     result = await capability_service.list_capability_enablement(
         user=SimpleNamespace(uid="admin"),  # type: ignore[arg-type]
         deps=deps,  # type: ignore[arg-type]
@@ -1042,3 +1047,6 @@ async def test_aggregate_list_exposes_optouts_and_platform_team_count(
     assert item.total_team_count == 12
     # 12 teams inherit it, 1 opted out → the dashboard renders 11.
     assert item.total_team_count - len(item.disabled_team_ids) == 11
+    # No enrolled instances → nothing broken, nothing unknown.
+    assert item.suspended_instances == 0
+    assert item.health_unknown_instances == 0

--- a/apps/control-plane-backend/tests/test_capability_impact.py
+++ b/apps/control-plane-backend/tests/test_capability_impact.py
@@ -1,0 +1,311 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Resting capability impact + the grant-side revive seam (CAPAB-01, #1975).
+
+Covers the two things the health/impact work turns on:
+- attribution is DERIVED, so an instance broken by capa1 must NOT count against
+  capa2 even when it selects both (the exact miscount the stored
+  `suspension_reason` cannot avoid);
+- a GRANT revives the suspensions it resolves — the bug where re-enabling a
+  capability left its agents suspended forever because only the never-scheduled
+  reconciliation sweep could clear them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from test_main import _FakeAgentInstanceStore, _make_record
+
+from control_plane_backend.agent_instances.suspension import SuspensionReason
+from control_plane_backend.capabilities import impact as impact_mod
+from control_plane_backend.capabilities.enablement import revive_dependent_instances
+
+
+def _record_with(
+    *,
+    agent_instance_id: str,
+    team_id: str,
+    selected: list[str],
+    suspension_reason: str | None = None,
+    source_runtime_id: str = "runtime-a",
+):
+    record = _make_record(
+        agent_instance_id=agent_instance_id,
+        team_id=team_id,
+        source_runtime_id=source_runtime_id,
+    )
+    record.tuning = record.tuning.model_copy(
+        update={"selected_capability_ids": selected}
+    )
+    record.suspension_reason = suspension_reason
+    return record
+
+
+def _deps_with(store: _FakeAgentInstanceStore) -> SimpleNamespace:
+    return SimpleNamespace(
+        get_agent_instance_store=lambda: store,
+        get_kpi_writer=lambda: None,
+        team_dependencies=SimpleNamespace(rebac=object()),
+    )
+
+
+def _patch_availability(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    available_by_source: dict[str, frozenset[str] | None],
+    usable_by_team: dict[str, set[str] | None],
+) -> None:
+    """Stub the two live-fact fetches the impact module makes."""
+
+    async def _fake_available(_deps):
+        return available_by_source
+
+    async def _fake_usable(_rebac, team_id):
+        return usable_by_team.get(str(team_id))
+
+    # `_available_capability_ids_by_source` is imported lazily from
+    # product.service INSIDE the impact functions, so patch it at the source.
+    import control_plane_backend.product.service as product_service
+
+    monkeypatch.setattr(
+        product_service, "_available_capability_ids_by_source", _fake_available
+    )
+    monkeypatch.setattr(impact_mod, "usable_capability_ids", _fake_usable)
+
+
+# ---------------------------------------------------------------------------
+# Attribution — the multi-capability miscount the stored reason cannot avoid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_impact_attributes_only_the_unusable_capability(monkeypatch) -> None:
+    """An instance selecting capa1 + capa2 but denied only capa1 counts against
+    capa1 ALONE — never capa2. This is the exact case a
+    `suspension_reason IS NOT NULL AND capa2 IN selected` query gets wrong."""
+
+    store = _FakeAgentInstanceStore(
+        [
+            _record_with(
+                agent_instance_id="inst",
+                team_id="team-a",
+                selected=["capa1", "capa2"],
+                suspension_reason=SuspensionReason.CAPABILITY_ACCESS_REVOKED.value,
+            )
+        ]
+    )
+    _patch_availability(
+        monkeypatch,
+        available_by_source={"runtime-a": frozenset({"capa1", "capa2"})},
+        usable_by_team={"team-a": {"capa2"}},  # capa1 revoked, capa2 still usable
+    )
+
+    result = await impact_mod.compute_capability_impact(_deps_with(store))
+
+    assert result["capa1"].suspended_instances == 1
+    assert "capa2" not in result  # NOT miscounted against the healthy capability
+
+
+@pytest.mark.asyncio
+async def test_impact_counts_pod_missing_capability(monkeypatch) -> None:
+    """A capability the pod no longer advertises breaks its selectors even when
+    ReBAC still grants `can_use` — the `capability_unavailable` half."""
+
+    store = _FakeAgentInstanceStore(
+        [_record_with(agent_instance_id="i", team_id="t", selected=["gone"])]
+    )
+    _patch_availability(
+        monkeypatch,
+        available_by_source={"runtime-a": frozenset()},  # pod ships nothing
+        usable_by_team={"t": {"gone"}},  # but ReBAC still allows it
+    )
+
+    result = await impact_mod.compute_capability_impact(_deps_with(store))
+
+    assert result["gone"].suspended_instances == 1
+
+
+@pytest.mark.asyncio
+async def test_impact_reports_unreachable_pod_as_unknown_not_broken(
+    monkeypatch,
+) -> None:
+    """An unreachable pod (None available set) is UNKNOWN, never broken — the
+    sweep's `skipped_unreachable` rule, so a restart is not reported as an
+    outage."""
+
+    store = _FakeAgentInstanceStore(
+        [_record_with(agent_instance_id="i", team_id="t", selected=["capa1"])]
+    )
+    _patch_availability(
+        monkeypatch,
+        available_by_source={"runtime-a": None},  # pod unreachable
+        usable_by_team={"t": {"capa1"}},
+    )
+
+    result = await impact_mod.compute_capability_impact(_deps_with(store))
+
+    assert result["capa1"].suspended_instances == 0
+    assert result["capa1"].skipped_unreachable == 1
+
+
+# ---------------------------------------------------------------------------
+# Revoke preview — forward-looking, excludes the already-broken
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_excludes_already_broken_instances(monkeypatch) -> None:
+    """ "This will suspend N agents" must mean agents that WORK today. An agent
+    already broken by the capability is not newly suspended by revoking it."""
+
+    # "works" lives in a team that currently HAS capa1; "already" lives in a
+    # team that has already lost it (and is suspended for it). Revoking capa1
+    # platform-wide breaks only the one that works today.
+    store = _FakeAgentInstanceStore(
+        [
+            _record_with(
+                agent_instance_id="works", team_id="team-ok", selected=["capa1"]
+            ),
+            _record_with(
+                agent_instance_id="already",
+                team_id="team-gone",
+                selected=["capa1"],
+                suspension_reason=SuspensionReason.CAPABILITY_ACCESS_REVOKED.value,
+            ),
+        ]
+    )
+    _patch_availability(
+        monkeypatch,
+        available_by_source={"runtime-a": frozenset({"capa1"})},
+        usable_by_team={
+            "team-ok": {"capa1"},  # works today → revoke would break it
+            "team-gone": set(),  # already lost capa1 → already broken
+        },
+    )
+
+    result = await impact_mod.preview_revoke_impact(
+        _deps_with(store), capability_id="capa1", team_id=None
+    )
+
+    assert result.suspended_instances == 1
+    assert {i.agent_instance_id for i in result.instances} == {"works"}
+
+
+# ---------------------------------------------------------------------------
+# The revive fix — the grant-side seam that was missing entirely
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revive_clears_suspension_when_all_capabilities_return() -> None:
+    """A grant that makes EVERY selected capability usable clears the
+    suspension — the re-enable path that previously left agents stranded."""
+
+    record = _record_with(
+        agent_instance_id="inst",
+        team_id="team-a",
+        selected=["capa1"],
+        suspension_reason=SuspensionReason.CAPABILITY_ACCESS_REVOKED.value,
+    )
+    store = _FakeAgentInstanceStore([record])
+
+    revived = await revive_dependent_instances(
+        agent_instance_store=store,
+        capability_id="capa1",
+        usable_capability_ids={"capa1"},
+        available_by_source={"runtime-a": frozenset({"capa1"})},
+        team_id="team-a",
+    )
+
+    assert revived == 1
+    assert record.suspension_reason is None
+
+
+@pytest.mark.asyncio
+async def test_revive_keeps_suspension_when_another_capability_still_missing() -> None:
+    """Re-enabling capa1 must NOT revive an instance still broken by capa2 — the
+    reason a grant cannot fake `selected - {id}` like the revoke path does."""
+
+    record = _record_with(
+        agent_instance_id="inst",
+        team_id="team-a",
+        selected=["capa1", "capa2"],
+        suspension_reason=SuspensionReason.CAPABILITY_ACCESS_REVOKED.value,
+    )
+    store = _FakeAgentInstanceStore([record])
+
+    revived = await revive_dependent_instances(
+        agent_instance_store=store,
+        capability_id="capa1",
+        usable_capability_ids={"capa1"},  # capa2 still NOT usable
+        available_by_source={"runtime-a": frozenset({"capa1", "capa2"})},
+        team_id="team-a",
+    )
+
+    assert revived == 0
+    assert record.suspension_reason == SuspensionReason.CAPABILITY_ACCESS_REVOKED.value
+
+
+@pytest.mark.asyncio
+async def test_revive_never_touches_config_invalid_suspension() -> None:
+    """A `capability_config_invalid` suspension is cleared only by a successful
+    save (RFC §3.9) — a grant must leave it alone even when access returns."""
+
+    record = _record_with(
+        agent_instance_id="inst",
+        team_id="team-a",
+        selected=["capa1"],
+        suspension_reason=SuspensionReason.CAPABILITY_CONFIG_INVALID.value,
+    )
+    store = _FakeAgentInstanceStore([record])
+
+    revived = await revive_dependent_instances(
+        agent_instance_store=store,
+        capability_id="capa1",
+        usable_capability_ids={"capa1"},
+        available_by_source={"runtime-a": frozenset({"capa1"})},
+        team_id="team-a",
+    )
+
+    assert revived == 0
+    assert record.suspension_reason == SuspensionReason.CAPABILITY_CONFIG_INVALID.value
+
+
+@pytest.mark.asyncio
+async def test_revive_skips_unreachable_pod() -> None:
+    """An unreachable pod means UNKNOWN — a grant must not clear a suspension it
+    cannot prove is resolved."""
+
+    record = _record_with(
+        agent_instance_id="inst",
+        team_id="team-a",
+        selected=["capa1"],
+        suspension_reason=SuspensionReason.CAPABILITY_ACCESS_REVOKED.value,
+    )
+    store = _FakeAgentInstanceStore([record])
+
+    revived = await revive_dependent_instances(
+        agent_instance_store=store,
+        capability_id="capa1",
+        usable_capability_ids={"capa1"},
+        available_by_source={"runtime-a": None},  # pod unreachable
+        team_id="team-a",
+    )
+
+    assert revived == 0
+    assert record.suspension_reason == SuspensionReason.CAPABILITY_ACCESS_REVOKED.value

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -785,7 +785,9 @@
         },
         "health": {
           "suspended": "{{count}} suspended",
-          "pending": "Live per-capability health arrives with the suspension sweep."
+          "unknown": "{{count}} unknown",
+          "unknownHint": "The runtime pod was unreachable, so this capability's health can't be determined right now.",
+          "healthy": "OK"
         },
         "defaultOnToast": "Default-on enabled platform-wide.",
         "defaultOffToast": "Default-on disabled platform-wide.",
@@ -795,7 +797,13 @@
           "title": "Disable default-on?",
           "message": "Turning off default-on revokes inherited access for every team and may suspend agent instances that depend on this capability.",
           "confirm": "Disable",
-          "cancel": "Cancel"
+          "cancel": "Cancel",
+          "impact": "This will suspend {{count}} agent(s) that currently work.",
+          "impactNone": "No running agents will be affected.",
+          "impactUnknown": "{{count}} agent(s) could not be checked — their pod was unreachable, so the impact is unknown.",
+          "showAffected": "Show affected agents",
+          "hideAffected": "Hide affected agents",
+          "affectedAgent": "{{name}} (team {{team}})"
         },
         "matrix": {
           "title": "{{name}} — team access",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -785,7 +785,9 @@
         },
         "health": {
           "suspended": "{{count}} suspendue(s)",
-          "pending": "L'état par capacité en temps réel arrive avec le balayage de suspension."
+          "unknown": "{{count}} inconnu(s)",
+          "unknownHint": "Le pod d'exécution était injoignable ; l'état de cette capacité ne peut pas être déterminé pour le moment.",
+          "healthy": "OK"
         },
         "defaultOnToast": "Activation par défaut appliquée à toute la plateforme.",
         "defaultOffToast": "Activation par défaut désactivée sur toute la plateforme.",
@@ -795,7 +797,13 @@
           "title": "Désactiver l'activation par défaut ?",
           "message": "Désactiver l'activation par défaut révoque l'accès hérité pour toutes les équipes et peut suspendre les instances d'agents qui dépendent de cette capacité.",
           "confirm": "Désactiver",
-          "cancel": "Annuler"
+          "cancel": "Annuler",
+          "impact": "Cela suspendra {{count}} agent(s) actuellement fonctionnel(s).",
+          "impactNone": "Aucun agent en cours d'exécution ne sera affecté.",
+          "impactUnknown": "{{count}} agent(s) n'ont pas pu être vérifiés — leur pod était injoignable, l'impact est donc inconnu.",
+          "showAffected": "Afficher les agents concernés",
+          "hideAffected": "Masquer les agents concernés",
+          "affectedAgent": "{{name}} (équipe {{team}})"
         },
         "matrix": {
           "title": "{{name}} — accès des équipes",

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.module.css
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.module.css
@@ -121,6 +121,49 @@
   font: var(--font-label-medium);
 }
 
+/* Disable-confirmation impact preview: the concrete count of agents this change
+ * would break, an optional unreachable-pod caveat, and the affected-agent
+ * drill-down. Sits under the dialog's generic message. */
+.impact {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  margin-top: var(--spacing-s);
+}
+
+.impactWarn {
+  margin: 0;
+  color: var(--warning);
+  font: var(--font-label-medium);
+}
+
+.impactNone {
+  margin: 0;
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}
+
+.impactUnknown {
+  margin: 0;
+  color: var(--on-surface-muted);
+  font: var(--font-body-small);
+}
+
+.affectedList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3xs);
+  margin: 0;
+  padding-left: var(--spacing-m);
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.affectedItem {
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}
+
 /* Button sets a fixed height (2rem at size="small") and clips overflow, but
  * leaves its label free to wrap. The action column is only just narrower than
  * the one-line label, so the label wrapped to two lines, overflowed the fixed

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.test.tsx
@@ -43,6 +43,7 @@ vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => 
   useAdminCapabilitiesQuery: () => h.list,
   useListTeamsQuery: () => ({ data: [] }),
   useSetCapabilityDefaultOnMutation: () => [vi.fn(), { isLoading: false }],
+  useLazyCapabilityRevokeImpactQuery: () => [vi.fn(), { data: undefined, isFetching: false }],
 }));
 
 vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
@@ -95,7 +96,7 @@ describe("CapabilitiesPage states", () => {
 });
 
 describe("CapabilitiesPage catalog rows", () => {
-  it("renders each capability with enabled-team count and neutral health", () => {
+  it("renders each capability with enabled-team count and a healthy resting state", () => {
     h.list = {
       data: {
         items: [cap({ id: "web_search", team_scope: "admin_gated", default_on: false, enabled_team_ids: ["nb"] })],
@@ -108,12 +109,44 @@ describe("CapabilitiesPage catalog rows", () => {
     // A non-default-on capability counts explicit grants only.
     expect(html).toContain(">1<");
 
-    // Health is neutral (no resting per-capability count until the sweep, #1975).
-    expect(html).toContain("rework.admin.capabilities.health.pending");
+    // Resting health with no suspended/unknown instances reads as healthy (#1975).
+    expect(html).toContain("rework.admin.capabilities.health.healthy");
     expect(html).not.toContain("rework.admin.capabilities.health.suspended");
+    expect(html).not.toContain("rework.admin.capabilities.health.unknown");
 
     // Manage-teams action is offered per row.
     expect(html).toContain("rework.admin.capabilities.manageTeams");
+  });
+
+  it("shows the resting suspended count from the row when the capability breaks agents", () => {
+    h.list = {
+      data: { items: [cap({ id: "web_search", enabled_team_ids: ["nb"], suspended_instances: 3 })] },
+      isLoading: false,
+      isError: false,
+    };
+    const html = render();
+
+    // The count comes from the row (`suspended_instances`), not session state.
+    expect(html).toContain("rework.admin.capabilities.health.suspended:3");
+    expect(html).not.toContain("rework.admin.capabilities.health.healthy");
+  });
+
+  it("shows a neutral unknown indicator when a pod was unreachable but nothing is broken", () => {
+    h.list = {
+      data: {
+        items: [
+          cap({ id: "web_search", enabled_team_ids: ["nb"], suspended_instances: 0, health_unknown_instances: 2 }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    };
+    const html = render();
+
+    // Unknown (unreachable pod) is distinct from suspended (broken).
+    expect(html).toContain("rework.admin.capabilities.health.unknown:2");
+    expect(html).not.toContain("rework.admin.capabilities.health.suspended");
+    expect(html).not.toContain("rework.admin.capabilities.health.healthy");
   });
 
   it("counts a default-on capability from the roster minus opt-outs, not its grants", () => {

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
@@ -32,6 +32,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useAdminCapabilitiesQuery,
+  useLazyCapabilityRevokeImpactQuery,
   useListTeamsQuery,
   useSetCapabilityDefaultOnMutation,
 } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
@@ -55,12 +56,15 @@ export default function CapabilitiesPage() {
   const { data: teams = [] } = useListTeamsQuery();
   const [setDefaultOn, { isLoading: isTogglingDefault }] = useSetCapabilityDefaultOnMutation();
 
-  // Session-observed suspended-instance counts per capability, sourced from the
-  // enablement mutations (revoke / default-off). The aggregate list carries no
-  // resting per-capability health count yet — that data lands with #1975.
-  const [suspendedByCapability, setSuspendedByCapability] = useState<Record<string, number>>({});
+  // Live impact preview fired on demand when the disable-confirmation dialog
+  // opens — a platform-wide (no teamId) preview of what turning default-on off
+  // would break right now. The resting per-capability health count in the
+  // table itself comes straight from the aggregate list (#1975), not from here.
+  const [fetchRevokeImpact, revokeImpact] = useLazyCapabilityRevokeImpactQuery();
+
   const [matrixCapabilityId, setMatrixCapabilityId] = useState<string | null>(null);
   const [pendingDefaultOff, setPendingDefaultOff] = useState<CapabilityEnablementItem | null>(null);
+  const [showAffected, setShowAffected] = useState(false);
   const [kindFilter, setKindFilter] = useState<"tool" | "agent">("tool");
 
   const allCapabilities = data?.items ?? [];
@@ -75,10 +79,6 @@ export default function CapabilitiesPage() {
   // behind it updates.
   const matrixCapability = capabilities.find((cap) => cap.id === matrixCapabilityId) ?? null;
 
-  const recordSuspended = (capabilityId: string, count: number) => {
-    setSuspendedByCapability((prev) => ({ ...prev, [capabilityId]: count }));
-  };
-
   const applyDefaultOn = async (capability: CapabilityEnablementItem, nextValue: boolean) => {
     try {
       const result = await setDefaultOn({
@@ -86,7 +86,6 @@ export default function CapabilitiesPage() {
         setCapabilityDefaultOnRequest: { default_on: nextValue },
       }).unwrap();
       const suspended = result.suspended_instances ?? 0;
-      recordSuspended(capability.id, suspended);
       if (suspended > 0) {
         showWarn({ summary: t("rework.admin.capabilities.defaultOffSuspendedToast", { count: suspended }) });
       } else {
@@ -104,11 +103,70 @@ export default function CapabilitiesPage() {
   const onToggleDefault = (capability: CapabilityEnablementItem) => {
     if (capability.default_on) {
       // Turning default-on off revokes inherited access team-by-team and can
-      // suspend dependent instances — confirm before firing.
+      // suspend dependent instances — confirm before firing, and preview the
+      // platform-wide impact (no teamId) so the admin sees what breaks.
       setPendingDefaultOff(capability);
+      setShowAffected(false);
+      void fetchRevokeImpact({ capabilityId: capability.id });
     } else {
       void applyDefaultOn(capability, true);
     }
+  };
+
+  const impact = revokeImpact.data;
+  const impactSuspended = impact?.suspended_instances ?? 0;
+  const impactUnknown = impact?.health_unknown_instances ?? 0;
+  const impactInstances = impact?.instances ?? [];
+
+  // Concrete impact for the disable-confirmation dialog: how many working agents
+  // this default-off would suspend, plus the affected-agent drill-down. While
+  // the preview is still loading we render nothing extra — the dialog keeps its
+  // generic message and stays actionable.
+  const renderImpactDetails = () => {
+    if (revokeImpact.isFetching || !impact) return null;
+    return (
+      <div className={styles.impact}>
+        <p className={impactSuspended > 0 ? styles.impactWarn : styles.impactNone}>
+          {impactSuspended > 0
+            ? t("rework.admin.capabilities.defaultOffConfirm.impact", { count: impactSuspended })
+            : t("rework.admin.capabilities.defaultOffConfirm.impactNone")}
+        </p>
+        {impactUnknown > 0 && (
+          <p className={styles.impactUnknown}>
+            {t("rework.admin.capabilities.defaultOffConfirm.impactUnknown", { count: impactUnknown })}
+          </p>
+        )}
+        {impactInstances.length > 0 && (
+          <>
+            <Button
+              color="on-surface"
+              variant="text"
+              size="small"
+              onClick={() => setShowAffected((prev) => !prev)}
+              aria-expanded={showAffected}
+            >
+              {t(
+                showAffected
+                  ? "rework.admin.capabilities.defaultOffConfirm.hideAffected"
+                  : "rework.admin.capabilities.defaultOffConfirm.showAffected",
+              )}
+            </Button>
+            {showAffected && (
+              <ul className={styles.affectedList}>
+                {impactInstances.map((instance) => (
+                  <li key={instance.agent_instance_id} className={styles.affectedItem}>
+                    {t("rework.admin.capabilities.defaultOffConfirm.affectedAgent", {
+                      name: instance.display_name,
+                      team: instance.team_id,
+                    })}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+    );
   };
 
   const columns: DataTableColumn<CapabilityEnablementItem>[] = [
@@ -171,18 +229,27 @@ export default function CapabilitiesPage() {
       label: t("rework.admin.capabilities.col.health"),
       size: "1fr",
       cellRenderer: (cap) => {
-        const suspended = suspendedByCapability[cap.id];
+        // Resting health straight from the aggregate list (#1975): agents this
+        // capability breaks AT REST (`suspended_instances`) vs. agents whose pod
+        // was unreachable so their health can't be determined
+        // (`health_unknown_instances`) — kept visually distinct.
+        const suspended = cap.suspended_instances ?? 0;
+        const unknown = cap.health_unknown_instances ?? 0;
         return (
           <div className={styles.centered}>
-            {suspended && suspended > 0 ? (
+            {suspended > 0 ? (
               <span className={styles.healthWarn}>
                 <Icon category="outlined" type="warning" />
                 {t("rework.admin.capabilities.health.suspended", { count: suspended })}
               </span>
-            ) : (
-              <Tooltip text={t("rework.admin.capabilities.health.pending")}>
-                <span className={styles.healthNeutral}>—</span>
+            ) : unknown > 0 ? (
+              <Tooltip text={t("rework.admin.capabilities.health.unknownHint")}>
+                <span className={styles.healthNeutral}>
+                  {t("rework.admin.capabilities.health.unknown", { count: unknown })}
+                </span>
               </Tooltip>
+            ) : (
+              <span className={styles.healthNeutral}>{t("rework.admin.capabilities.health.healthy")}</span>
             )}
           </div>
         );
@@ -250,13 +317,13 @@ export default function CapabilitiesPage() {
         teams={teams}
         open={matrixCapability !== null}
         onClose={() => setMatrixCapabilityId(null)}
-        onSuspended={recordSuspended}
       />
 
       <ConfirmationDialog
         open={pendingDefaultOff !== null}
         title={t("rework.admin.capabilities.defaultOffConfirm.title")}
         message={t("rework.admin.capabilities.defaultOffConfirm.message")}
+        details={renderImpactDetails()}
         confirmLabel={t("rework.admin.capabilities.defaultOffConfirm.confirm")}
         cancelLabel={t("rework.admin.capabilities.defaultOffConfirm.cancel")}
         criticalAction

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.tsx
@@ -51,8 +51,6 @@ interface CapabilityTeamMatrixDrawerProps {
   teams: Team[];
   open: boolean;
   onClose: () => void;
-  /** Bubble up the count of instances a revoke suspended, for the health column. */
-  onSuspended: (capabilityId: string, count: number) => void;
 }
 
 /** Segment order of the tri-state control; index ↔ choice for `ButtonGroup`. */
@@ -78,13 +76,7 @@ const OFF_TOAST_KEYS = {
   },
 } as const;
 
-export function CapabilityTeamMatrixDrawer({
-  capability,
-  teams,
-  open,
-  onClose,
-  onSuspended,
-}: CapabilityTeamMatrixDrawerProps) {
+export function CapabilityTeamMatrixDrawer({ capability, teams, open, onClose }: CapabilityTeamMatrixDrawerProps) {
   const { t } = useTranslation();
   const { showSuccess, showError, showWarn } = useToast();
   const [enableCapability, { isLoading: isEnabling }] = useEnableTeamCapabilityMutation();
@@ -207,7 +199,6 @@ export function CapabilityTeamMatrixDrawer({
     try {
       const result = await disableCapability({ capabilityId: capability.id, teamId, mode }).unwrap();
       const suspended = result.suspended_instances ?? 0;
-      onSuspended(capability.id, suspended);
       if (suspended > 0) {
         showWarn({ summary: t(keys.suspended, { team: teamLabel(teamId), count: suspended }) });
       } else {

--- a/apps/frontend/src/rework/components/shared/molecules/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConfirmationDialog/ConfirmationDialog.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEffect } from "react";
+import { useEffect, type ReactNode } from "react";
 import Button from "@shared/atoms/Button/Button.tsx";
 import { Portal } from "@shared/utils/Portal.tsx";
 import styles from "./ConfirmationDialog.module.css";
@@ -21,6 +21,8 @@ interface ConfirmationDialogProps {
   open: boolean;
   title: string;
   message?: string;
+  /** Extra content rendered under the message — e.g. an impact drill-down. */
+  details?: ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   criticalAction?: boolean;
@@ -32,6 +34,7 @@ export function ConfirmationDialog({
   open,
   title,
   message,
+  details,
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
   criticalAction = false,
@@ -64,6 +67,7 @@ export function ConfirmationDialog({
               {title}
             </p>
             {message && <p className={styles.message}>{message}</p>}
+            {details}
           </div>
           <div className={styles.actions}>
             <Button color="on-surface" variant="outlined" size="medium" onClick={onCancel}>

--- a/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
@@ -189,4 +189,7 @@ export const {
     useDisableTeamCapabilityMutation,
   usePutCapabilityDefaultOnControlPlaneV1AdminCapabilitiesCapabilityIdDefaultOnPutMutation:
     useSetCapabilityDefaultOnMutation,
+  // Fired on demand from the disable-confirmation dialog (lazy — not on render).
+  useLazyGetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetQuery:
+    useLazyCapabilityRevokeImpactQuery,
 } = enhancedControlPlaneApi;

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -431,6 +431,17 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: () => ({ url: `/control-plane/v1/admin/capabilities` }),
     }),
+    getCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGet: build.query<
+      GetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetApiResponse,
+      GetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/control-plane/v1/admin/capabilities/${queryArg.capabilityId}/revoke-impact`,
+        params: {
+          team_id: queryArg.teamId,
+        },
+      }),
+    }),
     putTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdPut: build.mutation<
       PutTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdPutApiResponse,
       PutTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdPutApiArg
@@ -990,6 +1001,13 @@ export type BootstrapPlatformAdminControlPlaneV1BootstrapPlatformAdminPostApiArg
 export type GetAdminCapabilitiesControlPlaneV1AdminCapabilitiesGetApiResponse =
   /** status 200 Successful Response */ CapabilityEnablementList;
 export type GetAdminCapabilitiesControlPlaneV1AdminCapabilitiesGetApiArg = void;
+export type GetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetApiResponse =
+  /** status 200 Successful Response */ CapabilityImpactPreview;
+export type GetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetApiArg = {
+  capabilityId: string;
+  /** Preview one team's disable. Omit for a platform-wide default-off preview. */
+  teamId?: string | null;
+};
 export type PutTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdPutApiResponse =
   /** status 200 Successful Response */ TeamCapabilityEnablementResult;
 export type PutTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdPutApiArg = {
@@ -1862,9 +1880,27 @@ export type CapabilityEnablementItem = {
   team_settings_fields?: FieldSpec[];
   /** "tool": a pod-advertised capability. "agent": a control-plane-side projection of an agent template into this same catalog (CAPAB-01, RFC §8.6) — every team's access to every agent is an explicit admin grant, exactly like a tool. */
   kind?: "tool" | "agent";
+  /** Agent instances this capability breaks AT REST, across every team (#1975 health). DERIVED per request — `suspension_reason` records why an instance is suspended, never which capability did it, so an instance broken by capa1 while also selecting capa2 must not count against capa2. An instance is counted when it selects this capability AND its team lacks `can_use` on it OR its pod no longer advertises it. */
+  suspended_instances?: number;
+  /** Instances selecting this capability whose runtime pod was unreachable, so their health is UNKNOWN rather than broken. Kept separate from `suspended_instances`: the reconciliation sweep skips an unreachable pod rather than suspending on a transient outage (#1975, RFC §3.9), and this count reports the same way. */
+  health_unknown_instances?: number;
 };
 export type CapabilityEnablementList = {
   items?: CapabilityEnablementItem[];
+};
+export type ImpactedInstanceSummary = {
+  agent_instance_id: string;
+  team_id: string;
+  display_name: string;
+};
+export type CapabilityImpactPreview = {
+  capability_id: string;
+  /** Agents that work today and would be suspended by this change. Excludes agents already broken by this capability — revoking it again does not newly break them. */
+  suspended_instances?: number;
+  /** Selecting instances whose pod is unreachable (impact unknown). */
+  health_unknown_instances?: number;
+  /** The affected agents, for the admin drill-down. */
+  instances?: ImpactedInstanceSummary[];
 };
 export type TeamCapabilityEnablementResult = {
   capability_id: string;
@@ -1875,6 +1911,8 @@ export type TeamCapabilityEnablementResult = {
   };
   /** Dependent agent instances suspended by this change (#1975). */
   suspended_instances?: number;
+  /** Dependent agent instances whose suspension this GRANT cleared (#1975). Only availability suspensions are cleared; an instance still missing another capability stays suspended, and a `capability_config_invalid` one is never touched here (RFC §3.9). */
+  revived_instances?: number;
 };
 export type EnableTeamCapabilityRequest = {
   settings?: {
@@ -1885,6 +1923,8 @@ export type CapabilityDefaultOnResult = {
   capability_id: string;
   default_on: boolean;
   suspended_instances?: number;
+  /** Dependent instances revived by turning default-on ON (#1975). */
+  revived_instances?: number;
 };
 export type SetCapabilityDefaultOnRequest = {
   default_on: boolean;
@@ -2240,6 +2280,8 @@ export const {
   useBootstrapPlatformAdminControlPlaneV1BootstrapPlatformAdminPostMutation,
   useGetAdminCapabilitiesControlPlaneV1AdminCapabilitiesGetQuery,
   useLazyGetAdminCapabilitiesControlPlaneV1AdminCapabilitiesGetQuery,
+  useGetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetQuery,
+  useLazyGetCapabilityRevokeImpactControlPlaneV1AdminCapabilitiesCapabilityIdRevokeImpactGetQuery,
   usePutTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdPutMutation,
   useDeleteTeamCapabilityControlPlaneV1AdminCapabilitiesCapabilityIdTeamsTeamIdDeleteMutation,
   usePutCapabilityDefaultOnControlPlaneV1AdminCapabilitiesCapabilityIdDefaultOnPutMutation,

--- a/docs/swift/platform/authz-endpoint-matrix.yaml
+++ b/docs/swift/platform/authz-endpoint-matrix.yaml
@@ -407,6 +407,11 @@ operations:
     review_status: approved
     required_permission: can_manage_platform # CAPAB-01 / RFC AGENT-CAPABILITY §8.5 — aggregate list gated on organization#can_manage_platform (_require_manage_any)
   - service: control-plane
+    method: GET
+    path: /control-plane/v1/admin/capabilities/{capability_id}/revoke-impact
+    review_status: approved
+    required_permission: can_manage # CAPAB-01 / RFC AGENT-CAPABILITY §8.5 — read-only revoke-impact preview gated on capability#can_manage, same as the disable mutation it precedes (preview_capability_revoke)
+  - service: control-plane
     method: PUT
     path: /control-plane/v1/admin/capabilities/{capability_id}/teams/{team_id}
     review_status: approved


### PR DESCRIPTION
## What & why

Two linked gaps in the capability suspension lifecycle (#1975), sharing one derived predicate.

### 🐛 Fix — grants never un-suspended their agents

`disable_capability_for_team` suspends dependents inline, but the three **grant** paths — enable-for-team, reset-to-default-on, and the default-on toggle — bare-returned `0`. The only path that clears an availability suspension was the reconciliation sweep, which has **no scheduled host yet** (the Temporal lifecycle queue is named as the intended one but is unwired).

**Consequence:** an admin who disabled a capability, watched N agents suspend, then re-enabled it, left those N agents suspended **indefinitely**. The undo didn't undo.

`revive_dependent_instances` now runs after each grant. It passes the **real** availability facts (`can_use` ∩ pod manifests), not the revoke path's synthetic `selected - {id}` — a grant *can't* fake that set, because a second selected capability may still be broken. It clears only availability reasons; a `capability_config_invalid` suspension is left untouched (RFC §3.9, only a successful save clears it).

### ✨ Feature — resting health column + impact preview

- The dashboard's **health column** read session-only React state that reset on refresh. It now shows the real **at-rest** count from a derived predicate (`selected ∩ not-usable`), computed once per list request (one ReBAC `ListObjects` per team, **not** per agent).
- **Attribution is derived, never read from `suspension_reason`** (which records *why*, not *which*). An agent broken by `capa1` while also selecting `capa2` is **not** miscounted against `capa2` — the exact miscount a naive `suspension_reason IS NOT NULL AND capa2 IN selected` query produces.
- **Unreachable pods report as UNKNOWN, never broken**, matching the sweep's `skipped_unreachable` rule — a pod restart is not an outage.
- A new `GET /admin/capabilities/{id}/revoke-impact` endpoint powers a live **"this will suspend N agents"** preview in the pre-disable confirmation dialog, with an affected-agent drill-down (name + team).

## Scope note

Personal-space capability scope (from `feat/agent-capability-1961`) is **intentionally not included**. Those two commits predate AUTHZ-05's authorization-model rewrite (`admin`→`platform_admin`, `owner/manager/member`→`team_*`) that landed on `swift-golive`, so rebasing them is a **port**, not a merge — it deserves its own PR and review. This work is team-scoped only.

## Testing

- **Backend:** 428 tests pass. New `test_capability_impact.py` covers the multi-capability attribution correctness, the revive fix, the config-invalid safety guard (caught a real counter bug during development), and unreachable-pod handling.
- **Frontend:** `make code-quality` clean (tsc + prettier); 45 CapabilitiesPage tests pass (1 updated for the new health states, 2 added).
- Generated OpenAPI client regenerated via `make update-control-plane-api`; new route added to `authz-endpoint-matrix.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)