### PR TITLE
Fix chart schema and migration hooks

### DIFF
--- a/deploy/charts/fred/templates/configmap-backend.yaml
+++ b/deploy/charts/fred/templates/configmap-backend.yaml
@@ -9,6 +9,20 @@ kind: ConfigMap
 metadata:
   name: "{{ .app.applicationName }}-back"
   namespace: {{ .root.Release.Namespace }}
+  {{- if and .app.migration .app.migration.enabled }}
+  annotations:
+    # The migration Job is a pre-install/pre-upgrade hook (weight 0) that mounts
+    # this resource. Helm applies regular resources only AFTER pre-install hooks
+    # have run, so on a fresh install the Job pod waits forever on a missing
+    # mount and the install fails on timeout; only the upgrade path worked, by
+    # accident, through the previous revision's resources. Promoting the mounted
+    # resources to weight -1 hooks guarantees they exist before the Job starts.
+    # Trade-off: as hook resources they are no longer tracked by the release and
+    # survive `helm uninstall` (recreated/overwritten on the next install).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 data:
   {{ $configFileName }}: |
 {{ .app.configuration | toYaml | indent 4 }}

--- a/deploy/charts/fred/templates/configmap-catalog.yaml
+++ b/deploy/charts/fred/templates/configmap-catalog.yaml
@@ -8,6 +8,20 @@ kind: ConfigMap
 metadata:
   name: "{{ .app.applicationName }}-catalog"
   namespace: {{ .root.Release.Namespace }}
+  {{- if and .app.migration .app.migration.enabled }}
+  annotations:
+    # The migration Job is a pre-install/pre-upgrade hook (weight 0) that mounts
+    # this resource. Helm applies regular resources only AFTER pre-install hooks
+    # have run, so on a fresh install the Job pod waits forever on a missing
+    # mount and the install fails on timeout; only the upgrade path worked, by
+    # accident, through the previous revision's resources. Promoting the mounted
+    # resources to weight -1 hooks guarantees they exist before the Job starts.
+    # Trade-off: as hook resources they are no longer tracked by the release and
+    # survive `helm uninstall` (recreated/overwritten on the next install).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 data:
 
 {{- if .app.agents_catalog }}

--- a/deploy/charts/fred/templates/hook-migration.yaml
+++ b/deploy/charts/fred/templates/hook-migration.yaml
@@ -23,6 +23,9 @@ spec:
         {{- if .app.podAnnotations }}
 {{ toYaml .app.podAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .app.migration.podAnnotations }}
+{{ toYaml .app.migration.podAnnotations | nindent 8 }}
+        {{- end }}
         {{- if .app.configuration }}
         configmap.configurations.checksum: "{{ .app.configuration | join "," | sha256sum }}"
         {{- end }}

--- a/deploy/charts/fred/templates/secrets-env.yaml
+++ b/deploy/charts/fred/templates/secrets-env.yaml
@@ -6,6 +6,20 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .app.applicationName }}-env
+  {{- if and .app.migration .app.migration.enabled }}
+  annotations:
+    # The migration Job is a pre-install/pre-upgrade hook (weight 0) that mounts
+    # this resource. Helm applies regular resources only AFTER pre-install hooks
+    # have run, so on a fresh install the Job pod waits forever on a missing
+    # mount and the install fails on timeout; only the upgrade path worked, by
+    # accident, through the previous revision's resources. Promoting the mounted
+    # resources to weight -1 hooks guarantees they exist before the Job starts.
+    # Trade-off: as hook resources they are no longer tracked by the release and
+    # survive `helm uninstall` (recreated/overwritten on the next install).
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 stringData:
   .env: |
     {{- range $key, $value := .app.dotenv }}

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -534,6 +534,88 @@
                 "additionalProperties": true
               }
             },
+            "extraVolumeMounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object"
+                },
+                "requests": {
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "envFrom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
             "probes": {
               "type": "object",
               "properties": {
@@ -2100,6 +2182,88 @@
                 "additionalProperties": true
               }
             },
+            "extraVolumeMounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object"
+                },
+                "requests": {
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "envFrom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
             "probes": {
               "type": "object",
               "properties": {
@@ -2789,6 +2953,88 @@
                     "type": "string"
                   }
                 },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumeMounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object"
+                },
+                "requests": {
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "envFrom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
                 "additionalProperties": true
               }
             },
@@ -7217,6 +7463,88 @@
                 "additionalProperties": true
               }
             },
+            "extraVolumeMounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object"
+                },
+                "requests": {
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "envFrom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
             "probes": {
               "type": "object",
               "properties": {
@@ -11642,6 +11970,88 @@
                 "additionalProperties": true
               }
             },
+            "extraVolumeMounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object"
+                },
+                "requests": {
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "envFrom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
             "probes": {
               "type": "object",
               "properties": {
@@ -13417,6 +13827,88 @@
                     "type": "string"
                   }
                 },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumeMounts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "extraVolumes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object"
+                },
+                "requests": {
+                  "type": "object"
+                }
+              },
+              "additionalProperties": false
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podSecurityContext": {
+              "type": "object"
+            },
+            "envFrom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {},
                 "additionalProperties": true
               }
             },

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -135,6 +135,9 @@
                 },
                 "resources": {
                   "type": "object"
+                },
+                "podAnnotations": {
+                  "type": "object"
                 }
               },
               "additionalProperties": false
@@ -1783,6 +1786,9 @@
                 },
                 "resources": {
                   "type": "object"
+                },
+                "podAnnotations": {
+                  "type": "object"
                 }
               },
               "additionalProperties": false
@@ -2556,6 +2562,9 @@
                   }
                 },
                 "resources": {
+                  "type": "object"
+                },
+                "podAnnotations": {
                   "type": "object"
                 }
               },
@@ -7064,6 +7073,9 @@
                 },
                 "resources": {
                   "type": "object"
+                },
+                "podAnnotations": {
+                  "type": "object"
                 }
               },
               "additionalProperties": false
@@ -11571,6 +11583,9 @@
                 },
                 "resources": {
                   "type": "object"
+                },
+                "podAnnotations": {
+                  "type": "object"
                 }
               },
               "additionalProperties": false
@@ -13430,6 +13445,9 @@
                   }
                 },
                 "resources": {
+                  "type": "object"
+                },
+                "podAnnotations": {
                   "type": "object"
                 }
               },

--- a/scripts/generate_chart_schema.py
+++ b/scripts/generate_chart_schema.py
@@ -301,6 +301,18 @@ def _base_app_props(extra: dict | None = None) -> dict:
         "httpRoute": _HTTP_ROUTE,
         "volumeMounts": _arr(_VOLUME_MOUNT),
         "volumes": _arr(_VOLUME),
+        # Pod- and container-level keys below are read by templates/deployment.yaml,
+        # job.yaml and hook-migration.yaml, but were absent from the schema, so
+        # values files legitimately using them were rejected by `helm template`.
+        "extraVolumeMounts": _arr(_VOLUME_MOUNT),
+        "extraVolumes": _arr(_VOLUME),
+        "resources": _obj({"limits": _OBJECT_FREE, "requests": _OBJECT_FREE}),
+        "imagePullSecrets": _arr(_obj({"name": _STRING}, additional=True)),
+        "podAnnotations": _OBJECT_FREE,
+        "podSecurityContext": _OBJECT_FREE,
+        "envFrom": _arr(_obj({}, additional=True)),
+        "nodeSelector": _OBJECT_FREE,
+        "tolerations": _arr(_obj({}, additional=True)),
         "probes": _PROBES,
         "securityContext": _SECURITY_CONTEXT,
         "serviceAccount": _SERVICE_ACCOUNT,

--- a/scripts/generate_chart_schema.py
+++ b/scripts/generate_chart_schema.py
@@ -261,6 +261,11 @@ _MIGRATION = _obj({
     "command": _arr(_STRING),
     "args": _arr(_STRING),
     "resources": _OBJECT_FREE,
+    # Annotations for the migration Job pod only. Distinct from the app-level
+    # podAnnotations, which are shared with the Deployment: a service-mesh
+    # sidecar that is desirable on a long-running Deployment keeps a hook Job
+    # from ever completing, so the opt-out must target the Job alone.
+    "podAnnotations": _OBJECT_FREE,
 })
 
 _COMMAND = _obj({


### PR DESCRIPTION
## Context

This MR fixes three issues that prevent the chart from installing cleanly when
migrations are enabled (`migration.enabled: true`), while remaining a no-op for
deployments that don't use them.

## Changes

1. **Chart values schema completed.** `values.schema.json` (generated by
   `generate_chart_schema.py` with `additionalProperties: false`) omitted nine
   keys that the templates already read: `resources`, `imagePullSecrets`,
   `extraVolumes`, `extraVolumeMounts`, `podAnnotations`, `podSecurityContext`,
   `envFrom`, `nodeSelector`, `tolerations`. Any values file using them was
   rejected by `helm template`. The change is purely additive: it only widens
   what validates, with no effect on rendering (byte-identical output). Schema
   regenerated via `make generate-chart-schema`.

2. **Migration-Job-only pod annotations.** The Job inherited the application's
   `podAnnotations`, which is not enough on a service-mesh cluster: the injected
   sidecar (linkerd, istio) doesn't stop when the migration container exits, so
   the pod stays NotReady and the hook blocks until timeout. Adds
   `migration.podAnnotations`, applied to the Job pod only.

3. **Mounted resources created before the migration hook.** With migrations
   enabled, a fresh `helm install` never completed: the Job (pre-install hook,
   weight 0) mounts the backend configmap, the catalog configmap and the `.env`
   secret, which are regular release resources applied only after hooks run. The
   pod therefore blocked on missing objects. These three resources are promoted
   to pre-install/pre-upgrade hooks at weight -1, guarded by the same
   `migration.enabled` condition.

## Compatibility

No impact on existing platforms: `migration.enabled` is `false` in
`values.yaml`, `values-gcp.yaml` and `fred-deployment-factory`. A platform
already running with migrations will see, on its next upgrade, these three
resources move from release-managed to hook-managed.