### PR TITLE
feat(CTRLP-15): native GCS content store for control-plane team assets

### DIFF
--- a/apps/control-plane-backend/config/schema/configuration.schema.json
+++ b/apps/control-plane-backend/config/schema/configuration.schema.json
@@ -143,6 +143,54 @@
       "type": "object",
       "additionalProperties": false
     },
+    "GcsContentStorageConfig": {
+      "description": "Google Cloud Storage content store. Authentication uses Application Default\nCredentials / Workload Identity (no JSON key required).",
+      "properties": {
+        "type": {
+          "const": "gcs",
+          "title": "Type",
+          "type": "string"
+        },
+        "bucket_name": {
+          "default": "control-plane-content",
+          "description": "Content store bucket name (suffix '-objects' is used for banner objects)",
+          "title": "Bucket Name",
+          "type": "string"
+        },
+        "project_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "GCP project id; inferred from ADC when empty.",
+          "title": "Project Id"
+        },
+        "signing_service_account_email": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Service account email used to sign V4 signed URLs for browser-facing banner/logo images, via IAM signBlob under Workload Identity (no JSON key). Required for content_storage.type=gcs; startup fails clearly when omitted. The Workload Identity service account must hold iam.serviceAccounts.signBlob on this account, which must have storage.objects.get on the objects bucket.",
+          "title": "Signing Service Account Email"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "GcsContentStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
     "InMemoryLogStorageConfig": {
       "properties": {
         "type": {
@@ -916,6 +964,7 @@
         "content_storage": {
           "discriminator": {
             "mapping": {
+              "gcs": "#/$defs/GcsContentStorageConfig",
               "local": "#/$defs/LocalContentStorageConfig",
               "minio": "#/$defs/MinioContentStorageConfig"
             },
@@ -927,6 +976,9 @@
             },
             {
               "$ref": "#/$defs/MinioContentStorageConfig"
+            },
+            {
+              "$ref": "#/$defs/GcsContentStorageConfig"
             }
           ],
           "title": "Content Storage"

--- a/apps/control-plane-backend/control_plane_backend/app/context.py
+++ b/apps/control-plane-backend/control_plane_backend/app/context.py
@@ -19,7 +19,12 @@ from fred_core.scheduler import (
     resolve_scheduler_backend,
 )
 from fred_core.sql import create_async_engine_from_config
-from fred_core.store import ContentStore, LocalContentStore, MinioContentStore
+from fred_core.store import (
+    ContentStore,
+    GcsContentStore,
+    LocalContentStore,
+    MinioContentStore,
+)
 from fred_core.tasks.service import TaskService
 from fred_core.teams.metadata_store import TeamMetadataStore
 from prometheus_client import start_http_server
@@ -33,6 +38,7 @@ from control_plane_backend.capabilities.settings_store import (
 from control_plane_backend.config.loader import get_loaded_config_file_path
 from control_plane_backend.config.models import (
     Configuration,
+    GcsContentStorageConfig,
     LocalContentStorageConfig,
     MinioContentStorageConfig,
 )
@@ -200,6 +206,26 @@ class ApplicationContext:
                     secure=cfg.secure,
                     public_endpoint=cfg.public_endpoint,
                     public_secure=cfg.public_secure,
+                )
+            elif isinstance(cfg, GcsContentStorageConfig):
+                # Fail fast at startup: banner/logo images are served straight to the
+                # browser via get_presigned_url, which needs a signing SA to mint V4
+                # signed URLs via IAM signBlob (no per-feature flag to detect that
+                # usage later, so a missing email must stop the boot here rather than
+                # surfacing as an opaque runtime error on first team-banner render).
+                if not cfg.signing_service_account_email:
+                    raise ValueError(
+                        "content_storage.type=gcs requires 'signing_service_account_email' "
+                        "to sign V4 signed URLs for team banner/logo images (IAM signBlob "
+                        "under Workload Identity, no JSON key). Set it to the signing "
+                        "service account that holds storage.objects.get on the objects "
+                        "bucket and on which the Workload Identity service account has "
+                        "iam.serviceAccounts.signBlob."
+                    )
+                self._content_store = GcsContentStore(
+                    bucket_name=f"{cfg.bucket_name}-objects",
+                    project_id=cfg.project_id,
+                    signing_service_account_email=cfg.signing_service_account_email,
                 )
             elif isinstance(cfg, LocalContentStorageConfig):
                 self._content_store = LocalContentStore(root_path=cfg.root_path)

--- a/apps/control-plane-backend/control_plane_backend/config/models.py
+++ b/apps/control-plane-backend/control_plane_backend/config/models.py
@@ -286,8 +286,37 @@ class LocalContentStorageConfig(BaseModel):
     )
 
 
+class GcsContentStorageConfig(BaseModel):
+    """
+    Google Cloud Storage content store. Authentication uses Application Default
+    Credentials / Workload Identity (no JSON key required).
+    """
+
+    type: Literal["gcs"]
+    bucket_name: str = Field(
+        default="control-plane-content",
+        description="Content store bucket name (suffix '-objects' is used for banner objects)",
+    )
+    project_id: str | None = Field(
+        default=None, description="GCP project id; inferred from ADC when empty."
+    )
+    signing_service_account_email: str | None = Field(
+        default=None,
+        description=(
+            "Service account email used to sign V4 signed URLs for browser-facing "
+            "banner/logo images, via IAM signBlob under Workload Identity (no JSON "
+            "key). Required for content_storage.type=gcs; startup fails clearly when "
+            "omitted. The Workload Identity service account must hold "
+            "iam.serviceAccounts.signBlob on this account, which must have "
+            "storage.objects.get on the objects bucket."
+        ),
+    )
+
+
 ContentStorageConfig = Annotated[
-    Union[LocalContentStorageConfig, MinioContentStorageConfig],
+    Union[
+        LocalContentStorageConfig, MinioContentStorageConfig, GcsContentStorageConfig
+    ],
     Field(discriminator="type"),
 ]
 

--- a/apps/control-plane-backend/pyproject.toml
+++ b/apps/control-plane-backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "control-plane-backend"
 readme = "README.md"
-version = "1.6.0"
+version = "1.6.1"
 license = "Apache-2.0"
 description = "Minimal control-plane backend for team lifecycle and policy resolution"
 authors = [{ name = "Fred", email = "noreply@example.com" }]

--- a/apps/control-plane-backend/tests/test_content_store_factory_gcs.py
+++ b/apps/control-plane-backend/tests/test_content_store_factory_gcs.py
@@ -1,0 +1,76 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Factory-level tests for the control-plane GCS content store (issue #2022).
+
+Mirrors knowledge-flow's equivalent fail-fast guard test: banner/logo images
+are served straight to the browser via get_presigned_url, so a GCS content
+store without a signing service account email is a deployment error that must
+surface clearly at startup rather than as a silently-missing banner later.
+"""
+
+from __future__ import annotations
+
+import pytest
+from control_plane_backend.app.context import ApplicationContext
+from control_plane_backend.config.loader import load_configuration
+from control_plane_backend.config.models import GcsContentStorageConfig
+from fred_core.store import GcsContentStore
+from fred_core.store import gcs_content_store as gcs_content_store_module
+
+
+def _context(monkeypatch: pytest.MonkeyPatch) -> ApplicationContext:
+    monkeypatch.setenv("CONFIG_FILE", "./config/configuration_test.yaml")
+    return ApplicationContext(load_configuration())
+
+
+def test_gcs_content_store_factory_fails_fast_without_signing_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _context(monkeypatch)
+    ctx.configuration.storage.content_storage = GcsContentStorageConfig(
+        type="gcs", bucket_name="fred"
+    )
+
+    with pytest.raises(ValueError, match="signing_service_account_email"):
+        ctx.get_content_store()
+
+
+class _FakeClient:
+    def bucket(self, name: str) -> object:
+        return object()
+
+
+def test_gcs_content_store_factory_builds_store_with_suffixed_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        gcs_content_store_module,
+        "build_gcs_client",
+        lambda project_id=None: _FakeClient(),
+    )
+    ctx = _context(monkeypatch)
+    ctx.configuration.storage.content_storage = GcsContentStorageConfig(
+        type="gcs",
+        bucket_name="fred",
+        signing_service_account_email="signer@project.iam.gserviceaccount.com",
+    )
+
+    store = ctx.get_content_store()
+
+    assert isinstance(store, GcsContentStore)
+    assert store.bucket_name == "fred-objects"
+    assert (
+        store.signing_service_account_email == "signer@project.iam.gserviceaccount.com"
+    )

--- a/apps/control-plane-backend/uv.lock
+++ b/apps/control-plane-backend/uv.lock
@@ -369,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "control-plane-backend"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/fred-agents/uv.lock
+++ b/apps/fred-agents/uv.lock
@@ -614,7 +614,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/frontend/public/release.md
+++ b/apps/frontend/public/release.md
@@ -1,3 +1,22 @@
+**v2.1.7** — 2026-07-20
+
+- **Summary**
+
+  Adds native Google Cloud Storage support for control-plane's team personalization assets (banner/logo images), and fixes GCS authentication on Trusted Partner Cloud / sovereign deployments such as S3NS.
+
+- **Features**
+
+  - Control-plane can now load team banner/logo assets from a native GCS bucket via Application Default Credentials / Workload Identity, in addition to the existing MinIO/S3-compatible and local filesystem backends (`content_storage.type: gcs`, control-plane-backend, fred-core, #2022)
+  - New `signing_service_account_email` config knob for control-plane's GCS content store — mints short-lived V4 signed URLs via IAM `signBlob` (keyless) so team banners/logos remain viewable in the browser, extending the signing mechanism already used for knowledge-flow's internal tabular Parquet reads (`docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md` §6)
+
+- **Bug Fixes**
+
+  - Fix `UniverseMismatchError` ("The configured universe domain (googleapis.com) does not match the universe domain found in the credentials") on every native-GCS backend (control-plane's new content store, knowledge-flow's content store and file store, fred-core's virtual filesystem) when deployed on a Trusted Partner Cloud / sovereign GCP variant such as S3NS — the GCS client now derives its universe domain from the loaded ADC credentials instead of assuming the public `googleapis.com` default, so the same code works unmodified on public GCP and on S3NS (`fred-core` 3.4.6, `knowledge-flow-backend` 1.5.3, `control-plane-backend` 1.6.1)
+
+- **Deployment note**
+
+  No new required config for existing MinIO/local deployments — additive only. GCS deployments (including already-running knowledge-flow-on-S3NS instances) pick up the universe-domain fix automatically on upgrade, no config change needed. Control-plane's new `gcs` backend needs `storage.content_storage.signing_service_account_email` set (see `deploy/charts/fred/values-gcp.yaml`) — the signing service account needs `storage.objects.get` on the control-plane `-objects` bucket, and the Workload Identity service account needs `iam.serviceAccounts.signBlob` on it (may reuse the same signing account already configured for knowledge-flow's tabular reads).
+
 **v2.1.6** — 2026-07-20
 
 - **Summary**

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/gcs_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/gcs_content_store.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from typing import BinaryIO, List, Optional
 
 import google.auth
+from fred_core.common.gcs_client import build_gcs_client
 from google.auth.transport.requests import Request as GoogleAuthRequest
-from google.cloud import storage
 from google.cloud.exceptions import NotFound
 
 from knowledge_flow_backend.core.stores.content.base_content_store import BaseContentStore, FileMetadata, StoredObjectInfo
@@ -85,7 +85,7 @@ class GcsContentStore(BaseContentStore):
         # the access token for IAM signBlob. None until the first signing call.
         self._signing_credentials = None
 
-        self.client = storage.Client(project=project_id) if project_id else storage.Client()
+        self.client = build_gcs_client(project_id)
         self.document_bucket = self.client.bucket(document_bucket)
         self.object_bucket = self.client.bucket(object_bucket)
         logger.info(

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/files/gcs_file_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/files/gcs_file_store.py
@@ -16,7 +16,7 @@ import hashlib
 import logging
 from typing import Optional
 
-from google.cloud import storage
+from fred_core.common.gcs_client import build_gcs_client
 from google.cloud.exceptions import NotFound
 
 from knowledge_flow_backend.core.stores.files.base_file_store import BaseFileStore, FileInfo
@@ -35,7 +35,7 @@ class GcsFileStore(BaseFileStore):
 
     def __init__(self, bucket_name: str, project_id: Optional[str] = None):
         self.bucket_name = bucket_name
-        self.client = storage.Client(project=project_id) if project_id else storage.Client()
+        self.client = build_gcs_client(project_id)
         self.bucket = self.client.bucket(bucket_name)
 
     def put(self, namespace: str, key: str, content: bytes, content_type: str = "application/octet-stream") -> FileInfo:

--- a/apps/knowledge-flow-backend/pyproject.toml
+++ b/apps/knowledge-flow-backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "knowledge-flow-backend"
 readme = "README.md"
-version = "1.5.2"
+version = "1.5.3"
 license = "Apache-2.0"
 description = "Knowledge Flow Backend"
 authors = [{ name = "Fred", email = "noreply@example.com" }]

--- a/apps/knowledge-flow-backend/tests/stores/content/test_gcs_content_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/content/test_gcs_content_store.py
@@ -112,7 +112,7 @@ def gcs_store(monkeypatch):
     from knowledge_flow_backend.core.stores.content import gcs_content_store
 
     buckets: dict[str, dict] = {}
-    monkeypatch.setattr(gcs_content_store.storage, "Client", lambda *a, **k: _FakeClient(buckets))
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient(buckets))
     store = gcs_content_store.GcsContentStore(document_bucket="kf-documents", object_bucket="kf-objects")
     store._buckets = buckets
     return store
@@ -215,7 +215,7 @@ def test_constructor_stores_signing_service_account_email(monkeypatch):
     """
     from knowledge_flow_backend.core.stores.content import gcs_content_store
 
-    monkeypatch.setattr(gcs_content_store.storage, "Client", lambda *a, **k: _FakeClient({}))
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient({}))
     store = gcs_content_store.GcsContentStore(
         document_bucket="kf-documents",
         object_bucket="kf-objects",
@@ -229,7 +229,7 @@ def test_constructor_defaults_signing_email_to_none(monkeypatch):
     """Construction without a signing email is allowed; the factory enforces it."""
     from knowledge_flow_backend.core.stores.content import gcs_content_store
 
-    monkeypatch.setattr(gcs_content_store.storage, "Client", lambda *a, **k: _FakeClient({}))
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient({}))
     store = gcs_content_store.GcsContentStore(document_bucket="kf-documents", object_bucket="kf-objects")
 
     assert store.signing_service_account_email is None
@@ -262,7 +262,7 @@ class _RecordingSignBucket:
 def _signing_store(monkeypatch, captured: dict, *, email="signer@project.iam.gserviceaccount.com"):
     from knowledge_flow_backend.core.stores.content import gcs_content_store
 
-    monkeypatch.setattr(gcs_content_store.storage, "Client", lambda *a, **k: _FakeClient({}))
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient({}))
     store = gcs_content_store.GcsContentStore(
         document_bucket="kf-documents",
         object_bucket="kf-objects",
@@ -328,7 +328,7 @@ def test_mint_access_token_uses_adc_and_refreshes(monkeypatch):
             self.token = "minted-token"
 
     fake_creds = _FakeCreds()
-    monkeypatch.setattr(gcs_content_store.storage, "Client", lambda *a, **k: _FakeClient({}))
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient({}))
     monkeypatch.setattr(gcs_content_store, "_load_adc_credentials", lambda: fake_creds)
 
     store = gcs_content_store.GcsContentStore(

--- a/apps/knowledge-flow-backend/uv.lock
+++ b/apps/knowledge-flow-backend/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1867,7 +1867,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-flow-backend"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },

--- a/deploy/charts/fred/values-gcp.yaml
+++ b/deploy/charts/fred/values-gcp.yaml
@@ -23,8 +23,9 @@
 # Helm DEEP-MERGES maps, so the base `content_storage.root_path` / `filesystem`
 # minio keys would remain and FAIL schema validation. Therefore the storage
 # blocks below are meant to REPLACE the base ones: either
-#   (a) edit the `x-kf-content-storage` / `x-kf-filesystem` / `x-kf-storage`
-#       anchors in values.yaml directly with the blocks shown here, or
+#   (a) edit the `x-kf-content-storage` / `x-kf-filesystem` / `x-kf-storage` /
+#       `x-cp-storage` anchors in values.yaml directly with the blocks shown
+#       here, or
 #   (b) keep a dedicated GKE values.yaml whose anchors already use these values.
 # The non-storage overrides (serviceAccount annotations, dotenv) are safe to use
 # as a `-f` overlay as-is.
@@ -32,6 +33,38 @@
 # Replace every <PLACEHOLDER> below for your project.
 
 applications:
+  control-plane-backend:
+    # --- Workload Identity: bind the KSA to a Google service account (GSA) ---
+    # The GSA needs roles/storage.objectAdmin on the content bucket, and
+    # iam.serviceAccounts.signBlob on the signing service account below
+    # (typically roles/iam.serviceAccountTokenCreator) — team banner/logo
+    # images are served straight to the browser via a V4 signed URL, so this
+    # signing account is required, not just an internal nicety (see
+    # docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md).
+    serviceAccount:
+      annotations:
+        iam.gke.io/gcp-service-account: "<GSA_NAME>@<GCP_PROJECT_ID>.iam.gserviceaccount.com"
+
+    configuration:
+      storage:
+        # --- Content store: native GCS (bucket must already exist) ---
+        # bucket_name is suffixed at runtime → -objects (team banners/logos).
+        content_storage:
+          type: gcs
+          bucket_name: "<CONTENT_BUCKET_PREFIX>" # e.g. <GCP_PROJECT_ID>-cp-content
+          project_id: "" # optional; inferred from ADC when empty
+          # Required: service account used to sign V4 signed URLs for
+          # browser-facing banner/logo images via IAM signBlob (keyless).
+          # Startup fails clearly if unset. It needs storage.objects.get on the
+          # -objects bucket; the GSA above needs iam.serviceAccounts.signBlob
+          # on it. May be the GSA itself (self-signing).
+          signing_service_account_email: "<GSA_NAME>@<GCP_PROJECT_ID>.iam.gserviceaccount.com"
+
+    dotenv:
+      KEYCLOAK_CONTROL_PLANE_CLIENT_SECRET: ""
+      FRED_POSTGRES_PASSWORD: ""
+      OPENFGA_API_TOKEN: ""
+
   knowledge-flow-backend:
     # --- Workload Identity: bind the KSA to a Google service account (GSA) ---
     # The GSA needs roles/storage.objectAdmin on the content + fs buckets, and

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -12533,6 +12533,7 @@
                     "content_storage": {
                       "discriminator": {
                         "mapping": {
+                          "gcs": "#/$defs/GcsContentStorageConfig",
                           "local": "#/$defs/LocalContentStorageConfig",
                           "minio": "#/$defs/MinioContentStorageConfig"
                         },
@@ -12632,6 +12633,54 @@
                             "access_key"
                           ],
                           "title": "MinioContentStorageConfig",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "Google Cloud Storage content store. Authentication uses Application Default\nCredentials / Workload Identity (no JSON key required).",
+                          "properties": {
+                            "type": {
+                              "const": "gcs",
+                              "title": "Type",
+                              "type": "string"
+                            },
+                            "bucket_name": {
+                              "default": "control-plane-content",
+                              "description": "Content store bucket name (suffix '-objects' is used for banner objects)",
+                              "title": "Bucket Name",
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "GCP project id; inferred from ADC when empty.",
+                              "title": "Project Id"
+                            },
+                            "signing_service_account_email": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Service account email used to sign V4 signed URLs for browser-facing banner/logo images, via IAM signBlob under Workload Identity (no JSON key). Required for content_storage.type=gcs; startup fails clearly when omitted. The Workload Identity service account must hold iam.serviceAccounts.signBlob on this account, which must have storage.objects.get on the objects bucket.",
+                              "title": "Signing Service Account Email"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "title": "GcsContentStorageConfig",
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -14311,6 +14360,7 @@
                     "content_storage": {
                       "discriminator": {
                         "mapping": {
+                          "gcs": "#/$defs/GcsContentStorageConfig",
                           "local": "#/$defs/LocalContentStorageConfig",
                           "minio": "#/$defs/MinioContentStorageConfig"
                         },
@@ -14410,6 +14460,54 @@
                             "access_key"
                           ],
                           "title": "MinioContentStorageConfig",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "Google Cloud Storage content store. Authentication uses Application Default\nCredentials / Workload Identity (no JSON key required).",
+                          "properties": {
+                            "type": {
+                              "const": "gcs",
+                              "title": "Type",
+                              "type": "string"
+                            },
+                            "bucket_name": {
+                              "default": "control-plane-content",
+                              "description": "Content store bucket name (suffix '-objects' is used for banner objects)",
+                              "title": "Bucket Name",
+                              "type": "string"
+                            },
+                            "project_id": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "GCP project id; inferred from ADC when empty.",
+                              "title": "Project Id"
+                            },
+                            "signing_service_account_email": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Service account email used to sign V4 signed URLs for browser-facing banner/logo images, via IAM signBlob under Workload Identity (no JSON key). Required for content_storage.type=gcs; startup fails clearly when omitted. The Workload Identity service account must hold iam.serviceAccounts.signBlob on this account, which must have storage.objects.get on the objects bucket.",
+                              "title": "Signing Service Account Email"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "title": "GcsContentStorageConfig",
                           "type": "object",
                           "additionalProperties": false
                         }

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -1049,6 +1049,31 @@ items:
       GitHub #2004 on branch `2004-capab-01-agent-template-capability-gating-gaps`.
       See `AGENT-CAPABILITY-RFC.md` §8.6's 2026-07-19 dated entry for the design.
 
+  - id: CTRLP-15
+    title: "Control-plane content store: native GCS backend for team banner/logo assets"
+    status: in_progress
+    owner: Dimitri
+    parent: FILES-06
+    refs:
+      rfc: "docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md §6"
+      execution: "GitHub issue #2022; branch 2022-make-control-plane-use-gcs-for-loading-its-initial-assets"
+    notes: >
+      Adds a `gcs` variant to control-plane's `storage.content_storage`
+      (`GcsContentStorageConfig`), backed by a new `fred_core.store.GcsContentStore`
+      (put_object + get_presigned_url). Unlike knowledge-flow's GCS content store,
+      whose browser-facing `get_presigned_url` stays unsupported in favor of
+      application-level HMAC tokens (FILES-06 / GCS-TABULAR-SIGNED-URL-RFC §2),
+      the control-plane has no such token flow for team banner/logo images —
+      `TeamService` hands the presigned URL straight to the frontend `<img>`. So
+      this store's `get_presigned_url` mints a real short-lived V4 signed URL via
+      IAM signBlob under Workload Identity (no JSON key), same mechanism as
+      knowledge-flow's internal tabular signing, formalized in
+      GCS-TABULAR-SIGNED-URL-RFC §6 (amendment 2026-07-20). Config requires
+      `signing_service_account_email`; startup fails fast if omitted while
+      `type: gcs` is set. MinIO/S3-compatible and local content stores are
+      unaffected. `deploy/charts/fred/values-gcp.yaml` gained a matching
+      `control-plane-backend` GCS example block.
+
   # ── EVAL ──────────────────────────────────────────────────────────────
 
   - id: EVAL-01

--- a/docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md
+++ b/docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md
@@ -171,3 +171,47 @@ surface for GCS deployments and leaves the indexed Parquet artifacts unusable.
 - A live GKE validation run proves DuckDB can query a Parquet artifact through
   the generated V4 signed URL.
 - GKE deployment docs list the required IAM permissions and config knobs.
+
+---
+
+## 6. Amendment (2026-07-20) — Browser-Facing Signed URLs For Control-Plane Assets
+
+§2 deliberately scoped signed-URL support to backend-internal tabular reads
+and left "a separate browser direct-download decision" open. Issue #2022 is
+that decision, for a narrower and different case than knowledge-flow document
+sharing.
+
+**Problem**: the control-plane serves team personalization assets (banner and
+logo images) straight to the browser — `TeamService` calls
+`ContentStore.get_presigned_url(...)` directly and hands the URL to the
+frontend `<img src>` (`control_plane_backend/teams/service.py`). Unlike
+knowledge-flow's document/VFS sharing, the control-plane has no
+application-level HMAC token flow to fall back on, so leaving
+`get_presigned_url` unsupported for GCS silently breaks team branding on GCS
+deployments (the caller already catches and logs, so the failure mode is a
+missing banner, not a crash).
+
+**Decision**: extend real V4 signed URLs, minted the same way (IAM `signBlob`
+under Workload Identity, no JSON key), to `fred_core.store.GcsContentStore`'s
+public `get_presigned_url(...)` — the method browser-facing callers use. This
+is scoped to `fred-core`'s generic object store (`libs/fred-core/fred_core/store/`),
+which backs the control-plane's team banner/logo objects only:
+
+- Config: `control-plane-backend`'s `storage.content_storage` gains a `gcs`
+  variant (`GcsContentStorageConfig`) with the same
+  `signing_service_account_email` field and fail-fast-at-startup validation
+  as knowledge-flow's `GcsStorageConfig`.
+- IAM: the signing service account needs `storage.objects.get` on the
+  control-plane's `-objects` bucket; the Workload Identity service account
+  needs `iam.serviceAccounts.signBlob` on it. Independent from — but may
+  reuse — the signing account configured for knowledge-flow's tabular reads.
+- TTL stays short (1 hour, set by the caller in `teams/service.py`).
+- Knowledge-flow's own `GcsContentStore.get_presigned_url` (browser-facing
+  document sharing) is **unchanged** — it still raises `NotImplementedError`
+  and relies on application-level HMAC tokens. This amendment does not revisit
+  that choice; the control-plane simply has no equivalent token mechanism to
+  reuse.
+
+This keeps the cross-backend invariant from §4: MinIO/S3-compatible and local
+content stores are unaffected: their `get_presigned_url` already worked for
+the browser-facing banner case.

--- a/libs/fred-core/fred_core/common/__init__.py
+++ b/libs/fred-core/fred_core/common/__init__.py
@@ -20,6 +20,7 @@ from .config_loader import (
 )
 from .env import coerce_bool, read_env_bool
 from .fastapi_handlers import register_exception_handlers
+from .gcs_client import build_gcs_client
 from .lru_cache import ThreadSafeLRUCache
 from .resilient_sink import ResilientSinkStore
 from .structures import (
@@ -64,6 +65,7 @@ __all__ = [
     "ResilientSinkStore",
     "TemporalSchedulerConfig",
     "ThreadSafeLRUCache",
+    "build_gcs_client",
     "coerce_bool",
     "load_configuration_with_config_files",
     "parse_yaml_mapping_file",

--- a/libs/fred-core/fred_core/common/gcs_client.py
+++ b/libs/fred-core/fred_core/common/gcs_client.py
@@ -1,0 +1,52 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Optional
+
+import google.auth
+from google.api_core.client_options import ClientOptions
+from google.cloud import storage
+
+
+def build_gcs_client(project_id: Optional[str] = None) -> storage.Client:
+    """Build a GCS client whose universe domain matches the loaded ADC credentials.
+
+    Why this exists:
+    - Bare ``storage.Client(project=project_id)`` implicitly assumes the
+      ``googleapis.com`` universe domain. Under Trusted Partner Cloud /
+      sovereign deployments (e.g. S3NS, the Thales/Google joint venture cloud
+      in France), Workload Identity Federation ADC credentials declare a
+      different universe domain (e.g. ``s3nsapis.fr``), and the client raises
+      ``google.api_core.universe.UniverseMismatchError`` the moment it tries
+      to authenticate: "The configured universe domain (googleapis.com) does
+      not match the universe domain found in the credentials (s3nsapis.fr)."
+    - Explicitly loading ADC and mirroring ``credentials.universe_domain``
+      into ``client_options`` makes every GCS-backed store portable across
+      public GCP and sovereign GCP variants with zero extra configuration —
+      the client always trusts whatever universe the credentials actually
+      belong to instead of assuming the public default.
+
+    Used by every native-GCS backend (fred-core's content store and virtual
+    filesystem, knowledge-flow's content store and file store) so the fix
+    lives in one place.
+    """
+
+    credentials, adc_project = google.auth.default()
+    return storage.Client(
+        project=project_id or adc_project,
+        credentials=credentials,
+        client_options=ClientOptions(universe_domain=credentials.universe_domain),
+    )

--- a/libs/fred-core/fred_core/filesystem/gcs_filesystem.py
+++ b/libs/fred-core/fred_core/filesystem/gcs_filesystem.py
@@ -17,12 +17,12 @@ import re
 import time
 from typing import List, Optional, Set
 
+from fred_core.common.gcs_client import build_gcs_client
 from fred_core.filesystem.structures import (
     BaseFilesystem,
     FilesystemResourceInfo,
     FilesystemResourceInfoResult,
 )
-from google.cloud import storage
 from google.cloud.exceptions import NotFound
 
 logger = logging.getLogger(__name__)
@@ -67,9 +67,7 @@ class GcsFilesystem(BaseFilesystem):
         # Prefix injected externally by the app if needed (mirrors MinioFilesystem).
         self.prefix: str | None = None
 
-        self.client = (
-            storage.Client(project=project_id) if project_id else storage.Client()
-        )
+        self.client = build_gcs_client(project_id)
         self.bucket = self.client.bucket(bucket_name)
 
     def health_check(self) -> dict:

--- a/libs/fred-core/fred_core/store/__init__.py
+++ b/libs/fred-core/fred_core/store/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from fred_core.store.base_content_store import ContentStore
+from fred_core.store.gcs_content_store import GcsContentStore
 from fred_core.store.local_content_store import LocalContentStore
 from fred_core.store.minio_content_store import MinioContentStore
 from fred_core.store.opensearch_mapping_validator import (
@@ -23,6 +24,7 @@ from fred_core.store.vector_search import VectorSearchHit
 
 __all__ = [
     "ContentStore",
+    "GcsContentStore",
     "LocalContentStore",
     "MappingValidationError",
     "MinioContentStore",

--- a/libs/fred-core/fred_core/store/gcs_content_store.py
+++ b/libs/fred-core/fred_core/store/gcs_content_store.py
@@ -1,0 +1,197 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import io
+import logging
+from datetime import timedelta
+from typing import BinaryIO, Optional
+
+import google.auth
+from google.auth.transport.requests import Request as GoogleAuthRequest
+from google.cloud.exceptions import NotFound
+
+from fred_core.common.gcs_client import build_gcs_client
+
+logger = logging.getLogger(__name__)
+
+# OAuth2 scope required to mint the access token that authorizes the IAM
+# signBlob call used for keyless V4 URL signing under Workload Identity.
+_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+
+def _load_adc_credentials():
+    """Return Application Default Credentials able to mint OAuth2 access tokens.
+
+    Why this exists:
+    - Keyless V4 signing needs an access token for the IAM signBlob API. This is
+      isolated as a module function so tests can substitute it without reaching
+      into the shared ``google.auth`` namespace.
+    """
+    credentials, _ = google.auth.default(scopes=[_CLOUD_PLATFORM_SCOPE])
+    return credentials
+
+
+class GcsContentStore:
+    """Content store backed by Google Cloud Storage.
+
+    Why this exists:
+    - Deployments on GKE want native GCS instead of MinIO, authenticated via
+      Application Default Credentials / Workload Identity (no JSON key).
+
+    Signed URLs need special care under Workload Identity: there is no service
+    account private key, so plain ``blob.generate_signed_url()`` fails. This
+    store mints short-lived V4 signed URLs via IAM ``signBlob`` impersonation
+    of ``signing_service_account_email`` instead — the same keyless mechanism
+    already used for backend-internal tabular Parquet reads in
+    knowledge-flow's ``GcsContentStore`` (see
+    ``docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md``). Callers here are
+    browser-facing (e.g. team banner images), which that RFC left open as "a
+    separate browser direct-download decision" — this class is that decision,
+    scoped to fred-core's generic object store only.
+
+    Basic usage:
+    ```python
+    from io import BytesIO
+    from fred_core.store import GcsContentStore
+
+    store = GcsContentStore(
+        bucket_name="fred-objects",
+        signing_service_account_email="fred-sa@my-project.iam.gserviceaccount.com",
+    )
+    store.put_object("teams/t1/banner.png", BytesIO(b"..."), content_type="image/png")
+    url = store.get_presigned_url("teams/t1/banner.png")
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket_name: str,
+        project_id: Optional[str] = None,
+        signing_service_account_email: Optional[str] = None,
+    ) -> None:
+        """Bind to a GCS bucket using ADC. The bucket must already exist.
+
+        `signing_service_account_email` is required to call `get_presigned_url`;
+        callers that only write objects can omit it, but the application factory
+        should fail fast when it is missing for a deployment that needs it.
+        """
+
+        self.bucket_name = bucket_name
+        self.signing_service_account_email = signing_service_account_email
+        # Lazily-acquired ADC credentials, cached and refreshed on demand to mint
+        # the access token for IAM signBlob. None until the first signing call.
+        self._signing_credentials = None
+
+        self.client = build_gcs_client(project_id)
+        self.bucket = self.client.bucket(bucket_name)
+        logger.info(
+            "[CONTENT][GCS] Initialized GcsContentStore bucket='%s'", bucket_name
+        )
+
+    @staticmethod
+    def _normalize_key(key: str) -> str:
+        """Remove a leading slash so GCS object names stay consistent.
+
+        Example:
+        ```python
+        GcsContentStore._normalize_key("/a/b.txt")  # "a/b.txt"
+        ```
+        """
+
+        return key.lstrip("/")
+
+    def put_object(self, key: str, stream: BinaryIO, *, content_type: str) -> None:
+        """Upload bytes to GCS under `key`.
+
+        Example:
+        ```python
+        from io import BytesIO
+        store.put_object("exports/run-42.json", BytesIO(b"{}"), content_type="application/json")
+        ```
+        """
+
+        object_name = self._normalize_key(key)
+        payload = stream.read()
+        if isinstance(payload, str):
+            payload = payload.encode("utf-8")
+        ct = content_type or "application/octet-stream"
+        blob = self.bucket.blob(object_name)
+        blob.upload_from_file(io.BytesIO(payload), content_type=ct)
+        logger.info(
+            "[CONTENT][GCS] put object=%s bucket='%s'", object_name, self.bucket_name
+        )
+
+    def _mint_access_token(self) -> str:
+        """Return a valid OAuth2 access token for the IAM signBlob signing call.
+
+        Credentials are cached on the instance and refreshed only when expired,
+        so steady-state signing avoids a token round-trip per call.
+        """
+        if self._signing_credentials is None:
+            self._signing_credentials = _load_adc_credentials()
+        if not self._signing_credentials.valid:
+            self._signing_credentials.refresh(GoogleAuthRequest())
+        token = self._signing_credentials.token
+        if not token:
+            raise RuntimeError(
+                "[CONTENT][GCS] ADC returned no access token for IAM signBlob signing"
+            )
+        return token
+
+    def get_presigned_url(
+        self, key: str, expires: timedelta = timedelta(hours=1)
+    ) -> str:
+        """Create a temporary browser-facing download URL for object `key`.
+
+        Mints a short-lived V4 signed URL via IAM `signBlob` impersonation of
+        `signing_service_account_email` — keyless, works under Workload
+        Identity. Requires the impersonated service account to hold
+        `storage.objects.get` on this bucket, and the caller's Workload
+        Identity service account to hold `iam.serviceAccounts.signBlob` on it.
+
+        Raises:
+            RuntimeError: no `signing_service_account_email` was configured.
+            FileNotFoundError: object does not exist.
+        """
+
+        if not self.signing_service_account_email:
+            raise RuntimeError(
+                f"[CONTENT][GCS] Cannot sign URL for '{key}': no "
+                "signing_service_account_email configured for this GCS content store."
+            )
+        object_name = self._normalize_key(key)
+        blob = self.bucket.blob(object_name)
+        try:
+            if not blob.exists(self.client):
+                raise FileNotFoundError(f"Object not found: {key}")
+        except NotFound as e:
+            raise FileNotFoundError(f"Object not found: {key}") from e
+
+        signed_url = blob.generate_signed_url(
+            version="v4",
+            expiration=expires,
+            method="GET",
+            service_account_email=self.signing_service_account_email,
+            access_token=self._mint_access_token(),
+        )
+        # Log the request, never the signed URL (it grants temporary read access).
+        logger.info(
+            "[CONTENT][GCS] minted V4 signed URL key=%s ttl=%ds",
+            key,
+            int(expires.total_seconds()),
+        )
+        return signed_url

--- a/libs/fred-core/fred_core/tests/common/test_gcs_client.py
+++ b/libs/fred-core/fred_core/tests/common/test_gcs_client.py
@@ -1,0 +1,72 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""build_gcs_client must mirror the ADC credentials' universe domain.
+
+Regression coverage for the Trusted Partner Cloud / sovereign deployment case
+(e.g. S3NS): bare `storage.Client(project=project_id)` assumes the
+`googleapis.com` universe domain and raises `UniverseMismatchError` the moment
+ADC credentials belong to a different universe (`s3nsapis.fr`, ...).
+"""
+
+from __future__ import annotations
+
+from fred_core.common import gcs_client
+
+
+class _FakeCredentials:
+    def __init__(self, universe_domain: str):
+        self.universe_domain = universe_domain
+
+
+def test_build_gcs_client_passes_credentials_universe_domain_through(monkeypatch):
+    fake_credentials = _FakeCredentials("s3nsapis.fr")
+    monkeypatch.setattr(
+        gcs_client.google.auth, "default", lambda: (fake_credentials, "adc-project")
+    )
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, *, project, credentials, client_options):
+            captured["project"] = project
+            captured["credentials"] = credentials
+            captured["universe_domain"] = client_options.universe_domain
+
+    monkeypatch.setattr(gcs_client.storage, "Client", _FakeClient)
+
+    gcs_client.build_gcs_client("explicit-project")
+
+    assert captured["project"] == "explicit-project"
+    assert captured["credentials"] is fake_credentials
+    assert captured["universe_domain"] == "s3nsapis.fr"
+
+
+def test_build_gcs_client_falls_back_to_adc_project_when_unset(monkeypatch):
+    fake_credentials = _FakeCredentials("googleapis.com")
+    monkeypatch.setattr(
+        gcs_client.google.auth, "default", lambda: (fake_credentials, "adc-project")
+    )
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, *, project, credentials, client_options):
+            captured["project"] = project
+
+    monkeypatch.setattr(gcs_client.storage, "Client", _FakeClient)
+
+    gcs_client.build_gcs_client(None)
+
+    assert captured["project"] == "adc-project"

--- a/libs/fred-core/fred_core/tests/filesystem/test_gcs_filesystem.py
+++ b/libs/fred-core/fred_core/tests/filesystem/test_gcs_filesystem.py
@@ -107,7 +107,7 @@ def gcs_fs(monkeypatch):
 
     store: dict[str, bytes] = {}
     monkeypatch.setattr(
-        gcs_filesystem.storage, "Client", lambda *a, **k: _FakeClient(store)
+        gcs_filesystem, "build_gcs_client", lambda project_id=None: _FakeClient(store)
     )
     fs = gcs_filesystem.GcsFilesystem(bucket_name="test-bucket")
     return fs
@@ -182,7 +182,7 @@ async def test_prefix_isolates_logical_root(monkeypatch):
 
     store: dict[str, bytes] = {}
     monkeypatch.setattr(
-        gcs_filesystem.storage, "Client", lambda *a, **k: _FakeClient(store)
+        gcs_filesystem, "build_gcs_client", lambda project_id=None: _FakeClient(store)
     )
     fs = gcs_filesystem.GcsFilesystem(bucket_name="b", prefix="vfs")
 
@@ -211,7 +211,7 @@ async def test_list_does_not_leak_sibling_prefix(monkeypatch):
         "team-alpha/docs/secret.txt": b"not yours",
     }
     monkeypatch.setattr(
-        gcs_filesystem.storage, "Client", lambda *a, **k: _FakeClient(store)
+        gcs_filesystem, "build_gcs_client", lambda project_id=None: _FakeClient(store)
     )
     fs = gcs_filesystem.GcsFilesystem(bucket_name="b", prefix="team-a")
 

--- a/libs/fred-core/fred_core/tests/store/test_gcs_content_store.py
+++ b/libs/fred-core/fred_core/tests/store/test_gcs_content_store.py
@@ -1,0 +1,187 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=redefined-outer-name
+
+"""Unit tests for GcsContentStore using fake GCS client/blob doubles (no network)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from io import BytesIO
+
+import pytest
+from fred_core.store import gcs_content_store
+from fred_core.store.gcs_content_store import GcsContentStore
+
+
+class _FakeBlob:
+    def __init__(self, bucket_store: dict, name: str):
+        self._bucket = bucket_store
+        self.name = name
+
+    def upload_from_file(self, stream, content_type=None):
+        self._bucket[self.name] = (stream.read(), content_type)
+
+    def exists(self, _client=None):
+        return self.name in self._bucket
+
+
+class _FakeBucket:
+    def __init__(self, bucket_store: dict):
+        self._bucket = bucket_store
+
+    def blob(self, name):
+        return _FakeBlob(self._bucket, name)
+
+
+class _FakeClient:
+    def __init__(self, buckets: dict):
+        self._buckets = buckets
+
+    def bucket(self, name):
+        return _FakeBucket(self._buckets.setdefault(name, {}))
+
+
+@pytest.fixture
+def store_and_buckets(monkeypatch) -> tuple[GcsContentStore, dict]:
+    buckets: dict[str, dict] = {}
+    monkeypatch.setattr(
+        gcs_content_store,
+        "build_gcs_client",
+        lambda project_id=None: _FakeClient(buckets),
+    )
+    return GcsContentStore(bucket_name="fred-objects"), buckets
+
+
+def test_put_object_writes_bytes(store_and_buckets):
+    store, buckets = store_and_buckets
+    store.put_object(
+        "teams/t1/banner.png", BytesIO(b"image-bytes"), content_type="image/png"
+    )
+
+    assert buckets["fred-objects"]["teams/t1/banner.png"] == (
+        b"image-bytes",
+        "image/png",
+    )
+
+
+def test_put_object_normalizes_leading_slash(store_and_buckets):
+    store, buckets = store_and_buckets
+    store.put_object("/teams/t1/banner.png", BytesIO(b"x"), content_type="image/png")
+
+    assert "teams/t1/banner.png" in buckets["fred-objects"]
+
+
+def test_get_presigned_url_requires_signing_email(store_and_buckets):
+    store, _buckets = store_and_buckets
+    with pytest.raises(RuntimeError, match="signing_service_account_email"):
+        store.get_presigned_url("teams/t1/banner.png")
+
+
+class _RecordingSignBlob:
+    def __init__(self, name: str, captured: dict, exists: bool = True):
+        self.name = name
+        self._captured = captured
+        self._exists = exists
+
+    def exists(self, _client=None):
+        return self._exists
+
+    def generate_signed_url(self, **kwargs):
+        self._captured.update(kwargs)
+        self._captured["object_name"] = self.name
+        return "https://storage.googleapis.com/fred-objects/x?X-Goog-Signature=deadbeef"
+
+
+class _RecordingSignBucket:
+    def __init__(self, captured: dict, exists: bool = True):
+        self._captured = captured
+        self._exists = exists
+
+    def blob(self, name):
+        return _RecordingSignBlob(name, self._captured, exists=self._exists)
+
+
+def _signing_store(monkeypatch, captured: dict, *, exists: bool = True):
+    monkeypatch.setattr(
+        gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient({})
+    )
+    s = GcsContentStore(
+        bucket_name="fred-objects",
+        signing_service_account_email="signer@project.iam.gserviceaccount.com",
+    )
+    monkeypatch.setattr(s, "_mint_access_token", lambda: "fake-access-token")
+    s.bucket = _RecordingSignBucket(captured, exists=exists)  # type: ignore[assignment]
+    return s
+
+
+def test_get_presigned_url_mints_v4_signed_url(monkeypatch):
+    captured: dict = {}
+    store = _signing_store(monkeypatch, captured)
+
+    url = store.get_presigned_url("teams/t1/banner.png", expires=timedelta(seconds=120))
+
+    assert url.startswith("https://storage.googleapis.com/")
+    assert captured["version"] == "v4"
+    assert captured["method"] == "GET"
+    assert captured["service_account_email"] == "signer@project.iam.gserviceaccount.com"
+    assert captured["access_token"] == "fake-access-token"
+    assert captured["expiration"] == timedelta(seconds=120)
+    assert captured["object_name"] == "teams/t1/banner.png"
+
+
+def test_get_presigned_url_missing_object_raises(monkeypatch):
+    captured: dict = {}
+    store = _signing_store(monkeypatch, captured, exists=False)
+
+    with pytest.raises(FileNotFoundError):
+        store.get_presigned_url("teams/t1/missing.png")
+
+
+def test_get_presigned_url_never_logs_the_url(monkeypatch, caplog):
+    captured: dict = {}
+    store = _signing_store(monkeypatch, captured)
+
+    with caplog.at_level(logging.DEBUG):
+        url = store.get_presigned_url("teams/t1/banner.png")
+
+    assert url not in caplog.text
+    assert "X-Goog-Signature" not in caplog.text
+
+
+def test_mint_access_token_uses_adc_and_refreshes(monkeypatch):
+    class _FakeCreds:
+        def __init__(self):
+            self.valid = False
+            self.token = None
+
+        def refresh(self, _request):
+            self.valid = True
+            self.token = "minted-token"  # nosec B105  # pragma: allowlist secret
+
+    fake_creds = _FakeCreds()
+    monkeypatch.setattr(
+        gcs_content_store, "build_gcs_client", lambda project_id=None: _FakeClient({})
+    )
+    monkeypatch.setattr(gcs_content_store, "_load_adc_credentials", lambda: fake_creds)
+
+    store = GcsContentStore(
+        bucket_name="fred-objects",
+        signing_service_account_email="signer@project.iam.gserviceaccount.com",
+    )
+
+    assert store._mint_access_token() == "minted-token"
+    assert store._mint_access_token() == "minted-token"

--- a/libs/fred-core/pyproject.toml
+++ b/libs/fred-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 description = "Core shared utilities for Fred backends (config, storage, security, and runtime helpers)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/fred-core/uv.lock
+++ b/libs/fred-core/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-runtime/uv.lock
+++ b/libs/fred-runtime/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-sdk/uv.lock
+++ b/libs/fred-sdk/uv.lock
@@ -501,7 +501,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.5"
+version = "3.4.6"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Adds a `gcs` variant to control-plane's `storage.content_storage` (`GcsContentStorageConfig` + `fred_core.store.GcsContentStore`), so team banner/logo images can load from a native GCS bucket via ADC/Workload Identity, matching knowledge-flow's existing GCS support (#2022).
- Since banner/logo URLs are handed straight to the browser (`teams/service.py` → `<img src>`), `GcsContentStore.get_presigned_url` mints real V4 signed URLs via IAM `signBlob`, extending the mechanism already used for knowledge-flow's internal tabular reads — formalized in `docs/swift/rfc/GCS-TABULAR-SIGNED-URL-RFC.md` §6.
- Fixes `UniverseMismatchError` on every native-GCS backend (control-plane's new content store, knowledge-flow's content/file stores, fred-core's virtual filesystem) under Trusted Partner Cloud / sovereign deployments such as S3NS — new shared `fred_core.common.build_gcs_client()` derives the client's universe domain from the loaded ADC credentials instead of assuming the public `googleapis.com` default.
- Version bumps: `fred-core` 3.4.5→3.4.6, `control-plane-backend` 1.6.0→1.6.1, `knowledge-flow-backend` 1.5.2→1.5.3.
- `apps/frontend/public/release.md` gets a v2.1.7 entry for the tag.

## Test plan
- [x] `make code-quality` green on `libs/fred-core`, `apps/control-plane-backend`, `apps/knowledge-flow-backend`
- [x] `make test` green on `libs/fred-runtime` (554 passed) after regenerating a stale local venv (unrelated to this change)
- [ ] CI full test suite (this PR is opened precisely to let CI confirm the rest)
- [ ] Live GKE/S3NS validation of the new control-plane GCS signed-URL path (banner upload + render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)