### PR TITLE
feat: finish agent audit fields — updated_by + creator name resolution (#1952)

### DIFF
--- a/apps/control-plane-backend/alembic/versions/0285dc3a0cdc_add_agent_instance_updated_by.py
+++ b/apps/control-plane-backend/alembic/versions/0285dc3a0cdc_add_agent_instance_updated_by.py
@@ -1,0 +1,55 @@
+"""add agent_instance.updated_by audit column
+
+Revision ID: 0285dc3a0cdc
+Revises: f824bb94e60d
+Create Date: 2026-07-20
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0285dc3a0cdc"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = (
+    "f824bb94e60d"  # pragma: allowlist secret
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the nullable `updated_by` audit column (#1952).
+
+    Why:
+        `created_by` records who enrolled the instance but edits were
+        anonymous. `updated_by` stamps the last editing user; NULL means the
+        instance was never user-edited (seed/startup saves have no acting
+        user).
+
+    How to use:
+        `alembic upgrade head`. A plain nullable ADD COLUMN, so it is
+        SQLite-compatible without a batch rewrite.
+    """
+
+    op.add_column(
+        "agent_instance",
+        sa.Column(
+            "updated_by",
+            sa.String(),
+            nullable=True,
+            comment=(
+                "Uid of the last user who edited the instance (#1952). NULL "
+                "when never user-edited (seed/startup saves have no acting "
+                "user)."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the `updated_by` column."""
+
+    op.drop_column("agent_instance", "updated_by")

--- a/apps/control-plane-backend/control_plane_backend/agent_instances/store.py
+++ b/apps/control-plane-backend/control_plane_backend/agent_instances/store.py
@@ -51,6 +51,7 @@ class AgentInstanceRecord:
         suspension_reason: str | None = None,
         created_at=None,
         updated_at=None,
+        updated_by: str | None = None,
     ) -> None:
         self.agent_instance_id = agent_instance_id
         self.team_id = team_id
@@ -68,6 +69,8 @@ class AgentInstanceRecord:
         self.suspension_reason = suspension_reason
         self.created_at = created_at
         self.updated_at = updated_at
+        # Last editing user's uid (#1952); None = never user-edited.
+        self.updated_by = updated_by
 
     @property
     def is_suspended(self) -> bool:
@@ -107,6 +110,7 @@ def _row_to_record(row: AgentInstanceRow) -> AgentInstanceRecord:
         suspension_reason=row.suspension_reason,
         created_at=row.created_at,
         updated_at=row.updated_at,
+        updated_by=row.updated_by,
     )
 
 
@@ -133,6 +137,7 @@ class AgentInstanceStore:
             enabled=record.enabled,
             suspension_reason=record.suspension_reason,
             created_by=record.created_by,
+            updated_by=record.updated_by,
             tuning_json=tuning_json,
             created_at=created_at,
             updated_at=updated_at,
@@ -223,9 +228,14 @@ class AgentInstanceStore:
         description: str | None = None,
         enabled: bool | None = None,
         tuning: ManagedAgentTuning | None = None,
+        updated_by: str | None = None,
         session: AsyncSession | None = None,
     ) -> AgentInstanceRecord | None:
-        """Update one instance scoped to team_id. Returns None if not found."""
+        """Update one instance scoped to team_id. Returns None if not found.
+
+        ``updated_by`` stamps the acting user's uid (#1952); None leaves the
+        stored value unchanged (seed/startup saves have no acting user).
+        """
         async with use_session(self._sessions, session) as s:
             rows = (
                 (
@@ -250,6 +260,8 @@ class AgentInstanceStore:
                 row.enabled = enabled
             if tuning is not None:
                 row.tuning_json = tuning.model_dump_json()
+            if updated_by is not None:
+                row.updated_by = updated_by
             row.updated_at = _utcnow()
         return await self.get(agent_instance_id)
 

--- a/apps/control-plane-backend/control_plane_backend/models/agent_instance_models.py
+++ b/apps/control-plane-backend/control_plane_backend/models/agent_instance_models.py
@@ -36,6 +36,14 @@ class AgentInstanceRow(Base):
         ),
     )
     created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(
+        String,
+        nullable=True,
+        comment=(
+            "Uid of the last user who edited the instance (#1952). NULL when "
+            "never user-edited (seed/startup saves have no acting user)."
+        ),
+    )
     tuning_json: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,

--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -189,6 +189,14 @@ class ManagedAgentInstanceSummary(BaseModel):
     created_at: datetime | None = None
     updated_at: datetime | None = None
     created_by: str | None = None
+    updated_by: str | None = Field(
+        default=None,
+        description=(
+            "Uid of the last user who edited the instance (#1952). "
+            "Server-authoritative and read-only; null when the instance was "
+            "never user-edited (seed/startup saves have no acting user)."
+        ),
+    )
     tuning_field_values: dict[str, TuningValue] = Field(
         default_factory=dict,
         description=(

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -1742,6 +1742,7 @@ def _record_to_summary(
         created_at=record.created_at,
         updated_at=record.updated_at,
         created_by=record.created_by,
+        updated_by=record.updated_by,
         tuning_field_values=record.tuning.values,
         selected_capability_ids=(
             list(record.tuning.selected_capability_ids)
@@ -2241,6 +2242,7 @@ async def update_agent_instance(
         description=request.description,
         enabled=request.status == "enabled" if request.status is not None else None,
         tuning=new_tuning,
+        updated_by=user.uid,
     )
     # A save that re-validated every ACTIVE capability slice through the pod
     # clears any suspension — the single clearing mechanism (#1975, RFC §3.9).

--- a/apps/control-plane-backend/control_plane_backend/users/api.py
+++ b/apps/control-plane-backend/control_plane_backend/users/api.py
@@ -3,7 +3,7 @@ import uuid as _uuid_mod
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, FastAPI, Path, Request, status
+from fastapi import APIRouter, Depends, FastAPI, Path, Query, Request, status
 from fastapi.responses import JSONResponse
 from fred_core import (
     ORGANIZATION_ID,
@@ -50,6 +50,9 @@ from control_plane_backend.users.service import (
 from control_plane_backend.users.service import (
     find_user_details_by_id,
     update_gcu_validation,
+)
+from control_plane_backend.users.service import (
+    get_users_by_ids as get_users_by_ids_from_service,
 )
 from control_plane_backend.users.service import (
     list_users as list_users_from_service,
@@ -146,6 +149,47 @@ async def list_users(
     - `GET /control-plane/v1/users`
     """
     return await list_users_from_service(user, deps)
+
+
+@router.get(
+    "/users/by-ids",
+    response_model=list[UserSummary],
+    response_model_exclude_none=True,
+    summary="Resolve a batch of user ids to display summaries.",
+)
+async def get_users_by_ids(
+    deps: UserDependencies,
+    ids: Annotated[list[str], Query(min_length=1, max_length=100)],
+    _user: KeycloakUser = Depends(get_current_user),
+) -> list[UserSummary]:
+    """
+    Resolve up to 100 user ids to normalized display summaries (#1952).
+
+    Why this endpoint exists:
+    - audit fields (`created_by` / `updated_by` on managed agent instances)
+      store raw uids; the frontend needs first/last names without pulling the
+      whole unpaginated realm through `GET /users` (admin-only)
+
+    How to use it:
+    - repeat the query param: `GET /users/by-ids?ids=a&ids=b`
+    - any authenticated user may call it; it only exposes display identity
+      (name/username/email), never roles or credentials
+    - every requested id gets exactly one entry, in request order; unknown ids
+      (or a disabled Keycloak M2M client) degrade to an id-only summary so the
+      caller can always fall back to rendering the uid
+
+    Example:
+    - `GET /control-plane/v1/users/by-ids?ids=75730f40-...`
+    """
+    summaries = await get_users_by_ids_from_service(ids, deps)
+    seen: set[str] = set()
+    results: list[UserSummary] = []
+    for user_id in ids:
+        if not user_id or user_id in seen:
+            continue
+        seen.add(user_id)
+        results.append(summaries.get(user_id) or UserSummary(id=user_id))
+    return results
 
 
 @router.post(

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -169,6 +169,7 @@ class _FakeAgentInstanceStore:
         description: str | None = None,
         enabled: bool | None = None,
         tuning: ManagedAgentTuning | None = None,
+        updated_by: str | None = None,
     ) -> AgentInstanceRecord | None:
         record = next(
             (
@@ -188,6 +189,8 @@ class _FakeAgentInstanceStore:
             record.enabled = enabled
         if tuning is not None:
             record.tuning = tuning
+        if updated_by is not None:
+            record.updated_by = updated_by
         return record
 
     async def list_all(self) -> list[AgentInstanceRecord]:
@@ -667,6 +670,23 @@ async def test_list_users_returns_empty_without_keycloak_m2m() -> None:
 
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_degrades_to_id_only_without_keycloak() -> None:
+    """/users/by-ids answers one entry per unique id, in order, even with no Keycloak (#1952)."""
+
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(
+            "/control-plane/v1/users/by-ids",
+            params=[("ids", "u-1"), ("ids", "u-2"), ("ids", "u-1")],
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": "u-1"}, {"id": "u-2"}]
 
 
 @pytest.mark.asyncio
@@ -2132,6 +2152,7 @@ async def test_agent_instance_store_create_overrides_sqlite_now_default(
                     enabled BOOLEAN NOT NULL,
                     suspension_reason VARCHAR(64),
                     created_by VARCHAR,
+                    updated_by VARCHAR,
                     tuning_json TEXT,
                     prompt_refs_json TEXT,
                     created_at DATETIME NOT NULL DEFAULT (now()),
@@ -5489,6 +5510,37 @@ async def test_patch_agent_instance_updates_display_name(
     assert payload["display_name"] == "Renamed Echo Agent"
     assert payload["agent_instance_id"] == "instance-1"
     assert payload["status"] == "enabled"
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_instance_stamps_updated_by(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PATCH stamps the acting user's uid into updated_by (#1952)."""
+
+    monkeypatch.setattr(
+        "control_plane_backend.product.api.get_team_by_id_from_service",
+        _fake_get_team_by_id,
+    )
+    record = _make_record()
+    assert record.updated_by is None
+    store = _FakeAgentInstanceStore([record])
+    app = create_app()
+    _patch_store(monkeypatch, store)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.patch(
+            "/control-plane/v1/teams/personal/agent-instances/instance-1",
+            json={"display_name": "Renamed Echo Agent"},
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    # No-security mode authenticates as the mock "admin" subject.
+    assert payload["updated_by"] == "admin"
+    assert record.updated_by == "admin"
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1392,6 +1392,7 @@
       },
       "formAgent": {
         "createdBy": "Created by {{user}}",
+        "updatedBy": "Updated by {{user}}",
         "fields": {
           "description": {
             "label": "Description",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1392,6 +1392,7 @@
       },
       "formAgent": {
         "createdBy": "Créé par {{user}}",
+        "updatedBy": "Modifié par {{user}}",
         "fields": {
           "description": {
             "label": "Description",

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -21,7 +21,9 @@ import type {
   AgentTemplateSummary,
   ManagedAgentFieldSpec,
   ManagedAgentInstanceSummary,
+  UserSummary,
 } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
+import { useUsersByIdsQuery } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements.ts";
 import { TuningFieldRenderer } from "./TuningFieldRenderer.tsx";
 import { CapabilityCard } from "./CapabilityCard/CapabilityCard.tsx";
 import styles from "./AgentFormBody.module.css";
@@ -49,6 +51,13 @@ function routeField(field: ManagedAgentFieldSpec): "prompts" | "settings" | "cha
   if (g === "prompts") return "prompts";
   if (g === "chat") return "chat";
   return "settings";
+}
+
+/** Human display for a resolved user: full name, else username, else the raw uid (#1952). */
+function userDisplayName(uid: string, summary: UserSummary | undefined): string {
+  if (!summary) return uid;
+  const fullName = [summary.first_name, summary.last_name].filter(Boolean).join(" ");
+  return fullName || summary.username || uid;
 }
 
 function formatRelativeDate(dateStr: string | null | undefined): string {
@@ -114,6 +123,13 @@ export function AgentFormBody({
   onCapabilityConfigChange,
 }: AgentFormBodyProps) {
   const { t } = useTranslation();
+
+  // Resolve audit uids (created_by / updated_by) to display names (#1952).
+  const auditUids = Array.from(
+    new Set([editInstance?.created_by, editInstance?.updated_by].filter((uid): uid is string => Boolean(uid))),
+  );
+  const { data: auditUsers = [] } = useUsersByIdsQuery({ ids: auditUids }, { skip: auditUids.length === 0 });
+  const auditUserById = new Map(auditUsers.map((summary) => [summary.id, summary]));
 
   const selectedTemplate = templates.find((tpl) => tpl.template_id === templateId);
   const templateMissing = mode === "edit" && !selectedTemplate;
@@ -299,8 +315,19 @@ export function AgentFormBody({
 
       {mode === "edit" && editInstance?.created_by && (
         <p className={styles.metadataFooter}>
-          {t("rework.teams.formAgent.createdBy", { user: editInstance.created_by })}
+          {t("rework.teams.formAgent.createdBy", {
+            user: userDisplayName(editInstance.created_by, auditUserById.get(editInstance.created_by)),
+          })}
           {editInstance.created_at && ` · ${formatRelativeDate(editInstance.created_at)}`}
+          {editInstance.updated_by && (
+            <>
+              {" — "}
+              {t("rework.teams.formAgent.updatedBy", {
+                user: userDisplayName(editInstance.updated_by, auditUserById.get(editInstance.updated_by)),
+              })}
+              {editInstance.updated_at && ` · ${formatRelativeDate(editInstance.updated_at)}`}
+            </>
+          )}
         </p>
       )}
     </div>

--- a/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
@@ -157,6 +157,8 @@ export const enhancedControlPlaneApi = api.enhanceEndpoints({
 
 export const {
   useListUsersControlPlaneV1UsersGetQuery: useListUsersQuery,
+  // Batch uid → display-name resolution for audit fields (#1952).
+  useGetUsersByIdsControlPlaneV1UsersByIdsGetQuery: useUsersByIdsQuery,
   useListTeamsControlPlaneV1TeamsGetQuery: useListTeamsQuery,
   useListAllTeamsControlPlaneV1TeamsAllGetQuery: useListAllTeamsQuery,
   useGetTeamControlPlaneV1TeamsTeamIdGetQuery: useGetTeamQuery,

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -50,6 +50,17 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({ url: `/control-plane/v1/users`, method: "POST", body: queryArg.createUserRequest }),
     }),
+    getUsersByIdsControlPlaneV1UsersByIdsGet: build.query<
+      GetUsersByIdsControlPlaneV1UsersByIdsGetApiResponse,
+      GetUsersByIdsControlPlaneV1UsersByIdsGetApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/control-plane/v1/users/by-ids`,
+        params: {
+          ids: queryArg.ids,
+        },
+      }),
+    }),
     deleteUserControlPlaneV1UsersUserIdDelete: build.mutation<
       DeleteUserControlPlaneV1UsersUserIdDeleteApiResponse,
       DeleteUserControlPlaneV1UsersUserIdDeleteApiArg
@@ -784,6 +795,10 @@ export type ListUsersControlPlaneV1UsersGetApiArg = void;
 export type CreateUserControlPlaneV1UsersPostApiResponse = /** status 201 Successful Response */ UserSummary;
 export type CreateUserControlPlaneV1UsersPostApiArg = {
   createUserRequest: CreateUserRequest;
+};
+export type GetUsersByIdsControlPlaneV1UsersByIdsGetApiResponse = /** status 200 Successful Response */ UserSummary[];
+export type GetUsersByIdsControlPlaneV1UsersByIdsGetApiArg = {
+  ids: string[];
 };
 export type DeleteUserControlPlaneV1UsersUserIdDeleteApiResponse = unknown;
 export type DeleteUserControlPlaneV1UsersUserIdDeleteApiArg = {
@@ -1601,6 +1616,8 @@ export type ManagedAgentInstanceSummary = {
   created_at?: string | null;
   updated_at?: string | null;
   created_by?: string | null;
+  /** Uid of the last user who edited the instance (#1952). Server-authoritative and read-only; null when the instance was never user-edited (seed/startup saves have no acting user). */
+  updated_by?: string | null;
   /** Current user-set values for this instance's tunable fields. Keyed by ManagedAgentFieldSpec.key. Empty when no fields have been customised. */
   tuning_field_values?: {
     [key: string]:
@@ -2269,6 +2286,8 @@ export const {
   useListUsersControlPlaneV1UsersGetQuery,
   useLazyListUsersControlPlaneV1UsersGetQuery,
   useCreateUserControlPlaneV1UsersPostMutation,
+  useGetUsersByIdsControlPlaneV1UsersByIdsGetQuery,
+  useLazyGetUsersByIdsControlPlaneV1UsersByIdsGetQuery,
   useDeleteUserControlPlaneV1UsersUserIdDeleteMutation,
   useGetUserDetailsControlPlaneV1UserGetQuery,
   useLazyGetUserDetailsControlPlaneV1UserGetQuery,

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -1249,3 +1249,25 @@ unconditionally and silently showed zero results for any team-admin-only caller.
 
 `controlPlaneOpenApi.ts` regenerated (`make update-control-plane-api`). No other
 route or schema changed.
+
+## 19. Contract Notes — audit-name resolution + `updated_by` (2026-07-20, #1952)
+
+**New endpoint:** `GET /users/by-ids?ids=<uid>&ids=<uid>` → `list[UserSummary]`
+(max 100 ids). Open to any authenticated user — it only exposes display identity
+(name/username/email), never roles or credentials. Every requested id yields
+exactly one entry, in request order, deduplicated; unknown ids (or a disabled
+Keycloak M2M client) degrade to an id-only summary so callers can always fall
+back to rendering the uid. Wraps the pre-existing internal service
+`users/service.py::get_users_by_ids`. The frontend agent-edit footer resolves
+`created_by`/`updated_by` through it (`useUsersByIdsQuery`) instead of showing
+raw uids (#1952); the unpaginated `platform_admin`-only `GET /users` stays
+untouched.
+
+**Schema:** `ManagedAgentInstanceSummary.updated_by: str | null` (read-only,
+server-authoritative). Backed by a new nullable `agent_instance.updated_by`
+column (Alembic `0285dc3a0cdc`, plain ADD COLUMN, SQLite-compatible), stamped
+with the acting user's uid on every `PATCH
+/teams/{team_id}/agent-instances/{id}`. NULL means never user-edited
+(seed/startup saves have no acting user).
+
+`controlPlaneOpenApi.ts` regenerated (`make update-control-plane-api`).

--- a/docs/swift/platform/authz-endpoint-matrix.yaml
+++ b/docs/swift/platform/authz-endpoint-matrix.yaml
@@ -391,6 +391,13 @@ operations:
     path: /control-plane/v1/users
     review_status: pending_review
     required_permission: pending_review
+  # Batch uid -> display-identity resolution for audit fields (#1952). Any
+  # authenticated user; exposes name/username/email only, never roles.
+  - service: control-plane
+    method: GET
+    path: /control-plane/v1/users/by-ids
+    review_status: approved
+    required_permission: authenticated_user
   - service: control-plane
     method: POST
     path: /control-plane/v1/users


### PR DESCRIPTION
## Summary

Port of #1940 to swift, remaining half (created_by storage already existed):

- **`agent_instance.updated_by` column** (Alembic `0285dc3a0cdc`, plain nullable ADD COLUMN, SQLite-compatible), stamped with the acting user's uid on every instance PATCH via `AgentInstanceStore.update(updated_by=...)`. NULL = never user-edited (seed/startup saves have no acting user).
- **Exposed read-only** on `ManagedAgentInstanceSummary.updated_by`.
- **`GET /users/by-ids`** (max 100 ids, any authenticated user, display identity only — never roles/credentials) wrapping the pre-existing `get_users_by_ids` service. One entry per unique id, in request order; unknown ids / disabled Keycloak M2M degrade to id-only summaries. Declared `approved` / `authenticated_user` in `authz-endpoint-matrix.yaml`.
- **Agent-edit footer** now shows "Created by <first/last name>" (fallback username, then uid) instead of the raw UID, plus "Updated by …" when set — via `useUsersByIdsQuery`. New i18n key `rework.teams.formAgent.updatedBy` (EN+FR).
- Docs: `CONTROL-PLANE-PRODUCT-CONTRACT.md` §19. `controlPlaneOpenApi.ts` regenerated (`make update-control-plane-api`).

Closes #1952

## Test plan

- `test_patch_agent_instance_stamps_updated_by` — PATCH stamps the acting user's uid
- `test_get_users_by_ids_degrades_to_id_only_without_keycloak` — order, dedup, id-only fallback
- Full control-plane suite green on this commit alone (474 passed), ruff + format clean, frontend `tsc --noEmit` clean
- Migration applied on a live local Postgres (`alembic upgrade head` → single head `0285dc3a0cdc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)