### PR TITLE
GitHub findings

### DIFF
--- a/apps/control-plane-backend/pyrightconfig.json
+++ b/apps/control-plane-backend/pyrightconfig.json
@@ -1,5 +1,6 @@
 {
   "typeCheckingMode": "standard",
   "venvPath": ".",
-  "venv": ".venv"
+  "venv": ".venv",
+  "reportUnreachable": "warning"
 }

--- a/apps/control-plane-backend/uv.lock
+++ b/apps/control-plane-backend/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -668,7 +668,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.3.4"
+version = "3.3.5"
 source = { editable = "../../libs/fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/apps/fred-agents/pyrightconfig.json
+++ b/apps/fred-agents/pyrightconfig.json
@@ -4,6 +4,7 @@
   "venvPath": ".",
   "venv": ".venv",
   "reportMissingTypeStubs": false,
+  "reportUnreachable": "warning",
   "extraPaths": [
     "../../libs/fred-core",
     "../../libs/fred-sdk",

--- a/apps/fred-agents/uv.lock
+++ b/apps/fred-agents/uv.lock
@@ -614,7 +614,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -705,7 +705,7 @@ dev = [
 
 [[package]]
 name = "fred-runtime"
-version = "3.3.6"
+version = "3.3.7"
 source = { editable = "../../libs/fred-runtime" }
 dependencies = [
     { name = "alembic" },
@@ -769,7 +769,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.3.4"
+version = "3.3.5"
 source = { editable = "../../libs/fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/apps/frontend/Makefile
+++ b/apps/frontend/Makefile
@@ -114,6 +114,10 @@ format-check: node_modules ## Check formatting with prettier (fails on unformatt
 format-fix: node_modules ## Reformat the codebase in place with prettier
 	npx prettier . --write
 
+.PHONY: lint
+lint: node_modules ## Lint src/ with ESLint (deliberately narrow rule set — see eslint.config.mjs)
+	npx eslint "src/**/*.{ts,tsx}"
+
 # knip (unused-export/dependency detection) is not wired in yet; see the
 # code-quality TODO below. Uncomment once the config is stable.
 # .PHONY: knip
@@ -126,7 +130,7 @@ format-fix: node_modules ## Reformat the codebase in place with prettier
 
 # TODO: add `knip` to the prerequisites below once it is wired in.
 .PHONY: code-quality
-code-quality: type-check format-check  ## Run all checks (type-check + prettier) — the gate to pass before committing
+code-quality: type-check format-check lint  ## Run all checks (type-check + prettier + eslint) — the gate to pass before committing
 	@echo "All frontend code quality checks completed"
 
 # TODO: add `knip-fix` to the prerequisites below once knip is wired in.

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -1,0 +1,36 @@
+// ESLint flat config (v9+/v10). Scope kept deliberately narrow — see docs/CONVENTIONS.md
+// entry for `apps/frontend` code-quality — rather than adopting a full recommended
+// rule set (which would require baselining a large pre-existing surface), each rule
+// here was validated to produce zero findings on the current apps/frontend/src tree
+// before being enabled, so `make code-quality` can treat any violation as a hard
+// failure with no baseline/ignore mechanism needed.
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  {
+    files: ["src/**/*.ts", "src/**/*.tsx"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      // Registered (not enabled) only so the pre-existing
+      // `eslint-disable-next-line react-hooks/exhaustive-deps` comments in this
+      // codebase resolve to a known rule instead of erroring as undefined.
+      "react-hooks": reactHooks,
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: "off",
+    },
+    rules: {
+      // Catches CodeQL's "Expression has no effect" (js/useless-expression) class
+      // of bug locally instead of only via a GitHub Code Quality scan.
+      "@typescript-eslint/no-unused-expressions": "error",
+    },
+  },
+];

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -53,10 +53,13 @@
         "@svgr/rollup": "^8.1.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-v8": "^4.1.7",
         "dayjs": "^1.11.13",
         "eslint": "^10.0.1",
+        "eslint-plugin-react-hooks": "7.1.1",
         "happy-dom": "^20.10.6",
         "prettier": "3.5.3",
         "prettier-plugin-css-order": "^2.2.0",
@@ -4904,6 +4907,249 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -6784,6 +7030,26 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -7474,6 +7740,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/highlight.js": {
@@ -11623,6 +11906,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -12376,6 +12672,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zrender": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -14,7 +14,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "prettier --check .",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -64,10 +65,13 @@
     "@svgr/rollup": "^8.1.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@typescript-eslint/eslint-plugin": "8.65.0",
+    "@typescript-eslint/parser": "8.65.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^4.1.7",
     "dayjs": "^1.11.13",
     "eslint": "^10.0.1",
+    "eslint-plugin-react-hooks": "7.1.1",
     "happy-dom": "^20.10.6",
     "prettier": "3.5.3",
     "prettier-plugin-css-order": "^2.2.0",
@@ -76,13 +80,6 @@
     "vite": "^6.4.2",
     "vite-tsconfig-paths": "6.1.1",
     "vitest": "^4.1.7"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest",
-      "plugin:@typescript-eslint/recommended"
-    ]
   },
   "browserslist": {
     "production": [

--- a/apps/frontend/public/release.md
+++ b/apps/frontend/public/release.md
@@ -1,3 +1,16 @@
+**v2.1.10** — 2026-07-22
+
+- **Summary**
+
+  Defense-in-depth authorization hardening for agent tool execution: every tool call in a
+  ReAct turn is now individually re-authorized, and JWTs are rejected if their issued
+  lifetime exceeds one hour, independent of what the issuing IdP was configured to allow.
+
+- **Security**
+
+  - Every tool call in a ReAct turn is now individually re-authorized against the caller's team (`CAN_READ`), not just once at turn start — a denied or stale team membership now blocks the specific tool call instead of being silently trusted for the rest of a long-running turn (`fred-runtime` 3.3.7)
+  - JWTs are now rejected when their issued lifetime (`exp - iat`) exceeds one hour, regardless of what the issuing IdP was configured to grant — closes a gap where token lifetime was entirely delegated to IdP configuration with no application-side ceiling; Fred's own service-to-service tokens are short-lived and auto-refreshed, so this does not affect normal traffic (`fred-core` 3.4.7)
+
 **v2.1.9** — 2026-07-21
 
 - **Summary**

--- a/apps/frontend/src/components/documents/common/DocumentIcon.tsx
+++ b/apps/frontend/src/components/documents/common/DocumentIcon.tsx
@@ -62,7 +62,7 @@ const ExtIcon: React.FC<ExtIconProps> = ({ ext, size = 20 }) => {
   return builtIn ?? <InsertDriveFileIcon style={style} />;
 };
 
-export const getDocumentIcon = (filename: string): ReactElement | null => {
+export const getDocumentIcon = (filename: string): ReactElement => {
   const ext = filename.split(".").pop()?.toLowerCase();
   return <ExtIcon ext={ext} />;
 };

--- a/apps/frontend/src/components/documents/data/DocumentDataDrawer.tsx
+++ b/apps/frontend/src/components/documents/data/DocumentDataDrawer.tsx
@@ -158,7 +158,7 @@ const DocumentDataDrawerContent: React.FC<{ doc: ProcessingGraphNode }> = ({ doc
   const formatError = (err: unknown): string => {
     if (!err) return "";
     if (typeof err === "string") return err;
-    if (err && typeof err === "object" && "status" in err) {
+    if (typeof err === "object" && "status" in err) {
       const anyErr = err as any;
       const detail = anyErr?.data?.detail ?? anyErr?.data;
       const detailStr = detail == null ? "" : typeof detail === "string" ? detail : JSON.stringify(detail);

--- a/apps/frontend/src/components/documents/data/DocumentDataTableList.tsx
+++ b/apps/frontend/src/components/documents/data/DocumentDataTableList.tsx
@@ -14,7 +14,6 @@
 
 import { Box, Chip, FormControl, InputLabel, MenuItem, Select, Stack, Typography } from "@mui/material";
 import TableChartIcon from "@mui/icons-material/TableChart";
-import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
 import { useMemo, useState } from "react";
@@ -155,7 +154,7 @@ export const DocumentDataTableList = ({ rows, search }: DocumentDataRowsProps) =
                     gap: 0.75,
                   }}
                 >
-                  {getDocumentIcon(doc.label) || <InsertDriveFileOutlinedIcon fontSize="small" />}
+                  {getDocumentIcon(doc.label)}
                   <Typography variant="body2" noWrap>
                     {doc.label}
                   </Typography>

--- a/apps/frontend/src/components/documents/data/DocumentDataVectorList.tsx
+++ b/apps/frontend/src/components/documents/data/DocumentDataVectorList.tsx
@@ -15,7 +15,6 @@
 import { Box, Chip, FormControl, InputLabel, MenuItem, Select, Stack, Typography } from "@mui/material";
 import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
 import { getDocumentIcon } from "../common/DocumentIcon.tsx";
-import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@mui/material/styles";
 import { useMemo, useState } from "react";
@@ -168,7 +167,7 @@ export const DocumentDataVectorList = ({ rows, search }: DocumentDataRowsProps) 
                     gap: 0.75,
                   }}
                 >
-                  {getDocumentIcon(doc.label) || <InsertDriveFileOutlinedIcon fontSize="small" />}
+                  {getDocumentIcon(doc.label)}
                   <Typography variant="body2" noWrap>
                     {doc.label}
                   </Typography>

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1610,6 +1610,7 @@
         "stats": {
           "passed": "Passed",
           "failed": "Failed",
+          "insufficient": "Insufficient",
           "execErrors": "Exec. errors",
           "scoringErrors": "Scoring errors"
         },

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1643,6 +1643,8 @@
           "metrics": "Metrics"
         },
         "caseTitle": "Case detail",
+        "copyJson": "Copy JSON",
+        "copied": "Copied",
         "latency": "Latency",
         "input": "Input",
         "expected": "Expected output",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1643,6 +1643,8 @@
           "metrics": "Métriques"
         },
         "caseTitle": "Détail du cas",
+        "copyJson": "Copier en JSON",
+        "copied": "Copié",
         "latency": "Latence",
         "input": "Entrée",
         "expected": "Sortie attendue",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1610,6 +1610,7 @@
         "stats": {
           "passed": "Réussis",
           "failed": "Échoués",
+          "insufficient": "Insuffisants",
           "execErrors": "Erreurs exéc.",
           "scoringErrors": "Erreurs scoring"
         },

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -99,7 +99,7 @@ export default function ManagedChatPage() {
 
   const { activeTeam } = useFrontendBootstrap();
   const isPersonalTeam = teamId === activeTeam?.id;
-  const { data: fetchedTeam } = useGetTeamQuery({ teamId }, { skip: !teamId || isPersonalTeam });
+  const { data: fetchedTeam } = useGetTeamQuery({ teamId }, { skip: isPersonalTeam });
   const team = isPersonalTeam ? activeTeam : fetchedTeam;
   const { canAdministerAdmins } = useTeamCapabilities(team);
   const isAdmin = isPersonalTeam || canAdministerAdmins;

--- a/apps/frontend/src/rework/components/shared/molecules/FullPageModal/FullPageModal.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/FullPageModal/FullPageModal.tsx
@@ -49,13 +49,7 @@ export const FullPageModal = ({ isOpen, onClose, children, id }: FullPageModalPr
 
   return (
     <Portal id="modal-portal">
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={`${id}-title`}
-        className={styles.modal}
-        data-state={isOpen ? "open" : "closed"}
-      >
+      <div role="dialog" aria-modal="true" aria-labelledby={`${id}-title`} className={styles.modal} data-state="open">
         {children}
       </div>
     </Portal>

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.module.css
@@ -310,6 +310,10 @@
   gap: var(--spacing-s);
 }
 
+.spacer {
+  flex: 1;
+}
+
 .caseSection {
   display: flex;
   flex-direction: column;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -356,6 +356,7 @@ export default function EvaluationRunDetail({
       <div className={styles.statRow}>
         <StatCard label={t("rework.evaluation.detail.stats.passed")} value={run.passed_cases} tone="success" />
         <StatCard label={t("rework.evaluation.detail.stats.failed")} value={run.failed_cases} tone="error" />
+        <StatCard label={t("rework.evaluation.detail.stats.insufficient")} value={run.insufficient_cases} tone="info" />
         <StatCard
           label={t("rework.evaluation.detail.stats.execErrors")}
           value={run.execution_error_cases}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -522,6 +522,10 @@ function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: Retu
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
+    // navigator.clipboard is undefined in non-secure contexts (plain HTTP,
+    // except localhost), older browsers, and some test DOM environments —
+    // accessing .writeText on it would throw synchronously.
+    if (!navigator.clipboard) return;
     navigator.clipboard
       .writeText(JSON.stringify(caseData, null, 2))
       .then(() => {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -520,6 +520,15 @@ export default function EvaluationRunDetail({
 
 function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: ReturnType<typeof useTranslation>["t"] }) {
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear a pending "reset to idle" timer on unmount (drawer closed within
+  // the 2s window) so it can't fire setCopied after this component is gone.
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const handleCopy = () => {
     // navigator.clipboard is undefined in non-secure contexts (plain HTTP,
@@ -530,7 +539,8 @@ function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: Retu
       .writeText(JSON.stringify(caseData, null, 2))
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
       })
       .catch(() => {});
   };

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@shared/atoms/Button/Button";
 import Disclosure from "@shared/atoms/Disclosure/Disclosure";
+import IconButton from "@shared/atoms/IconButton/IconButton";
 import ProgressBar from "@shared/atoms/ProgressBar/ProgressBar";
 import { TaskStateBadge } from "@shared/atoms/TaskStateBadge/TaskStateBadge";
 import { TaskProgressBar } from "@shared/atoms/TaskProgressBar/TaskProgressBar";
@@ -507,7 +508,7 @@ export default function EvaluationRunDetail({
         open={!!selectedCase}
         onClose={() => setSelectedCase(null)}
         title={t("rework.evaluation.detail.caseTitle")}
-        width="560px"
+        width="880px"
       >
         {selectedCase && <CaseDetail caseData={selectedCase} t={t} />}
       </InlineDrawer>
@@ -518,6 +519,18 @@ export default function EvaluationRunDetail({
 // ── Case drawer body ─────────────────────────────────────────────────────────
 
 function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: ReturnType<typeof useTranslation>["t"] }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(JSON.stringify(caseData, null, 2))
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
+  };
+
   return (
     <div className={styles.caseBody}>
       <div className={styles.caseMetaRow}>
@@ -528,16 +541,25 @@ function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: Retu
         <span className={styles.muted}>
           {t("rework.evaluation.detail.col.status")}: {caseData.status}
         </span>
+        <span className={styles.spacer} />
+        <IconButton
+          color="on-surface"
+          variant="icon"
+          size="small"
+          icon={{ category: "outlined", type: copied ? "check_circle" : "content_copy" }}
+          aria-label={copied ? t("rework.evaluation.detail.copied") : t("rework.evaluation.detail.copyJson")}
+          onClick={handleCopy}
+        />
       </div>
 
       <FieldBlock label={t("rework.evaluation.detail.input")} value={caseData.input} />
       {(caseData.expected_output || caseData.actual_output) && (
         <div className={styles.compareGrid}>
           {caseData.expected_output && (
-            <FieldBlock label={t("rework.evaluation.detail.expected")} value={caseData.expected_output} />
+            <FieldBlock label={t("rework.evaluation.detail.expected")} value={caseData.expected_output} tall />
           )}
           {caseData.actual_output && (
-            <FieldBlock label={t("rework.evaluation.detail.actual")} value={caseData.actual_output} />
+            <FieldBlock label={t("rework.evaluation.detail.actual")} value={caseData.actual_output} tall />
           )}
         </div>
       )}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationShared.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationShared.module.css
@@ -52,3 +52,7 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+.fieldValueTall {
+  max-height: 400px;
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationShared.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationShared.tsx
@@ -95,12 +95,14 @@ export function StatusPill({ label, tone }: { label: string; tone: StatusTone })
   return <span className={`${styles.pill} ${toneClass[tone]}`}>{label}</span>;
 }
 
-/** Labelled, monospace, scrollable text block (case input/output, etc.). */
-export function FieldBlock({ label, value }: { label: string; value: string }) {
+/** Labelled, monospace, scrollable text block (case input/output, etc.).
+ * `tall` raises the scroll cap for contexts with room to spare (the case
+ * drawer) — compact contexts (e.g. a `CaseCard` preview) keep the default. */
+export function FieldBlock({ label, value, tall = false }: { label: string; value: string; tall?: boolean }) {
   return (
     <div className={styles.fieldBlock}>
       <span className={styles.fieldLabel}>{label}</span>
-      <pre className={styles.fieldValue}>{value}</pre>
+      <pre className={`${styles.fieldValue} ${tall ? styles.fieldValueTall : ""}`}>{value}</pre>
     </div>
   );
 }

--- a/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
+++ b/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
@@ -56,6 +56,12 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({ url: `/evaluation/v1/runs/${queryArg.runId}/cases/${queryArg.caseId}` }),
     }),
+    getRunReportEvaluationV1RunsRunIdReportGet: build.query<
+      GetRunReportEvaluationV1RunsRunIdReportGetApiResponse,
+      GetRunReportEvaluationV1RunsRunIdReportGetApiArg
+    >({
+      query: (queryArg) => ({ url: `/evaluation/v1/runs/${queryArg.runId}/report` }),
+    }),
     streamRunEventsEvaluationV1RunsRunIdEventsGet: build.query<
       StreamRunEventsEvaluationV1RunsRunIdEventsGetApiResponse,
       StreamRunEventsEvaluationV1RunsRunIdEventsGetApiArg
@@ -106,6 +112,12 @@ const injectedRtkApi = api.injectEndpoints({
           team_id: queryArg.teamId,
         },
       }),
+    }),
+    deleteEvaluationEvaluationV1EvaluationsEvaluationIdDelete: build.mutation<
+      DeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteApiResponse,
+      DeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteApiArg
+    >({
+      query: (queryArg) => ({ url: `/evaluation/v1/evaluations/${queryArg.evaluationId}`, method: "DELETE" }),
     }),
     listTasksEvaluationV1TasksGet: build.query<
       ListTasksEvaluationV1TasksGetApiResponse,
@@ -184,6 +196,11 @@ export type GetRunCaseEvaluationV1RunsRunIdCasesCaseIdGetApiArg = {
   runId: string;
   caseId: string;
 };
+export type GetRunReportEvaluationV1RunsRunIdReportGetApiResponse =
+  /** status 200 Successful Response */ RunReportResponse;
+export type GetRunReportEvaluationV1RunsRunIdReportGetApiArg = {
+  runId: string;
+};
 export type StreamRunEventsEvaluationV1RunsRunIdEventsGetApiResponse = /** status 200 Successful Response */ any;
 export type StreamRunEventsEvaluationV1RunsRunIdEventsGetApiArg = {
   runId: string;
@@ -216,6 +233,10 @@ export type ListEvaluationsEvaluationV1EvaluationsGetApiResponse =
   /** status 200 Successful Response */ EvaluationListResponse;
 export type ListEvaluationsEvaluationV1EvaluationsGetApiArg = {
   teamId: string;
+};
+export type DeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteApiResponse = unknown;
+export type DeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteApiArg = {
+  evaluationId: string;
 };
 export type ListTasksEvaluationV1TasksGetApiResponse = /** status 200 Successful Response */ TaskListResponse;
 export type ListTasksEvaluationV1TasksGetApiArg = {
@@ -324,6 +345,7 @@ export type EvaluationRun = {
   completed_cases: number;
   passed_cases: number;
   failed_cases: number;
+  insufficient_cases: number;
   execution_error_cases: number;
   scoring_error_cases: number;
   snapshot: RunSnapshot;
@@ -377,13 +399,17 @@ export type EvaluationCaseListResponse = {
   cases: EvaluationCaseResponse[];
   total: number;
 };
-export type TelemetrySessionResponse = {
-  available: boolean;
-  url?: string | null;
-};
-export type TelemetryInfoResponse = {
-  enabled: boolean;
-  langfuse_session_url?: string | null;
+export type RunReportEvaluation = {
+  evaluation_id: string;
+  name: string;
+  version: string;
+  team_id: string;
+  team_name?: string | null;
+  author: string | null;
+  created_by: string;
+  origin: string;
+  completeness: string;
+  created_at: string;
 };
 export type RunAnalysisResult = {
   summary: string;
@@ -391,6 +417,25 @@ export type RunAnalysisResult = {
   weaknesses: string[];
   recommendations: string[];
   risk_level: string;
+};
+export type RunReportResponse = {
+  schema_version?: "1";
+  generated_at: string;
+  evaluation: RunReportEvaluation;
+  run: EvaluationRun;
+  metric_averages?: {
+    [key: string]: number;
+  } | null;
+  analysis?: RunAnalysisResult | null;
+  cases: EvaluationCaseResponse[];
+};
+export type TelemetrySessionResponse = {
+  available: boolean;
+  url?: string | null;
+};
+export type TelemetryInfoResponse = {
+  enabled: boolean;
+  langfuse_session_url?: string | null;
 };
 export type RunAnalysisResponse = {
   run_id: string;
@@ -410,7 +455,8 @@ export type EvaluationDetailResponse = {
   evaluation_id: string;
   name: string;
   version: string;
-  author: string;
+  author: string | null;
+  created_by: string;
   team_id: string;
   origin: "capture" | "upload" | "manual";
   completeness: EvaluationCompleteness;
@@ -421,6 +467,8 @@ export type EvaluationDetailResponse = {
 export type CreateEvaluationRequest = {
   team_id: string;
   name: string;
+  version?: string | null;
+  author?: string | null;
   origin: "upload" | "manual";
   source_filename?: string | null;
   cases: EvaluationCase[];
@@ -429,7 +477,8 @@ export type EvaluationSummaryResponse = {
   evaluation_id: string;
   name: string;
   version: string;
-  author: string;
+  author: string | null;
+  created_by: string;
   team_id: string;
   origin: "capture" | "upload" | "manual";
   completeness: EvaluationCompleteness;
@@ -548,6 +597,8 @@ export const {
   useLazyListRunCasesEvaluationV1RunsRunIdCasesGetQuery,
   useGetRunCaseEvaluationV1RunsRunIdCasesCaseIdGetQuery,
   useLazyGetRunCaseEvaluationV1RunsRunIdCasesCaseIdGetQuery,
+  useGetRunReportEvaluationV1RunsRunIdReportGetQuery,
+  useLazyGetRunReportEvaluationV1RunsRunIdReportGetQuery,
   useStreamRunEventsEvaluationV1RunsRunIdEventsGetQuery,
   useLazyStreamRunEventsEvaluationV1RunsRunIdEventsGetQuery,
   useCancelRunEvaluationV1RunsRunIdCancelPostMutation,
@@ -559,6 +610,7 @@ export const {
   useCreateEvaluationEvaluationV1EvaluationsPostMutation,
   useListEvaluationsEvaluationV1EvaluationsGetQuery,
   useLazyListEvaluationsEvaluationV1EvaluationsGetQuery,
+  useDeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteMutation,
   useListTasksEvaluationV1TasksGetQuery,
   useLazyListTasksEvaluationV1TasksGetQuery,
   useGetTaskEvaluationV1TasksTaskIdGetQuery,

--- a/apps/knowledge-flow-backend/.baseline/basedpyright-baseline.json
+++ b/apps/knowledge-flow-backend/.baseline/basedpyright-baseline.json
@@ -1,3 +1,74 @@
 {
-    "files": {}
+    "files": {
+        "./knowledge_flow_backend/common/processing_profile_context.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./knowledge_flow_backend/common/source_utils.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./knowledge_flow_backend/core/processors/input/common/image_describer.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 13,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./knowledge_flow_backend/core/processors/output/vectorization_processor/vectorization_processor.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./knowledge_flow_backend/features/kpi/prometheus_service.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./knowledge_flow_backend/features/metadata/service.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./knowledge_flow_backend/features/resources/utils.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            }
+        ]
+    }
 }

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -527,9 +527,9 @@ class ProcessingConfig(BaseModel):
     def normalize_profile(self, profile: IngestionProcessingProfile | str | None) -> IngestionProcessingProfile:
         if profile is None:
             return self.default_profile
-        if isinstance(profile, str):
-            return IngestionProcessingProfile(profile)
-        return profile
+        # IngestionProcessingProfile is itself a str subclass, so this also covers
+        # (and is idempotent for) an already-valid enum member.
+        return IngestionProcessingProfile(profile)
 
     def get_profile_config(self, profile: IngestionProcessingProfile | str | None) -> "ProcessingConfig.ProfileConfig":
         profile = self.normalize_profile(profile)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/compat/fastapi_mcp_patch.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/compat/fastapi_mcp_patch.py
@@ -93,11 +93,21 @@ fastapi_mcp_utils.resolve_schema_references = resolve_schema_references
 
 async def _ensure_session_manager_started_stateless(self) -> None:
     """Patched version: creates the session manager with stateless=True."""
+    # A fixed sleep() after spawning the manager task only protects the caller that
+    # started it. A concurrent caller sees _manager_started already True and returns
+    # immediately, racing the still-starting task group ("Task group is not
+    # initialized") under any concurrent first-request load. An Event makes every
+    # caller wait for the manager to actually be running instead.
+    if getattr(self, "_manager_ready", None) is None:
+        self._manager_ready = asyncio.Event()
+
     if self._manager_started:
+        await self._manager_ready.wait()
         return
 
     async with self._startup_lock:
         if self._manager_started:
+            await self._manager_ready.wait()
             return
 
         _logger.debug("Starting StreamableHTTP session manager (stateless=True)")
@@ -114,6 +124,7 @@ async def _ensure_session_manager_started_stateless(self) -> None:
             try:
                 async with self._session_manager.run():
                     _logger.info("StreamableHTTP session manager is running (stateless)")
+                    self._manager_ready.set()
                     await asyncio.Event().wait()
             except asyncio.CancelledError:
                 _logger.info("StreamableHTTP session manager is shutting down")
@@ -121,10 +132,15 @@ async def _ensure_session_manager_started_stateless(self) -> None:
             except Exception:
                 _logger.exception("Error in StreamableHTTP session manager")
                 raise
+            finally:
+                # Unblock any caller waiting on readiness even if run() failed before
+                # starting, so they fail fast on the real error instead of hanging.
+                self._manager_ready.set()
 
         self._manager_task = asyncio.create_task(_run_manager())
         self._manager_started = True
-        await asyncio.sleep(0.1)
+
+    await self._manager_ready.wait()
 
 
 FastApiHttpSessionManager._ensure_session_manager_started = _ensure_session_manager_started_stateless

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/filesystem_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/filesystem_content_store.py
@@ -176,7 +176,11 @@ class FileSystemContentStore(BaseContentStore):
         """
         file_path = self._get_primary_file_path(document_uid)
         f = open(file_path, "rb")
-        f.seek(start)
+        try:
+            f.seek(start)
+        except Exception:
+            f.close()
+            raise
 
         # Create a wrapper to limit the stream to the requested length (main's version)
         class RangeStreamWrapper(io.IOBase):
@@ -318,7 +322,11 @@ class FileSystemContentStore(BaseContentStore):
             return f
 
         # ranged stream
-        f.seek(start or 0)
+        try:
+            f.seek(start or 0)
+        except Exception:
+            f.close()
+            raise
 
         # NOTE: Using the RawIOBase/BufferedReader pattern here for the Generic Object API (similar to HEAD)
         # as it was part of the set of new methods.

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/clickhouse_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/clickhouse_vector_store.py
@@ -500,7 +500,6 @@ class ClickHouseVectorStoreAdapter(BaseVectorStore):
                     chunk_uid, vec, text = row
                 else:
                     chunk_uid, vec = row
-                    text = ""
                 entry: Dict[str, Any] = {"chunk_uid": chunk_uid, "vector": list(vec)}
                 if with_document:
                     entry["text"] = text or ""

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_manager/corpus_manager_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_manager/corpus_manager_controller.py
@@ -108,7 +108,7 @@ class CorpusManagerController:
             try:
                 return self.service.build_corpus_toc(payload).model_dump()
             except Exception as e:
-                self._handle_exception(e, "build_toc")
+                return self._handle_exception(e, "build_toc")
 
         @router.post(
             "/corpus/revectorize",
@@ -126,7 +126,7 @@ class CorpusManagerController:
             try:
                 return self.service.revectorize_corpus(payload).model_dump()
             except Exception as e:
-                self._handle_exception(e, "revectorize")
+                return self._handle_exception(e, "revectorize")
 
         @router.post(
             "/corpus/purge-vectors",
@@ -144,7 +144,7 @@ class CorpusManagerController:
             try:
                 return self.service.purge_vectors(payload).model_dump()
             except Exception as e:
-                self._handle_exception(e, "purge_vectors")
+                return self._handle_exception(e, "purge_vectors")
 
         @router.post(
             "/corpus/tasks/get",
@@ -160,7 +160,7 @@ class CorpusManagerController:
             try:
                 return self.service.tasks_get(payload).model_dump()
             except Exception as e:
-                self._handle_exception(e, "tasks_get")
+                return self._handle_exception(e, "tasks_get")
 
         @router.post(
             "/corpus/tasks/result",
@@ -176,7 +176,7 @@ class CorpusManagerController:
             try:
                 return self.service.tasks_result(payload)
             except Exception as e:
-                self._handle_exception(e, "tasks_result")
+                return self._handle_exception(e, "tasks_result")
 
         @router.post(
             "/corpus/tasks/list",
@@ -192,4 +192,4 @@ class CorpusManagerController:
             try:
                 return self.service.tasks_list(payload)
             except Exception as e:
-                self._handle_exception(e, "tasks_list")
+                return self._handle_exception(e, "tasks_list")

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/mcp_fs_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/filesystem/mcp_fs_controller.py
@@ -117,7 +117,7 @@ class McpFilesystemController:
             try:
                 return await self.service.ls(user, path)
             except Exception as e:
-                self._handle_exception(e, "List")
+                return self._handle_exception(e, "List")
 
         @router.get("/fs/stat/{path:path}", tags=["Filesystem"], summary="Get file information", operation_id="stat_file_or_directory")
         async def stat(
@@ -127,7 +127,7 @@ class McpFilesystemController:
             try:
                 return await self.service.stat(user, path)
             except Exception as e:
-                self._handle_exception(e, "Stat")
+                return self._handle_exception(e, "Stat")
 
         @router.get("/fs/cat/{path:path}", tags=["Filesystem"], summary="Read a file", operation_id="read_file")
         async def cat(
@@ -146,7 +146,7 @@ class McpFilesystemController:
                     max_chars=max_chars,
                 )
             except Exception as e:
-                self._handle_exception(e, "Cat")
+                return self._handle_exception(e, "Cat")
 
         @router.get(
             "/fs/page/{path:path}",
@@ -171,21 +171,21 @@ class McpFilesystemController:
                     max_chars=max_chars,
                 )
             except Exception as e:
-                self._handle_exception(e, "ReadFilePage")
+                return self._handle_exception(e, "ReadFilePage")
 
         @router.post("/fs/write/{path:path}", tags=["Filesystem"], summary="Write a file", operation_id="write_file")
         async def write(path: str, data: str = Body(..., embed=True), user: KeycloakUser = Depends(get_current_user)):
             try:
                 return await self.service.write(user, path, data)
             except Exception as e:
-                self._handle_exception(e, "Write")
+                return self._handle_exception(e, "Write")
 
         @router.delete("/fs/delete/{path:path}", tags=["Filesystem"], summary="Delete a file", operation_id="delete_file")
         async def delete(path: str, user: KeycloakUser = Depends(get_current_user)):
             try:
                 return await self.service.delete(user, path)
             except Exception as e:
-                self._handle_exception(e, "Delete")
+                return self._handle_exception(e, "Delete")
 
         @router.post(
             "/fs/copy-to-shared/{path:path}",
@@ -197,7 +197,7 @@ class McpFilesystemController:
             try:
                 return await self.service.copy_to_shared(user, path)
             except Exception as e:
-                self._handle_exception(e, "CopyToShared")
+                return self._handle_exception(e, "CopyToShared")
 
         @router.post("/fs/upload/{path:path}", tags=["Filesystem"], summary="Upload a binary file", operation_id="upload_file")
         async def upload(
@@ -216,7 +216,7 @@ class McpFilesystemController:
                     "download_url": self._download_href(request, path),
                 }
             except Exception as e:
-                self._handle_exception(e, "Upload")
+                return self._handle_exception(e, "Upload")
 
         @router.get("/fs/download/{path:path}", tags=["Filesystem"], summary="Download a binary file", operation_id="download_file")
         async def download(
@@ -233,7 +233,7 @@ class McpFilesystemController:
                 media_type = mimetypes.guess_type(path)[0] or "application/octet-stream"
                 return Response(content=data, media_type=media_type)
             except Exception as e:
-                self._handle_exception(e, "Download")
+                return self._handle_exception(e, "Download")
 
         @router.get(
             "/fs/share/{path:path}",
@@ -264,7 +264,7 @@ class McpFilesystemController:
             except HTTPException:
                 raise
             except Exception as e:
-                self._handle_exception(e, "Share")
+                return self._handle_exception(e, "Share")
 
         @router.post("/fs/edit/{path:path}", tags=["Filesystem"], summary="Edit a file", operation_id="edit_file")
         async def edit(
@@ -281,25 +281,25 @@ class McpFilesystemController:
                     replace_all=payload.replace_all,
                 )
             except Exception as e:
-                self._handle_exception(e, "Edit")
+                return self._handle_exception(e, "Edit")
 
         @router.get("/fs/glob", tags=["Filesystem"], summary="Find files matching a glob", operation_id="glob")
         async def glob(pattern: str, path: str = "/", user: KeycloakUser = Depends(get_current_user)):
             try:
                 return await self.service.glob(user, pattern, path)
             except Exception as e:
-                self._handle_exception(e, "Glob")
+                return self._handle_exception(e, "Glob")
 
         @router.get("/fs/grep", tags=["Filesystem"], summary="Search files by regex", operation_id="grep")
         async def grep(pattern: str, path: str = "/", user: KeycloakUser = Depends(get_current_user)):
             try:
                 return await self.service.grep(user, pattern, path)
             except Exception as e:
-                self._handle_exception(e, "Grep")
+                return self._handle_exception(e, "Grep")
 
         @router.post("/fs/mkdir/{path:path}", tags=["Filesystem"], summary="Create a directory/folder", operation_id="mkdir")
         async def mkdir(path: str, user: KeycloakUser = Depends(get_current_user)):
             try:
                 return await self.service.mkdir(user, path)
             except Exception as e:
-                self._handle_exception(e, "Mkdir")
+                return self._handle_exception(e, "Mkdir")

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/resources/utils.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/resources/utils.py
@@ -34,9 +34,7 @@ def build_resource_from_create(payload: ResourceCreate, library_tag_id: str, use
         raise ValueError(f"YAML kind '{yaml_kind}' does not match payload.kind '{payload.kind.value}'")
 
     schema = header.get("schema")
-    if not schema:
-        schema = {}
-    elif not isinstance(schema, dict):
+    if schema and not isinstance(schema, dict):
         raise ValueError("Missing or invalid 'schema' in header.")
 
     # 3) body must exist

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/scheduler_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/scheduler_controller.py
@@ -113,7 +113,7 @@ class SchedulerController:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e)) from e
             except Exception as e:
-                raise_internal_error(logger, "Failed to submit process-documents workflow", e)
+                return raise_internal_error(logger, "Failed to submit process-documents workflow", e)
 
         @router.post(
             "/process-library",
@@ -144,4 +144,4 @@ class SchedulerController:
                     document_count=len(req.document_uids) if req.document_uids else None,
                 )
             except Exception as e:
-                raise_internal_error(logger, "Failed to submit process-library workflow", e)
+                return raise_internal_error(logger, "Failed to submit process-library workflow", e)

--- a/apps/knowledge-flow-backend/pyrightconfig.json
+++ b/apps/knowledge-flow-backend/pyrightconfig.json
@@ -9,6 +9,7 @@
   "reportMissingTypeStubs": false,
   "reportIncompatibleMethodOverride": "error",
   "reportIncompatibleVariableOverride": "error",
+  "reportUnreachable": "warning",
   "executionEnvironments": [
     {
       "root": ".",

--- a/apps/knowledge-flow-backend/uv.lock
+++ b/apps/knowledge-flow-backend/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },

--- a/developer_tools/benchmarks/ws_bench.go
+++ b/developer_tools/benchmarks/ws_bench.go
@@ -192,7 +192,7 @@ func main() {
 		for i := 0; i < cfg.Clients; i++ {
 			wg.Add(1)
 			sessionID := cfg.SessionID
-			if cfg.Protocol != "sse" && len(wsSessionIDs) > 0 {
+			if cfg.Protocol != "sse" && i < len(wsSessionIDs) {
 				sessionID = wsSessionIDs[i]
 			}
 			startDelay := delayPerClient * time.Duration(i)

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -42,6 +42,22 @@
 > never routed to OpenFGA. Collaborative teams are unchanged: still OpenFGA
 > `CAN_READ`, still fail-closed. See §2.2.
 
+> ✅ **Per-tool-call reverify / service-agent regression fix — 2026-07-22
+> (EVAL-03 follow-up).** `ToolObservabilityMiddleware._reverify_team_authorization`
+> (added the same day to close a least-privilege gap — a stale/revoked team
+> membership was trusted for a whole ReAct turn after the one OpenFGA check at
+> turn start) called the low-level `check_permission_or_raise` primitive
+> unconditionally, without the `is_service_agent` bypass `_authorize_execution_or_raise`
+> already grants at turn start (EVAL-AUTH Solution A, above). This broke every
+> tool call made by the evaluation worker's service identity — turn start
+> passed, the first tool call then failed closed with `AuthorizationError`.
+> Fix: `_authorize_and_resolve` now stamps the trusted `is_service_agent`
+> verdict (computed once from the JWT, never from caller-supplied `context`)
+> into `PortableContext.baggage`; the per-tool-call reverify reads it and skips
+> the ReBAC check for service-agent callers, mirroring the turn-start decision
+> instead of re-deriving a stricter one. Regular users are unaffected — the
+> least-privilege re-check still runs for every non-service-agent call.
+
 This document is the authoritative design reference for the Phase 1 runtime
 execution contract. It describes what was frozen, where it lives, what the
 architectural boundaries are, and what is explicitly deferred.

--- a/libs/fred-core/.baseline/basedpyright-baseline.json
+++ b/libs/fred-core/.baseline/basedpyright-baseline.json
@@ -1,3 +1,24 @@
 {
-    "files": {}
+    "files": {
+        "./fred_core/logs/opensearch_log_store.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./fred_core/security/rebac/rebac_engine.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            }
+        ]
+    }
 }

--- a/libs/fred-core/fred_core/security/oidc.py
+++ b/libs/fred-core/fred_core/security/oidc.py
@@ -422,6 +422,26 @@ def decode_jwt(token: str) -> KeycloakUser:
     iat, exp = payload.get("iat"), payload.get("exp")
     if isinstance(iat, (int, float)) and isinstance(exp, (int, float)):
         lifetime_seconds = exp - iat
+        if lifetime_seconds < 0:
+            # `verify_exp` above only checks exp against "now" — it does not
+            # relate exp to iat, so a token claiming iat after its own exp
+            # (malformed, or a confused/misconfigured IdP) can still pass it
+            # as long as exp itself is still in the future. That negative
+            # lifetime would otherwise fail the ">" ceiling check below
+            # silently instead of being rejected.
+            logger.warning(
+                "[AUTH] JWT has negative lifetime (exp before iat): iat=%s exp=%s sub=%s",
+                iat,
+                exp,
+                payload.get("sub"),
+            )
+            raise HTTPException(
+                status_code=401,
+                detail="Token has invalid iat/exp claims",
+                headers={
+                    "WWW-Authenticate": "Bearer error='invalid_token', error_description='exp before iat'"
+                },
+            )
         if lifetime_seconds > MAX_TOKEN_LIFETIME_SECONDS:
             logger.warning(
                 "[AUTH] JWT lifetime exceeds policy ceiling: lifetime=%ss max=%ss sub=%s",

--- a/libs/fred-core/fred_core/security/oidc.py
+++ b/libs/fred-core/fred_core/security/oidc.py
@@ -50,6 +50,15 @@ CLOCK_SKEW_SECONDS = int(os.getenv("FRED_JWT_CLOCK_SKEW", "0"))  # optional leew
 JWT_CACHE_ENABLED = read_env_bool("FRED_JWT_CACHE_ENABLED", default=True)
 JWT_CACHE_TTL_SECONDS = int(os.getenv("FRED_JWT_CACHE_TTL", "60"))
 JWT_CACHE_MAX_SIZE = int(os.getenv("FRED_JWT_CACHE_SIZE", "512"))
+# Application-side ceiling on token lifetime (exp - iat), independent of
+# whatever an IdP was configured to issue. Unlike STRICT_ISSUER/STRICT_AUDIENCE
+# (opt-in, gated behind the c3 profile, never enabled by any config in this
+# repo), this stays on by default: a misconfigured or unfamiliar IdP issuing
+# long-lived tokens should not be silently trusted. Fred's own M2M provider
+# (`backend_to_backend_auth.py`) already mints short-lived, auto-refreshed
+# tokens per call, so this does not affect normal service-to-service traffic
+# — raise the env var if a deployment genuinely needs a longer ceiling.
+MAX_TOKEN_LIFETIME_SECONDS = int(os.getenv("FRED_JWT_MAX_LIFETIME_SECONDS", "3600"))
 
 # Initialize global variables (to be set later)
 KEYCLOAK_ENABLED = False
@@ -403,6 +412,30 @@ def decode_jwt(token: str) -> KeycloakUser:
             detail="Invalid token",
             headers={"WWW-Authenticate": "Bearer error='invalid_token'"},
         )
+
+    # Defense-in-depth ceiling on token lifetime, independent of the issuing
+    # IdP's own configuration (see MAX_TOKEN_LIFETIME_SECONDS docstring above).
+    # `verify_exp` above only rejects a token that has already expired; this
+    # additionally rejects one that was never supposed to live this long in
+    # the first place, regardless of whether it currently happens to still be
+    # valid.
+    iat, exp = payload.get("iat"), payload.get("exp")
+    if isinstance(iat, (int, float)) and isinstance(exp, (int, float)):
+        lifetime_seconds = exp - iat
+        if lifetime_seconds > MAX_TOKEN_LIFETIME_SECONDS:
+            logger.warning(
+                "[AUTH] JWT lifetime exceeds policy ceiling: lifetime=%ss max=%ss sub=%s",
+                lifetime_seconds,
+                MAX_TOKEN_LIFETIME_SECONDS,
+                payload.get("sub"),
+            )
+            raise HTTPException(
+                status_code=401,
+                detail="Token lifetime exceeds the maximum permitted duration",
+                headers={
+                    "WWW-Authenticate": "Bearer error='invalid_token', error_description='token lifetime too long'"
+                },
+            )
 
     # Extract client roles
     client_roles = []

--- a/libs/fred-core/fred_core/tests/common/test_lru_cache.py
+++ b/libs/fred-core/fred_core/tests/common/test_lru_cache.py
@@ -45,12 +45,14 @@ class TestThreadSafeLRUCacheBasicOps:
     def test_delete_existing_returns_value(self) -> None:
         cache: ThreadSafeLRUCache[str, int] = ThreadSafeLRUCache()
         cache.set("k", 99)
-        assert cache.delete("k") == 99
+        deleted = cache.delete("k")
+        assert deleted == 99
         assert cache.get("k") is None
 
     def test_delete_missing_returns_none(self) -> None:
         cache: ThreadSafeLRUCache[str, int] = ThreadSafeLRUCache()
-        assert cache.delete("ghost") is None
+        deleted = cache.delete("ghost")
+        assert deleted is None
 
     def test_keys_empty(self) -> None:
         cache: ThreadSafeLRUCache[str, int] = ThreadSafeLRUCache()

--- a/libs/fred-core/fred_core/tests/security/test_oidc_token_lifetime.py
+++ b/libs/fred-core/fred_core/tests/security/test_oidc_token_lifetime.py
@@ -88,6 +88,27 @@ def test_token_exceeding_lifetime_ceiling_is_rejected(_rsa_keypair):
     assert "lifetime" in exc.value.detail.lower()
 
 
+def test_token_with_exp_before_iat_is_rejected(monkeypatch, _rsa_keypair):
+    """A malformed/confused-IdP token can claim iat after its own exp while
+    exp is still in the future — `verify_exp` alone would accept it, and the
+    ">" ceiling check silently passes a negative lifetime. Must be rejected
+    explicitly rather than falling through.
+
+    PyJWT itself rejects any iat beyond `leeway` in the future ("not yet
+    valid"), which would normally catch this first — so this needs a
+    positive `FRED_JWT_CLOCK_SKEW` (a real, supported deployment knob) to
+    construct an iat PyJWT tolerates while still exceeding exp.
+    """
+    priv_pem, _ = _rsa_keypair
+    monkeypatch.setattr(oidc, "CLOCK_SKEW_SECONDS", 60)
+    now = int(time.time())
+    token = _token(priv_pem, iat=now + 30, exp=now + 10, sub="u-5")
+    with pytest.raises(HTTPException) as exc:
+        oidc.decode_jwt(token)
+    assert exc.value.status_code == 401
+    assert "iat" in exc.value.detail.lower() or "exp" in exc.value.detail.lower()
+
+
 def test_token_without_iat_claim_is_not_checked(_rsa_keypair):
     """Some tokens omit `iat`; the ceiling check is skipped rather than
     guessing — `verify_exp` above still governs plain expiry."""

--- a/libs/fred-core/fred_core/tests/security/test_oidc_token_lifetime.py
+++ b/libs/fred-core/fred_core/tests/security/test_oidc_token_lifetime.py
@@ -1,0 +1,118 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+
+"""Application-side ceiling on JWT lifetime (`MAX_TOKEN_LIFETIME_SECONDS`).
+
+`decode_jwt`'s `verify_exp` only rejects a token that has already expired; it
+never checked how long a token was *issued* to live in the first place, so a
+misconfigured or unfamiliar IdP handing out multi-hour tokens would be
+trusted without complaint. This is independent of STRICT_ISSUER/STRICT_AUDIENCE
+(c3-gated) — it stays on by default, since Fred's own M2M provider already
+mints short-lived, auto-refreshed tokens and is unaffected by it.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import HTTPException
+
+from fred_core.security import oidc
+
+_REALM = "http://localhost:8080/realms/app"
+_CLIENT = "app"
+
+
+@pytest.fixture
+def _rsa_keypair():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return priv_pem, key.public_key()
+
+
+@pytest.fixture(autouse=True)
+def _keycloak_enabled(monkeypatch, _rsa_keypair):
+    _, public_key = _rsa_keypair
+    monkeypatch.setattr(oidc, "KEYCLOAK_ENABLED", True)
+    monkeypatch.setattr(oidc, "KEYCLOAK_URL", _REALM)
+    monkeypatch.setattr(oidc, "KEYCLOAK_CLIENT_ID", _CLIENT)
+    monkeypatch.setattr(
+        oidc,
+        "_get_jwks_client",
+        lambda: SimpleNamespace(
+            get_signing_key_from_jwt=lambda token: SimpleNamespace(key=public_key)
+        ),
+    )
+
+
+def _token(priv_pem: bytes, *, iat: int, exp: int, sub: str) -> str:
+    return pyjwt.encode(
+        {
+            "iss": _REALM,
+            "aud": _CLIENT,
+            "sub": sub,
+            "preferred_username": "alice",
+            "iat": iat,
+            "exp": exp,
+        },
+        priv_pem,
+        algorithm="RS256",
+    )
+
+
+def test_token_within_lifetime_ceiling_is_accepted(_rsa_keypair):
+    priv_pem, _ = _rsa_keypair
+    now = int(time.time())
+    token = _token(priv_pem, iat=now, exp=now + 300, sub="u-1")  # 5 min, well under 1h
+    user = oidc.decode_jwt(token)
+    assert user.uid == "u-1"
+
+
+def test_token_exceeding_lifetime_ceiling_is_rejected(_rsa_keypair):
+    priv_pem, _ = _rsa_keypair
+    now = int(time.time())
+    token = _token(priv_pem, iat=now, exp=now + 7200, sub="u-2")  # 2 hours
+    with pytest.raises(HTTPException) as exc:
+        oidc.decode_jwt(token)
+    assert exc.value.status_code == 401
+    assert "lifetime" in exc.value.detail.lower()
+
+
+def test_token_without_iat_claim_is_not_checked(_rsa_keypair):
+    """Some tokens omit `iat`; the ceiling check is skipped rather than
+    guessing — `verify_exp` above still governs plain expiry."""
+    priv_pem, _ = _rsa_keypair
+    now = int(time.time())
+    token = pyjwt.encode(
+        {
+            "iss": _REALM,
+            "aud": _CLIENT,
+            "sub": "u-3",
+            "preferred_username": "alice",
+            "exp": now + 7200,
+        },
+        priv_pem,
+        algorithm="RS256",
+    )
+    user = oidc.decode_jwt(token)
+    assert user.uid == "u-3"
+
+
+def test_lifetime_ceiling_is_configurable_via_env(monkeypatch, _rsa_keypair):
+    priv_pem, _ = _rsa_keypair
+    monkeypatch.setattr(oidc, "MAX_TOKEN_LIFETIME_SECONDS", 60)
+    now = int(time.time())
+    token = _token(priv_pem, iat=now, exp=now + 300, sub="u-4")  # 5 min > 60s ceiling
+    with pytest.raises(HTTPException) as exc:
+        oidc.decode_jwt(token)
+    assert exc.value.status_code == 401

--- a/libs/fred-core/pyproject.toml
+++ b/libs/fred-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 description = "Core shared utilities for Fred backends (config, storage, security, and runtime helpers)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/fred-core/pyrightconfig.json
+++ b/libs/fred-core/pyrightconfig.json
@@ -6,5 +6,6 @@
   "venv": ".venv",
   "typeCheckingMode": "standard",
   "reportMissingTypeStubs": false,
+  "reportUnreachable": "warning",
   "stubPath": "stubs"
 }

--- a/libs/fred-core/uv.lock
+++ b/libs/fred-core/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-runtime/.baseline/basedpyright-baseline.json
+++ b/libs/fred-runtime/.baseline/basedpyright-baseline.json
@@ -1,3 +1,32 @@
 {
-    "files": {}
+    "files": {
+        "./fred_runtime/common/mcp_runtime.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            }
+        ],
+        "./tests/test_conversational_memory.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 13,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 13,
+                    "lineCount": 1
+                }
+            }
+        ]
+    }
 }

--- a/libs/fred-runtime/fred_runtime/__main__.py
+++ b/libs/fred-runtime/fred_runtime/__main__.py
@@ -77,7 +77,6 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "dump-openapi":
         return _cmd_dump_openapi(args)
     parser.error(f"unknown command: {args.command}")
-    return 2
 
 
 if __name__ == "__main__":

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -1486,6 +1486,18 @@ async def _authorize_and_resolve(
     await _enforce_session_ownership(request, authenticated_user, container)
     await _authorize_execution_or_raise(request, authenticated_user, container)
     internal_req = _to_internal_request(request)
+    # Stamp the trusted service-agent verdict (never the caller-supplied
+    # context) so per-tool-call re-authorization can mirror the bypass
+    # `_authorize_execution_or_raise` already granted above (RFC EVAL-AUTH,
+    # Solution A) instead of re-running a ReBAC check this identity was
+    # never meant to satisfy. Overwritten unconditionally, both ways, so a
+    # caller can't spoof it via a body-supplied `context.is_service_agent`.
+    ctx = dict(internal_req.context or {})
+    if authenticated_user is not None and is_service_agent(authenticated_user):
+        ctx["is_service_agent"] = "true"
+    else:
+        ctx.pop("is_service_agent", None)
+    internal_req.context = ctx
     target = await _resolve_agent_instance(
         request=internal_req,
         registry=registry,
@@ -2418,6 +2430,7 @@ async def _iterate_runtime_event_payloads(
                 "checkpoint_id": resolved_checkpoint_id,
                 "execution_action": execution_action,
                 "exchange_id": exchange_id,
+                "is_service_agent": ctx.get("is_service_agent"),
             }.items()
             if isinstance(value, str) and value
         },

--- a/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
@@ -77,8 +77,11 @@ from collections.abc import Awaitable, Callable
 from contextlib import nullcontext
 from typing import Any, Optional
 
+from fred_core.common.team_id import is_personal_team_id
 from fred_core.kpi import BaseKPIWriter, KPIActor
 from fred_core.logs.audit_log import emit_audit_log
+from fred_core.security.models import Resource
+from fred_core.security.rebac.rebac_engine import RebacReference, TeamPermission
 from fred_sdk.contracts.context import BoundRuntimeContext
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages.tool import ToolMessage
@@ -86,6 +89,7 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
 from fred_runtime.common.context_aware_tool import ContextAwareTool
+from fred_runtime.runtime_context import get_runtime_context
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +154,52 @@ class ToolObservabilityMiddleware(AgentMiddleware):
             name = getattr(request.tool, "name", None)
         return str(name) if name else "unknown"
 
+    @staticmethod
+    async def _reverify_team_authorization(
+        *, user_id: Optional[str], team_id: Optional[str]
+    ) -> None:
+        """
+        Per-tool-call ReBAC re-check (RUNTIME least-privilege gap, see
+        docs/swift audit): `_authorize_execution_or_raise` (agent_app.py)
+        verifies CAN_READ on the turn's team exactly once, at turn start.
+        Every tool call after that — potentially many, in a long ReAct loop —
+        ran unchecked, trusting that one decision for the rest of the turn.
+        This re-runs the same OpenFGA check at the one chokepoint every tool
+        call already passes through, so a stale/dropped team membership (or a
+        tool call scoped to a different team than the one authorized at turn
+        start) is caught here instead of silently trusted.
+
+        Uses the low-level `check_permission_or_raise` primitive (subject/
+        resource references, no `KeycloakUser`) because only the portable
+        `user_id`/`team_id` strings are available at this layer — the
+        personal-team self-heal and org-team bootstrap already ran once at
+        turn start for this exact team_id, so skipping them here is safe.
+
+        Scope: authorizes the *team* a call is scoped to, not any specific
+        resource a tool argument may reference (e.g. a document_uid) — that
+        remains each downstream service's own responsibility (several already
+        do it, e.g. knowledge-flow-backend's per-document ReBAC checks).
+        """
+        try:
+            rebac = get_runtime_context().config.rebac_engine
+        except RuntimeError:
+            # No pod-wide RuntimeContext set up (e.g. a unit test exercising
+            # this middleware in isolation) — nothing to check against.
+            return
+        if rebac is None or not rebac.enabled:
+            return  # dev/local (identity-only) or Noop engine — mirrors turn start
+        if not team_id or is_personal_team_id(team_id):
+            # Personal spaces aren't injected as a team_id into tool calls
+            # (`ContextAwareTool._inject_context_if_needed`); nothing to recheck.
+            return
+        if not user_id:
+            return
+        await rebac.check_permission_or_raise(
+            RebacReference(Resource.USER, user_id),
+            TeamPermission.CAN_READ,
+            RebacReference(Resource.TEAM, team_id),
+        )
+
     async def awrap_tool_call(
         self,
         request: ToolCallRequest,
@@ -177,6 +227,9 @@ class ToolObservabilityMiddleware(AgentMiddleware):
         emit_audit_log("agent.tool.invocation.started", **base_dims)
         with timer_ctx as kpi_dims:
             try:
+                await self._reverify_team_authorization(
+                    user_id=base_dims.get("user_id"), team_id=base_dims.get("team_id")
+                )
                 result = await handler(request)
             except asyncio.CancelledError:
                 # Never swallow cancellation — record it as its own terminal

--- a/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
@@ -156,7 +156,7 @@ class ToolObservabilityMiddleware(AgentMiddleware):
 
     @staticmethod
     async def _reverify_team_authorization(
-        *, user_id: Optional[str], team_id: Optional[str]
+        *, user_id: Optional[str], team_id: Optional[str], is_service_agent: bool
     ) -> None:
         """
         Per-tool-call ReBAC re-check (RUNTIME least-privilege gap, see
@@ -174,6 +174,14 @@ class ToolObservabilityMiddleware(AgentMiddleware):
         `user_id`/`team_id` strings are available at this layer — the
         personal-team self-heal and org-team bootstrap already ran once at
         turn start for this exact team_id, so skipping them here is safe.
+
+        `is_service_agent` mirrors the *other* branch `_authorize_execution_or_raise`
+        takes at turn start (RFC EVAL-AUTH, Solution A): the evaluation worker's
+        service identity is authorized without any OpenFGA tuple, so re-running
+        the ReBAC check here would reject an identity that was never meant to
+        hold one. The flag is computed once from the trusted JWT at turn start
+        and threaded through `PortableContext.baggage` — never re-derived from
+        anything caller-suppliable at this layer.
 
         Scope: authorizes the *team* a call is scoped to, not any specific
         resource a tool argument may reference (e.g. a document_uid) — that
@@ -193,6 +201,8 @@ class ToolObservabilityMiddleware(AgentMiddleware):
             # (`ContextAwareTool._inject_context_if_needed`); nothing to recheck.
             return
         if not user_id:
+            return
+        if is_service_agent:
             return
         await rebac.check_permission_or_raise(
             RebacReference(Resource.USER, user_id),
@@ -228,7 +238,12 @@ class ToolObservabilityMiddleware(AgentMiddleware):
         with timer_ctx as kpi_dims:
             try:
                 await self._reverify_team_authorization(
-                    user_id=base_dims.get("user_id"), team_id=base_dims.get("team_id")
+                    user_id=base_dims.get("user_id"),
+                    team_id=base_dims.get("team_id"),
+                    is_service_agent=self._binding.portable_context.baggage.get(
+                        "is_service_agent"
+                    )
+                    == "true",
                 )
                 result = await handler(request)
             except asyncio.CancelledError:

--- a/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
@@ -181,7 +181,7 @@ class ToolObservabilityMiddleware(AgentMiddleware):
         the ReBAC check here would reject an identity that was never meant to
         hold one. The flag is computed once from the trusted JWT at turn start
         and threaded through `PortableContext.baggage` — never re-derived from
-        anything caller-suppliable at this layer.
+        anything caller-supplied at this layer.
 
         Scope: authorizes the *team* a call is scoped to, not any specific
         resource a tool argument may reference (e.g. a document_uid) — that

--- a/libs/fred-runtime/fred_runtime/runtime_context.py
+++ b/libs/fred-runtime/fred_runtime/runtime_context.py
@@ -218,7 +218,7 @@ class RuntimeContext:
 _RUNTIME_CONTEXT: RuntimeContext | None = None
 
 
-def set_runtime_context(context: RuntimeContext) -> None:
+def set_runtime_context(context: RuntimeContext | None) -> None:
     """
     Set the global runtime context for fred-runtime adapters.
 
@@ -228,6 +228,8 @@ def set_runtime_context(context: RuntimeContext) -> None:
 
     How to use it:
     - call once during app startup after configuration is loaded
+    - `None` is accepted so tests can restore the pre-test state (including
+      "never set") without reaching into the private `_RUNTIME_CONTEXT` global
     """
 
     global _RUNTIME_CONTEXT

--- a/libs/fred-runtime/pyproject.toml
+++ b/libs/fred-runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-runtime"
-version = "3.3.6"
+version = "3.3.7"
 description = "Runtime adapters and infrastructure wiring for Fred v2 agents."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/libs/fred-runtime/pyrightconfig.json
+++ b/libs/fred-runtime/pyrightconfig.json
@@ -2,6 +2,7 @@
   "include": ["fred_runtime", "tests"],
   "typeCheckingMode": "standard",
   "reportMissingTypeStubs": false,
+  "reportUnreachable": "warning",
   "venvPath": ".",
   "venv": ".venv",
   "extraPaths": ["../fred-core", "../fred-sdk"],

--- a/libs/fred-runtime/tests/test_tool_observability_middleware.py
+++ b/libs/fred-runtime/tests/test_tool_observability_middleware.py
@@ -38,9 +38,15 @@ from fred_core.kpi.kpi_reader_structures import KPIQuery, KPIQueryResult
 from fred_core.kpi.kpi_writer import KPIWriter
 from fred_core.kpi.kpi_writer_structures import KPIEvent
 from fred_core.logs.log_setup import AUDIT_LOGGER_NAME
+from fred_core.security.models import AuthorizationError, Resource
 from fred_runtime.common.context_aware_tool import ContextAwareTool
 from fred_runtime.react.middleware.tool_observability import (
     ToolObservabilityMiddleware,
+)
+from fred_runtime.runtime_context import (
+    RuntimeConfig,
+    RuntimeContext,
+    set_runtime_context,
 )
 from fred_sdk.contracts.context import (
     BoundRuntimeContext,
@@ -436,6 +442,150 @@ async def test_native_capability_tool_gets_kpi_and_audit_coverage() -> None:
 # ---------------------------------------------------------------------------
 # _base_dims: identifiers only, sourced from BoundRuntimeContext
 # ---------------------------------------------------------------------------
+
+
+class _FakeRebacEngine:
+    """Minimal duck-typed stand-in for `RebacEngine` — only the two members
+    `_reverify_team_authorization` actually calls."""
+
+    def __init__(self, *, enabled: bool, deny: bool = False) -> None:
+        self.enabled = enabled
+        self._deny = deny
+        self.calls: List[tuple[str, str]] = []
+
+    async def check_permission_or_raise(
+        self, subject: Any, permission: Any, resource: Any, **_: Any
+    ) -> None:
+        self.calls.append((subject.id, resource.id))
+        if self._deny:
+            raise AuthorizationError(
+                subject.id, str(permission), Resource.TEAM, "denied by test double"
+            )
+
+
+def _with_rebac_engine(engine: _FakeRebacEngine | None):
+    """Context manager installing a fake pod-wide RuntimeContext for the
+    duration of one test, restoring whatever was there before on exit — the
+    global is process-wide (`set_runtime_context`), so tests must not leak it."""
+    import fred_runtime.runtime_context as runtime_context_module
+
+    class _Ctx:
+        def __enter__(self) -> None:
+            self._previous = runtime_context_module._RUNTIME_CONTEXT
+            set_runtime_context(
+                RuntimeContext(
+                    RuntimeConfig(
+                        knowledge_flow_url="http://kf.invalid",
+                        rebac_engine=engine,
+                    )
+                )
+            )
+
+        def __exit__(self, *exc_info: object) -> None:
+            runtime_context_module._RUNTIME_CONTEXT = self._previous
+
+    return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_reverify_team_authorization_blocks_denied_tool_call() -> None:
+    """The gap this closes: `_authorize_execution_or_raise` only checks
+    CAN_READ on the turn's team once, at turn start. This is the per-tool-call
+    re-check at the shared chokepoint — a denial here must block the handler
+    from ever running, exactly like any other tool-execution failure."""
+    engine = _FakeRebacEngine(enabled=True, deny=True)
+    middleware = ToolObservabilityMiddleware(kpi=None, binding=_binding())
+    request = _request(name="fake.search", tool_obj=None)
+    handler_called = False
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        nonlocal handler_called
+        handler_called = True
+        return ToolMessage(content="ok", name="fake.search", tool_call_id="call-1")
+
+    with _with_rebac_engine(engine):
+        with _AuditEvents() as audit:
+            with pytest.raises(AuthorizationError):
+                await middleware.awrap_tool_call(request, handler)
+
+    assert handler_called is False
+    assert engine.calls == [("user-1", "team-1")]
+    assert audit.event_names() == [
+        "agent.tool.invocation.started",
+        "agent.tool.invocation.completed",
+    ]
+    assert audit.records[1].outcome == "failed"  # type: ignore[attr-defined]
+    assert audit.records[1].error_code == "AuthorizationError"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_reverify_team_authorization_allows_when_rebac_grants() -> None:
+    engine = _FakeRebacEngine(enabled=True, deny=False)
+    middleware = ToolObservabilityMiddleware(kpi=None, binding=_binding())
+    request = _request(name="fake.search", tool_obj=None)
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="ok", name="fake.search", tool_call_id="call-1")
+
+    with _with_rebac_engine(engine):
+        result = await middleware.awrap_tool_call(request, handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.content == "ok"
+    assert engine.calls == [("user-1", "team-1")]
+
+
+@pytest.mark.asyncio
+async def test_reverify_team_authorization_skips_when_rebac_disabled() -> None:
+    """A Noop/disabled engine (identity-only dev posture) must not block
+    anything — mirrors the same skip `_authorize_execution_or_raise` applies
+    at turn start."""
+    engine = _FakeRebacEngine(enabled=False, deny=True)
+    middleware = ToolObservabilityMiddleware(kpi=None, binding=_binding())
+    request = _request(name="fake.search", tool_obj=None)
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="ok", name="fake.search", tool_call_id="call-1")
+
+    with _with_rebac_engine(engine):
+        result = await middleware.awrap_tool_call(request, handler)
+
+    assert isinstance(result, ToolMessage)
+    assert engine.calls == []
+
+
+@pytest.mark.asyncio
+async def test_reverify_team_authorization_skips_for_personal_team() -> None:
+    """Personal spaces are never injected as a `team_id` into tool calls
+    (`ContextAwareTool._inject_context_if_needed`) — nothing to recheck, even
+    against a would-deny-everything engine."""
+    engine = _FakeRebacEngine(enabled=True, deny=True)
+    middleware = ToolObservabilityMiddleware(
+        kpi=None,
+        binding=BoundRuntimeContext(
+            runtime_context=PortableRuntimeContext(),
+            portable_context=PortableContext(
+                request_id="request-1",
+                correlation_id="correlation-1",
+                actor="user-1",
+                tenant="team-1",
+                environment=PortableEnvironment.DEV,
+                session_id="session-1",
+                user_id="user-1",
+                team_id="personal-user-1",
+            ),
+        ),
+    )
+    request = _request(name="fake.search", tool_obj=None)
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="ok", name="fake.search", tool_call_id="call-1")
+
+    with _with_rebac_engine(engine):
+        result = await middleware.awrap_tool_call(request, handler)
+
+    assert isinstance(result, ToolMessage)
+    assert engine.calls == []
 
 
 def test_base_dims_includes_identifiers_from_portable_context_and_baggage() -> None:

--- a/libs/fred-runtime/tests/test_tool_observability_middleware.py
+++ b/libs/fred-runtime/tests/test_tool_observability_middleware.py
@@ -591,6 +591,32 @@ async def test_reverify_team_authorization_skips_for_personal_team() -> None:
     assert engine.calls == []
 
 
+@pytest.mark.asyncio
+async def test_reverify_team_authorization_skips_for_service_agent() -> None:
+    """Regression test for the EVAL-03 fix (PR #2060): the evaluation
+    worker's service identity is authorized once at turn start without any
+    OpenFGA tuple (`_authorize_execution_or_raise`, RFC EVAL-AUTH Solution
+    A) — the trusted verdict is stamped into `PortableContext.baggage` as
+    `is_service_agent`. The reverify must mirror that bypass instead of
+    re-running a ReBAC check this identity was never meant to satisfy, even
+    against a would-deny-everything engine."""
+    engine = _FakeRebacEngine(enabled=True, deny=True)
+    middleware = ToolObservabilityMiddleware(
+        kpi=None, binding=_binding(baggage={"is_service_agent": "true"})
+    )
+    request = _request(name="fake.search", tool_obj=None)
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="ok", name="fake.search", tool_call_id="call-1")
+
+    with _with_rebac_engine(engine):
+        result = await middleware.awrap_tool_call(request, handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.content == "ok"
+    assert engine.calls == []
+
+
 def test_base_dims_includes_identifiers_from_portable_context_and_baggage() -> None:
     middleware = ToolObservabilityMiddleware(
         kpi=None,

--- a/libs/fred-runtime/tests/test_tool_observability_middleware.py
+++ b/libs/fred-runtime/tests/test_tool_observability_middleware.py
@@ -46,6 +46,7 @@ from fred_runtime.react.middleware.tool_observability import (
 from fred_runtime.runtime_context import (
     RuntimeConfig,
     RuntimeContext,
+    get_runtime_context,
     set_runtime_context,
 )
 from fred_sdk.contracts.context import (
@@ -467,11 +468,13 @@ def _with_rebac_engine(engine: _FakeRebacEngine | None):
     """Context manager installing a fake pod-wide RuntimeContext for the
     duration of one test, restoring whatever was there before on exit — the
     global is process-wide (`set_runtime_context`), so tests must not leak it."""
-    import fred_runtime.runtime_context as runtime_context_module
 
     class _Ctx:
         def __enter__(self) -> None:
-            self._previous = runtime_context_module._RUNTIME_CONTEXT
+            try:
+                self._previous: RuntimeContext | None = get_runtime_context()
+            except RuntimeError:
+                self._previous = None
             set_runtime_context(
                 RuntimeContext(
                     RuntimeConfig(
@@ -482,7 +485,7 @@ def _with_rebac_engine(engine: _FakeRebacEngine | None):
             )
 
         def __exit__(self, *exc_info: object) -> None:
-            runtime_context_module._RUNTIME_CONTEXT = self._previous
+            set_runtime_context(self._previous)
 
     return _Ctx()
 

--- a/libs/fred-runtime/uv.lock
+++ b/libs/fred-runtime/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -641,7 +641,7 @@ dev = [
 
 [[package]]
 name = "fred-runtime"
-version = "3.3.6"
+version = "3.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -727,7 +727,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.3.4"
+version = "3.3.5"
 source = { editable = "../fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/libs/fred-sdk/pyproject.toml
+++ b/libs/fred-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-sdk"
-version = "3.3.4"
+version = "3.3.5"
 description = "Authoring SDK for Fred agents — graph, ReAct, and team agent primitives."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/libs/fred-sdk/pyrightconfig.json
+++ b/libs/fred-sdk/pyrightconfig.json
@@ -4,6 +4,7 @@
   "include": ["fred_sdk", "tests"],
   "typeCheckingMode": "standard",
   "reportMissingTypeStubs": false,
+  "reportUnreachable": "warning",
   "venvPath": ".",
   "venv": ".venv",
   "extraPaths": [

--- a/libs/fred-sdk/uv.lock
+++ b/libs/fred-sdk/uv.lock
@@ -501,7 +501,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -592,7 +592,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.3.4"
+version = "3.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "fred-core" },


### PR DESCRIPTION
## Summary

Code-quality sweep (CodeQL findings, typing hardening) plus a same-day
regression fix caught while validating the evaluator against a live stack.

**CodeQL findings resolved**
- `py/mixed-returns`: return the `NoReturn` call instead of just annotating it
- All 5 `js/trivial-conditional` findings
- Two dead local variable assignments (unused-local-variable)

**Type-checking hardening**
- `basedpyright reportUnreachable` enabled across all Python projects
  (fred-core, fred-sdk, fred-runtime, knowledge-flow-backend)
- ESLint wired for real into `apps/frontend` code-quality (was previously
  configured but not actually run)

**Security / correctness fixes**
- Enforce a maximum JWT lifetime independent of the issuing IdP
  (`fred-core/security/oidc.py`, new test coverage)
- Fix the `wsSessionIDs` bounds check to bind to the actual loop index
  (`developer_tools/benchmarks/ws_bench.go`)
- Close leaked file handles on `seek()` failure in `FileSystemContentStore`
- Replace a fixed `sleep` with an `Event` to signal MCP session manager
  readiness (removes a timing-dependent race)
- Separate the mutating call from the assertion in LRU cache delete tests
  (test was asserting on the wrong state)

**EVAL-03 regression fix**
`ToolObservabilityMiddleware._reverify_team_authorization` (added earlier the
same day to close a least-privilege gap — a stale/revoked team membership was
trusted for a whole ReAct turn after the single OpenFGA check at turn start)
called the ReBAC check unconditionally, without the `is_service_agent` bypass
`_authorize_execution_or_raise` already grants at turn start (RFC EVAL-AUTH,
Solution A). This broke every tool call made by the evaluation worker's
service identity — turn start passed, the first tool call then failed closed
with `AuthorizationError`.

Fix: the trusted `is_service_agent` verdict (computed once from the JWT,
never from caller-supplied `context`) is now stamped into
`PortableContext.baggage` and read by the per-tool-call reverify, mirroring
the turn-start decision instead of re-deriving a stricter one. Regular users
are unaffected — the least-privilege re-check still runs for every
non-service-agent call.

Dated entry added to `RUNTIME-EXECUTION-CONTRACT.md` documenting the
regression and fix (frozen execution contract, per `CLAUDE.md`).

## Test plan

- [x] `make code-quality` (ruff, bandit, basedpyright) — clean across touched
      projects
- [x] Full `fred-runtime` test suite (566 tests) — passing, including new
      `test_tool_observability_middleware.py` coverage for the reverify fix
- [x] New `test_oidc_token_lifetime.py` coverage for the JWT max-lifetime fix
- [x] Live-validated against a full local stack (control-plane,
      knowledge-flow-backend, fred-agents, fred-evaluation-backend): ran an
      end-to-end evaluation exercising `search_documents_using_vectorization`
      through the evaluation worker's service identity — confirmed zero
      `AuthorizationError` post-fix, cases completing normally
