### PR TITLE
fix(EVAL-AUTH): apply service_agent bypass to tabular dataset access

### DIFF
--- a/.claude/skills/live-observability-session/SKILL.md
+++ b/.claude/skills/live-observability-session/SKILL.md
@@ -2,7 +2,7 @@
 name: live-observability-session
 description: Start Fred's backends and watch their logs/metrics/audit trail live while the developer drives the frontend/chat by hand. Use for manual observability or KPI test campaigns, or to diagnose a "does X actually log/emit/audit correctly" question against the three-stream model in OBSERVABILITY-AND-AUDIT.md.
 user-invocable: true
-argument-hint: [optional: which backends — default all 3 APIs + both Temporal workers]
+argument-hint: [optional: which backends — default 3 core APIs + 2 Temporal workers; add fred-evaluation-backend (+worker) when the session involves agent evaluation]
 ---
 
 # Live Observability Session
@@ -61,9 +61,26 @@ Run each from its own app directory at the monorepo root (`~/Fred/fred`), each i
 | `apps/knowledge-flow-backend` | `make run` | 8111 | yes — `make run-worker` |
 | `apps/fred-agents` | `make run` | 8000 | no |
 
-That's up to 5 background processes (3 APIs + 2 workers). Launch them in parallel — independent
-Bash calls in one message — not sequentially. If the developer only cares about one slice (e.g.
-"just check ingestion KPIs"), ask which subset before launching all 5; don't pay the startup cost
+**Agent evaluation adds a fourth app, in a separate sibling repo** —
+`~/Fred/fred-agent-evaluator/apps/fred-evaluation-backend` (not under `~/Fred/fred`). Include it
+whenever the session involves running or checking an agent evaluation/scoring campaign:
+
+| App | Command | Port | Has a Temporal worker? |
+|---|---|---|---|
+| `fred-agent-evaluator/apps/fred-evaluation-backend` | `make run` | 8336 | yes — `make run-worker-prod` (not plain `run-worker`: this target exports `CONFIG_FILE=configuration_prod.yaml` explicitly and enables M2M against Keycloak, matching how the other three backends run in this stack) |
+
+Its `config/.env` already pins `CONFIG_FILE` to `configuration_prod.yaml` by default (check it
+like the others, don't assume). **This backend's prod config disables both `prometheus` and
+`opensearch` in its logging/metrics block** (`configuration_prod.yaml` → `logging.prometheus.enabled:
+false`, `logging.opensearch.enabled: false`) — its `/metrics` route 404s and it does not feed the
+shared `app-logs-index`. Don't report either as broken; it's the app's own config, not a bug. Its
+only live signal in this stack is its own stdout (Monitor it the same way as the other three) plus
+whatever it writes to Postgres/Temporal directly.
+
+That's up to 7 background processes when evaluation is in scope (4 APIs + 3 workers), or 5 when
+it isn't (3 APIs + 2 workers). Launch whichever set is in scope in parallel — independent Bash
+calls in one message — not sequentially. If the developer only cares about one slice (e.g. "just
+check ingestion KPIs"), ask which subset before launching all of them; don't pay the startup cost
 of backends that aren't part of this session's question.
 
 `make run` installs deps first if needed (`run: dev run-local`) — the first launch after a
@@ -95,7 +112,9 @@ session if it's been a while — it's the target spec, not always the current di
    standalone Prometheus (see Preconditions), so read them by curling each backend's own metrics
    endpoint directly, e.g. `curl localhost:8222/metrics` (control-plane), `localhost:8111/metrics`
    (knowledge-flow), `localhost:8000/metrics` (fred-agents) — grep the raw Prometheus-exposition
-   text output for the metric name you care about. If the developer's session *does* have a real
+   text output for the metric name you care about. `fred-evaluation-backend` (8336) is the
+   exception — its prod config disables `prometheus`, so it has no `/metrics` route; don't curl
+   it, its signal is stdout only. If the developer's session *does* have a real
    Prometheus reachable (a different, non-default setup), `curl localhost:9090/api/v1/query?query=...`
    works the same way — don't assume either way, check the port first. Every label actually
    reaching the KPI store is filtered through `PROMETHEUS_ALLOWED_LABELS` in
@@ -130,6 +149,8 @@ available).
 
 ## Ending the session
 
-Stop the 5 background processes when the developer is done (or when they start a `make clean` /
-infra wipe cycle — those invalidate the running `.venv`s and containers respectively). Don't leave
-them running silently across an unrelated task.
+Stop whichever background processes this session started (5 without evaluation in scope, 7 with
+`fred-evaluation-backend` included) when the developer is done — or when they start a `make clean`
+/ infra wipe cycle (those invalidate the running `.venv`s and containers respectively) either in
+`~/Fred/fred` or, separately, in `~/Fred/fred-agent-evaluator`. Don't leave them running silently
+across an unrelated task.

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/tabular/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/tabular/service.py
@@ -25,7 +25,7 @@ from datetime import timedelta
 
 import duckdb
 import pandas as pd
-from fred_core import DocumentPermission, KeycloakUser, RebacDisabledResult
+from fred_core import DocumentPermission, KeycloakUser, RebacDisabledResult, is_service_agent
 from fred_core.common import OwnerFilter
 from fred_core.documents.document_structures import DocumentMetadata
 
@@ -414,6 +414,15 @@ class TabularService:
 
         if isinstance(authorized_document_ref, RebacDisabledResult):
             visible_documents = await self.metadata_store.get_all_metadata({})
+        elif is_service_agent(user):
+            # EVAL-AUTH (Solution A), mirrors tag_service.resolve_authorized_tag_ids_in_rebac:
+            # the evaluation worker holds no per-user document relations by design, so the
+            # per-user READ lookup above is always empty and would zero out every dataset.
+            # Authorize via the team-scoped tag set instead; fail closed without one.
+            if not scoped_tag_ids:
+                return []
+            tag_documents = await asyncio.gather(*(self.metadata_store.get_metadata_in_tag(tag_id) for tag_id in scoped_tag_ids))
+            visible_documents = [metadata for documents in tag_documents for metadata in documents]
         else:
             authorized_ids = [document.id for document in authorized_document_ref]
             if not authorized_ids:

--- a/apps/knowledge-flow-backend/tests/services/test_tabular_service_service_agent.py
+++ b/apps/knowledge-flow-backend/tests/services/test_tabular_service_service_agent.py
@@ -1,0 +1,134 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""service_agent recognition in tabular dataset authorization (RFC EVAL-AUTH, Solution A).
+
+The evaluation worker (service_agent) must read the TEAM's tabular corpus, scoped to
+team_id, even though it holds no per-user document relations — mirrors
+test_tag_service_service_agent.py, one layer up (documents instead of tags).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fred_core import KeycloakUser
+from fred_core.common import OwnerFilter
+
+from knowledge_flow_backend.application_context import ApplicationContext
+from knowledge_flow_backend.features.tabular.service import TabularService
+from tests.services.test_tabular_service import _FakeRebac, _FakeTagService, _ingest_csv
+
+
+def _user(roles: list[str]) -> KeycloakUser:
+    return KeycloakUser(uid="u", username="u", email="u@example.com", roles=roles)
+
+
+@pytest.mark.asyncio
+async def test_service_agent_sees_team_dataset_despite_empty_user_baseline(tmp_path: Path, metadata_store):
+    content_store = ApplicationContext.get_instance().get_content_store()
+    content_store.clear()
+
+    await _ingest_csv(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        document_uid="doc-team-a",
+        file_name="sales-team-a.csv",
+        content="city,amount\nParis,10\n",
+        tag_ids=["tag-team-a"],
+        tag_names=["Team A"],
+    )
+
+    service = TabularService()
+    # A service_agent holds zero per-user document relations by design.
+    service.rebac = _FakeRebac(set())
+    service.tag_service = _FakeTagService(
+        readable_tag_ids=set(),
+        team_scopes={"team-a": {"tag-team-a"}},
+    )
+
+    datasets = await service.list_datasets(
+        _user(["service_agent"]),
+        owner_filter=OwnerFilter.TEAM,
+        team_id="team-a",
+    )
+    assert [dataset.document_uid for dataset in datasets] == ["doc-team-a"]
+
+    schema = await service.describe_dataset(
+        _user(["service_agent"]),
+        "doc-team-a",
+        owner_filter=OwnerFilter.TEAM,
+        team_id="team-a",
+    )
+    assert schema.document_uid == "doc-team-a"
+
+
+@pytest.mark.asyncio
+async def test_service_agent_without_team_fails_closed(tmp_path: Path, metadata_store):
+    content_store = ApplicationContext.get_instance().get_content_store()
+    content_store.clear()
+
+    await _ingest_csv(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        document_uid="doc-team-a",
+        file_name="sales-team-a.csv",
+        content="city,amount\nParis,10\n",
+        tag_ids=["tag-team-a"],
+        tag_names=["Team A"],
+    )
+
+    service = TabularService()
+    service.rebac = _FakeRebac(set())
+    service.tag_service = _FakeTagService(
+        readable_tag_ids=set(),
+        team_scopes={"team-a": {"tag-team-a"}},
+    )
+
+    assert await service.list_datasets(_user(["service_agent"])) == []
+
+
+@pytest.mark.asyncio
+async def test_normal_user_still_uses_per_user_rebac_lookup(tmp_path: Path, metadata_store):
+    content_store = ApplicationContext.get_instance().get_content_store()
+    content_store.clear()
+
+    await _ingest_csv(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        document_uid="doc-team-a",
+        file_name="sales-team-a.csv",
+        content="city,amount\nParis,10\n",
+        tag_ids=["tag-team-a"],
+        tag_names=["Team A"],
+    )
+
+    service = TabularService()
+    # A regular user with no readable-document tuple must still be denied, even
+    # though the team owns the tag — the service_agent bypass must not leak to them.
+    service.rebac = _FakeRebac(set())
+    service.tag_service = _FakeTagService(
+        readable_tag_ids=set(),
+        team_scopes={"team-a": {"tag-team-a"}},
+    )
+
+    assert (
+        await service.list_datasets(
+            _user(["viewer"]),
+            owner_filter=OwnerFilter.TEAM,
+            team_id="team-a",
+        )
+        == []
+    )


### PR DESCRIPTION
## Summary
- The evaluation worker's M2M service account (`service-account-fred-evaluation-worker`) holds no per-user ReBAC relations by design (RFC EVAL-AUTH, Solution A). `tag_service.py` already authorizes it via the request's team-scoped tag set, but `TabularService._resolve_authorized_datasets` still gated on the per-user `lookup_user_resources()` call, which is always empty for this identity — zeroing out every tabular dataset and 403'ing `get_tabular_dataset_schema` on every agent-evaluation run that touches team-owned tabular corpus.
- Mirrors the existing `tag_service.py` pattern: for `is_service_agent(user)`, resolve visible documents via the team-scoped tag set instead of the per-user lookup, failing closed without a team context.
- Bonus: extends `.claude/skills/live-observability-session/SKILL.md` to cover `fred-evaluation-backend` (separate sibling repo, no `/metrics`/OpenSearch in its prod config) — found needed while live-debugging this issue.

## Root cause (see #2018 for the full diagnostic trail, including the initial — corrected — hypothesis)
Confirmed via live reproduction with `fred-evaluation-backend` running a real evaluation campaign against `fred.github.assistant`: `get_tabular_dataset_schema` 403'd on every case touching the team's tabular corpus, while open-ended vector search silently returned empty results for the same underlying reason. Traced to `knowledge_flow_backend/features/tabular/service.py` never having received the `is_service_agent` bypass that `tag_service.py` and `control-plane-backend/teams/service.py` already have.

## Test plan
- [x] `make code-quality` (knowledge-flow-backend) — clean
- [x] `make test` (knowledge-flow-backend) — 381 passed, no regressions
- [x] New tests: `tests/services/test_tabular_service_service_agent.py` — service_agent sees team-owned dataset; fails closed without team scope; a normal user with the same empty ReBAC baseline still gets denied (no bypass leak)
- [x] Live-verified: restarted knowledge-flow-backend with the fix and re-ran the actual evaluation campaign — `get_tabular_dataset_schema` now completes cleanly (audit log `outcome: succeeded` with no `403`/`Not authorized` in between), where it 403'd on every prior call

Fixes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)