### PR TITLE
#2036 make evaluation agent reachbale by frontend

### DIFF
--- a/apps/frontend/dockerfiles/docker-entrypoint.sh
+++ b/apps/frontend/dockerfiles/docker-entrypoint.sh
@@ -9,10 +9,12 @@ set -eu
 #   FRONTEND_AGENTIC_UPSTREAM=http://host.docker.internal:8000 \
 #   FRONTEND_KNOWLEDGE_FLOW_UPSTREAM=http://host.docker.internal:8111 \
 #   FRONTEND_CONTROL_PLANE_UPSTREAM=http://host.docker.internal:8222 \
+#   FRONTEND_EVALUATION_UPSTREAM=http://host.docker.internal:8336 \
 #   /usr/local/bin/fred-frontend-entrypoint.sh
 : "${FRONTEND_AGENTIC_UPSTREAM:=http://fred-agents}"
 : "${FRONTEND_KNOWLEDGE_FLOW_UPSTREAM:=http://knowledge-flow-backend:8000}"
 : "${FRONTEND_CONTROL_PLANE_UPSTREAM:=http://control-plane-backend:8222}"
+: "${FRONTEND_EVALUATION_UPSTREAM:=http://fred-evaluation-backend}"
 : "${FRONTEND_CLIENT_MAX_BODY_SIZE:=150m}"
 
 cat > /etc/nginx/conf.d/fred.conf <<EOF
@@ -47,6 +49,15 @@ server {
 
     location /control-plane/ {
         proxy_pass ${FRONTEND_CONTROL_PLANE_UPSTREAM};
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    location /evaluation/ {
+        proxy_pass ${FRONTEND_EVALUATION_UPSTREAM};
         proxy_http_version 1.1;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;


### PR DESCRIPTION
## Summary
- `docker-entrypoint.sh` generated the container's nginx config with proxy blocks for
  only three backends (agentic, knowledge-flow, control-plane). fred-agent-evaluator
  (API at `/evaluation/v1/...`) had no route, so in any containerized/K8s deployment
  requests fell through to the SPA catch-all instead of reaching the evaluator.
- Adds `FRONTEND_EVALUATION_UPSTREAM` (default `http://fred-evaluation-backend`) and a
  `location /evaluation/` block, same shape as `/knowledge-flow/` and `/control-plane/`.
- No websocket Upgrade/Connection headers: the evaluator does have SSE endpoints
  (`/runs/{id}/events`, `/tasks/{id}/events`), but `/control-plane/` already proxies its
  own SSE endpoint with the same plain header set, so this follows that precedent rather
  than the agentic block's websocket-upgrade headers.
- fred-deployment-factory's GKE chart already sets `FRONTEND_EVALUATION_UPSTREAM` on the
  frontend pod in anticipation of this — no deployment-repo change needed.

Closes #2036.

## Test plan
- [x] `sh -n docker-entrypoint.sh` — shell syntax check
- [x] Rendered the heredoc through `nginx:alpine` in Docker (with `--add-host` for each
      upstream) and ran `nginx -t` — config syntax passed, `/evaluation/` block rendered
      byte-for-byte as expected
- [x] Confirmed evaluator's real API base (`/evaluation/v1`, `config/models.py`) matches
      the frontend's generated client paths (`evaluationOpenApi.ts`)
- [ ] Manual: build the frontend image, run with `FRONTEND_EVALUATION_UPSTREAM` pointed
      at a live evaluator, confirm `/evaluation/v1/...` reaches it through the container
