### PR TITLE
fix(CTRLP-14): reserve agent-kind capability id namespace (GitHub #20…

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/capabilities/catalog.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/catalog.py
@@ -48,6 +48,7 @@ async def aggregate_capability_catalog(
     # Lazy import breaks the product.service ↔ capabilities import cycle: the
     # pod-catalog fetch protocol lives with the rest of the runtime-source code.
     from control_plane_backend.product.service import (
+        AGENT_CAPABILITY_NAMESPACE_PREFIX,
         _agent_capabilities_for_source,
         _available_capabilities_for_source,
     )
@@ -87,6 +88,26 @@ async def aggregate_capability_catalog(
                     entry.id,
                     source.base_url,
                     CAPABILITY_ID_PATTERN,
+                )
+                continue
+            if entry.kind != "agent" and entry.id.startswith(
+                AGENT_CAPABILITY_NAMESPACE_PREFIX
+            ):
+                # `AGENT_CAPABILITY_NAMESPACE_PREFIX` is reserved exclusively
+                # for kind="agent" template projections (GitHub #2004 item 4)
+                # so the two kinds can never collide in this flat dict —
+                # admitting a same-prefixed tool id would defeat that
+                # guarantee and silently shadow (or be shadowed by) the real
+                # agent-template entry. Quarantine at the same chokepoint as
+                # the invalid-id check above, rather than letting it overwrite.
+                logger.error(
+                    "[capability-catalog] refusing kind=%r capability id %r "
+                    'from %s: the %r prefix is reserved for kind="agent" '
+                    "template projections — rename this tool/MCP-server id",
+                    entry.kind,
+                    entry.id,
+                    source.base_url,
+                    AGENT_CAPABILITY_NAMESPACE_PREFIX,
                 )
                 continue
             catalog[entry.id] = entry

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -23,7 +23,7 @@ from fred_core.common.team_id import is_personal_team_id
 from fred_core.kpi.kpi_writer import to_kpi_actor
 from fred_core.kpi.kpi_writer_structures import KPIActor
 from fred_core.security.models import Resource
-from fred_core.security.rebac.rebac_engine import Relation, RebacReference, RelationType
+from fred_core.security.rebac.rebac_engine import RebacReference, Relation, RelationType
 from fred_core.tasks import ErasureReason
 from fred_sdk.contracts.capability import (
     CapabilityCatalogEntry,

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -23,7 +23,7 @@ from fred_core.common.team_id import is_personal_team_id
 from fred_core.kpi.kpi_writer import to_kpi_actor
 from fred_core.kpi.kpi_writer_structures import KPIActor
 from fred_core.security.models import Resource
-from fred_core.security.rebac.rebac_engine import RebacReference, RelationType
+from fred_core.security.rebac.rebac_engine import Relation, RebacReference, RelationType
 from fred_core.tasks import ErasureReason
 from fred_sdk.contracts.capability import (
     CapabilityCatalogEntry,
@@ -515,6 +515,19 @@ async def _available_capabilities_for_source(
     return list(merged.values())
 
 
+AGENT_CAPABILITY_NAMESPACE_PREFIX = "agent__"
+"""Reserved id prefix for every `kind="agent"` catalog entry (GitHub #2004
+item 4). `kind="tool"` entries share the SAME flat capability catalog dict
+(`capabilities/catalog.py::aggregate_capability_catalog`) and the same FGA
+object type — nothing stopped a tool/MCP-server id from coincidentally
+matching an (unprefixed) template id, which silently overwrote one or the
+other (later-registration-wins). Reserving this prefix for agent projections
+and rejecting any `kind="tool"` entry that lands in it (enforced in
+`aggregate_capability_catalog`) makes the collision structurally impossible
+rather than merely unlikely. See `rename_agent_capability_ids_to_namespaced_form`
+below for the one-time tuple-rename migration this prefix required."""
+
+
 def template_capability_id(runtime_id: str, agent_id: str) -> str:
     """
     Colon-free FGA-safe capability id for one agent template (CAPAB-01, RFC
@@ -524,9 +537,12 @@ def template_capability_id(runtime_id: str, agent_id: str) -> str:
     the same crash class `#1988` fixed for `mcp:<id>` capabilities. This is a
     parallel identifier used ONLY for ReBAC checks and the admin catalog —
     never for routing, which keeps using `template_id`.
+
+    2026-07-20 (GitHub #2004 item 4): prefixed with `AGENT_CAPABILITY_NAMESPACE_PREFIX`
+    so this id can never collide with a `kind="tool"` id (see that constant).
     """
 
-    return f"{runtime_id}__{agent_id}"
+    return f"{AGENT_CAPABILITY_NAMESPACE_PREFIX}{runtime_id}__{agent_id}"
 
 
 async def _agent_capabilities_for_source(
@@ -1665,6 +1681,123 @@ async def grant_existing_teams_served_templates(
         summary.already_granted,
         summary.skipped_unreachable_sources,
         summary.skipped_dependency_not_satisfied,
+    )
+    return summary
+
+
+_ORG_REF = RebacReference(type=Resource.ORGANIZATION, id=ORGANIZATION_ID)
+
+
+@dataclass
+class TemplateIdNamespaceMigrationSummary:
+    templates_checked: int = 0
+    skipped_unreachable_sources: int = 0
+    tuples_renamed: int = 0
+
+
+async def rename_agent_capability_ids_to_namespaced_form(
+    deps: ProductServiceDependencies,
+    *,
+    dry_run: bool = False,
+) -> TemplateIdNamespaceMigrationSummary:
+    """
+    One-time compatibility migration for the `AGENT_CAPABILITY_NAMESPACE_PREFIX`
+    fix (GitHub #2004 item 4, RFC §8.6 2026-07-20 dated entry).
+
+    `template_capability_id` used to return the un-prefixed
+    `f"{runtime_id}__{agent_id}"`. Any FGA tuple written before this migration
+    ships (anchor, `enabled`/`disabled` per team, `default_on`,
+    `personal_on`/`personal_disabled`) is keyed on that old id. Simply
+    changing the id-generating function would silently orphan every one of
+    those tuples — teams that already had a template enabled would
+    instantly lose access the moment this code deploys.
+
+    Renames each such tuple in place: writes the identical
+    (subject, relation) pair under the new `agent__`-prefixed resource id,
+    then deletes the old one. Idempotent and safe to re-run — a tuple already
+    renamed (or never granted) has nothing to move under the old id and is
+    silently skipped, exactly like `grant_existing_teams_served_templates`.
+
+    How to use it: run once, before this code deploys, the same
+    deploy-sequencing rule as `grant_existing_teams_served_templates` (both
+    rehearsed against a copy of real data first, never attempted for the
+    first time in production). `dry_run=True` reports what WOULD be renamed
+    without writing.
+    """
+
+    rebac = deps.team_dependencies.rebac
+    template_entries: dict[str, CapabilityCatalogEntry] = {}
+    unreachable_sources = 0
+    for source in deps.configuration.platform.runtime_catalog_sources:
+        if not source.enabled:
+            continue
+        entries = await _agent_capabilities_for_source(
+            source.base_url, source.runtime_id
+        )
+        if entries is None:
+            unreachable_sources += 1
+            continue
+        for entry in entries:
+            template_entries[entry.id] = entry
+    summary = TemplateIdNamespaceMigrationSummary(
+        templates_checked=len(template_entries),
+        skipped_unreachable_sources=unreachable_sources,
+    )
+
+    teams = await deps.team_dependencies.get_team_metadata_store().list_all()
+
+    for new_id in template_entries:
+        old_id = new_id.removeprefix(AGENT_CAPABILITY_NAMESPACE_PREFIX)
+        if old_id == new_id:
+            # Defensive: template_capability_id always applies the prefix, so
+            # a catalog entry without it would mean a non-agent-projection id
+            # ended up in `template_entries` — never move a tuple in that case.
+            continue
+        old_ref = RebacReference(type=Resource.CAPABILITY, id=old_id)
+        new_ref = RebacReference(type=Resource.CAPABILITY, id=new_id)
+
+        # Org-subject tuples: anchor + the three platform-wide class markers.
+        for relation in (
+            RelationType.ORGANIZATION,
+            RelationType.DEFAULT_ON,
+            RelationType.PERSONAL_ON,
+            RelationType.PERSONAL_DISABLED,
+        ):
+            if await rebac.has_direct_relation(_ORG_REF, relation, old_ref):
+                summary.tuples_renamed += 1
+                if not dry_run:
+                    await rebac.add_relation(
+                        Relation(subject=_ORG_REF, relation=relation, resource=new_ref)
+                    )
+                    await rebac.delete_relation(
+                        Relation(subject=_ORG_REF, relation=relation, resource=old_ref)
+                    )
+
+        # Team-subject tuples: the per-team enable/disable grant.
+        for team in teams:
+            team_ref = RebacReference(type=Resource.TEAM, id=str(team.id))
+            for relation in (RelationType.ENABLED, RelationType.DISABLED):
+                if await rebac.has_direct_relation(team_ref, relation, old_ref):
+                    summary.tuples_renamed += 1
+                    if not dry_run:
+                        await rebac.add_relation(
+                            Relation(
+                                subject=team_ref, relation=relation, resource=new_ref
+                            )
+                        )
+                        await rebac.delete_relation(
+                            Relation(
+                                subject=team_ref, relation=relation, resource=old_ref
+                            )
+                        )
+
+    logger.info(
+        "[template-id-namespace-migration] sweep done dry_run=%s "
+        "templates_checked=%d tuples_renamed=%d skipped_unreachable_sources=%d",
+        dry_run,
+        summary.templates_checked,
+        summary.tuples_renamed,
+        summary.skipped_unreachable_sources,
     )
     return summary
 

--- a/apps/control-plane-backend/tests/test_capability_enablement_1980.py
+++ b/apps/control-plane-backend/tests/test_capability_enablement_1980.py
@@ -46,6 +46,7 @@ from control_plane_backend.capabilities.enablement import (
     validate_team_settings,
 )
 from control_plane_backend.capabilities.settings_store import TeamCapabilitySettings
+from control_plane_backend.product import service as product_service
 from fred_core import CapabilityPermission, RebacDisabledResult
 from fred_core.security.models import Resource
 from fred_core.security.rebac.rebac_engine import (
@@ -141,6 +142,14 @@ class _FakeRebac:
         default_on_ids = _ids(org_key, "default_on")
         usable = (enabled_ids | default_on_ids) - disabled_ids
         return [RebacReference(type=resource_type, id=cid) for cid in usable]
+
+
+# Real `template_capability_id` output (GitHub #2004 item 4: `agent__`
+# namespace prefix) — derived, never hand-typed, so these tests can't drift
+# from the id `is_template_capability_instance` actually computes.
+SQL_EXPERT_TEMPLATE_ID = product_service.template_capability_id(
+    "runtime-a", "sql_expert"
+)
 
 
 def _entry(
@@ -367,7 +376,7 @@ async def test_enable_capability_for_team_rejects_agent_capability_missing_tool_
     rebac = _FakeRebac()
     settings = _FakeSettingsStore()
     sql_expert = _entry(
-        "runtime-a__sql_expert",
+        SQL_EXPERT_TEMPLATE_ID,
         kind="agent",
         default_capability_ids=("mcp-knowledge-flow-mcp-tabular",),
     )
@@ -384,7 +393,7 @@ async def test_enable_capability_for_team_rejects_agent_capability_missing_tool_
 
     # Rejected before any write: no tuple, no settings row.
     assert rebac.tuples == set()
-    assert ("team-a", "runtime-a__sql_expert") not in settings._rows
+    assert ("team-a", SQL_EXPERT_TEMPLATE_ID) not in settings._rows
 
 
 @pytest.mark.asyncio
@@ -395,7 +404,7 @@ async def test_enable_capability_for_team_allows_agent_capability_when_tool_depe
     settings = _FakeSettingsStore()
     tool_entry = _entry("mcp-knowledge-flow-mcp-tabular")
     sql_expert = _entry(
-        "runtime-a__sql_expert",
+        SQL_EXPERT_TEMPLATE_ID,
         kind="agent",
         default_capability_ids=("mcp-knowledge-flow-mcp-tabular",),
     )
@@ -422,7 +431,7 @@ async def test_enable_capability_for_team_allows_agent_capability_when_tool_depe
     assert (
         "team:team-a",
         "enabled",
-        "capability:runtime-a__sql_expert",
+        f"capability:{SQL_EXPERT_TEMPLATE_ID}",
     ) in rebac.tuples
 
 
@@ -435,7 +444,7 @@ async def test_disable_agent_template_capability_suspends_its_instances() -> Non
 
     rebac = _FakeRebac()
     settings = _FakeSettingsStore()
-    sql_expert = _entry("runtime-a__sql_expert", kind="agent")
+    sql_expert = _entry(SQL_EXPERT_TEMPLATE_ID, kind="agent")
     await enable_capability_for_team(
         rebac=rebac,
         settings_store=settings,
@@ -488,12 +497,12 @@ async def test_suspend_dependent_instances_is_idempotent_for_agent_template() ->
     first = await suspend_dependent_instances(
         agent_instance_store=store,
         team_id="team-a",
-        capability_id="runtime-a__sql_expert",
+        capability_id=SQL_EXPERT_TEMPLATE_ID,
     )
     second = await suspend_dependent_instances(
         agent_instance_store=store,
         team_id="team-a",
-        capability_id="runtime-a__sql_expert",
+        capability_id=SQL_EXPERT_TEMPLATE_ID,
     )
 
     assert first == 1
@@ -523,15 +532,15 @@ async def test_revive_dependent_instances_revives_agent_template_instance() -> N
     suspended = await suspend_dependent_instances(
         agent_instance_store=store,
         team_id="team-a",
-        capability_id="runtime-a__sql_expert",
+        capability_id=SQL_EXPERT_TEMPLATE_ID,
     )
     assert suspended == 1
     assert instance.suspension_reason == "capability_access_revoked"
 
     revived = await enablement.revive_dependent_instances(
         agent_instance_store=store,
-        capability_id="runtime-a__sql_expert",
-        usable_capability_ids={"runtime-a__sql_expert"},
+        capability_id=SQL_EXPERT_TEMPLATE_ID,
+        usable_capability_ids={SQL_EXPERT_TEMPLATE_ID},
         available_by_source={"runtime-a": frozenset()},
         team_id="team-a",
     )
@@ -560,7 +569,7 @@ async def test_revive_dependent_instances_keeps_agent_template_suspended_when_st
 
     revived = await enablement.revive_dependent_instances(
         agent_instance_store=store,
-        capability_id="runtime-a__sql_expert",
+        capability_id=SQL_EXPERT_TEMPLATE_ID,
         usable_capability_ids=set(),  # still not usable
         available_by_source={"runtime-a": frozenset()},
         team_id="team-a",
@@ -581,7 +590,7 @@ async def test_personal_scope_enabled_rejects_agent_capability_missing_tool_depe
     rebac = _FakeRebac()
     store = _FakeAgentInstanceStore([])
     sql_expert = _entry(
-        "runtime-a__sql_expert",
+        SQL_EXPERT_TEMPLATE_ID,
         kind="agent",
         default_capability_ids=("mcp-knowledge-flow-mcp-tabular",),
     )
@@ -936,7 +945,7 @@ async def test_aggregation_unions_agent_kind_projections(monkeypatch) -> None:
     async def _fake_fetch_agents(base_url: str, runtime_id: str):
         return [
             CapabilityCatalogEntry(
-                id=f"{runtime_id}__sentinel",
+                id=product_service.template_capability_id(runtime_id, "sentinel"),
                 version="1",
                 name="agent.sentinel.name",
                 description="agent.sentinel.description",
@@ -966,9 +975,74 @@ async def test_aggregation_unions_agent_kind_projections(monkeypatch) -> None:
 
     catalog = await aggregate_capability_catalog(deps)
 
-    assert set(catalog) == {"doc_access", "runtime-a__sentinel"}
-    assert catalog["runtime-a__sentinel"].kind == "agent"
+    sentinel_id = product_service.template_capability_id("runtime-a", "sentinel")
+    assert set(catalog) == {"doc_access", sentinel_id}
+    assert catalog[sentinel_id].kind == "agent"
     assert catalog["doc_access"].kind == "tool"
+
+
+@pytest.mark.asyncio
+async def test_aggregation_refuses_tool_id_colliding_with_reserved_agent_namespace(
+    monkeypatch,
+) -> None:
+    """2026-07-20, GitHub #2004 item 4: `AGENT_CAPABILITY_NAMESPACE_PREFIX`
+    (`agent__`) is reserved exclusively for `kind="agent"` template
+    projections. A `kind="tool"` entry that happens to land in that
+    namespace (a coincidental MCP-server/tool id, or a future authoring bug)
+    must be quarantined at the same chokepoint as an invalid-pattern id —
+    never silently admitted to shadow (or be shadowed by) the real agent
+    entry sharing that id."""
+
+    from types import SimpleNamespace
+
+    from control_plane_backend.capabilities.catalog import (
+        aggregate_capability_catalog,
+    )
+
+    colliding_tool_id = product_service.template_capability_id(
+        "runtime-a", "sql_expert"
+    )
+
+    async def _fake_fetch(base_url: str):
+        return [_entry("doc_access"), _entry(colliding_tool_id, kind="tool")]
+
+    async def _fake_fetch_agents(base_url: str, runtime_id: str):
+        return [
+            CapabilityCatalogEntry(
+                id=colliding_tool_id,
+                version="1",
+                name="agent.sql_expert.name",
+                description="agent.sql_expert.description",
+                icon="smart_toy",
+                kind="agent",
+                team_scope=TeamScopePolicy.ADMIN_GATED,
+            )
+        ]
+
+    monkeypatch.setattr(
+        product_service, "_available_capabilities_for_source", _fake_fetch
+    )
+    monkeypatch.setattr(
+        product_service, "_agent_capabilities_for_source", _fake_fetch_agents
+    )
+    deps = SimpleNamespace(
+        configuration=SimpleNamespace(
+            platform=SimpleNamespace(
+                runtime_catalog_sources=[
+                    SimpleNamespace(
+                        enabled=True, base_url="http://pod", runtime_id="runtime-a"
+                    )
+                ]
+            )
+        )
+    )
+
+    catalog = await aggregate_capability_catalog(deps)
+
+    # The tool entry is refused; the real agent entry (fetched second) wins
+    # the id, never overwritten — the collision this prefix exists to prevent.
+    assert set(catalog) == {"doc_access", colliding_tool_id}
+    assert catalog[colliding_tool_id].kind == "agent"
 
 
 @pytest.mark.asyncio
@@ -1301,7 +1375,7 @@ async def test_personal_scope_disabled_to_enabled_revives_suspended_agent_templa
     from control_plane_backend.capabilities import service as capability_service
 
     rebac = _FakeRebac()
-    entry = _entry("runtime-a__sql_expert", kind="agent")
+    entry = _entry(SQL_EXPERT_TEMPLATE_ID, kind="agent")
 
     # The template's own id is never added to `selected_capability_ids` (only
     # tool capabilities an instance activated live there) — this instance
@@ -1316,7 +1390,7 @@ async def test_personal_scope_disabled_to_enabled_revives_suspended_agent_templa
     store = _FakeAgentInstanceStore([dependent])
 
     async def _fake_catalog(_deps):
-        return {"runtime-a__sql_expert": entry}
+        return {SQL_EXPERT_TEMPLATE_ID: entry}
 
     monkeypatch.setattr(
         capability_service, "aggregate_capability_catalog", _fake_catalog
@@ -1326,12 +1400,12 @@ async def test_personal_scope_disabled_to_enabled_revives_suspended_agent_templa
         store,
         rebac,
         available_by_source={"runtime-a": frozenset()},
-        usable_ids={"runtime-a__sql_expert"},
+        usable_ids={SQL_EXPERT_TEMPLATE_ID},
     )
 
     result = await capability_service.set_personal_scope(
         user=SimpleNamespace(uid="admin"),
-        capability_id="runtime-a__sql_expert",
+        capability_id=SQL_EXPERT_TEMPLATE_ID,
         scope="enabled",
         deps=deps,
     )

--- a/apps/control-plane-backend/tests/test_capability_namespace_migration_2004.py
+++ b/apps/control-plane-backend/tests/test_capability_namespace_migration_2004.py
@@ -1,0 +1,257 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GitHub #2004 item 4 — `kind="tool"`/`kind="agent"` capability-id namespace
+separation (RFC `AGENT-CAPABILITY-RFC.md` §8.6, 2026-07-20 dated entry).
+
+`template_capability_id` now reserves the `AGENT_CAPABILITY_NAMESPACE_PREFIX`
+(`agent__`) exclusively for `kind="agent"` projections, so a `kind="tool"` id
+can never again collide with one in the shared flat capability catalog
+(`aggregate_capability_catalog` — collision-rejection tests live alongside
+the rest of that aggregation suite in `test_capability_enablement_1980.py`).
+
+This file covers the companion piece: `rename_agent_capability_ids_to_
+namespaced_form`, the one-time migration that renames FGA tuples already
+persisted under the pre-fix, un-prefixed id so the format change never
+orphans a live grant.
+"""
+
+# pyright: reportArgumentType=false
+# ^ this suite passes a lightweight `SimpleNamespace` deps double, and a fake
+#   rebac, in place of the real typed protocols, on purpose (same convention
+#   as test_capability_selection_1974.py / test_capability_enablement_1980.py).
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from control_plane_backend.config.models import RuntimeCatalogSourceConfig
+from control_plane_backend.product import service
+from fred_core.security.models import Resource
+from fred_core.security.rebac.rebac_engine import (
+    ORGANIZATION_ID,
+    RebacReference,
+    Relation,
+    RelationType,
+)
+from fred_sdk.contracts.capability import CapabilityCatalogEntry
+from fred_sdk.contracts.models import TeamScopePolicy
+
+_ORG_REF = RebacReference(type=Resource.ORGANIZATION, id=ORGANIZATION_ID)
+
+
+class _FakeMigrationRebac:
+    """Tracks tuples as plain `(subject, relation, resource)` string triples
+    and answers `has_direct_relation` straight off that set — enough to
+    exercise a rename migration without a live OpenFGA."""
+
+    def __init__(self) -> None:
+        self.tuples: set[tuple[str, str, str]] = set()
+
+    def _key(
+        self, subject: RebacReference, relation: RelationType, resource: RebacReference
+    ) -> tuple[str, str, str]:
+        return (
+            f"{subject.type.value}:{subject.id}",
+            relation.value,
+            f"{resource.type.value}:{resource.id}",
+        )
+
+    async def seed(
+        self, subject: RebacReference, relation: RelationType, resource: RebacReference
+    ) -> None:
+        self.tuples.add(self._key(subject, relation, resource))
+
+    async def has_direct_relation(
+        self,
+        subject: RebacReference,
+        relation: RelationType,
+        resource: RebacReference,
+        *,
+        consistency_token: str | None = None,
+    ) -> bool:
+        return self._key(subject, relation, resource) in self.tuples
+
+    async def add_relation(self, relation: Relation, **kwargs: object) -> str | None:
+        self.tuples.add(
+            self._key(relation.subject, relation.relation, relation.resource)
+        )
+        return None
+
+    async def delete_relation(self, relation: Relation) -> str | None:
+        self.tuples.discard(
+            self._key(relation.subject, relation.relation, relation.resource)
+        )
+        return None
+
+
+class _FakeTeamMetadataStore:
+    def __init__(self, team_ids: list[str]) -> None:
+        self._teams = [SimpleNamespace(id=tid) for tid in team_ids]
+
+    async def list_all(self):
+        return self._teams
+
+
+def _deps(
+    rebac: _FakeMigrationRebac,
+    team_ids: list[str],
+    *,
+    runtime_id: str = "runtime-a",
+    unreachable: bool = False,
+):
+    return SimpleNamespace(
+        team_dependencies=SimpleNamespace(
+            rebac=rebac,
+            get_team_metadata_store=lambda: _FakeTeamMetadataStore(team_ids),
+        ),
+        configuration=SimpleNamespace(
+            platform=SimpleNamespace(
+                runtime_catalog_sources=[
+                    RuntimeCatalogSourceConfig(
+                        runtime_id=runtime_id,
+                        base_url=f"http://{runtime_id}/pod/v1",
+                        enabled=not unreachable,
+                    )
+                ]
+            )
+        ),
+    )
+
+
+def _wire_agent_catalog(monkeypatch: pytest.MonkeyPatch, new_id: str) -> None:
+    async def _fake_fetch_agents(base_url: str, runtime_id: str):
+        return [
+            CapabilityCatalogEntry(
+                id=new_id,
+                version="1",
+                name="agent.sql_expert.name",
+                description="agent.sql_expert.description",
+                icon="smart_toy",
+                kind="agent",
+                team_scope=TeamScopePolicy.ADMIN_GATED,
+            )
+        ]
+
+    monkeypatch.setattr(service, "_agent_capabilities_for_source", _fake_fetch_agents)
+
+
+@pytest.mark.asyncio
+async def test_rename_migration_moves_every_relation_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    new_id = service.template_capability_id("runtime-a", "sql_expert")
+    old_id = new_id.removeprefix(service.AGENT_CAPABILITY_NAMESPACE_PREFIX)
+    _wire_agent_catalog(monkeypatch, new_id)
+
+    rebac = _FakeMigrationRebac()
+    old_ref = RebacReference(type=Resource.CAPABILITY, id=old_id)
+    team_a = RebacReference(type=Resource.TEAM, id="team-a")
+    team_b = RebacReference(type=Resource.TEAM, id="team-b")
+    await rebac.seed(_ORG_REF, RelationType.ORGANIZATION, old_ref)
+    await rebac.seed(_ORG_REF, RelationType.DEFAULT_ON, old_ref)
+    await rebac.seed(_ORG_REF, RelationType.PERSONAL_ON, old_ref)
+    await rebac.seed(team_a, RelationType.ENABLED, old_ref)
+    await rebac.seed(team_b, RelationType.DISABLED, old_ref)
+
+    summary = await service.rename_agent_capability_ids_to_namespaced_form(
+        _deps(rebac, ["team-a", "team-b"])
+    )
+
+    new_ref_key = f"capability:{new_id}"
+    old_ref_key = f"capability:{old_id}"
+    assert summary.templates_checked == 1
+    assert summary.tuples_renamed == 5
+    assert summary.skipped_unreachable_sources == 0
+    # Every relation moved to the new id...
+    assert (
+        f"organization:{ORGANIZATION_ID}",
+        "organization",
+        new_ref_key,
+    ) in rebac.tuples
+    assert (
+        f"organization:{ORGANIZATION_ID}",
+        "default_on",
+        new_ref_key,
+    ) in rebac.tuples
+    assert (
+        f"organization:{ORGANIZATION_ID}",
+        "personal_on",
+        new_ref_key,
+    ) in rebac.tuples
+    assert ("team:team-a", "enabled", new_ref_key) in rebac.tuples
+    assert ("team:team-b", "disabled", new_ref_key) in rebac.tuples
+    # ...and nothing is left under the old id.
+    assert not any(t[2] == old_ref_key for t in rebac.tuples)
+
+
+@pytest.mark.asyncio
+async def test_rename_migration_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    new_id = service.template_capability_id("runtime-a", "sql_expert")
+    old_id = new_id.removeprefix(service.AGENT_CAPABILITY_NAMESPACE_PREFIX)
+    _wire_agent_catalog(monkeypatch, new_id)
+
+    rebac = _FakeMigrationRebac()
+    old_ref = RebacReference(type=Resource.CAPABILITY, id=old_id)
+    team_a = RebacReference(type=Resource.TEAM, id="team-a")
+    await rebac.seed(team_a, RelationType.ENABLED, old_ref)
+
+    deps = _deps(rebac, ["team-a"])
+    first = await service.rename_agent_capability_ids_to_namespaced_form(deps)
+    second = await service.rename_agent_capability_ids_to_namespaced_form(deps)
+
+    assert first.tuples_renamed == 1
+    assert second.tuples_renamed == 0
+    assert ("team:team-a", "enabled", f"capability:{new_id}") in rebac.tuples
+
+
+@pytest.mark.asyncio
+async def test_rename_migration_dry_run_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    new_id = service.template_capability_id("runtime-a", "sql_expert")
+    old_id = new_id.removeprefix(service.AGENT_CAPABILITY_NAMESPACE_PREFIX)
+    _wire_agent_catalog(monkeypatch, new_id)
+
+    rebac = _FakeMigrationRebac()
+    old_ref = RebacReference(type=Resource.CAPABILITY, id=old_id)
+    team_a = RebacReference(type=Resource.TEAM, id="team-a")
+    await rebac.seed(team_a, RelationType.ENABLED, old_ref)
+
+    summary = await service.rename_agent_capability_ids_to_namespaced_form(
+        _deps(rebac, ["team-a"]), dry_run=True
+    )
+
+    assert summary.tuples_renamed == 1
+    assert ("team:team-a", "enabled", f"capability:{old_id}") in rebac.tuples
+    assert not any(t[2] == f"capability:{new_id}" for t in rebac.tuples)
+
+
+@pytest.mark.asyncio
+async def test_rename_migration_skips_unreachable_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unreachable(base_url: str, runtime_id: str):
+        return None
+
+    monkeypatch.setattr(service, "_agent_capabilities_for_source", _unreachable)
+
+    rebac = _FakeMigrationRebac()
+    summary = await service.rename_agent_capability_ids_to_namespaced_form(
+        _deps(rebac, [])
+    )
+
+    assert summary.templates_checked == 0
+    assert summary.skipped_unreachable_sources == 1
+    assert summary.tuples_renamed == 0

--- a/apps/control-plane-backend/tests/test_capability_selection_1974.py
+++ b/apps/control-plane-backend/tests/test_capability_selection_1974.py
@@ -81,6 +81,12 @@ _PROBE_ENTRY = CapabilityCatalogEntry(
     icon="hub",
 )
 
+# Real `template_capability_id` output (GitHub #2004 item 4: `agent__`
+# namespace prefix) — derived, never hand-typed, so these tests can't drift.
+RAGS_SAMPLE_ECHO_TEMPLATE_ID = service.template_capability_id(
+    "runtime-a", "rags.sample.echo"
+)
+
 
 def _template_payload(
     default_capability_ids: list[str] | None = None,
@@ -409,7 +415,7 @@ async def test_enroll_no_selection_materializes_only_granted_defaults(
 ) -> None:
     _wire_rebac(
         monkeypatch,
-        {"personal": {"demo_echo", "runtime-a__rags.sample.echo"}},
+        {"personal": {"demo_echo", RAGS_SAMPLE_ECHO_TEMPLATE_ID}},
     )
     app, store = _setup(monkeypatch, default_capability_ids=["demo_echo", "probe_echo"])
     calls = _fake_pod_validate(monkeypatch)
@@ -494,7 +500,7 @@ async def test_enroll_no_selection_rejected_when_no_default_capability_is_usable
     instance would be silently created with `selected_capability_ids=[]`;
     now it must be rejected (422) instead."""
 
-    _wire_rebac(monkeypatch, {"personal": {"runtime-a__rags.sample.echo"}})
+    _wire_rebac(monkeypatch, {"personal": {RAGS_SAMPLE_ECHO_TEMPLATE_ID}})
     app, store = _setup(monkeypatch, default_capability_ids=["demo_echo", "probe_echo"])
     _fake_pod_validate(monkeypatch)
     async with AsyncClient(
@@ -517,7 +523,7 @@ async def test_enroll_explicit_selection_denied_by_rebac_is_403(
 ) -> None:
     # Template itself granted (else this would 404 before ever reaching the
     # capability-selection check) but not the explicitly-requested capability.
-    _wire_rebac(monkeypatch, {"personal": {"runtime-a__rags.sample.echo"}})
+    _wire_rebac(monkeypatch, {"personal": {RAGS_SAMPLE_ECHO_TEMPLATE_ID}})
     app, store = _setup(monkeypatch)
     _fake_pod_validate(monkeypatch)
     async with AsyncClient(
@@ -572,7 +578,7 @@ async def test_update_capability_config_only_materializes_still_none_instance(
     reached `_apply_capability_selection(selected_ids=None)` and skipped the
     ReBAC check the same way enroll did.
 
-    Also grants the template capability itself (`runtime-a__rags.sample.echo`)
+    Also grants the template capability itself (`RAGS_SAMPLE_ECHO_TEMPLATE_ID`)
     so this update clears the separate, later "2026-07-19 fix (GitHub #2004
     item 1)" template-access gate at the top of `update_agent_instance` — this
     test isolates the capability-selection gap, not that one (covered by
@@ -580,7 +586,7 @@ async def test_update_capability_config_only_materializes_still_none_instance(
     """
     record = _make_record()
     assert record.tuning.selected_capability_ids is None
-    _wire_rebac(monkeypatch, {"personal": {"runtime-a__rags.sample.echo", "demo_echo"}})
+    _wire_rebac(monkeypatch, {"personal": {RAGS_SAMPLE_ECHO_TEMPLATE_ID, "demo_echo"}})
     app, store = _setup(
         monkeypatch,
         records=[record],
@@ -760,8 +766,17 @@ async def test_update_unknown_capability_id_is_typed_422(
 
 def test_template_capability_id_is_colon_free() -> None:
     cap_id = service.template_capability_id("runtime-a", "rags.sample.echo")
-    assert cap_id == "runtime-a__rags.sample.echo"
+    assert cap_id == "agent__runtime-a__rags.sample.echo"
     assert ":" not in cap_id
+
+
+def test_template_capability_id_is_namespaced_under_reserved_prefix() -> None:
+    """2026-07-20, GitHub #2004 item 4: every `kind="agent"` id must start
+    with `AGENT_CAPABILITY_NAMESPACE_PREFIX` — `aggregate_capability_catalog`
+    relies on this to reject a colliding `kind="tool"` id at admission time."""
+
+    cap_id = service.template_capability_id("runtime-a", "rags.sample.echo")
+    assert cap_id.startswith(service.AGENT_CAPABILITY_NAMESPACE_PREFIX)
 
 
 @pytest.mark.asyncio
@@ -791,7 +806,7 @@ async def test_agent_projection_always_hardcodes_admin_gated(
     assert entries is not None and len(entries) == 1
     assert entries[0].kind == "agent"
     assert entries[0].team_scope == TeamScopePolicy.ADMIN_GATED
-    assert entries[0].id == "runtime-a__rags.sample.echo"
+    assert entries[0].id == RAGS_SAMPLE_ECHO_TEMPLATE_ID
 
 
 @pytest.mark.asyncio
@@ -857,7 +872,7 @@ async def test_list_agent_templates_hides_template_team_is_not_granted(
 async def test_list_agent_templates_shows_template_when_granted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _wire_rebac(monkeypatch, {"personal": {"runtime-a__rags.sample.echo"}})
+    _wire_rebac(monkeypatch, {"personal": {RAGS_SAMPLE_ECHO_TEMPLATE_ID}})
     app, _store = _setup(monkeypatch)
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -946,7 +961,7 @@ async def test_grant_existing_teams_served_templates_migration(
             )
 
     rebac = _FakeTemplateGrantRebac(
-        already_granted={"team-already-granted": {"runtime-a__rags.sample.echo"}}
+        already_granted={"team-already-granted": {RAGS_SAMPLE_ECHO_TEMPLATE_ID}}
     )
     deps = SimpleNamespace(
         team_dependencies=SimpleNamespace(
@@ -975,7 +990,7 @@ async def test_grant_existing_teams_served_templates_migration(
     assert summary.templates_checked == 1
     assert summary.already_granted == 1
     assert summary.grants_written == 1
-    assert rebac.enabled_writes == [("team-needs-grant", "runtime-a__rags.sample.echo")]
+    assert rebac.enabled_writes == [("team-needs-grant", RAGS_SAMPLE_ECHO_TEMPLATE_ID)]
 
 
 @pytest.mark.asyncio
@@ -1011,7 +1026,7 @@ async def test_grant_existing_teams_served_templates_migration_preserves_explici
             )
 
     rebac = _FakeTemplateGrantRebac(
-        already_disabled={"team-explicitly-disabled": {"runtime-a__rags.sample.echo"}}
+        already_disabled={"team-explicitly-disabled": {RAGS_SAMPLE_ECHO_TEMPLATE_ID}}
     )
     deps = SimpleNamespace(
         team_dependencies=SimpleNamespace(

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -1045,9 +1045,15 @@ items:
       enabling an agent without its tool dependencies granted.
       2026-07-19: the deferred `depends_on` fast-follow, plus three backend
       robustness gaps found reviewing this work (revoke-doesn't-suspend,
-      migration idempotency, import bypass), are being closed together under
-      GitHub #2004 on branch `2004-capab-01-agent-template-capability-gating-gaps`.
-      See `AGENT-CAPABILITY-RFC.md` §8.6's 2026-07-19 dated entry for the design.
+      migration idempotency, import bypass), closed together under GitHub
+      #2004, merged via #2015 on `swift`. See `AGENT-CAPABILITY-RFC.md` §8.6's
+      2026-07-19 dated entry for the design.
+      2026-07-20: #2004 item 4 (kind="tool"/kind="agent" catalog-id namespace
+      collision) closed on the follow-up branch
+      `2004-capab-01ctrlp-14-follow-up-...` — `agent__` reserved id prefix +
+      admission-time rejection + one-time tuple-rename migration. See
+      `AGENT-CAPABILITY-RFC.md` §8.6's 2026-07-20 dated entry. All five #2004
+      items now resolved; issue closes with this branch's PR.
 
   # ── EVAL ──────────────────────────────────────────────────────────────
 

--- a/docs/swift/rfc/AGENT-CAPABILITY-RFC.md
+++ b/docs/swift/rfc/AGENT-CAPABILITY-RFC.md
@@ -1705,6 +1705,41 @@ capability of `kind="agent"` in this exact same object space:
 > Not in this pass: `kind="tool"`/`kind="agent"` catalog-id namespace
 > separation (#2004 item 4, low likelihood, opportunistic).
 
+> **2026-07-20 — item 4 closed: `kind="tool"`/`kind="agent"` catalog-id
+> namespace separation.** Both kinds share one flat capability catalog dict
+> (`aggregate_capability_catalog`) and one FGA object type; nothing stopped a
+> tool/MCP-server id from coincidentally matching an (unprefixed)
+> `template_capability_id` and silently overwriting it (or being overwritten
+> by it) — later-registration-wins, no log, no error. Rejected a log-and-skip
+> collision guard (still lets one entry silently vanish from the catalog,
+> just with an unread log line) in favor of making the collision
+> structurally impossible:
+>
+> - `template_capability_id(runtime_id, agent_id)` now returns
+>   `f"agent__{runtime_id}__{agent_id}"` — `AGENT_CAPABILITY_NAMESPACE_PREFIX`
+>   (`product/service.py`), a namespace reserved exclusively for `kind="agent"`
+>   projections.
+> - `aggregate_capability_catalog` (`capabilities/catalog.py`) rejects, at its
+>   existing invalid-id quarantine chokepoint, any `kind="tool"` entry whose
+>   id starts with that reserved prefix — logged as an error, not silently
+>   admitted. This closes the loophole a bare naming convention would leave
+>   open (nothing else stops a future tool/MCP-server author from choosing an
+>   `agent__`-prefixed id by accident).
+> - **Migration required:** live FGA tuples already exist under the
+>   un-prefixed id (anchor, `enabled`/`disabled` per team, `default_on`,
+>   `personal_on`/`personal_disabled`) from testing before this fix landed.
+>   `rename_agent_capability_ids_to_namespaced_form` (`product/service.py`,
+>   companion to `grant_existing_teams_served_templates`) renames each
+>   in place — same deploy-sequencing rule: run once, before this code
+>   deploys, rehearsed against a copy of real data first. Idempotent — a
+>   tuple already renamed (or never granted) has nothing to move and is
+>   skipped.
+>
+> Rejected alternative: a separate FGA object type for `kind="agent"` — would
+> reopen the "same object space, no new type" decision this section already
+> made (§7.5's rejection of a parallel admission model), for a problem a
+> reserved id prefix fully solves within the existing model.
+
 ---
 
 ## 9. Frontend (mix of generated + custom widgets — confirmed direction)


### PR DESCRIPTION
## Summary

Closes the last open item from #2004 — the CAPAB-01/CTRLP-14 backend robustness follow-up. Items 1, 2, 3, and 5 already shipped via #2015 (merged 2026-07-19); this PR closes **item 4**: `kind="tool"` and `kind="agent"` capabilities shared one flat catalog dict and one FGA object type with no guard against a same-id collision. A colliding tool id would silently overwrite (or be overwritten by) an agent-template entry — no log, no error, just a capability quietly vanishing from the admin catalog.

Rejected a cheap log-and-skip collision guard in favor of making the collision structurally impossible:

- `template_capability_id()` now returns an `agent__`-prefixed id (`AGENT_CAPABILITY_NAMESPACE_PREFIX`), a namespace reserved exclusively for `kind="agent"` projections.
- `aggregate_capability_catalog` (`capabilities/catalog.py`) rejects, at its existing invalid-id quarantine chokepoint, any `kind="tool"` entry whose id lands in that reserved namespace — closing the loophole a bare naming convention would leave open.
- **Migration required:** live FGA tuples already exist under the un-prefixed id from testing before this fix. `rename_agent_capability_ids_to_namespaced_form` (`product/service.py`, companion to `grant_existing_teams_served_templates`) renames each in place — anchor, `enabled`/`disabled` per team, `default_on`, `personal_on`/`personal_disabled`. Idempotent, `dry_run` supported. Run once before this code deploys, same deploy-sequencing rule as the existing template-grant migration.

Rejected alternative: a separate FGA object type for `kind="agent"` — would reopen the "same object space, no new type" decision already made for agent-template capabilities, for a problem a reserved id prefix fully solves within the existing model.

## Changes

- `capabilities/catalog.py` — admission-time rejection of colliding `kind="tool"` ids
- `product/service.py` — namespaced `template_capability_id()`, new `rename_agent_capability_ids_to_namespaced_form` migration + `TemplateIdNamespaceMigrationSummary`
- `tests/test_capability_namespace_migration_2004.py` (new) — migration rename/idempotency/dry-run/unreachable-source coverage
- `tests/test_capability_enablement_1980.py`, `tests/test_capability_selection_1974.py` — existing fixtures hardcoded the pre-fix id format; now derived via `template_capability_id()`/`AGENT_CAPABILITY_NAMESPACE_PREFIX` so they can't drift again, plus a new collision-rejection test
- `docs/swift/rfc/AGENT-CAPABILITY-RFC.md` — §8.6 amended with a 2026-07-20 dated entry (design + rejected alternatives)
- `docs/swift/data/id-legend.yaml` — CTRLP-14 notes updated

## Test plan

- [x] `make code-quality` (control-plane-backend) — ruff, bandit, basedpyright clean
- [x] `make test` (control-plane-backend) — 476 passed, including 4 new tests
- [ ] Rehearse `rename_agent_capability_ids_to_namespaced_form` against a copy of real data before go-live (per the deploy-sequencing rule it documents)

Closes #2004
