### PR TITLE
Swift UX bug pass: personal prompts scoping, library tree picker, capability-toggle shift, empty-folder hints (#2023)

### DIFF
--- a/.claude/skills/add-fred-capability/SKILL.md
+++ b/.claude/skills/add-fred-capability/SKILL.md
@@ -60,6 +60,9 @@ save-time validation, owned tables, a router, a chat control, or a custom chat p
 Declare as ClassVars on the subclass (`base.py` is authoritative):
 
 - `ConfigModel` — what the user sends at agent creation → drives `manifest.config_fields`.
+  A `FieldSpec` may set `ui=UIHints(widget="document_libraries")` to render the
+  library/document tree picker in the agent form instead of the type-derived default
+  input (#2023); unknown widget ids fall back gracefully.
 - `StoredConfigModel` — what is persisted after `validate_config`; **defaults to
   `ConfigModel`**, so omit it unless save-time enrichment derives extra state.
 - `TurnOptionsModel` — typed chat-time values from a chat control; `EmptyModel` if none. `[T0]`

--- a/apps/control-plane-backend/control_plane_backend/config/models.py
+++ b/apps/control-plane-backend/control_plane_backend/config/models.py
@@ -102,6 +102,10 @@ class ManagedAgentUiHints(BaseModel):
     textarea: bool = False
     group: str | None = None
     hide: bool = False
+    # Mirrors fred_sdk UIHints.widget: names a frontend stock form
+    # widget (e.g. "document_libraries"); unknown/None falls back to the
+    # type-derived default input.
+    widget: str | None = None
 
 
 class ManagedAgentFieldSpec(BaseModel):

--- a/apps/control-plane-backend/control_plane_backend/product/default_prompts.py
+++ b/apps/control-plane-backend/control_plane_backend/product/default_prompts.py
@@ -133,48 +133,6 @@ DEFAULT_PROMPTS: list[DefaultPromptSpec] = [
         ),
     ),
     DefaultPromptSpec(
-        category="monitoring",
-        name_fr="Supervision système",
-        name_en="System supervision",
-        description_fr="Analyse métriques et logs, priorise les alertes, propose des actions.",
-        description_en="Analyzes metrics and logs, prioritizes alerts, proposes corrective actions.",
-        text_fr=(
-            "Tu es un assistant de supervision et de monitoring.\n"
-            "Analyse les métriques, logs ou alertes fournis. "
-            "Identifie les anomalies, tendances et risques.\n"
-            "Priorise les alertes par criticité (critique, majeure, mineure) "
-            "et propose des actions correctives concrètes pour chaque incident détecté."
-        ),
-        text_en=(
-            "You are a supervision and monitoring assistant.\n"
-            "Analyze the provided metrics, logs, or alerts. "
-            "Identify anomalies, trends, and risks.\n"
-            "Prioritize alerts by criticality (critical, major, minor) "
-            "and propose concrete corrective actions for each detected incident."
-        ),
-    ),
-    DefaultPromptSpec(
-        category="migration",
-        name_fr="Migration & transformation",
-        name_en="Migration & transformation",
-        description_fr="Accompagne les projets de migration avec plan, risques et critères de validation.",
-        description_en="Guides migration projects with plan, risks and validation criteria.",
-        text_fr=(
-            "Tu es un expert en migration et transformation de systèmes d'information.\n"
-            "Accompagne les projets de migration (cloud, données, applications) en identifiant "
-            "les dépendances, risques et étapes critiques.\n"
-            "Propose des plans de migration détaillés, des stratégies de rollback et des "
-            "critères de validation pour chaque phase."
-        ),
-        text_en=(
-            "You are an expert in information system migration and transformation.\n"
-            "Guide migration projects (cloud, data, applications) by identifying dependencies, "
-            "risks, and critical steps.\n"
-            "Propose detailed migration plans, rollback strategies, and validation criteria "
-            "for each phase."
-        ),
-    ),
-    DefaultPromptSpec(
         category="conversational",
         name_fr="Assistant généraliste",
         name_en="General assistant",

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -2967,10 +2967,12 @@ async def list_context_prompts(
     *,
     lang: str = "en",
 ) -> list[ContextPromptSummary]:
-    """Return personal + team prompts + platform defaults for the context picker.
+    """Return the space's own prompts + platform defaults for the context picker.
 
-    DB records are ordered by session_count DESC; defaults are appended at the end
-    so frequently-used custom prompts appear first.
+    Personal prompts appear only in the personal space — a team context
+    exposes the team's prompts, never the caller's personal ones. DB records are
+    ordered by session_count DESC; defaults are appended at the end so
+    frequently-used custom prompts appear first.
     """
 
     store = deps.get_prompt_store()

--- a/apps/control-plane-backend/control_plane_backend/prompts/store.py
+++ b/apps/control-plane-backend/control_plane_backend/prompts/store.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from fred_core.common import TeamId
 from fred_core.sql import make_session_factory, use_session
-from sqlalchemy import delete, literal, select, union_all, update
+from sqlalchemy import delete, literal, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import CursorResult
@@ -429,7 +429,12 @@ class PromptStore:
         team_id: TeamId,
         session: AsyncSession | None = None,
     ) -> list[ContextPromptRecord]:
-        """Return the union of personal + team prompts ordered by session_count DESC for the context picker."""
+        """Return the context-picker prompts of one space, ordered by session_count DESC.
+
+        Personal prompts never leave the personal space: browsing a team
+        returns that team's prompts only; browsing the personal space returns the
+        user's personal prompts (labelled scope="personal").
+        """
 
         personal_str = str(personal_team_id)
         team_str = str(team_id)
@@ -456,10 +461,7 @@ class PromptStore:
             PromptRow.category,
         ).where(PromptRow.team_id == team_str)
 
-        if personal_str == team_str:
-            combined = personal_q
-        else:
-            combined = union_all(personal_q, team_q)
+        combined = personal_q if personal_str == team_str else team_q
 
         async with use_session(self._sessions, session) as s:
             rows = (await s.execute(combined)).all()

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -526,12 +526,13 @@ class _FakePromptStore:
     ) -> list:
         from control_plane_backend.prompts.store import ContextPromptRecord
 
+        # Mirrors the real store: personal prompts only in the personal space.
+        scope = "personal" if str(personal_team_id) == str(team_id) else "team"
         seen_ids: set[str] = set()
         results = []
         for r in self._records:
-            if r.team_id in (personal_team_id, team_id) and r.prompt_id not in seen_ids:
+            if r.team_id == str(team_id) and r.prompt_id not in seen_ids:
                 seen_ids.add(r.prompt_id)
-                scope = "personal" if r.team_id == personal_team_id else "team"
                 results.append(
                     ContextPromptRecord(
                         prompt_id=r.prompt_id,
@@ -7051,10 +7052,10 @@ async def test_prompt_update_increments_version(
 
 
 @pytest.mark.asyncio
-async def test_get_context_prompts_returns_personal_and_team(
+async def test_get_context_prompts_excludes_personal_in_team_space(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """GET /prompts/context returns the union of personal and team prompts with scope field."""
+    """GET /prompts/context on a team never exposes the caller's personal prompts."""
 
     monkeypatch.setattr(
         "control_plane_backend.product.api.get_team_by_id_from_service",
@@ -7079,12 +7080,45 @@ async def test_get_context_prompts_returns_personal_and_team(
     assert resp.status_code == 200
     body = resp.json()
     ids = [item["id"] for item in body]
-    assert "p-personal" in ids
+    assert "p-personal" not in ids
     assert "p-team" in ids
-    # team prompt has higher session_count so should appear first
     assert body[0]["id"] == "p-team"
     assert body[0]["scope"] == "team"
-    assert body[1]["scope"] == "personal"
+
+
+@pytest.mark.asyncio
+async def test_get_context_prompts_personal_space_returns_personal_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /prompts/context on the personal team returns the user's prompts as scope=personal."""
+
+    monkeypatch.setattr(
+        "control_plane_backend.product.api.get_team_by_id_from_service",
+        _fake_get_team_by_id,
+    )
+    personal = _make_prompt_record(
+        prompt_id="p-personal", team_id=_PERSONAL_TEAM_ID, name="My prompt"
+    )
+    team_p = _make_prompt_record(
+        prompt_id="p-team", team_id="bid-team", name="Team prompt"
+    )
+    store = _FakePromptStore([personal, team_p])
+    app = create_app()
+    _patch_prompt_store(monkeypatch, store)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(
+            f"/control-plane/v1/teams/{_PERSONAL_TEAM_ID}/prompts/context"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = [item["id"] for item in body]
+    assert "p-personal" in ids
+    assert "p-team" not in ids
+    assert body[0]["scope"] == "personal"
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -132,7 +132,7 @@
     },
     "document_access": {
       "name": "Document access",
-      "description": "Search documents uploaded to Fred using semantic similarity (RAG)."
+      "description": "Search documents uploaded using semantic similarity (RAG)."
     }
   },
   "chatbot": {
@@ -1062,6 +1062,8 @@
         "shareTitle": "Copy to Team space"
       },
       "empty": {
+        "agentFiles": "This agent hasn't created any files for you yet. Files it generates for you will appear here.",
+        "agents": "No agent files yet. Files your agents create for you will appear here, grouped by agent.",
         "createLibrary": "Create a library (folder) to start adding documents.",
         "folder": "This folder is empty."
       },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -132,7 +132,7 @@
     },
     "document_access": {
       "name": "Accès aux documents",
-      "description": "Recherchez dans les documents téléversés dans Fred par similarité sémantique (RAG)."
+      "description": "Recherchez dans les documents téléversés par similarité sémantique (RAG)."
     }
   },
   "chatbot": {
@@ -1062,6 +1062,8 @@
         "shareTitle": "Copier dans l'espace d'équipe"
       },
       "empty": {
+        "agentFiles": "Cet agent n'a encore créé aucun fichier pour vous. Les fichiers qu'il génère pour vous apparaîtront ici.",
+        "agents": "Aucun fichier d'agent pour l'instant. Les fichiers créés pour vous par vos agents apparaîtront ici, regroupés par agent.",
         "createLibrary": "Créez une bibliothèque (dossier) pour commencer à ajouter des documents.",
         "folder": "Ce dossier est vide."
       },

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/CapabilityCard/CapabilityCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/CapabilityCard/CapabilityCard.module.css
@@ -37,8 +37,10 @@
   font: var(--font-label-medium);
 }
 
+/* Emphasis only — same font metrics as .name so toggling never shifts the list */
 .nameActive {
-  font: var(--font-title-small);
+  color: var(--primary);
+  font-weight: 600;
 }
 
 .description {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx
@@ -15,6 +15,7 @@
 import Button from "@shared/atoms/Button/Button.tsx";
 import TextArea from "@shared/atoms/TextArea/TextArea.tsx";
 import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
+import { DocumentLibraryScopePicker } from "@shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx";
 import { PromptPicker } from "@shared/molecules/PromptPicker/PromptPicker.tsx";
 import Select from "@shared/molecules/Select/Select.tsx";
 import TagInput from "@shared/molecules/TagInput/TagInput.tsx";
@@ -182,6 +183,24 @@ export function TuningFieldRenderer({ field, value, onChange, disabled, error, t
 
   if (field.type === "array") {
     const tags = Array.isArray(value) ? (value as string[]) : [];
+
+    // `ui.widget` stock form widgets. "document_libraries" renders the
+    // library/document tree picker instead of a raw tag-id text input; an
+    // unknown widget id falls through to the default TagInput.
+    if (field.ui?.widget === "document_libraries") {
+      return (
+        <div className={styles.field}>
+          <span className={styles.label}>{label}</span>
+          <DocumentLibraryScopePicker
+            teamId={teamId}
+            selectedTagIds={tags}
+            onChange={(tagIds) => onChange(field.key, tagIds)}
+          />
+          {fieldDescription && <p className={styles.hint}>{fieldDescription}</p>}
+          {error && <p className={styles.error}>{error}</p>}
+        </div>
+      );
+    }
 
     return (
       <div className={styles.field}>

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/AgentFilesystemBrowser/AgentFilesystemBrowser.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/AgentFilesystemBrowser/AgentFilesystemBrowser.module.css
@@ -13,14 +13,7 @@
  * limitations under the License.
  */
 
-/* The rows themselves are the shared FolderRow / DocRow molecules (identical to the corpus).
- * This wrapper only adds the horizontal filet + indentation, exactly like DocumentWorkspace:
- * padding-left insets the content, never the full-width bottom border. */
-.row {
-  border-bottom: 1px solid var(--outline-retreat);
-}
-
-/* Empty-directory hint, same rendering as the corpus workspace's .hint */
+/* Empty-area hint, same rendering as the corpus workspace's .hint */
 .hint {
   padding: var(--spacing-2xs) var(--spacing-xs);
   color: var(--on-surface-muted);

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/AgentFilesystemBrowser/AgentFilesystemBrowser.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/AgentFilesystemBrowser/AgentFilesystemBrowser.tsx
@@ -17,6 +17,7 @@ import { FolderRow } from "@shared/molecules/FolderRow/FolderRow.tsx";
 import { useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 import { useLsQuery } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 import TeamFilesystemBrowser from "../TeamFilesystemBrowser/TeamFilesystemBrowser.tsx";
+import styles from "./AgentFilesystemBrowser.module.css";
 
 /** One /fs/list entry (only `path` = agent_instance_id, and `type` matter here). */
 interface FsEntry {
@@ -43,16 +44,22 @@ interface AgentFilesystemBrowserProps {
  * (download/delete + the généré provenance badge).
  */
 export default function AgentFilesystemBrowser({ fsTeamId, userId }: AgentFilesystemBrowserProps) {
+  const { t } = useTranslation();
   const agentsRoot = `teams/${fsTeamId}/agents`;
   const { data: instances, isLoading: namesLoading } =
     useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery({ teamId: fsTeamId });
-  const { data: agentDirs } = useLsQuery({ path: agentsRoot });
+  const { data: agentDirs, isLoading: dirsLoading } = useLsQuery({ path: agentsRoot });
 
   // Wait for names before labelling, so a real agent never flashes "Removed agent".
   if (namesLoading) return null;
 
   const labelById = buildAgentLabels(instances ?? []);
   const folders = (Array.isArray(agentDirs) ? (agentDirs as FsEntry[]) : []).filter((entry) => isDirectory(entry.type));
+
+  // No agent has files yet: explain what the area is for instead of rendering nothing.
+  if (!dirsLoading && folders.length === 0) {
+    return <div className={styles.hint}>{t("rework.resources.empty.agents")}</div>;
+  }
 
   return (
     <>
@@ -116,7 +123,9 @@ function AgentFolder({ instanceId, name, filesRoot }: AgentFolderProps) {
         onToggle={() => setExpanded((value) => !value)}
       />
       {/* baseDepth=1 indents the agent's files one level under its folder, matching the rest of the tree. */}
-      {expanded && <TeamFilesystemBrowser root={filesRoot} baseDepth={1} />}
+      {expanded && (
+        <TeamFilesystemBrowser root={filesRoot} baseDepth={1} emptyHintKey="rework.resources.empty.agentFiles" />
+      )}
     </>
   );
 }

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/TeamFilesystemBrowser/TeamFilesystemBrowser.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/TeamFilesystemBrowser/TeamFilesystemBrowser.tsx
@@ -95,6 +95,10 @@ interface TeamFilesystemBrowserProps {
    * are always writable by their owner; only the shared area is gated by CAN_UPDATE_RESOURCES.
    * Defaults to true so existing private-root call sites are unaffected. */
   canWrite?: boolean;
+  /** i18n key of the hint shown when this root has no entries, so an expanded-but-empty area
+   * explains itself instead of rendering nothing. Nested folders always use the generic
+   * empty-folder message. */
+  emptyHintKey?: string;
 }
 
 /**
@@ -103,24 +107,38 @@ interface TeamFilesystemBrowserProps {
  * Folders expand in place; each folder carries upload + new-folder actions; files carry
  * download + delete. Adding at the root is the root header "+" (FsRootAddMenu).
  */
-export default function TeamFilesystemBrowser({ root, baseDepth = 0, canWrite = true }: TeamFilesystemBrowserProps) {
+export default function TeamFilesystemBrowser({
+  root,
+  baseDepth = 0,
+  canWrite = true,
+  emptyHintKey,
+}: TeamFilesystemBrowserProps) {
   const { refetch } = useLsQuery({ path: root });
-  return <FsLevel path={root} depth={baseDepth} canWrite={canWrite} onChanged={() => void refetch()} />;
+  return (
+    <FsLevel
+      path={root}
+      depth={baseDepth}
+      canWrite={canWrite}
+      emptyHintKey={emptyHintKey}
+      onChanged={() => void refetch()}
+    />
+  );
 }
 
 interface FsLevelProps {
   path: string;
   depth: number;
   canWrite: boolean;
+  emptyHintKey?: string;
   /** refetch of the directory that owns these entries (so deletes here update the list). */
   onChanged: () => void;
 }
 
 /** Renders the entries of one directory; recurses into expanded folders. */
-function FsLevel({ path, depth, canWrite, onChanged }: FsLevelProps) {
+function FsLevel({ path, depth, canWrite, emptyHintKey, onChanged }: FsLevelProps) {
   const { t } = useTranslation();
   const { showConfirmationDialog } = useConfirmationDialog();
-  const { data } = useLsQuery({ path });
+  const { data, isLoading } = useLsQuery({ path });
   const [deleteFile, { isLoading: isDeleting }] = useDeleteFileMutation();
   const [copyToShared] = useCopyToSharedMutation();
 
@@ -146,6 +164,16 @@ function FsLevel({ path, depth, canWrite, onChanged }: FsLevelProps) {
       message: t("rework.resources.confirm.shareMessage", { name }),
       onConfirm: () => void copyToShared({ path: encodeURI(childPath) }).unwrap(),
     });
+
+  // Loaded-and-empty: explain what the area is for instead of an expand that shows
+  // nothing — mirrors the corpus workspace's empty-folder hint.
+  if (!isLoading && Array.isArray(data) && entries.length === 0) {
+    return (
+      <div className={styles.hint} style={{ paddingLeft: depth * INDENT_STEP }}>
+        {t(emptyHintKey ?? "rework.resources.empty.folder")}
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/frontend/src/rework/config/promptCategories.ts
+++ b/apps/frontend/src/rework/config/promptCategories.ts
@@ -18,6 +18,10 @@ export interface PromptCategoryDef {
   pillFg: string;
 }
 
+/**
+ * The categories offered in pickers and filters: the functional 7 only.
+ * Categories retired from the taxonomy live in LEGACY_PROMPT_CATEGORIES below.
+ */
 export const PROMPT_CATEGORIES: PromptCategoryDef[] = [
   {
     id: "doc-assist",
@@ -55,6 +59,27 @@ export const PROMPT_CATEGORIES: PromptCategoryDef[] = [
     pillFg: "var(--warning)",
   },
   {
+    id: "conversational",
+    labelKey: "rework.promptCategories.conversational",
+    icon: "chat",
+    pillBg: "var(--tertiary-container)",
+    pillFg: "var(--tertiary)",
+  },
+  {
+    id: "integration",
+    labelKey: "rework.promptCategories.integration",
+    icon: "hub",
+    pillBg: "var(--surface-container-high)",
+    pillFg: "var(--on-surface-retreat)",
+  },
+];
+
+/**
+ * Retired categories: never offered in pickers/filters, but prompts that
+ * still carry them (pre-existing rows, imports) keep their pill rendering.
+ */
+const LEGACY_PROMPT_CATEGORIES: PromptCategoryDef[] = [
+  {
     id: "monitoring",
     labelKey: "rework.promptCategories.monitoring",
     icon: "show_chart",
@@ -70,20 +95,6 @@ export const PROMPT_CATEGORIES: PromptCategoryDef[] = [
     pillFg: "var(--primary)",
   },
   {
-    id: "conversational",
-    labelKey: "rework.promptCategories.conversational",
-    icon: "chat",
-    pillBg: "var(--tertiary-container)",
-    pillFg: "var(--tertiary)",
-  },
-  {
-    id: "integration",
-    labelKey: "rework.promptCategories.integration",
-    icon: "hub",
-    pillBg: "var(--surface-container-high)",
-    pillFg: "var(--on-surface-retreat)",
-  },
-  {
     id: "other",
     labelKey: "rework.promptCategories.other",
     icon: "chat_bubble",
@@ -93,8 +104,8 @@ export const PROMPT_CATEGORIES: PromptCategoryDef[] = [
 ];
 
 export const PROMPT_CATEGORY_MAP: Record<PromptCategory, PromptCategoryDef> = Object.fromEntries(
-  PROMPT_CATEGORIES.map((c) => [c.id, c]),
+  [...PROMPT_CATEGORIES, ...LEGACY_PROMPT_CATEGORIES].map((c) => [c.id, c]),
 ) as Record<PromptCategory, PromptCategoryDef>;
 
-/** Number of categories shown before the "show more" link. */
-export const CATEGORY_INITIAL_VISIBLE = 6;
+/** Number of categories shown before the "show more" link — all 7, no fold. */
+export const CATEGORY_INITIAL_VISIBLE = 7;

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1474,6 +1474,7 @@ export type ManagedAgentUiHints = {
   textarea?: boolean;
   group?: string | null;
   hide?: boolean;
+  widget?: string | null;
 };
 export type ManagedAgentFieldSpec = {
   key: string;
@@ -1503,6 +1504,8 @@ export type UiHints = {
   textarea?: boolean;
   group?: string | null;
   hide?: boolean;
+  /** Names a frontend stock form widget to render this field instead of the type-derived default input. Known ids: 'document_libraries' (library/document tree picker for an array of library tag ids). Unknown ids fall back to the default input, so older frontends degrade gracefully. */
+  widget?: string | null;
 };
 export type FieldSpec = {
   key: string;

--- a/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
+++ b/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
@@ -785,6 +785,8 @@ export type UiHints = {
   multiline?: boolean;
   placeholder?: string | null;
   textarea?: boolean;
+  /** Names a frontend stock form widget to render this field instead of the type-derived default input. Known ids: 'document_libraries' (library/document tree picker for an array of library tag ids). Unknown ids fall back to the default input, so older frontends degrade gracefully. */
+  widget?: string | null;
 };
 export type FieldSpec = {
   default?:

--- a/docs/swift/capabilities/AUTHORING.md
+++ b/docs/swift/capabilities/AUTHORING.md
@@ -53,7 +53,12 @@ Declared as ClassVars on the `AgentCapability` subclass; see `base.py` docstring
 authoritative rules. In one line each:
 
 - **`ConfigModel`** — what the user *sends* at agent creation (drives
-  `manifest.config_fields`).
+  `manifest.config_fields`). A `FieldSpec` may set `ui=UIHints(widget=...)` to
+  name a frontend stock **form** widget for the agent-creation form (#2023) —
+  distinct from chat-turn controls. Known ids: `document_libraries` (the
+  library/document tree picker for an array of library tag ids; see
+  `document_access.library_tag_ids`). Unknown ids fall back to the
+  type-derived default input, so older frontends degrade gracefully.
 - **`StoredConfigModel`** — what the platform *persists* after `validate_config`
   enrichment; defaults to `ConfigModel` (RFC §3.2, §3.8).
 - **`TurnOptionsModel`** — typed chat-time values from a chat control; `EmptyModel` if

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -1271,3 +1271,12 @@ with the acting user's uid on every `PATCH
 (seed/startup saves have no acting user).
 
 `controlPlaneOpenApi.ts` regenerated (`make update-control-plane-api`).
+
+## 20. Contract Notes — prompts-context personal scoping (2026-07-20, #2023)
+
+**Behavior change:** `GET /teams/{team_id}/prompts/context` no longer merges
+the caller's personal prompts into a non-personal team's context (#2023) — a
+team space returns the team's prompts + platform defaults only; the personal
+space returns the caller's prompts (scope `personal`) + defaults. Response
+shape unchanged. Already-attached personal prompts keep resolving at
+prepare-execution (see `design/PROMPTS.md` §5/§6).

--- a/docs/swift/design/PROMPTS.md
+++ b/docs/swift/design/PROMPTS.md
@@ -132,9 +132,10 @@ forwards that scalar into `RuntimeContext.context_prompt_text`; the runtime
 contract does not know about the ordered prompt list.
 
 Library-prompt resolution is scoped to the caller's authorized teams — the active
-team plus the caller's personal team (`PromptStore.get_for_team`), matching the
-union the context picker surfaces (§6). A session cannot resolve a prompt owned by
-an unrelated team by id.
+team plus the caller's personal team (`PromptStore.get_for_team`). This is wider
+than what the context picker surfaces (§6): the picker no longer offers personal
+prompts in a team space, but an already-attached personal prompt keeps resolving.
+A session cannot resolve a prompt owned by an unrelated team by id.
 
 At execution the runtime folds `context_prompt_text` into the final system prompt.
 `fred_runtime.react.react_prompting.compose_system_prompt` is the single composer
@@ -166,7 +167,9 @@ The shipped prompt UI has two parts:
 
 The context picker reads
 `GET /control-plane/v1/teams/{team_id}/prompts/context`, which returns the
-caller's personal prompts, current team prompts, and platform defaults. DB
+space's own prompts plus platform defaults. Personal prompts appear only in the
+personal space — a team context never exposes the caller's personal prompts
+(changed 2026-07-20, #2023; previously the endpoint returned the union). DB
 prompts are ordered by usage, and defaults are appended.
 
 Agent-form import/save/version-drift UX is not complete; it is tracked as

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -1073,6 +1073,26 @@ unaudited in a shipped environment.
 - Regression coverage:
   `libs/fred-runtime/tests/test_deep_agent_middleware.py`.
 
+### 8.18 ✅ `FieldSpec.ui.widget` stock form-widget hint — #2023 (2026-07-20)
+
+**What changed.** `UIHints` (`fred_sdk/contracts/models.py`) gained an optional
+`widget: str | None` field. It names a frontend stock **form** widget to render
+that field in the agent-creation/edit form instead of the type-derived default
+input — distinct from the chat-turn `ChatControlSpec.widget` registry. First
+consumer: `document_access.library_tag_ids` sets
+`ui=UIHints(widget="document_libraries")`, rendered by the frontend
+`TuningFieldRenderer` as the `DocumentLibraryScopePicker` tree instead of a raw
+tag-id `TagInput`. Control-plane's `ManagedAgentUiHints` mirror gained the same
+field.
+
+**Why.** Users had to hand-type library tag ids when configuring the
+document-access capability on an agent; the tree picker already existed for the
+chat composer. Additive and backward compatible: `None`/unknown widget ids fall
+back to the default input, and older pods simply omit the field.
+
+`controlPlaneOpenApi.ts` and `runtimeOpenApi.ts` regenerated
+(`make update-control-plane-api` / `make update-runtime-api`).
+
 ---
 
 ## 8. Developer CLI — `fred-agents-cli`

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1242,6 +1242,49 @@ _(none yet)_
 
 ---
 
+## Swift UX bug pass — #2023 / #1952 (2026-07-20)
+
+Fixes shipped together from live-testing feedback; all `Functional`, awaiting
+design review.
+
+### `CapabilityCard` (agent form Tools tab)
+
+Toggling a capability no longer changes the name's font size
+(`--font-label-medium` → `--font-title-small` caused every card below to jump).
+Active emphasis is now weight + `--primary` color at identical metrics; only
+the config sub-form still expands, which is expected.
+
+### `TeamFilesystemBrowser` / `AgentFilesystemBrowser` (Resources tabs)
+
+Expanding an empty folder now shows the same explanatory hint pattern as the
+corpus workspace (`.hint`, `--on-surface-muted`, body-small) instead of an
+empty dropdown: generic `rework.resources.empty.folder` for folders, dedicated
+`empty.agentFiles` inside an agent's space, and `empty.agents` when no agent
+has files at all.
+
+### `TuningFieldRenderer` — `document_libraries` widget (agent form)
+
+An array field whose `ui.widget` is `document_libraries`
+(document_access `library_tag_ids`) renders the `DocumentLibraryScopePicker`
+tree instead of the raw tag-id `TagInput`. Unknown widget ids fall back to the
+`TagInput`.
+
+### `AgentFormBody` audit footer (#1952)
+
+"Created by" resolves the uid to first/last name (fallback username, then uid)
+via `GET /users/by-ids`, and shows "Updated by …" when the instance has been
+user-edited (`updated_by`).
+
+### `CategoryPicker` / prompt category surfaces
+
+Pickers and filters offer exactly 7 functional categories (doc-assist,
+summary, extraction, writing, analysis, conversational, integration).
+`monitoring`, `migration` and `other` are retired from selection but keep
+their pill rendering on pre-existing prompts; the "show more" fold is gone
+(7 visible).
+
+---
+
 ## UX review agenda
 
 _Priority order for the next UX session. Update before each session._

--- a/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
@@ -78,7 +78,7 @@ from fred_sdk.contracts.context import (
     ToolContentKind,
     ToolInvocationResult,
 )
-from fred_sdk.contracts.models import FieldSpec
+from fred_sdk.contracts.models import FieldSpec, UIHints
 from fred_sdk.contracts.runtime import DocumentSearchResult
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.tools import BaseTool, tool
@@ -311,6 +311,9 @@ class DocumentAccessCapability(
                     "Restrict search to these document library tag ids. Empty = "
                     "no capability-side restriction (still bounded by the session)."
                 ),
+                # Rendered as the library/document tree picker, not a raw
+                # tag-id text input.
+                ui=UIHints(widget="document_libraries"),
             ),
             FieldSpec(
                 key="document_uids",

--- a/libs/fred-sdk/fred_sdk/contracts/models.py
+++ b/libs/fred-sdk/fred_sdk/contracts/models.py
@@ -98,6 +98,16 @@ class UIHints(BaseModel):
     textarea: bool = False
     group: Optional[str] = None
     hide: bool = False
+    widget: Optional[str] = Field(
+        default=None,
+        description=(
+            "Names a frontend stock form widget to render this field instead "
+            "of the type-derived default input. Known ids: "
+            "'document_libraries' (library/document tree picker for an array "
+            "of library tag ids). Unknown ids fall back to the default input, "
+            "so older frontends degrade gracefully."
+        ),
+    )
 
 
 class FieldSpec(BaseModel):


### PR DESCRIPTION
## Summary

Four UX bugs from live testing (2026-07-20), in three commits:

1. **Personal prompts stay out of team spaces** — `GET /teams/{team_id}/prompts/context` no longer merges the caller's personal prompts into a non-personal team's context; the personal space returns them as `scope=personal`. Already-attached personal prompts keep resolving at prepare-execution (resolution scope unchanged). Design change recorded in `PROMPTS.md` §5/§6 and product contract §20.
2. **7 functional prompt categories** — pickers/filters offer exactly: Document research, Document summary, Data extraction, Professional writing, Analysis & evaluation, General Assistant, Tool orchestration. The `monitoring`/`migration` default prompts are no longer seeded; retired categories keep their pill rendering on pre-existing rows (backend enum untouched, imports safe).
3. **Library/document tree picker in the agent form** — additive `UIHints.widget` hint on fred-sdk `FieldSpec` (contract §8.18); `document_access.library_tag_ids` declares `widget="document_libraries"` and `TuningFieldRenderer` renders the existing `DocumentLibraryScopePicker` tree instead of a raw tag-id text input. Unknown ids fall back gracefully. `AUTHORING.md` + `add-fred-capability` skill updated; both OpenAPI clients regenerated. *(The legacy tool's rag-scope behavior parity and the tree/summarize tools stay with #1906.)*
4. **Capability toggle layout shift + empty-folder dropdowns** — active capability name keeps identical font metrics (no list jump); Resources/Agents tabs show the corpus-style explanatory hint when a folder/agent space is empty (EN+FR keys).

Closes #2023

## Test plan

- Control-plane: 476 passed (2 new context-prompt scoping tests), ruff + format clean
- fred-runtime: 554 passed; fred-sdk: 233 passed
- Frontend: `tsc --noEmit` clean, test suite green, prettier clean
- Verified live during the session: tree picker renders in the agent form (empty-state confirmed against a corpus-less DB), composer controls end-to-end after #2030

🤖 Generated with [Claude Code](https://claude.com/claude-code)