### PR TITLE
evaluation manual metric selection

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1496,6 +1496,11 @@
           "placeholder": "Select an instance",
           "loading": "Loading instances..."
         },
+        "instanceTools": {
+          "label": "Tools enabled on this agent",
+          "inherited": "This instance follows its template's default tools — no per-instance override.",
+          "none": "No tools enabled on this instance."
+        },
         "agent": {
           "label": "Agent ID",
           "placeholder": "agent-..."
@@ -1531,6 +1536,21 @@
         "timeout": {
           "label": "Case timeout (s)"
         },
+        "builtinMetrics": {
+          "label": "Metrics",
+          "help": "Pick which metrics to score this run against — nothing is added automatically.",
+          "answerRelevancy": "Answer Relevancy",
+          "answerRelevancyDesc": "Does the answer address the question asked?",
+          "faithfulness": "Faithfulness",
+          "faithfulnessDesc": "Does the answer stay grounded in the retrieved context?",
+          "contextualRelevancy": "Contextual Relevancy",
+          "contextualRelevancyDesc": "Is the retrieved context relevant to the question?",
+          "contextualPrecision": "Contextual Precision",
+          "contextualPrecisionDesc": "Are the most relevant chunks ranked first? Requires an expected output.",
+          "contextualRecall": "Contextual Recall",
+          "contextualRecallDesc": "Does the context cover everything the expected output needs? Requires an expected output.",
+          "none": "Select at least one metric to start a run."
+        },
         "metrics": {
           "label": "Custom metrics",
           "help": "Natural-language criteria, judged alongside the built-in metrics",
@@ -1542,6 +1562,12 @@
           "criteria": "Criterion to evaluate",
           "criteriaPlaceholder": "e.g. The answer must name the method and cite the figure reported in the paper.",
           "parameters": "Fields the judge may read",
+          "parameterOptions": {
+            "input": "Input",
+            "actualOutput": "Actual output",
+            "expectedOutput": "Expected output",
+            "retrievalContext": "Retrieved context"
+          },
           "threshold": "Pass threshold"
         },
         "recap": {
@@ -1555,6 +1581,7 @@
           "judge": "Judge",
           "concurrency": "Concurrency",
           "timeout": "Timeout",
+          "metrics": "Metrics",
           "customMetrics": "Custom metrics",
           "profile": "Profile",
           "profileAuto": "Automatic"

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1496,6 +1496,11 @@
           "placeholder": "Sélectionnez une instance",
           "loading": "Chargement des instances..."
         },
+        "instanceTools": {
+          "label": "Tools activés sur cet agent",
+          "inherited": "Cette instance suit les tools par défaut de son template — aucune personnalisation propre à l'instance.",
+          "none": "Aucun tool activé sur cette instance."
+        },
         "agent": {
           "label": "Identifiant d'agent",
           "placeholder": "agent-..."
@@ -1531,6 +1536,21 @@
         "timeout": {
           "label": "Délai par cas (s)"
         },
+        "builtinMetrics": {
+          "label": "Métriques",
+          "help": "Choisis les métriques à calculer pour ce run — rien n'est ajouté automatiquement.",
+          "answerRelevancy": "Pertinence de la réponse",
+          "answerRelevancyDesc": "La réponse traite-t-elle la question posée ?",
+          "faithfulness": "Fidélité",
+          "faithfulnessDesc": "La réponse reste-t-elle ancrée dans le contexte récupéré ?",
+          "contextualRelevancy": "Pertinence contextuelle",
+          "contextualRelevancyDesc": "Le contexte récupéré est-il pertinent pour la question ?",
+          "contextualPrecision": "Précision contextuelle",
+          "contextualPrecisionDesc": "Les extraits les plus pertinents sont-ils classés en premier ? Nécessite une réponse attendue.",
+          "contextualRecall": "Rappel contextuel",
+          "contextualRecallDesc": "Le contexte couvre-t-il tout ce que la réponse attendue nécessite ? Nécessite une réponse attendue.",
+          "none": "Sélectionne au moins une métrique pour lancer un run."
+        },
         "metrics": {
           "label": "Métriques personnalisées",
           "help": "Critères en langage naturel, notés par le juge en plus des métriques intégrées",
@@ -1542,6 +1562,12 @@
           "criteria": "Critère à évaluer",
           "criteriaPlaceholder": "ex. La réponse doit nommer la méthode et citer le chiffre rapporté du papier.",
           "parameters": "Champs évalués par le juge",
+          "parameterOptions": {
+            "input": "Entrée",
+            "actualOutput": "Réponse produite",
+            "expectedOutput": "Réponse attendue",
+            "retrievalContext": "Contexte récupéré"
+          },
           "threshold": "Seuil de réussite"
         },
         "recap": {
@@ -1555,6 +1581,7 @@
           "judge": "Juge",
           "concurrency": "Concurrence",
           "timeout": "Délai",
+          "metrics": "Métriques",
           "customMetrics": "Métriques personnalisées",
           "profile": "Profil",
           "profileAuto": "Automatique"

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationForms.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationForms.module.css
@@ -69,6 +69,75 @@
   gap: var(--spacing-m);
 }
 
+.toolChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2xs);
+}
+
+.toolChip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-full);
+  background: var(--secondary-container);
+  padding: 2px var(--spacing-s);
+  color: var(--on-secondary-container);
+  font: var(--font-label-medium);
+}
+
+.metricList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.metricRow {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-s);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius-s);
+  background: var(--surface-container);
+  padding: var(--spacing-s) var(--spacing-m);
+  color: var(--on-surface);
+}
+
+.metricMeta {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--spacing-3xs);
+  min-width: 0;
+}
+
+.metricName {
+  color: var(--on-surface);
+  font: var(--font-label-medium);
+}
+
+.metricDesc {
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}
+
+.paramRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-m);
+}
+
+.paramOption {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+  cursor: pointer;
+  color: var(--on-surface);
+  font: var(--font-body-small);
+}
+
 .caseCard {
   display: flex;
   flex-direction: column;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
@@ -212,6 +212,10 @@ export default function EvaluationRuns({
         startRunRequest: {
           team_id: teamId,
           target: { kind: "managed_instance", agent_instance_id: rerunManagedTarget.agent_instance_id },
+          // The previous run's metric selection isn't exposed by the read API (only
+          // team_id/target are reused today) — default to the historical baseline
+          // metric until rerun is extended to carry the original choice forward.
+          metrics: ["answer_relevancy"],
         },
       }).unwrap();
       onOpenRun(result.run_id);

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/RunCreate.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/RunCreate.tsx
@@ -23,13 +23,53 @@ import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { taskRegistered } from "@rework/features/tasks/taskSlice";
 import Button from "@shared/atoms/Button/Button";
+import IconButton from "@shared/atoms/IconButton/IconButton";
+import Switch from "@shared/atoms/Switch/Switch";
+import TextArea from "@shared/atoms/TextArea/TextArea";
+import TextInput from "@shared/atoms/TextInput/TextInput";
 import Select from "@shared/molecules/Select/Select";
 import SelectableCard from "@shared/molecules/SelectableCard/SelectableCard";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import type { OptionModel } from "@models/Option.model.ts";
-import { useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery } from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
+import {
+  useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery,
+  useGetTeamAgentTemplatesControlPlaneV1TeamsTeamIdAgentTemplatesGetQuery,
+} from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
 import { useStartRunEvaluationV1EvaluationsEvaluationIdRunsPostMutation } from "../../../../../../../slices/evaluation/evaluationOpenApi";
 import styles from "./EvaluationForms.module.css";
+
+// Built-in DeepEval metrics selectable for a run — the user picks explicitly, there is
+// no automatic profile detection anymore (EVAL-CUSTOM-METRIC, manual metric selection).
+const BUILTIN_METRICS = [
+  { id: "answer_relevancy", key: "answerRelevancy" },
+  { id: "faithfulness", key: "faithfulness" },
+  { id: "contextual_relevancy", key: "contextualRelevancy" },
+  { id: "contextual_precision", key: "contextualPrecision" },
+  { id: "contextual_recall", key: "contextualRecall" },
+] as const;
+
+// Curated subset of DeepEval's LLMTestCaseParams: the only ones the evaluator actually
+// populates from a case's trace (see fred-deepeval-cli core/scorer.py::_trace_to_test_case).
+// Exposing the rest (TOOLS_CALLED, MCP_*, ...) would let a user pick a field that is
+// always empty for this evaluator.
+const CUSTOM_METRIC_PARAMETERS = [
+  { value: "INPUT", key: "input" },
+  { value: "ACTUAL_OUTPUT", key: "actualOutput" },
+  { value: "EXPECTED_OUTPUT", key: "expectedOutput" },
+  { value: "RETRIEVAL_CONTEXT", key: "retrievalContext" },
+] as const;
+
+interface CustomMetricRow {
+  id: string;
+  name: string;
+  criteria: string;
+  parameters: string[];
+  threshold: string;
+}
+
+function newCustomMetricRow(): CustomMetricRow {
+  return { id: crypto.randomUUID(), name: "", criteria: "", parameters: [], threshold: "0.5" };
+}
 
 interface RunCreateProps {
   teamId: string;
@@ -45,9 +85,18 @@ export default function RunCreate({ teamId, evaluationId, evaluationName, onCanc
   const dispatch = useDispatch();
 
   const [agentInstanceId, setAgentInstanceId] = useState("");
+  const [selectedMetrics, setSelectedMetrics] = useState<string[]>(["answer_relevancy"]);
+  const [customMetrics, setCustomMetrics] = useState<CustomMetricRow[]>([]);
 
-  const { data: instances, isLoading: instancesLoading } =
-    useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery({ teamId }, { skip: !teamId });
+  const {
+    data: instances,
+    isLoading: instancesLoading,
+    refetch: refetchInstances,
+  } = useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery({ teamId }, { skip: !teamId });
+  const { data: templates } = useGetTeamAgentTemplatesControlPlaneV1TeamsTeamIdAgentTemplatesGetQuery(
+    { teamId },
+    { skip: !teamId },
+  );
 
   const [startRun, { isLoading }] = useStartRunEvaluationV1EvaluationsEvaluationIdRunsPostMutation();
 
@@ -57,6 +106,50 @@ export default function RunCreate({ teamId, evaluationId, evaluationName, onCanc
     key: inst.agent_instance_id,
   }));
 
+  // Tool access on an instance can be changed by any teammate at any time — refetch
+  // right when it's picked for an eval, so the tool list below reflects the live
+  // configuration instead of whatever was cached when this screen happened to open.
+  const handleSelectInstance = (instanceId: string) => {
+    setAgentInstanceId(instanceId);
+    void refetchInstances();
+  };
+
+  const selectedInstance = instances?.find((inst) => inst.agent_instance_id === agentInstanceId);
+  const selectedTemplate = templates?.find((tpl) => tpl.template_id === selectedInstance?.template_id);
+  const capabilityById = new Map((selectedTemplate?.available_capabilities ?? []).map((cap) => [cap.id, cap]));
+  // null means "inherits the template's default selection" (no explicit per-instance
+  // override) — distinct from an empty array, which means the instance has no tools.
+  const activeCapabilityIds = selectedInstance?.selected_capability_ids ?? null;
+  const activeCapabilities = (activeCapabilityIds ?? [])
+    .map((id) => capabilityById.get(id))
+    .filter((cap): cap is NonNullable<typeof cap> => !!cap);
+
+  const toggleMetric = (metricId: string) =>
+    setSelectedMetrics((prev) => (prev.includes(metricId) ? prev.filter((m) => m !== metricId) : [...prev, metricId]));
+
+  const addCustomMetric = () => setCustomMetrics((prev) => [...prev, newCustomMetricRow()]);
+  const removeCustomMetric = (id: string) => setCustomMetrics((prev) => prev.filter((r) => r.id !== id));
+  const updateCustomMetric = (id: string, field: "name" | "criteria" | "threshold", value: string) =>
+    setCustomMetrics((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+  const toggleCustomMetricParam = (id: string, param: string) =>
+    setCustomMetrics((prev) =>
+      prev.map((r) =>
+        r.id === id
+          ? {
+              ...r,
+              parameters: r.parameters.includes(param)
+                ? r.parameters.filter((p) => p !== param)
+                : [...r.parameters, param],
+            }
+          : r,
+      ),
+    );
+
+  // Only rows with a name, a criterion, and at least one field are sent — a row left
+  // half-filled while editing is silently dropped rather than rejected at submit time.
+  const validCustomMetrics = customMetrics.filter((r) => r.name.trim() && r.criteria.trim() && r.parameters.length > 0);
+  const canSubmit = !!agentInstanceId && selectedMetrics.length > 0;
+
   const handleSubmit = async () => {
     try {
       const result = await startRun({
@@ -64,6 +157,13 @@ export default function RunCreate({ teamId, evaluationId, evaluationName, onCanc
         startRunRequest: {
           team_id: teamId,
           target: { kind: "managed_instance", agent_instance_id: agentInstanceId },
+          metrics: selectedMetrics,
+          custom_metrics: validCustomMetrics.map((r) => ({
+            name: r.name.trim(),
+            criteria: r.criteria.trim(),
+            parameters: r.parameters,
+            threshold: Number(r.threshold) || 0.5,
+          })),
         },
       }).unwrap();
       // Register the launched run into the shared task store so it streams via
@@ -124,10 +224,128 @@ export default function RunCreate({ teamId, evaluationId, evaluationName, onCanc
               ? t("rework.evaluation.create.instance.loading")
               : t("rework.evaluation.create.instance.placeholder")
           }
-          onChange={setAgentInstanceId}
+          onChange={handleSelectInstance}
         />
 
+        {agentInstanceId && (
+          <div className={styles.field}>
+            <span className={styles.fieldLabel}>{t("rework.evaluation.create.instanceTools.label")}</span>
+            {activeCapabilityIds === null ? (
+              <p className={styles.note}>{t("rework.evaluation.create.instanceTools.inherited")}</p>
+            ) : activeCapabilities.length === 0 ? (
+              <p className={styles.note}>{t("rework.evaluation.create.instanceTools.none")}</p>
+            ) : (
+              <div className={styles.toolChips}>
+                {activeCapabilities.map((cap) => (
+                  <span key={cap.id} className={styles.toolChip}>
+                    {t(cap.name)}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
         <p className={styles.note}>{t("rework.evaluation.create.securityNote")}</p>
+      </div>
+
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>{t("rework.evaluation.create.builtinMetrics.label")}</span>
+        <p className={styles.note}>{t("rework.evaluation.create.builtinMetrics.help")}</p>
+        <ul className={styles.metricList}>
+          {BUILTIN_METRICS.map((metric) => {
+            const checked = selectedMetrics.includes(metric.id);
+            return (
+              <li key={metric.id} className={styles.metricRow}>
+                <Switch
+                  checked={checked}
+                  onChange={() => toggleMetric(metric.id)}
+                  aria-label={t(`rework.evaluation.create.builtinMetrics.${metric.key}`)}
+                />
+                <span className={styles.metricMeta}>
+                  <span className={styles.metricName}>
+                    {t(`rework.evaluation.create.builtinMetrics.${metric.key}`)}
+                  </span>
+                  <span className={styles.metricDesc}>
+                    {t(`rework.evaluation.create.builtinMetrics.${metric.key}Desc`)}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+        {selectedMetrics.length === 0 && (
+          <p className={styles.note}>{t("rework.evaluation.create.builtinMetrics.none")}</p>
+        )}
+      </div>
+
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>{t("rework.evaluation.create.metrics.label")}</span>
+        <p className={styles.note}>{t("rework.evaluation.create.metrics.help")}</p>
+        <div className={styles.caseList}>
+          {customMetrics.map((row, idx) => (
+            <div key={row.id} className={styles.caseCard}>
+              <div className={styles.caseCardHead}>
+                <span className={styles.muted}>{t("rework.evaluation.create.metrics.n", { n: idx + 1 })}</span>
+                <IconButton
+                  color="error"
+                  variant="icon"
+                  size="small"
+                  icon={{ category: "outlined", type: "delete" }}
+                  aria-label={t("rework.evaluation.create.metrics.remove")}
+                  onClick={() => removeCustomMetric(row.id)}
+                />
+              </div>
+              <TextInput
+                label={t("rework.evaluation.create.metrics.name")}
+                value={row.name}
+                placeholder={t("rework.evaluation.create.metrics.namePlaceholder")}
+                onChange={(e) => updateCustomMetric(row.id, "name", e.target.value)}
+              />
+              <TextArea
+                label={t("rework.evaluation.create.metrics.criteria")}
+                value={row.criteria}
+                rows={2}
+                placeholder={t("rework.evaluation.create.metrics.criteriaPlaceholder")}
+                onChange={(e) => updateCustomMetric(row.id, "criteria", e.target.value)}
+              />
+              <div className={styles.field}>
+                <span className={styles.fieldLabel}>{t("rework.evaluation.create.metrics.parameters")}</span>
+                <div className={styles.paramRow}>
+                  {CUSTOM_METRIC_PARAMETERS.map((param) => (
+                    <label key={param.value} className={styles.paramOption}>
+                      <Switch
+                        checked={row.parameters.includes(param.value)}
+                        onChange={() => toggleCustomMetricParam(row.id, param.value)}
+                      />
+                      {t(`rework.evaluation.create.metrics.parameterOptions.${param.key}`)}
+                    </label>
+                  ))}
+                </div>
+              </div>
+              <TextInput
+                type="number"
+                min={0}
+                max={1}
+                step={0.1}
+                label={t("rework.evaluation.create.metrics.threshold")}
+                value={row.threshold}
+                onChange={(e) => updateCustomMetric(row.id, "threshold", e.target.value)}
+              />
+            </div>
+          ))}
+          <div>
+            <Button
+              color="on-surface"
+              variant="outlined"
+              size="small"
+              icon={{ category: "outlined", type: "add" }}
+              onClick={addCustomMetric}
+            >
+              {t("rework.evaluation.create.metrics.add")}
+            </Button>
+          </div>
+        </div>
       </div>
 
       <div className={styles.recap}>
@@ -140,6 +358,16 @@ export default function RunCreate({ teamId, evaluationId, evaluationName, onCanc
           <span className={styles.muted}>{t("rework.evaluation.create.recap.instance")}</span>
           <span className={styles.recapValue}>{agentInstanceId || "—"}</span>
         </div>
+        <div className={styles.recapRow}>
+          <span className={styles.muted}>{t("rework.evaluation.create.recap.metrics")}</span>
+          <span className={styles.recapValue}>{selectedMetrics.length}</span>
+        </div>
+        {validCustomMetrics.length > 0 && (
+          <div className={styles.recapRow}>
+            <span className={styles.muted}>{t("rework.evaluation.create.recap.customMetrics")}</span>
+            <span className={styles.recapValue}>{validCustomMetrics.length}</span>
+          </div>
+        )}
       </div>
 
       <div className={styles.nav}>
@@ -150,7 +378,7 @@ export default function RunCreate({ teamId, evaluationId, evaluationName, onCanc
           color="primary"
           variant="filled"
           size="medium"
-          disabled={!agentInstanceId || isLoading}
+          disabled={!canSubmit || isLoading}
           onClick={handleSubmit}
         >
           {isLoading ? t("rework.evaluation.runCreate.starting") : t("rework.evaluation.runCreate.submit")}

--- a/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
+++ b/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
@@ -277,9 +277,17 @@ export type ManagedInstanceTarget = {
   kind: "managed_instance";
   agent_instance_id: string;
 };
+export type CustomMetricSpecInput = {
+  name: string;
+  criteria: string;
+  parameters: string[];
+  threshold?: number;
+};
 export type StartRunRequest = {
   team_id: string;
   target: ManagedInstanceTarget;
+  metrics: string[];
+  custom_metrics?: CustomMetricSpecInput[];
 };
 export type RuntimeAgentTarget = {
   kind: "runtime_agent";
@@ -436,6 +444,62 @@ export type TaskTarget = {
   id: string;
   label: string;
 };
+export type IngestionDetail = {
+  processed: number;
+  total: number;
+  failed: number;
+  preview: number;
+  vectorized: number;
+  sql_indexed: number;
+};
+export type EvaluationDetail = {
+  campaign_id: string;
+  completed: number;
+  total: number;
+  passed: number;
+  failed: number;
+  execution_errors: number;
+  scoring_errors: number;
+};
+export type TaskLogDetail = {
+  level: "info" | "warn" | "error";
+  message: string;
+};
+export type MigrationResult = {
+  import_id: string;
+  source_platform: string;
+  identities_created?: number;
+  users_processed?: number;
+  users_skipped?: string[];
+  teams_imported?: number;
+  teams_skipped?: number;
+  teams_provisioned?: number;
+  team_roles_granted?: number;
+  team_roles_skipped?: number;
+  platform_roles_granted?: number;
+  agents_imported?: number;
+  agents_skipped?: number;
+  agents_gap?: number;
+  tags_imported?: number;
+  tags_skipped?: number;
+  docs_imported?: number;
+  docs_skipped?: number;
+  warnings?: string[];
+};
+export type MigrationDetail = {
+  step_id: string;
+  processed: number;
+  total: number;
+  failed: number;
+  result?: MigrationResult | null;
+};
+export type ErasureReason = "user_deleted" | "member_removed" | "idle_expired";
+export type ErasureDetail = {
+  reason?: ErasureReason | null;
+  stores_ok?: number;
+  stores_total?: number;
+  attempts?: number;
+};
 export type TaskSummary = {
   task_id: string;
   kind: string;
@@ -449,18 +513,10 @@ export type TaskSummary = {
   created_at: string;
   updated_at: string;
   scheduled_for?: string | null;
+  detail?: IngestionDetail | EvaluationDetail | TaskLogDetail | MigrationDetail | ErasureDetail | null;
 };
 export type TaskListResponse = {
   tasks: TaskSummary[];
-};
-export type EvaluationDetail = {
-  campaign_id: string;
-  completed: number;
-  total: number;
-  passed: number;
-  failed: number;
-  execution_errors: number;
-  scoring_errors: number;
 };
 export type EvaluationTaskEvent = {
   task_id: string;


### PR DESCRIPTION
# Pull Request

## 1. What problem does this solve — and where is it tracked?

**ID:** no ID — routine issue-driven work; the scope is narrow enough it doesn't need one (see `id-legend.yaml` narrowing rule). Tracked as issue #2044 on this repo, paired with `fred-agent-evaluator` issue #37 (backend contract).

**Problem in one sentence:** Automatic profile-based metric selection (RAG/SQL tag detection) couldn't account for tools manually attached to a general-purpose agent, so evaluations often ran with incomplete or wrong metric coverage — this replaces it with explicit, analyst-driven metric selection.

**Backlog ref:** `docs/swift/backlog/AGENT-EVALUATION-BACKLOG.md` — items "configurable validation profiles by agent type" / "define recommended metrics by agent type". Note: this PR does **not** check that box off or reword it — see §5, that's a known gap.

---

## 2. Before you wrote a single line of code

**RFC written?** Not in this repo. The design decision (manual metric selection, custom GEval criteria, the `metrics`/`custom_metrics` contract shape) is documented in the paired backend repo's `docs/rfc/EVAL-CUSTOM-METRIC-RFC.md`, amended in the companion PR (issue #37). This PR only implements the frontend consumer of that already-decided contract — no independent design choice was made here that would need its own RFC.

**Plan presented to the team before implementation?** Presented to and confirmed with the requesting analyst directly, not a broader team review — no Slack thread, no meeting. The existing code (`RunCreate.tsx`, `evaluationOpenApi.ts`, the backend's automatic-profile mechanism) was read and understood before anything was written, and the scope was explicitly narrowed to metrics only (structural checks / `resolve_profile` left untouched) in that discussion.

**Confirmation received?** Yes — explicit go-ahead from the requesting analyst after the plan (files to touch, the 5-metric catalog, the custom-metric shape) was laid out.

---

## 3. What you built

`RunCreate.tsx` gained a manual metric-selection UI: a checkbox list of the 5 built-in DeepEval metrics (Answer Relevancy checked by default, the rest opt-in) plus a custom-metric editor (name, criteria, parameters, threshold — add/remove rows), both wired into `StartRunRequest.metrics` / `.custom_metrics` (new fields on the generated client, sourced from the paired backend PR). Also added a live "tools enabled on this agent" panel under the instance selector: it resolves the selected instance's `selected_capability_ids` against the team's capability catalog and force-refetches at the moment of selection, so the analyst sees the agent's *current* tool configuration — not a stale cached one — before evaluating it.

---

## 4. Proof of quality

**Tests added or updated:**

| Test | File | What it covers |
| ---- | ---- | -------------- |
| — | — | None. This repo's `rework/` components have no existing unit-test harness for this view, and none was added here. |

**`make code-quality` output (paste the last line or "all checks passed"):**

```
npx tsc --noEmit
npx prettier . --check
Checking formatting...
All matched files use Prettier code style!
All frontend code quality checks completed
```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```
n/a — frontend-only change, no Python package touched.
```

**`make test` output (paste the summary line — pass count, 0 failures):**

```
Not run — no frontend unit-test suite exists for this component. Not fabricating a pass count.
Manually verified: tsc + prettier clean; feature exercised live against a running
local stack by the requesting analyst (not by me — I had no credentials for that
environment).
```

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | **Not done.** `AGENT-EVALUATION-BACKLOG.md` still lists the old "configurable validation profiles by agent type" item; not closed out or reworded here. |
| New behaviour, API field, or contract change                      | `evaluationOpenApi.ts` regenerated from the backend's updated OpenAPI spec (not hand-edited), per the mandatory client-regeneration rule. No frontend design doc updated. |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | `evaluationOpenApi.ts` — regenerated only, never hand-edited. |
| UX component implemented or visual status changed                 | **Not done.** No `Checkbox`/multi-select atom existed before this PR (`COMPONENT-UX.md:1006` confirms it was absent); this PR built the selection UI inline in `RunCreate.tsx` instead of as a promoted shared atom, and `COMPONENT-UX.md` was not updated to record that decision. |
| Phase progress row exists for this area                           | n/a — no phase-tracking row for this screen in the backlog file. |
| WORKPLAN sprint item finished                                     | n/a — `WORKPLAN.md` is frozen; never written to. |
| Code and a design doc now diverge                                 | Yes: `AGENT-EVALUATION-BACKLOG.md`'s "configurable validation profiles by agent type" item now describes a mechanism this PR intentionally replaces, and the doc doesn't say so. |

---

## 6. Close-out statement

```
## Task close-out
- Code: RunCreate.tsx — manual built-in/custom metric selection UI + live
  agent-tools display; evaluationOpenApi.ts regenerated (not hand-edited)
- Tests: none added — no existing unit-test harness for this component;
  verified via tsc + prettier only, plus live manual testing by the
  requesting analyst
- Docs updated: none in this repo (gap — AGENT-EVALUATION-BACKLOG.md and
  COMPONENT-UX.md were identified as needing updates and were not touched)
- Backlog: not closed out
- Skipped steps: doc updates (backlog item close-out, COMPONENT-UX.md), no
  dedicated frontend RFC (design lives in the paired backend RFC), no
  automated test coverage
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

Two distinct risks:
1. **UI risk (low):** a bug in the checkbox/custom-metric logic could let an analyst start a run with the wrong metric set — confusing, but not data-corrupting, since the backend independently validates `metrics` against its own catalog before accepting a run.
2. **Coupling risk (real rollback hazard):** the backend's `StartRunRequest.metrics` field is **required, non-empty**. If this PR is reverted *without* also reverting the paired backend PR (`fred-agent-evaluator` #37), "New run" breaks entirely — every `POST .../runs` call 422s because the old frontend never sends `metrics`.

**How do we roll back?**

Revert this PR **and** the paired backend PR (`fred-agent-evaluator` #37) together — not independently. Reverting only one side leaves either a broken "New run" (frontend reverted, backend still requires `metrics`) or an unused backend field (backend reverted, frontend still sends fields the old backend schema rejects via `extra="forbid"`).