### PR TITLE
fix(FRONT): tolerate an undeployed fred-agent-evaluator in nginx

### DIFF
--- a/apps/frontend/dockerfiles/docker-entrypoint.sh
+++ b/apps/frontend/dockerfiles/docker-entrypoint.sh
@@ -28,7 +28,7 @@ set -eu
 # /evaluation/ unreachable. Resolving it as a variable at request time
 # (via `resolver`) keeps startup independent of that upstream's presence.
 if [ -z "${FRONTEND_DNS_RESOLVER:-}" ]; then
-    FRONTEND_DNS_RESOLVER="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null)"
+    FRONTEND_DNS_RESOLVER="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)"
 fi
 : "${FRONTEND_DNS_RESOLVER:=127.0.0.11}"
 

--- a/apps/frontend/dockerfiles/docker-entrypoint.sh
+++ b/apps/frontend/dockerfiles/docker-entrypoint.sh
@@ -11,11 +11,26 @@ set -eu
 #   FRONTEND_CONTROL_PLANE_UPSTREAM=http://host.docker.internal:8222 \
 #   FRONTEND_EVALUATION_UPSTREAM=http://host.docker.internal:8336 \
 #   /usr/local/bin/fred-frontend-entrypoint.sh
+# FRONTEND_DNS_RESOLVER overrides the resolver nginx uses for optional
+# upstreams (default: the container's own nameserver, from /etc/resolv.conf,
+# falling back to Docker's embedded DNS 127.0.0.11).
 : "${FRONTEND_AGENTIC_UPSTREAM:=http://fred-agents}"
 : "${FRONTEND_KNOWLEDGE_FLOW_UPSTREAM:=http://knowledge-flow-backend:8000}"
 : "${FRONTEND_CONTROL_PLANE_UPSTREAM:=http://control-plane-backend:8222}"
 : "${FRONTEND_EVALUATION_UPSTREAM:=http://fred-evaluation-backend}"
 : "${FRONTEND_CLIENT_MAX_BODY_SIZE:=150m}"
+
+# fred-agent-evaluator is optional: some platforms don't deploy it, so
+# FRONTEND_EVALUATION_UPSTREAM's hostname may not resolve. A literal
+# proxy_pass target is resolved eagerly at nginx startup — an unresolvable
+# host would then make nginx refuse to start at all ("host not found in
+# upstream"), crash-looping the whole frontend instead of just leaving
+# /evaluation/ unreachable. Resolving it as a variable at request time
+# (via `resolver`) keeps startup independent of that upstream's presence.
+if [ -z "${FRONTEND_DNS_RESOLVER:-}" ]; then
+    FRONTEND_DNS_RESOLVER="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null)"
+fi
+: "${FRONTEND_DNS_RESOLVER:=127.0.0.11}"
 
 cat > /etc/nginx/conf.d/fred.conf <<EOF
 server {
@@ -24,6 +39,7 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
     client_max_body_size ${FRONTEND_CLIENT_MAX_BODY_SIZE};
+    resolver ${FRONTEND_DNS_RESOLVER} valid=10s;
 
     location /fred/agents/v2 {
         proxy_pass ${FRONTEND_AGENTIC_UPSTREAM};
@@ -57,7 +73,8 @@ server {
     }
 
     location /evaluation/ {
-        proxy_pass ${FRONTEND_EVALUATION_UPSTREAM};
+        set \$evaluation_upstream ${FRONTEND_EVALUATION_UPSTREAM};
+        proxy_pass \$evaluation_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;


### PR DESCRIPTION
## Summary
- PR #2037 added a static `proxy_pass` for `/evaluation/`. Nginx resolves a literal `proxy_pass` hostname eagerly at config-load time, so on any platform where `fred-agent-evaluator` isn't deployed, DNS resolution fails and nginx refuses to start at all (`host not found in upstream`) — crash-looping the whole frontend, not just leaving the evaluator unreachable. Reported by Sébastien.
- Fix: add a `resolver` directive (nameserver extracted from `/etc/resolv.conf`, Docker embedded DNS `127.0.0.11` fallback) and switch `/evaluation/`'s `proxy_pass` to a variable, so resolution happens at request time instead of at boot. Nginx now always starts; an absent evaluator surfaces as a per-request 502 (already handled by the `ServiceNotice` UI component) instead of a pod crash-loop.
- Mechanical infra bug fix restoring deployability — no RFC/doc change (not an architecture or API decision).

Closes #2047.

## Test plan
- [x] `docker run` against the real `nginx-unprivileged:1.31.0-alpine` base image with `FRONTEND_EVALUATION_UPSTREAM` set to an unresolvable host: nginx starts and stays running (`nginx -t` passes; process does not exit).
- [x] Same setup with the evaluator container actually reachable on the network: request proxies through correctly (verified the response body originates from the real upstream, not the frontend's local static handler).
- [ ] CI frontend build/lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)