### PR TITLE
fix(wtf): disable Prometheus KPI exporter ports in worktree configs

### DIFF
--- a/scripts/wtf/src/wtf/__init__.py
+++ b/scripts/wtf/src/wtf/__init__.py
@@ -524,26 +524,45 @@ def warn_unpatched_default_ports(wt: Path, ports: dict[str, int]) -> None:
             info(f)
 
 
+def disable_prometheus_exporter(content: str) -> str:
+    """Force `observability.kpi.prometheus.enabled: false` in a service config.
+
+    Every backend (and Temporal worker) binds a hardcoded Prometheus scrape port
+    (`observability.kpi.prometheus.port`) that is identical across worktrees, and
+    the sink model defaults to enabled — so the second worktree to start a service
+    dies with "Address already in use" on the metrics port, not the service port.
+    Handles both config shapes: an explicit `enabled: true` right under the
+    `prometheus:` key, and a block that only sets `port:` (relying on the
+    enabled-by-default model).
+    """
+    patched = re.sub(
+        r"^(\s*)prometheus:\n(\s+)enabled: true\b",
+        r"\1prometheus:\n\2enabled: false",
+        content,
+        flags=re.MULTILINE,
+    )
+    return re.sub(
+        r"^(\s*)prometheus:\n(\s+)port:",
+        r"\1prometheus:\n\2enabled: false\n\2port:",
+        patched,
+        flags=re.MULTILINE,
+    )
+
+
 def apply_patch_pipeline(wt: Path, branch: str, ports: dict[str, int], autorun_task: str | None = None) -> None:
     """Apply the full worktree patch pipeline: prod configs, .vscode, and skip-worktree hiding."""
-    # Disable prometheus metrics in prod configs
-    for svc in PYTHON_SERVICES:
-        prod_cfg = wt / service_dir(svc) / "config" / "configuration_prod.yaml"
-        if prod_cfg.exists():
-            content = prod_cfg.read_text()
-            patched = content.replace("metrics_enabled: true", "metrics_enabled: false")
-            if patched != content:
-                prod_cfg.write_text(patched)
-
     # Patch inter-service URLs that reference another service by its default port.
     # Every service in DEFAULT_PORTS is rewritten (not just knowledge-flow): fred-agents
     # also dials control-plane via platform.control_plane_url, and leaving that at the
     # default port makes managed agent-instance execution fail with a connection error.
+    # The same pass disables the Prometheus KPI exporter, whose scrape port cannot be
+    # shared between worktrees.
     for cfg_path in inter_service_config_paths(wt):
         content = cfg_path.read_text()
         patched = content
         for svc, default_port in DEFAULT_PORTS.items():
             patched = patched.replace(f"localhost:{default_port}", f"localhost:{ports[svc]}")
+        patched = disable_prometheus_exporter(patched)
         if patched != content:
             cfg_path.write_text(patched)
             info(f"Patched {cfg_path.relative_to(wt)}")


### PR DESCRIPTION
## Problem

Starting a second wtf worktree crashes the control-plane (and knowledge-flow) with:

```
OSError: [Errno 98] Address already in use
```

The uvicorn service port is correctly reallocated per worktree — the crash is the **Prometheus KPI scrape endpoint**. Each backend binds a hardcoded `observability.kpi.prometheus.port` (control-plane `9222`, knowledge-flow `9111`, KF Temporal worker `9112`) that is identical in every worktree, and `KpiPrometheusSinkConfig.enabled` defaults to `true`.

wtf already has a step meant to prevent this, but it rewrites `metrics_enabled: true` — a key that no longer exists anywhere since the schema moved to `observability.kpi.prometheus.enabled`. The disable step has silently been a no-op.

## Fix

- Remove the dead `metrics_enabled` loop.
- Add `disable_prometheus_exporter()` and fold it into the existing inter-service config pass (which already covers dev, prod, and worker configs and already skip-worktrees them). It inserts or flips `enabled: false` under the `kpi:` → `prometheus:` block, handling both shapes found in the repo (`enabled: true` present, or only `port:` relying on the enabled-by-default model).

Verified against all pristine configs on `swift`: the three colliding files get `enabled: false`; dev configs (already disabled), `mcp_catalog.yaml` (different `prometheus:` shape), and block-less files are untouched.

## Known residual gap

`apps/control-plane-backend/config/configuration_worker.yaml` has **no** `observability.kpi.prometheus` block, so its worker falls back to the model default (enabled, port `9000`) — still a cross-worktree collision, but one wtf cannot fix by substitution without synthesizing a YAML block. Worth adding an explicit block to that config in a follow-up.