### PR TITLE
fix: resources status/delete, KPI presets 503, evaluation telemetry polling, conversation erasure

### DIFF
--- a/apps/control-plane-backend/config/configuration_worker.yaml
+++ b/apps/control-plane-backend/config/configuration_worker.yaml
@@ -52,3 +52,30 @@ storage:
 
 policies:
   purge_catalog_path: ./conversation_policy_catalog.yaml
+
+platform:
+  # Must mirror configuration_prod.yaml's runtime_catalog_sources — the
+  # lifecycle worker resolves a session's runtime here (checkpoint + history
+  # erase) via ConversationErasureService._resolve_runtime_base_url. Left
+  # empty, every source lookup misses regardless of which runtime is actually
+  # registered, and conversation erasure never converges (CTRLP-12): each
+  # tick logs "unresolved runtime: source '<id>' is disabled or missing" and
+  # re-queues the same sessions forever.
+  knowledge_flow_base_url: http://127.0.0.1:8111/knowledge-flow/v1
+  runtime_catalog_sources:
+    - runtime_id: fred-samples-agents
+      base_url: http://127.0.0.1:8010/samples/agents/v1
+      enabled: true
+      ingress_prefix: /samples/agents/v1
+    - runtime_id: fred-agents
+      base_url: http://127.0.0.1:8000/fred/agents/v2
+      enabled: true
+      ingress_prefix: /fred/agents/v2
+    - runtime_id: rags-agents
+      base_url: http://127.0.0.1:8013/rags/agents/v2
+      enabled: true
+      ingress_prefix: /rags/agents/v2
+    - runtime_id: dt-agents
+      base_url: http://127.0.0.1:8020/dt/agents/v2
+      enabled: true
+      ingress_prefix: /dt/agents/v2

--- a/apps/control-plane-backend/control_plane_backend/app/context.py
+++ b/apps/control-plane-backend/control_plane_backend/app/context.py
@@ -142,6 +142,7 @@ class ApplicationContext:
         return self._kpi_writer
 
     def get_kpi_store(self):  # -> OpenSearchKPIStore | None
+        from fred_core.common.resilient_sink import ResilientSinkStore
         from fred_core.kpi.kpi_writer import KPIWriter
         from fred_core.kpi.opensearch_kpi_store import OpenSearchKPIStore
         from fred_core.kpi.prometheus_kpi_store import PrometheusKPIStore
@@ -152,6 +153,11 @@ class ApplicationContext:
         store = writer.store
         if isinstance(store, PrometheusKPIStore):
             store = store._delegate
+        # ResilientSinkStore (#2009) wraps the real store for fail-open writes —
+        # unwrap it too, or every read-side KPI-preset query 503s even though
+        # the write path underneath is a perfectly healthy OpenSearchKPIStore.
+        if isinstance(store, ResilientSinkStore):
+            store = store.wrapped
         return store if isinstance(store, OpenSearchKPIStore) else None
 
     def start_metrics_exporter(self) -> None:

--- a/apps/control-plane-backend/control_plane_backend/scheduler/lifecycle_actions.py
+++ b/apps/control-plane-backend/control_plane_backend/scheduler/lifecycle_actions.py
@@ -129,8 +129,9 @@ async def delete_conversation_and_mark_done(
 
     if not receipt.ok:
         logger.warning(
-            "lifecycle erase incomplete for session %s; leaving queued for retry",
+            "lifecycle erase incomplete for session %s; leaving queued for retry. stores=%r",
             session_id,
+            [(s.store, s.ok, s.error) for s in receipt.stores],
         )
         return ConversationActionResult(
             conversation_id=session_id, action="erase_incomplete", ok=False

--- a/apps/control-plane-backend/tests/test_lifecycle_actions.py
+++ b/apps/control-plane-backend/tests/test_lifecycle_actions.py
@@ -149,7 +149,13 @@ async def test_erase_at_expiry_leaves_queued_on_partial_receipt() -> None:
     the next tick retries. A hidden-but-never-erased conversation is a defect."""
 
     async def _erase(**_kwargs: Any) -> Any:
-        return SimpleNamespace(ok=False)
+        return SimpleNamespace(
+            ok=False,
+            stores=[
+                SimpleNamespace(store="attachments", ok=True, error=None),
+                SimpleNamespace(store="runtime_checkpoint", ok=False, error="boom"),
+            ],
+        )
 
     queue = _FakeQueueStore()
     result = await delete_conversation_and_mark_done(
@@ -306,7 +312,13 @@ async def test_repeatedly_failing_erasure_flags_stalled_but_keeps_retrying(
 
     async def _erase_partial(**_kwargs: Any) -> Any:
         return SimpleNamespace(
-            ok=False, stores=[SimpleNamespace(ok=True), SimpleNamespace(ok=False)]
+            ok=False,
+            stores=[
+                SimpleNamespace(store="attachments", ok=True, error=None),
+                SimpleNamespace(
+                    store="runtime_checkpoint", ok=False, error="unresolved runtime"
+                ),
+            ],
         )
 
     queue = _FakeQueueStore()

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1058,6 +1058,9 @@
       "confirm": {
         "deleteMessage": "Remove \"{{name}}\" from this folder?",
         "deleteTitle": "Remove document",
+        "deleteFolderMessageEmpty": "Delete the empty folder \"{{name}}\"?",
+        "deleteFolderMessageWithDocs": "Delete \"{{name}}\" and its {{count}} document(s)? This cannot be undone.",
+        "deleteFolderTitle": "Delete folder",
         "shareMessage": "Copy \"{{name}}\" into the team space (Espace d'equipe)? The original stays where it is.",
         "shareTitle": "Copy to Team space"
       },
@@ -1100,6 +1103,8 @@
       },
       "title": "Resources",
       "toast": {
+        "deleteFolderError": "Could not delete the folder",
+        "deleteFolderSuccess": "Folder deleted",
         "processError": "Could not start processing",
         "processStarted": "Processing started"
       }

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1058,6 +1058,9 @@
       "confirm": {
         "deleteMessage": "Retirer « {{name}} » de ce dossier ?",
         "deleteTitle": "Retirer le document",
+        "deleteFolderMessageEmpty": "Supprimer le dossier vide « {{name}} » ?",
+        "deleteFolderMessageWithDocs": "Supprimer « {{name}} » et ses {{count}} document(s) ? Cette action est irréversible.",
+        "deleteFolderTitle": "Supprimer le dossier",
         "shareMessage": "Copier « {{name}} » dans l'espace d'équipe ? L'original reste à sa place.",
         "shareTitle": "Copier dans l'espace d'équipe"
       },
@@ -1100,6 +1103,8 @@
       },
       "title": "Ressources",
       "toast": {
+        "deleteFolderError": "Impossible de supprimer le dossier",
+        "deleteFolderSuccess": "Dossier supprimé",
         "processError": "Impossible de lancer le traitement",
         "processStarted": "Traitement lancé"
       }

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
@@ -26,6 +26,7 @@ import {
   type OwnerFilter,
   type TagWithItemsId,
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation,
+  useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation,
   useListAllTagsKnowledgeFlowV1TagsGetQuery,
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation,
 } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
@@ -129,6 +130,7 @@ const DocumentWorkspace = forwardRef<DocumentWorkspaceHandle, DocumentWorkspaceP
 
   const [browseDocumentsByTag] = useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation();
   const [processDocuments] = useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation();
+  const [deleteTag] = useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation();
 
   const selectedNode = selectedFolderFull ? findNode(tree, selectedFolderFull) : null;
   const selectedTag = selectedNode?.tagsHere[0] ?? null;
@@ -231,6 +233,46 @@ const DocumentWorkspace = forwardRef<DocumentWorkspaceHandle, DocumentWorkspaceP
     [processDocuments, showSuccess, showError, t, loadTagPage, perTag],
   );
 
+  // Deletes the folder's tag; the backend cascades to sub-folders and untags/
+  // deletes their documents (TagPermission.DELETE, tag_service.py), so this is
+  // safe to offer for both empty and populated folders — the confirmation
+  // message just makes the blast radius explicit before it happens.
+  const confirmDeleteFolder = useCallback(
+    (node: TagNode) => {
+      const tag = node.tagsHere[0];
+      if (!tag) return;
+      const docCount = tag.item_ids?.length ?? 0;
+      showConfirmationDialog({
+        title: t("rework.resources.confirm.deleteFolderTitle"),
+        message:
+          docCount > 0
+            ? t("rework.resources.confirm.deleteFolderMessageWithDocs", { name: node.name, count: docCount })
+            : t("rework.resources.confirm.deleteFolderMessageEmpty", { name: node.name }),
+        onConfirm: () =>
+          void deleteTag({ tagId: tag.id })
+            .unwrap()
+            .then(() => {
+              showSuccess?.({ summary: t("rework.resources.toast.deleteFolderSuccess") });
+              setExpanded((prev) => {
+                const next = new Set(prev);
+                next.delete(node.full);
+                return next;
+              });
+              setSelectedFolderFull((prev) => (prev === node.full ? null : prev));
+              void refetchTags();
+            })
+            .catch((e: unknown) => {
+              showError?.({
+                summary: t("validation.error"),
+                detail:
+                  (e as { data?: { detail?: string } })?.data?.detail ?? t("rework.resources.toast.deleteFolderError"),
+              });
+            }),
+      });
+    },
+    [deleteTag, showConfirmationDialog, showSuccess, showError, t, refetchTags],
+  );
+
   const moreActionsFor = useCallback(
     (doc: DocumentMetadata, tag: TagNode["tagsHere"][number]): DocRowMoreAction[] => {
       // Both actions below write to the tag/document (toggle-retrievable, delete),
@@ -312,6 +354,7 @@ const DocumentWorkspace = forwardRef<DocumentWorkspaceHandle, DocumentWorkspaceP
                 : undefined
             }
             onCreateSubfolder={canCreateFolder ? () => openCreateFolder(node.full) : undefined}
+            onDelete={tag && canCreateFolder ? () => confirmDeleteFolder(node) : undefined}
           />
         </div>
 

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/deriveDocStatus.ts
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/deriveDocStatus.ts
@@ -27,10 +27,16 @@ export interface ResolvedDocStatus {
  * live processing/failed run is reflected immediately; otherwise the answer is
  * read from `processing.stages`.
  *
- * - `vector === "done"` is the signal that a document is queryable → `ready`.
+ * - `vector === "done"` (chunked+embedded, backend `ProcessingStage.VECTORIZED`)
+ *   or `sql === "done"` (tabular-indexed, `ProcessingStage.SQL_INDEXED`) each
+ *   independently mean "queryable" → `ready`. A CSV/XLSX document only ever
+ *   completes the `sql` stage (it's never chunked/embedded), so checking
+ *   `vector` alone left every tabular document stuck at `raw` forever, even
+ *   after a full page reload — this isn't a staleness gap, both stages are
+ *   genuine, mutually-exclusive-per-file-type completion signals.
  * - nothing processed yet (only stored) → `raw` (a legitimate choice, not an error).
  */
-const QUERYABLE_STAGE = "vector";
+const QUERYABLE_STAGES = ["vector", "sql"];
 
 export function deriveDocStatus(doc: DocumentMetadata, task?: TaskViewModel): ResolvedDocStatus {
   if (task) {
@@ -44,6 +50,6 @@ export function deriveDocStatus(doc: DocumentMetadata, task?: TaskViewModel): Re
 
   if (values.some((s) => s === "failed")) return { status: "failed", progress: null };
   if (values.some((s) => s === "in_progress")) return { status: "processing", progress: null };
-  if (stages[QUERYABLE_STAGE] === "done") return { status: "ready", progress: null };
+  if (QUERYABLE_STAGES.some((stage) => stages[stage] === "done")) return { status: "ready", progress: null };
   return { status: "raw", progress: null };
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -186,11 +186,15 @@ export default function EvaluationRunDetail({
   const [analyzeRun, { isLoading: isAnalyzing }] = useAnalyzeRunEvaluationV1RunsRunIdAnalyzePostMutation();
 
   const { data: telemetry } = useGetTelemetryEvaluationV1TelemetryGetQuery();
+  // Unlike `run`/`cases` above, this poll had no isLive gate — it kept hitting
+  // the backend every 10s indefinitely, even long after the run went terminal,
+  // as long as the drawer stayed open. Match the sibling queries' pattern:
+  // poll while live, single fetch once terminal.
   const { data: langfuseSession } = useGetTelemetrySessionEvaluationV1TelemetrySessionRunIdGetQuery(
     { runId },
     {
       skip: !runId || !telemetry?.enabled,
-      pollingInterval: 10000,
+      pollingInterval: isLive ? 10000 : 0,
     },
   );
 


### PR DESCRIPTION
## Summary
Five independent fixes found during a live end-to-end validation session on
`swift` (nginx /evaluation route + AUTHZ-08 personal-team ReBAC), each
scoped and committed separately:

- **Tabular "Ready" status**: `deriveDocStatus` only checked the `vector`
  processing stage — CSV/XLSX documents complete via `sql` instead, so
  every tabular upload stayed stuck on "Raw" forever, reload or not.
- **KPI presets 503**: `get_kpi_store()` didn't unwrap `ResilientSinkStore`
  (added in #2009), so `/kpi/presets/user_token_usage_*` ("My token usage")
  always 503'd even with a healthy OpenSearch-backed KPI store underneath.
- **Delete folder in Corpus**: `FolderRow.onDelete` and the
  `DELETE /tags/{tag_id}` endpoint both already existed, but
  `DocumentWorkspace` never wired them together — no folder was deletable
  from the UI. Confirmation dialog warns when the folder isn't empty
  (deletion cascades to its documents).
- **Evaluation telemetry polling**: `EvaluationRunDetail` polled
  `telemetry/session` every 10s indefinitely, unlike the sibling `run`/
  `cases` queries which correctly stop once the run is terminal.
- **Conversation erasure never converges**: `configuration_worker.yaml` was
  missing the entire `platform.runtime_catalog_sources` block that
  `configuration_prod.yaml` (API) has, so the lifecycle worker could never
  resolve a session's runtime to erase its checkpoint/history — every
  10-minute tick re-queued the same conversations forever. Also adds
  per-store failure detail to the "erase incomplete" log line, which was
  the only reason this was findable at all.

## Test plan
- [x] Reproduced and verified each fix live against a running stack
      (control-plane, knowledge-flow, fred-agents, fred-evaluation-backend)
- [x] Tabular ingestion → "Ready" badge confirmed in UI after fix
- [x] KPI presets confirmed returning 200 after control-plane restart
- [x] Folder delete (empty + non-empty, cascade) confirmed via logs +
      OpenSearch doc-count delta
- [x] Conversation erasure confirmed converging (`deleted=1`) after the
      worker config fix, via the added diagnostic log
- [x] `tsc --noEmit`, `prettier --check`, `ruff check` clean on all touched
      files
- [ ] `make code-quality` / `make test` at the repo root (not run this
      session — recommend before merge)