### PR TITLE
feat: agent card redesign — origin/role, chat button, icon guessing

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -174,6 +174,15 @@ class ManagedAgentInstanceSummary(BaseModel):
     template_id: str
     display_name: str
     description: str | None = None
+    role: str = Field(
+        description=(
+            "Short one-line summary of what this agent does, distinct from "
+            "the longer `description` — shown on the agent card so a "
+            "teammate can recall the agent's purpose without reading the "
+            "full description. Server-set to `display_name` at enrollment "
+            "until independently edited (#2076)."
+        ),
+    )
     status: Literal["enabled", "disabled"]
     suspension_reason: SuspensionReason | None = Field(
         default=None,
@@ -505,6 +514,15 @@ class CreateAgentInstanceRequest(BaseModel):
     )
     display_name: str = Field(..., min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=500)
+    role: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description=(
+            "Optional short one-line summary of what this agent does. "
+            "Defaults to `display_name` when omitted (#2076)."
+        ),
+    )
     tuning_field_values: dict[str, TuningValue] | None = Field(
         default=None,
         description=(
@@ -541,6 +559,15 @@ class UpdateAgentInstanceRequest(BaseModel):
 
     display_name: str | None = Field(default=None, min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=500)
+    role: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description=(
+            "Short one-line summary of what this agent does. Omit to leave "
+            "the current role unchanged (#2076)."
+        ),
+    )
     status: Literal["enabled", "disabled"] | None = Field(
         default=None,
         description="Set to 'enabled' or 'disabled' to toggle the instance. None leaves the current status unchanged.",

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -1922,6 +1922,7 @@ def _record_to_summary(
         template_id=record.template_id,
         display_name=record.display_name,
         description=record.description,
+        role=record.tuning.role,
         status="enabled" if record.enabled else "disabled",
         suspension_reason=(
             SuspensionReason(record.suspension_reason)
@@ -2199,7 +2200,7 @@ async def enroll_agent_instance(
 
     tuning = template.default_tuning.model_copy(
         update={
-            "role": request.display_name,
+            "role": request.role or request.display_name,
             "description": request.description or request.display_name,
         }
     )
@@ -2427,6 +2428,17 @@ async def update_agent_instance(
                 asset_uploads=asset_uploads,
             )
         new_tuning = base
+
+    if request.role is not None:
+        # A role rename is a plain string edit — unlike tuning_field_values/
+        # capability_ids above, it never needs the live-pod contract refresh,
+        # so it's applied independently instead of joining that trigger set
+        # (#2076). Same "None means unchanged" convention as display_name/
+        # description below. Layers on top of `new_tuning` when the heavier
+        # branch above already ran for the same request.
+        new_tuning = (new_tuning or record.tuning).model_copy(
+            update={"role": request.role}
+        )
 
     updated = await store.update(
         agent_instance_id=agent_instance_id,

--- a/apps/control-plane-backend/tests/test_cli.py
+++ b/apps/control-plane-backend/tests/test_cli.py
@@ -339,6 +339,7 @@ def test_completion_candidates_suggest_team_and_instance_ids() -> None:
             team_id=TeamId("af27a03a-48d4-451c-aaf4-6d5aa44733f1"),
             template_id="fred-agents:fred.github.sentinel",
             display_name="Sentinel",
+            role="Sentinel",
             status="enabled",
         )
     ]
@@ -433,6 +434,7 @@ def test_run_command_enroll_uses_template_default_display_name(capsys) -> None:
                     "template_id": "fred-agents:fred.github.sentinel",
                     "display_name": body["display_name"],
                     "description": body.get("description"),
+                    "role": body.get("role") or body["display_name"],
                     "status": "enabled",
                     "created_at": None,
                     "updated_at": None,
@@ -635,6 +637,7 @@ def test_run_command_unbind_deletes_instance_and_refreshes_cache(capsys) -> None
                 team_id=TeamId("fredlab"),
                 template_id="fred-agents:fred.github.sentinel",
                 display_name="Sentinel",
+                role="Sentinel",
                 status="enabled",
             )
         ],

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -1398,6 +1398,7 @@ async def test_team_agent_instances_returns_managed_identity(
             "template_id": "runtime-a:rags.sample.echo",
             "display_name": "Echo Team Agent",
             "description": "Managed echo agent",
+            "role": "Echo Team Agent",
             "status": "enabled",
             "created_by": "internal-admin",
             "tuning_field_values": {},

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -919,8 +919,11 @@
       }
     },
     "agentCard": {
+      "activate": "Activate",
       "catalogWarning": "MCP configuration drift — recreate to resolve",
       "chat": "Chat",
+      "deactivate": "Deactivate",
+      "edit": "Edit",
       "noDescription": "No description yet.",
       "suspended": "Suspended — a capability this agent uses is broken or unavailable. Edit the agent to fix it.",
       "suspendedToggleLocked": "This agent is suspended. Fix its capabilities in the edit form before re-enabling it."

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -920,8 +920,8 @@
     },
     "agentCard": {
       "catalogWarning": "MCP configuration drift — recreate to resolve",
+      "chat": "Chat",
       "noDescription": "No description yet.",
-      "startChat": "New chat",
       "suspended": "Suspended — a capability this agent uses is broken or unavailable. Edit the agent to fix it.",
       "suspendedToggleLocked": "This agent is suspended. Fix its capabilities in the edit form before re-enabling it."
     },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -919,8 +919,11 @@
       }
     },
     "agentCard": {
+      "activate": "Activer",
       "catalogWarning": "Dérive de configuration MCP — recréer pour résoudre",
       "chat": "Discuter",
+      "deactivate": "Désactiver",
+      "edit": "Modifier",
       "noDescription": "Pas encore de description.",
       "suspended": "Suspendu — une capacité utilisée par cet agent est défectueuse ou indisponible. Modifiez l'agent pour corriger le problème.",
       "suspendedToggleLocked": "Cet agent est suspendu. Corrigez ses capacités dans le formulaire d'édition avant de le réactiver."

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -920,8 +920,8 @@
     },
     "agentCard": {
       "catalogWarning": "Dérive de configuration MCP — recréer pour résoudre",
+      "chat": "Discuter",
       "noDescription": "Pas encore de description.",
-      "startChat": "Nouveau chat",
       "suspended": "Suspendu — une capacité utilisée par cet agent est défectueuse ou indisponible. Modifiez l'agent pour corriger le problème.",
       "suspendedToggleLocked": "Cet agent est suspendu. Corrigez ses capacités dans le formulaire d'édition avant de le réactiver."
     },

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -83,6 +83,7 @@ type AgentFormBodyProps = {
   templates: AgentTemplateSummary[];
   templateId: string;
   displayName: string;
+  role: string;
   description: string;
   tuningFieldValues: Record<string, unknown>;
   /** Explicit list of active capability ids ([] = none active). */
@@ -99,6 +100,7 @@ type AgentFormBodyProps = {
   editInstance?: ManagedAgentInstanceSummary;
   teamId?: string;
   onDisplayNameChange: (v: string) => void;
+  onRoleChange: (v: string) => void;
   onDescriptionChange: (v: string) => void;
   onTuningChange: (key: string, value: unknown) => void;
   onCapabilitySelectionChange: (ids: string[]) => void;
@@ -112,6 +114,7 @@ export function AgentFormBody({
   templates,
   templateId,
   displayName,
+  role,
   description,
   tuningFieldValues,
   selectedCapabilityIds,
@@ -125,6 +128,7 @@ export function AgentFormBody({
   editInstance,
   teamId,
   onDisplayNameChange,
+  onRoleChange,
   onDescriptionChange,
   onTuningChange,
   onCapabilitySelectionChange,
@@ -271,6 +275,14 @@ export function AgentFormBody({
             required
             disabled={isSubmitting}
             error={nameError}
+          />
+          <TextInput
+            label={t("rework.teams.formAgent.fields.role.label")}
+            placeholder={displayName}
+            value={role}
+            onChange={(e) => onRoleChange(e.target.value)}
+            maxLength={255}
+            disabled={isSubmitting}
           />
           <TextArea
             label={t("rework.teams.formAgent.fields.description.label")}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.test.ts
@@ -28,11 +28,12 @@ const EMPTY_CAPABILITY_STATE = {
 };
 
 describe("buildAgentFormSubmitPayload", () => {
-  it("trims display name and description on create submit", () => {
+  it("trims display name, role, and description on create submit", () => {
     const payload = buildAgentFormSubmitPayload(
       {
         templateId: "runtime:agent",
         displayName: "  DT Aegis  ",
+        role: "  Guardian  ",
         description: "  Guardrails  ",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
@@ -42,6 +43,7 @@ describe("buildAgentFormSubmitPayload", () => {
 
     expect(payload).toMatchObject({
       displayName: "DT Aegis",
+      role: "Guardian",
       description: "Guardrails",
     });
   });
@@ -51,6 +53,7 @@ describe("buildAgentFormSubmitPayload", () => {
       {
         templateId: "runtime:agent",
         displayName: "Agent",
+        role: "",
         description: "",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
@@ -70,6 +73,7 @@ describe("buildAgentFormSubmitPayload", () => {
       {
         templateId: "runtime:agent",
         displayName: "Agent",
+        role: "",
         description: "",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
@@ -94,6 +98,7 @@ describe("buildAgentFormSubmitPayload", () => {
       {
         templateId: "runtime:agent",
         displayName: "Agent",
+        role: "",
         description: "",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
@@ -31,6 +31,7 @@ import { TemplateBrowser } from "./TemplateBrowser/TemplateBrowser.tsx";
 export type AgentFormPayload = {
   templateId: string;
   displayName: string;
+  role: string;
   description: string;
   tuningFieldValues: Record<string, unknown>;
   /** Explicit list of active capability ids ([] = none active). */
@@ -69,6 +70,7 @@ type AgentFormModalProps = {
 type FormState = {
   templateId: string;
   displayName: string;
+  role: string;
   description: string;
   tuningValues: Record<string, unknown>;
   selectedCapabilityIds: string[];
@@ -118,6 +120,7 @@ export function buildAgentFormSubmitPayload(
   return {
     templateId: form.templateId,
     displayName: form.displayName.trim(),
+    role: form.role.trim(),
     description: form.description.trim(),
     tuningFieldValues: form.tuningValues,
     selectedCapabilityIds: effectiveCapabilityIds,
@@ -164,6 +167,7 @@ export default function AgentFormModal({
   const [form, setForm] = useState<FormState>({
     templateId: "",
     displayName: "",
+    role: "",
     description: "",
     tuningValues: {},
     selectedCapabilityIds: [],
@@ -184,6 +188,7 @@ export default function AgentFormModal({
       setForm({
         templateId: editInstance.template_id,
         displayName: editInstance.display_name,
+        role: editInstance.role,
         description: editInstance.description ?? "",
         tuningValues: (editInstance.tuning_field_values as Record<string, unknown>) ?? {},
         selectedCapabilityIds: editInstance.selected_capability_ids ?? [],
@@ -198,6 +203,7 @@ export default function AgentFormModal({
       setForm({
         templateId: "",
         displayName: "",
+        role: "",
         description: "",
         tuningValues: {},
         selectedCapabilityIds: [],
@@ -220,6 +226,7 @@ export default function AgentFormModal({
     setForm({
       templateId: id,
       displayName: tpl?.display_name ?? "",
+      role: "",
       description: tpl?.description_by_lang?.[lang] ?? tpl?.description ?? "",
       tuningValues: defaultTuningValues,
       selectedCapabilityIds: [],
@@ -350,6 +357,7 @@ export default function AgentFormModal({
               templates={templates}
               templateId={form.templateId}
               displayName={form.displayName}
+              role={form.role}
               description={form.description}
               tuningFieldValues={form.tuningValues}
               selectedCapabilityIds={form.selectedCapabilityIds}
@@ -363,6 +371,7 @@ export default function AgentFormModal({
               editInstance={editInstance}
               teamId={teamId}
               onDisplayNameChange={(v) => setForm((prev) => ({ ...prev, displayName: v }))}
+              onRoleChange={(v) => setForm((prev) => ({ ...prev, role: v }))}
               onDescriptionChange={(v) => setForm((prev) => ({ ...prev, description: v }))}
               onTuningChange={handleTuningChange}
               onCapabilitySelectionChange={(ids) => setForm((prev) => ({ ...prev, selectedCapabilityIds: ids }))}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -35,18 +35,6 @@
   overflow: auto;
 }
 
-/* Enabled cards are wrapped in <Link> — remove link decoration and fill the cell height */
-.chatLink {
-  display: block;
-  height: 100%;
-  text-decoration: none;
-}
-
-/* Disabled card wrapper — same cell sizing, no link */
-.disabledCard {
-  height: 100%;
-}
-
 .podFilter {
   display: flex;
   justify-content: center;

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -16,7 +16,7 @@ import Button from "@shared/atoms/Button/Button.tsx";
 import AgentCard from "@shared/organisms/AgentCard/AgentCard.tsx";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { useFrontendBootstrap } from "../../../../hooks/useFrontendBootstrap.ts";
@@ -93,8 +93,8 @@ function extractApiErrorDetail(error: unknown): string {
  * Lists the managed agent instances for the current team and exposes
  * create / edit / delete operations for team admins.
  *
- * Enabled agents are wrapped in a <Link> so the whole card navigates to the
- * managed-chat route. Disabled agents render the card without navigation.
+ * Chat is a dedicated button inside `AgentCard` (#2076), not a whole-card
+ * click — `AgentCard` builds its own managed-chat link from `teamId`.
  */
 export default function TeamAgentsPage() {
   const { teamId } = useParams();
@@ -147,6 +147,7 @@ export default function TeamAgentsPage() {
     const request: CreateAgentInstanceRequest = {
       template_id: payload.templateId,
       display_name: payload.displayName,
+      role: payload.role || undefined,
       description: payload.description || undefined,
       tuning_field_values:
         Object.keys(payload.tuningFieldValues).length > 0
@@ -187,6 +188,7 @@ export default function TeamAgentsPage() {
     if (!teamId || !editingInstance) return;
     const request: UpdateAgentInstanceRequest = {
       display_name: payload.displayName,
+      role: payload.role || undefined,
       description: payload.description || undefined,
       tuning_field_values:
         Object.keys(payload.tuningFieldValues).length > 0
@@ -341,34 +343,18 @@ export default function TeamAgentsPage() {
             .filter((instance) => canManageAgents || !instance.suspension_reason)
             .map((instance) => {
               const template = availableTemplates.find((tpl) => tpl.template_id === instance.template_id);
-              const card = (
+              return (
                 <AgentCard
+                  key={instance.agent_instance_id}
                   instance={instance}
                   templateDisplayName={template?.display_name || instance.template_id}
-                  templateCategory={template?.category}
                   runtimeId={template?.source_runtime_id}
+                  teamId={teamId}
                   canManageAgents={canManageAgents}
                   offline={templatesUnavailable}
                   onEdit={() => setEditingInstance(instance)}
                   onToggleEnabled={() => handleToggleEnabled(instance)}
                 />
-              );
-
-              // A suspended instance never gets a chat link even if its stored
-              // status is still "enabled" (#1975, RFC §3.9): execution would be
-              // refused server-side, so it falls into the non-navigating branch.
-              return instance.status === "enabled" && !instance.suspension_reason ? (
-                <Link
-                  key={instance.agent_instance_id}
-                  to={`/team/${teamId}/managed-chat/${instance.agent_instance_id}`}
-                  className={styles.chatLink}
-                >
-                  {card}
-                </Link>
-              ) : (
-                <div key={instance.agent_instance_id} className={styles.disabledCard}>
-                  {card}
-                </div>
               );
             })}
         </div>

--- a/apps/frontend/src/rework/components/shared/atoms/Button/Button.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Button/Button.tsx
@@ -26,6 +26,7 @@ interface ButtonProps extends ComponentPropsWithoutRef<"button"> {
 }
 export default function Button({ children, color, variant, size, icon, className, ...props }: ButtonProps) {
   const buttonClasses = [styles.btn, styles[`btn-${color}`], styles[`btn-${size}`], styles[`btn-${variant}`]];
+  if (className) buttonClasses.push(className);
   const layerClasses = [styles["state-layer"], styles[`icon-${icon ? "left" : "none"}`]];
 
   return (

--- a/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.module.css
@@ -3,6 +3,9 @@
   max-width: var(--content-prose-max-width);
   color: var(--on-surface);
   font: var(--font-body-large);
+  /* Long-form reading zone (chat messages, document preview) — opts back
+   * into selection against the page-wide `user-select: none` default. */
+  user-select: text;
   word-break: break-word;
   overflow-wrap: anywhere;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
@@ -148,7 +148,7 @@
   justify-content: flex-end;
   align-items: center;
   gap: var(--spacing-xs);
-  padding: 0 var(--spacing-xs) var(--spacing-xs);
+  padding: 0 var(--spacing-s) var(--spacing-s);
 }
 
 .actionsLeft {
@@ -168,18 +168,37 @@
 
 /* The rotating conic-gradient border that used to signal the whole card was
    clickable now lives on the Chat button instead (#2076) — it's the one
-   action that starts a conversation. Doubled class for specificity: Button's
-   own `.btn-primary.btn-outlined` sets `--btn-border` unconditionally (same
-   0-2-0 weight), so a single `.chatButton:hover` would tie and lose on
-   source order alone. */
+   action that starts a conversation. Tripled class for guaranteed
+   specificity: Button's own `.btn-primary.btn-outlined` (and its `:hover`
+   variant) match at the same weight otherwise, which would make the winner
+   depend on stylesheet load order alone. */
 .chatButton {
   animation: rotate-gradient 2s linear infinite;
   animation-play-state: paused;
 }
 
-.chatButton.chatButton:hover:not(:disabled) {
-  animation-play-state: running;
+/* Default border uses the neutral outline token instead of Button's own
+   primary-colored outline. The real border is reserved at the hover width
+   (2px) at all times and made transparent — the visible 1px rest-state line
+   is drawn with an inset box-shadow instead, which doesn't take up layout
+   space. Without this, animating border-width from 1px to 2px on hover grows
+   the button's intrinsic (content-sized, non-fixed-width) footprint by 2px
+   and shifts it and its neighbors. */
+.chatButton.chatButton.chatButton {
+  border-width: 2px;
   --btn-border: transparent;
+  box-shadow: inset 0 0 0 1px var(--outline);
+}
+
+.chatButton.chatButton.chatButton:hover:not(:disabled) {
+  animation-play-state: running;
+  box-shadow: none;
+  /* Cancels Button's own outlined-hover state layer (a semi-transparent
+     on-surface tint on the inner `.state-layer` div) — without this it paints
+     over the gradient background below and the dark interior visibly
+     lightens on hover, which reads as competing with the gradient border. */
+  --btn-background-surface: transparent;
+  --btn-text-color: var(--on-surface);
   /* design-token exception: full-spectrum conic gradient (white→cyan→violet→peach→pink→white),
      matching the card's former hover treatment. No semantic token family covers this rainbow
      sequence; discretising to 5 tokens would destroy the animation effect. */

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
@@ -172,7 +172,7 @@
 .actions {
   display: flex;
   justify-content: flex-end;
-  padding: 0 var(--spacing-2xs) var(--spacing-2xs);
+  padding: 0 var(--spacing-xs) var(--spacing-xs);
 }
 
 /* ── "Start Chat" hover overlay ────────────────────────────────────────────── */

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
@@ -13,7 +13,6 @@
   --agent-icon-background-color: var(--secondary-container);
   --agent-icon-color: var(--on-secondary-container);
   --agent-icon-opacity: 1;
-  --agent-card-cursor: pointer;
 }
 
 .agentCard[data-enabled="false"] {
@@ -23,35 +22,22 @@
   --agent-icon-background-color: var(--surface-container-lowest);
   --agent-icon-color: var(--on-surface-retreat);
   --agent-icon-opacity: 0.2;
-  --agent-card-cursor: default;
 }
 
 /* ── Card shell ────────────────────────────────────────────────────────────── */
+/* The card itself is no longer an interactive/clickable surface (#2076) — only
+   the edit/toggle icon buttons and the Chat button are, each with their own
+   hover state. No card-level cursor or hover treatment here. */
 
 .agentCard {
-  position: relative;
-  animation: rotate-gradient 2s linear infinite;
-  animation-play-state: paused;
-  cursor: var(--agent-card-cursor);
-  border: 2px solid transparent;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--spacing-2xs);
   border-radius: var(--radius-m);
   background-color: var(--surface-container);
   width: 100%;
   height: 100%;
-  --blur: 0px;
-  --newChatDisplay: none;
-
-  &:hover:not([data-enabled="false"]) {
-    --blur: 5px;
-    --newChatDisplay: flex;
-    animation-play-state: running;
-    /* design-token exception: full-spectrum conic gradient (white→cyan→violet→peach→pink→white).
-       No semantic token family covers this rainbow sequence; discretising to 5 tokens
-       would destroy the animation effect. Approved exception — do not replace with tokens. */
-    background:
-      linear-gradient(var(--surface-container), var(--surface-container)) padding-box,
-      conic-gradient(from var(--angle), #ffffff, #65e0f6, #9299ff, #e1c39c, #d665b4, #ffffff) border-box;
-  }
 }
 
 @keyframes rotate-gradient {
@@ -62,20 +48,10 @@
 
 /* ── Inner layout ──────────────────────────────────────────────────────────── */
 
-.stateLayer {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: var(--spacing-2xs);
-  height: 100%;
-}
-
 .agentInfo {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-s);
-  filter: blur(var(--blur));
-  transition: filter 150ms ease;
   padding: var(--spacing-m) var(--spacing-m) var(--spacing-2xs);
 }
 
@@ -103,8 +79,18 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: var(--spacing-2xs);
+  gap: var(--spacing-3xs);
   min-width: 0;
+}
+
+/* Origin · template, e.g. "fred-agents · Generalist" — raw source_runtime_id,
+   not a prettified label (#2076). */
+.agentOrigin {
+  overflow: hidden;
+  color: var(--on-surface-muted);
+  font: var(--font-label-small);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agentName {
@@ -115,26 +101,14 @@
   white-space: nowrap;
 }
 
-.agentMeta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--spacing-xs);
-}
-
-.agentCategory {
+/* Short one-line summary of what the agent does (#2076) — distinct from the
+   longer `agentDescription` below. */
+.agentRole {
+  overflow: hidden;
   color: var(--agent-meta-color);
-  font: var(--font-label-large);
-}
-
-.agentTemplate {
-  color: var(--on-surface-retreat);
-  font: var(--font-label-small);
-}
-
-.agentPod {
-  color: var(--on-surface-muted);
-  font: var(--font-label-small);
+  font: var(--font-body-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .catalogWarning {
@@ -167,32 +141,49 @@
   font: var(--font-body-medium);
 }
 
-/* ── Actions row (not blurred — stays accessible on hover) ─────────────────── */
+/* ── Actions row — edit/toggle grouped left, Chat flush right (#2076) ───────── */
 
 .actions {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-xs);
   padding: 0 var(--spacing-xs) var(--spacing-xs);
 }
 
-/* ── "Start Chat" hover overlay ────────────────────────────────────────────── */
-
-.newChat {
-  display: var(--newChatDisplay);
-  position: absolute;
-  top: 0;
-  left: 0;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: var(--spacing-2xs);
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  color: var(--on-surface);
-  font: var(--font-title-medium);
+.actionsLeft {
+  display: flex;
+  gap: var(--spacing-3xs);
+  margin-right: auto;
 }
 
-.newChatIcon {
-  font-size: 1.25rem;
+.chatLink {
+  text-decoration: none;
+}
+
+/* Label never wraps regardless of container width (design-system rule). */
+.chatButton {
+  white-space: nowrap;
+}
+
+/* The rotating conic-gradient border that used to signal the whole card was
+   clickable now lives on the Chat button instead (#2076) — it's the one
+   action that starts a conversation. Doubled class for specificity: Button's
+   own `.btn-primary.btn-outlined` sets `--btn-border` unconditionally (same
+   0-2-0 weight), so a single `.chatButton:hover` would tie and lose on
+   source order alone. */
+.chatButton {
+  animation: rotate-gradient 2s linear infinite;
+  animation-play-state: paused;
+}
+
+.chatButton.chatButton:hover:not(:disabled) {
+  animation-play-state: running;
+  --btn-border: transparent;
+  /* design-token exception: full-spectrum conic gradient (white→cyan→violet→peach→pink→white),
+     matching the card's former hover treatment. No semantic token family covers this rainbow
+     sequence; discretising to 5 tokens would destroy the animation effect. */
+  background:
+    linear-gradient(var(--surface-container), var(--surface-container)) padding-box,
+    conic-gradient(from var(--angle), #ffffff, #65e0f6, #9299ff, #e1c39c, #d665b4, #ffffff) border-box;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import { IconType } from "@shared/utils/Type.ts";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { useFrontendProperties } from "../../../../../hooks/useFrontendProperties.ts";
 import { ManagedAgentInstanceSummary } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
 import styles from "./AgentCard.module.scss";
@@ -23,8 +25,9 @@ import styles from "./AgentCard.module.scss";
 export interface AgentCardProps {
   instance: ManagedAgentInstanceSummary;
   templateDisplayName?: string;
-  templateCategory?: string;
   runtimeId?: string;
+  /** Needed to build the managed-chat route for the Chat button. */
+  teamId?: string;
   canManageAgents: boolean;
   offline?: boolean;
   onEdit: () => void;
@@ -34,8 +37,8 @@ export interface AgentCardProps {
 export default function AgentCard({
   instance,
   templateDisplayName,
-  templateCategory,
   runtimeId,
+  teamId,
   canManageAgents,
   offline = false,
   onEdit,
@@ -48,38 +51,51 @@ export default function AgentCard({
   // chat affordance) and its enable toggle is LOCKED — the fix is in settings.
   const isSuspended = !!instance.suspension_reason;
   const isEnabled = !offline && !isSuspended && instance.status === "enabled";
+  // Raw source_runtime_id, not a prettified label (e.g. "fred-agents"), per
+  // the agent card redesign (#2076).
+  const origin = [runtimeId, templateDisplayName].filter(Boolean).join(" · ");
+
+  const chatButton = (
+    <Button
+      color="primary"
+      variant="outlined"
+      size="medium"
+      icon={{ category: "outlined", type: "reviews" }}
+      className={styles.chatButton}
+      disabled={!isEnabled}
+    >
+      {t("rework.agentCard.chat")}
+    </Button>
+  );
 
   return (
     <div className={styles.agentCard} data-enabled={isEnabled}>
-      <div className={styles.stateLayer}>
-        <div className={styles.agentInfo}>
-          <div className={styles.agentPresentation}>
-            <div className={styles.agentIcon}>
-              <Icon category={"outlined"} type={agentIconName as IconType} />
-            </div>
-            <div className={styles.agentIdentity}>
-              <div className={styles.agentName}>{instance.display_name}</div>
-              <div className={styles.agentMeta}>
-                {templateCategory && <span className={styles.agentCategory}>{templateCategory}</span>}
-                {templateDisplayName && <span className={styles.agentTemplate}>{templateDisplayName}</span>}
-                {runtimeId && <span className={styles.agentPod}>{runtimeId}</span>}
-              </div>
-            </div>
+      <div className={styles.agentInfo}>
+        <div className={styles.agentPresentation}>
+          <div className={styles.agentIcon}>
+            <Icon category={"outlined"} type={agentIconName as IconType} />
           </div>
-          <div className={styles.agentDescription}>{instance.description || t("rework.agentCard.noDescription")}</div>
+          <div className={styles.agentIdentity}>
+            {origin && <div className={styles.agentOrigin}>{origin}</div>}
+            <div className={styles.agentName}>{instance.display_name}</div>
+            <div className={styles.agentRole}>{instance.role}</div>
+          </div>
         </div>
+        <div className={styles.agentDescription}>{instance.description || t("rework.agentCard.noDescription")}</div>
+      </div>
 
-        {isSuspended ? (
-          <div className={styles.suspensionWarning}>{t("rework.agentCard.suspended")}</div>
-        ) : (
-          instance.catalog_warnings &&
-          instance.catalog_warnings.length > 0 && (
-            <div className={styles.catalogWarning}>{t("rework.agentCard.catalogWarning")}</div>
-          )
-        )}
+      {isSuspended ? (
+        <div className={styles.suspensionWarning}>{t("rework.agentCard.suspended")}</div>
+      ) : (
+        instance.catalog_warnings &&
+        instance.catalog_warnings.length > 0 && (
+          <div className={styles.catalogWarning}>{t("rework.agentCard.catalogWarning")}</div>
+        )
+      )}
 
+      <div className={styles.actions}>
         {canManageAgents && (
-          <div className={styles.actions}>
+          <div className={styles.actionsLeft}>
             <IconButton
               color="on-surface"
               variant="icon"
@@ -90,9 +106,7 @@ export default function AgentCard({
               disabled={isSuspended}
               title={isSuspended ? t("rework.agentCard.suspendedToggleLocked") : undefined}
               icon={{ category: "outlined", type: isEnabled ? "visibility" : "visibility_off" }}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
+              onClick={() => {
                 if (isSuspended) return;
                 onToggleEnabled();
               }}
@@ -102,24 +116,18 @@ export default function AgentCard({
               variant="icon"
               size="medium"
               icon={{ category: "outlined", type: "edit" }}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onEdit();
-              }}
+              onClick={onEdit}
             />
           </div>
         )}
+        {isEnabled && teamId ? (
+          <Link to={`/team/${teamId}/managed-chat/${instance.agent_instance_id}`} className={styles.chatLink}>
+            {chatButton}
+          </Link>
+        ) : (
+          chatButton
+        )}
       </div>
-
-      {isEnabled && (
-        <div className={styles.newChat}>
-          <span className={styles.newChatIcon}>
-            <Icon category={"outlined"} type={"reviews"} />
-          </span>
-          {t("rework.agentCard.startChat")}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
@@ -15,6 +15,7 @@
 import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
 import { materialIcons, type MaterialIconType } from "@shared/utils/Type.ts";
 import { guessAgentIcon } from "@shared/utils/agentIcon.ts";
 import { useTranslation } from "react-i18next";
@@ -52,6 +53,11 @@ export default function AgentCard({
   // chat affordance) and its enable toggle is LOCKED — the fix is in settings.
   const isSuspended = !!instance.suspension_reason;
   const isEnabled = !offline && !isSuspended && instance.status === "enabled";
+  const toggleTooltip = isSuspended
+    ? t("rework.agentCard.suspendedToggleLocked")
+    : isEnabled
+      ? t("rework.agentCard.deactivate")
+      : t("rework.agentCard.activate");
   // Best-effort keyword guess from the agent's own identity, falling back to
   // the site's configured default icon when nothing matches (#2076 follow-up).
   // `agentIconName` is an untyped site-config string; guessAgentIcon's
@@ -106,28 +112,31 @@ export default function AgentCard({
       <div className={styles.actions}>
         {canManageAgents && (
           <div className={styles.actionsLeft}>
-            <IconButton
-              color="on-surface"
-              variant="icon"
-              size="medium"
-              // A suspended instance has a LOCKED enable toggle (#1975, RFC §3.9):
-              // the fix is in the edit form, not a re-enable. Disable it so an
-              // editor cannot toggle a broken agent back into the catalog.
-              disabled={isSuspended}
-              title={isSuspended ? t("rework.agentCard.suspendedToggleLocked") : undefined}
-              icon={{ category: "outlined", type: isEnabled ? "visibility" : "visibility_off" }}
-              onClick={() => {
-                if (isSuspended) return;
-                onToggleEnabled();
-              }}
-            />
-            <IconButton
-              color="on-surface"
-              variant="icon"
-              size="medium"
-              icon={{ category: "outlined", type: "edit" }}
-              onClick={onEdit}
-            />
+            <Tooltip text={toggleTooltip}>
+              <IconButton
+                color="on-surface"
+                variant="icon"
+                size="medium"
+                // A suspended instance has a LOCKED enable toggle (#1975, RFC §3.9):
+                // the fix is in the edit form, not a re-enable. Disable it so an
+                // editor cannot toggle a broken agent back into the catalog.
+                disabled={isSuspended}
+                icon={{ category: "outlined", type: isEnabled ? "visibility" : "visibility_off" }}
+                onClick={() => {
+                  if (isSuspended) return;
+                  onToggleEnabled();
+                }}
+              />
+            </Tooltip>
+            <Tooltip text={t("rework.agentCard.edit")}>
+              <IconButton
+                color="on-surface"
+                variant="icon"
+                size="medium"
+                icon={{ category: "outlined", type: "edit" }}
+                onClick={onEdit}
+              />
+            </Tooltip>
           </div>
         )}
         {isEnabled && teamId ? (

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
@@ -15,7 +15,8 @@
 import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
-import { IconType } from "@shared/utils/Type.ts";
+import { materialIcons, type MaterialIconType } from "@shared/utils/Type.ts";
+import { guessAgentIcon } from "@shared/utils/agentIcon.ts";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useFrontendProperties } from "../../../../../hooks/useFrontendProperties.ts";
@@ -51,6 +52,15 @@ export default function AgentCard({
   // chat affordance) and its enable toggle is LOCKED — the fix is in settings.
   const isSuspended = !!instance.suspension_reason;
   const isEnabled = !offline && !isSuspended && instance.status === "enabled";
+  // Best-effort keyword guess from the agent's own identity, falling back to
+  // the site's configured default icon when nothing matches (#2076 follow-up).
+  // `agentIconName` is an untyped site-config string; guessAgentIcon's
+  // fallback must be a real MaterialIconType, so it's validated the same way
+  // `toIconType` does, narrowed to the material (non-custom) subset.
+  const defaultIcon: MaterialIconType = (materialIcons as readonly string[]).includes(agentIconName)
+    ? (agentIconName as MaterialIconType)
+    : "smart_toy";
+  const iconName = guessAgentIcon(instance.display_name, instance.role, instance.description ?? "", defaultIcon);
   // Raw source_runtime_id, not a prettified label (e.g. "fred-agents"), per
   // the agent card redesign (#2076).
   const origin = [runtimeId, templateDisplayName].filter(Boolean).join(" · ");
@@ -73,7 +83,7 @@ export default function AgentCard({
       <div className={styles.agentInfo}>
         <div className={styles.agentPresentation}>
           <div className={styles.agentIcon}>
-            <Icon category={"outlined"} type={agentIconName as IconType} />
+            <Icon category={"outlined"} type={iconName} />
           </div>
           <div className={styles.agentIdentity}>
             {origin && <div className={styles.agentOrigin}>{origin}</div>}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -5,10 +5,13 @@
   border-radius: var(--radius-m);
   background-color: var(--surface-container);
   width: 290px;
-  overflow: hidden;
+  /* No overflow: hidden here — an admin-avatar tooltip in the footer must be
+   * able to escape the card bounds. The banner below clips its own square
+   * corners to match the card's rounded top instead. */
 }
 
 .teamBanner {
+  border-radius: var(--radius-m) var(--radius-m) 0 0;
   width: 100%;
   height: 96px;
   object-fit: cover;

--- a/apps/frontend/src/rework/components/shared/utils/Type.ts
+++ b/apps/frontend/src/rework/components/shared/utils/Type.ts
@@ -111,6 +111,14 @@ export const materialIcons = [
   "graphic_eq",
   "extension",
   "smart_toy",
+  "gavel",
+  "shield",
+  "support_agent",
+  "translate",
+  "payments",
+  "code",
+  "campaign",
+  "travel_explore",
 ] as const;
 
 export type MaterialIconType = (typeof materialIcons)[number];

--- a/apps/frontend/src/rework/components/shared/utils/Type.ts
+++ b/apps/frontend/src/rework/components/shared/utils/Type.ts
@@ -119,6 +119,16 @@ export const materialIcons = [
   "code",
   "campaign",
   "travel_explore",
+  "cloud",
+  "bug_report",
+  "architecture",
+  "assignment",
+  "school",
+  "receipt_long",
+  "shopping_cart",
+  "handshake",
+  "request_quote",
+  "history",
 ] as const;
 
 export type MaterialIconType = (typeof materialIcons)[number];

--- a/apps/frontend/src/rework/components/shared/utils/agentIcon.test.ts
+++ b/apps/frontend/src/rework/components/shared/utils/agentIcon.test.ts
@@ -28,16 +28,80 @@ describe("guessAgentIcon", () => {
     expect(guessAgentIcon("Sentinelle", "Surveille la sécurité des systèmes", "", "smart_toy")).toBe("shield");
   });
 
-  it("prefers the first matching rule when multiple keywords are present", () => {
-    // "legal" (gavel) is listed before "code" (code) in the rule order.
-    expect(guessAgentIcon("Multi", "Reviews legal contracts for our codebase", "", "smart_toy")).toBe("gavel");
-  });
-
   it("falls back to the provided default when nothing matches", () => {
     expect(guessAgentIcon("Blorp", "Does a thing", "Nothing keyword-worthy here", "widgets")).toBe("widgets");
   });
 
   it("is case-insensitive", () => {
     expect(guessAgentIcon("TRANSLATOR", "TRANSLATES DOCUMENTS", "", "smart_toy")).toBe("translate");
+  });
+
+  it("reads 'pilote' as French project-steering jargon, not aviation (#2076 follow-up)", () => {
+    // "pilote"/"piloter"/"pilotage" mean project steering in French business
+    // usage ("comité de pilotage", "piloter un projet") — there is no
+    // aviation category (out of scope for an ESN's day-to-day assistants),
+    // so this word is deliberately reinterpreted rather than left unmatched.
+    expect(guessAgentIcon("Copilote", "Pilote nos projets clients", "", "person")).toBe("assignment");
+  });
+
+  it("picks the category with the most matching keywords, not just the first one that matches", () => {
+    // "contrat" alone would match `gavel` (legal), but the description leans
+    // much more heavily into procurement vocabulary — the higher-scoring
+    // category should win even though `gavel` is listed earlier in the rules.
+    const description =
+      "Gère les achats fournisseurs : commande, approvisionnement, et négocie le contrat de procurement.";
+    expect(guessAgentIcon("Acheteur", "", description, "smart_toy")).toBe("shopping_cart");
+  });
+
+  it("breaks a tie between equally-scored categories by array order", () => {
+    // "voyage" (map, listed in the Office group) and "legal" (gavel, listed
+    // later in the Legal group) each score exactly one keyword match — map
+    // wins purely because it comes first in AGENT_ICON_RULES.
+    expect(guessAgentIcon("Mixte", "legal voyage", "", "smart_toy")).toBe("map");
+  });
+
+  it.each([
+    ["Automatise nos pipelines CI/CD et le code de nos microservices", "code"],
+    ["Optimise notre infrastructure cloud et les déploiements kubernetes", "cloud"],
+    ["Modélise le schéma de notre base de données", "database"],
+    ["Documente l'architecture technique de nos systèmes", "architecture"],
+    ["Écrit les tests de non-régression et traque les bugs", "bug_report"],
+    ["Réalise des audits de cybersécurité et détecte les vulnérabilités", "shield"],
+    ["Synchronise les flux de données entre nos outils (ETL)", "sync_alt"],
+    ["Construit des tableaux de bord et calcule nos KPI", "analytics"],
+    ["Prépare le reporting mensuel dans un tableur Excel", "table_chart"],
+    ["Répond aux questions en cherchant dans notre base documentaire (RAG)", "find_in_page"],
+    ["Fait de la veille concurrentielle et explore les tendances du marché", "travel_explore"],
+    ["Rédige des articles de blog et du contenu marketing", "edit_note"],
+    ["Résume les longs comptes rendus de réunion", "summarize"],
+    ["Traduit nos documents en plusieurs langues", "translate"],
+    ["Génère la documentation technique et les rapports", "description"],
+    ["Extrait le texte d'un PDF", "picture_as_pdf"],
+    ["Prépare des présentations PowerPoint pour les clients", "slideshow"],
+    ["Retouche des images pour le design graphique", "image"],
+    ["Transcrit et monte des vidéos", "video_file"],
+    ["Transcrit des podcasts audio", "audio_file"],
+    ["Classe et archive nos fichiers", "folder"],
+    ["Trie et répond automatiquement aux e-mails", "mail"],
+    ["Organise le planning et prend les rendez-vous de réunion", "edit_calendar"],
+    ["Suit les jalons et la planification de notre gestion de projet", "assignment"],
+    ["Tient à jour la checklist de suivi des tâches to-do", "check_circle"],
+    ["Consulte l'historique et la traçabilité des journaux d'audit", "history"],
+    ["Organise les déplacements professionnels et l'itinéraire de voyage", "map"],
+    ["Répond aux questions fréquentes des collaborateurs (FAQ)", "forum"],
+    ["Répond aux tickets du service client et de l'assistance", "support_agent"],
+    ["Dépanne nos outils internes et fait de la maintenance", "build"],
+    ["Aide au recrutement et à l'onboarding RH", "groups"],
+    ["Conçoit des parcours de formation et d'e-learning", "school"],
+    ["Suit la trésorerie et la comptabilité de l'entreprise", "payments"],
+    ["Émet les factures et gère la facturation", "receipt_long"],
+    ["Passe les commandes auprès de nos fournisseurs", "shopping_cart"],
+    ["Relit nos contrats du point de vue juridique", "gavel"],
+    ["Vérifie la conformité et la gouvernance de nos politiques internes", "admin_panel_settings"],
+    ["Négocie avec nos prospects en tant que commercial", "handshake"],
+    ["Rédige les devis en réponse à un appel d'offres", "request_quote"],
+    ["Lance des campagnes marketing sur les réseaux sociaux", "campaign"],
+  ])("matches %j as %s", (description, expectedIcon) => {
+    expect(guessAgentIcon("Assistant", "", description, "smart_toy")).toBe(expectedIcon);
   });
 });

--- a/apps/frontend/src/rework/components/shared/utils/agentIcon.test.ts
+++ b/apps/frontend/src/rework/components/shared/utils/agentIcon.test.ts
@@ -1,0 +1,43 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { guessAgentIcon } from "./agentIcon";
+
+describe("guessAgentIcon", () => {
+  it("matches a keyword in the role when the name and description are unhelpful", () => {
+    expect(guessAgentIcon("Aegis", "Reviews contracts for legal compliance", "", "smart_toy")).toBe("gavel");
+  });
+
+  it("matches a keyword in the description when the name and role are unhelpful", () => {
+    expect(guessAgentIcon("Aegis", "", "Handles customer support tickets", "smart_toy")).toBe("support_agent");
+  });
+
+  it("matches French keywords, not just English ones", () => {
+    expect(guessAgentIcon("Sentinelle", "Surveille la sécurité des systèmes", "", "smart_toy")).toBe("shield");
+  });
+
+  it("prefers the first matching rule when multiple keywords are present", () => {
+    // "legal" (gavel) is listed before "code" (code) in the rule order.
+    expect(guessAgentIcon("Multi", "Reviews legal contracts for our codebase", "", "smart_toy")).toBe("gavel");
+  });
+
+  it("falls back to the provided default when nothing matches", () => {
+    expect(guessAgentIcon("Blorp", "Does a thing", "Nothing keyword-worthy here", "widgets")).toBe("widgets");
+  });
+
+  it("is case-insensitive", () => {
+    expect(guessAgentIcon("TRANSLATOR", "TRANSLATES DOCUMENTS", "", "smart_toy")).toBe("translate");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/utils/agentIcon.ts
+++ b/apps/frontend/src/rework/components/shared/utils/agentIcon.ts
@@ -1,0 +1,150 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { MaterialIconType } from "./Type.ts";
+
+/**
+ * Ordered keyword → icon rules for `guessAgentIcon` (#2076 follow-up).
+ *
+ * Deterministic keyword heuristic, not an LLM call: cheap, instant, and
+ * reproducible, at the cost of missing an abstractly-worded mission with no
+ * matching keyword (falls through to the site default in that case). Order
+ * matters — more specific domains are listed before generic catch-alls so a
+ * narrower match wins (e.g. "legal contract review" hits `legal` before the
+ * generic `writing` rule could claim "review").
+ *
+ * Keywords are matched case-insensitively as plain substrings against the
+ * agent's name + role + description combined, in both French and English —
+ * the two languages this app ships translations for.
+ */
+const AGENT_ICON_RULES: { icon: MaterialIconType; keywords: string[] }[] = [
+  {
+    icon: "gavel",
+    keywords: ["legal", "juridique", "contrat", "contract", "compliance", "conformité", "droit", "law"],
+  },
+  {
+    icon: "shield",
+    keywords: ["sécurité", "securite", "security", "secure", "vulnérab", "vulnerab", "threat", "menace", "pentest"],
+  },
+  {
+    icon: "support_agent",
+    keywords: ["support", "assistance", "helpdesk", "help desk", "service client", "customer service", "sav"],
+  },
+  {
+    icon: "translate",
+    keywords: ["traduc", "translat", "langue", "language"],
+  },
+  {
+    icon: "payments",
+    keywords: ["finance", "financ", "facture", "invoice", "budget", "comptab", "accounting", "paiement", "payment"],
+  },
+  {
+    icon: "code",
+    keywords: [
+      "code",
+      "coding",
+      "dévelop",
+      "develop",
+      "programm",
+      "github",
+      "software",
+      "logiciel",
+      "devops",
+      "ingénieur",
+      "engineer",
+    ],
+  },
+  {
+    icon: "database",
+    keywords: ["base de données", "database", "sql", "entrepôt de données", "data warehouse"],
+  },
+  {
+    icon: "analytics",
+    keywords: ["analytic", "analyse", "statistiq", "statistic", "dashboard", "kpi", "métrique", "metric"],
+  },
+  {
+    icon: "campaign",
+    keywords: ["marketing", "campagne", "campaign", "publicité", "advertis", "réseaux sociaux", "social media"],
+  },
+  {
+    icon: "groups",
+    keywords: ["rh", "ressources humaines", "recrut", "recruit", "onboarding", "talent"],
+  },
+  {
+    icon: "travel_explore",
+    keywords: ["recherche", "research", "veille", "explorat", "investigat"],
+  },
+  {
+    icon: "picture_as_pdf",
+    keywords: ["pdf"],
+  },
+  {
+    icon: "slideshow",
+    keywords: ["présentation", "presentation", "slide", "powerpoint", "ppt"],
+  },
+  {
+    icon: "video_file",
+    keywords: ["vidéo", "video"],
+  },
+  {
+    icon: "audio_file",
+    keywords: ["audio", "podcast", "voix", "voice"],
+  },
+  {
+    icon: "image",
+    keywords: ["image", "photo", "visuel"],
+  },
+  {
+    icon: "edit_calendar",
+    keywords: ["planning", "calendar", "calendrier", "schedul", "rendez-vous", "réunion", "meeting"],
+  },
+  {
+    icon: "mail",
+    keywords: ["email", "e-mail", "courriel"],
+  },
+  {
+    icon: "summarize",
+    keywords: ["résum", "summar", "synthèse", "synthesis"],
+  },
+  {
+    icon: "edit_note",
+    keywords: ["rédac", "writ", "draft", "contenu", "content", "blog", "article"],
+  },
+  {
+    icon: "admin_panel_settings",
+    keywords: ["admin", "gouvernance", "governance", "politique", "policy"],
+  },
+  {
+    icon: "search",
+    keywords: ["search", "rechercher", "lookup", "requête"],
+  },
+];
+
+/**
+ * Guess a Material Symbol for an agent card from its name, role, and
+ * description — a best-effort visual hint, not a guarantee of relevance.
+ *
+ * Falls back to `fallback` (normally the site's configured default agent
+ * icon) when no keyword rule matches.
+ */
+export function guessAgentIcon(
+  displayName: string,
+  role: string,
+  description: string,
+  fallback: MaterialIconType,
+): MaterialIconType {
+  const haystack = `${displayName} ${role} ${description}`.toLowerCase();
+  const match = AGENT_ICON_RULES.find((rule) => rule.keywords.some((keyword) => haystack.includes(keyword)));
+  return match?.icon ?? fallback;
+}

--- a/apps/frontend/src/rework/components/shared/utils/agentIcon.ts
+++ b/apps/frontend/src/rework/components/shared/utils/agentIcon.ts
@@ -15,40 +15,31 @@
 import type { MaterialIconType } from "./Type.ts";
 
 /**
- * Ordered keyword → icon rules for `guessAgentIcon` (#2076 follow-up).
+ * Keyword → icon rules for `guessAgentIcon` (#2076 follow-up).
  *
- * Deterministic keyword heuristic, not an LLM call: cheap, instant, and
- * reproducible, at the cost of missing an abstractly-worded mission with no
- * matching keyword (falls through to the site default in that case). Order
- * matters — more specific domains are listed before generic catch-alls so a
- * narrower match wins (e.g. "legal contract review" hits `legal` before the
- * generic `writing` rule could claim "review").
+ * The 40 categories cover the day-to-day activities of a digital-services
+ * company (ESN) — office work, engineering, finance, HR, legal, sales — the
+ * intended audience for these ReAct assistants. Deliberately not exhaustive
+ * of every possible profession (e.g. no aviation/medical/food-service
+ * categories): a keyword-matching heuristic degrades in quality well before
+ * it degrades in speed (see #2076 discussion) — collisions between
+ * lookalike keywords across unrelated categories get more likely, and more
+ * order-dependent, as the rule count grows. 40 well-differentiated, broadly
+ * relevant categories is judged the right size for this audience; adding
+ * niche categories on a one-off basis is a trap; extend deliberately.
  *
- * Keywords are matched case-insensitively as plain substrings against the
- * agent's name + role + description combined, in both French and English —
- * the two languages this app ships translations for.
+ * Each rule is scored by how many of its distinct keywords appear in the
+ * agent's name + role + description (case-insensitive substring match) —
+ * not just whether at least one does. The highest-scoring rule wins; ties
+ * keep the first one in array order, so near-duplicate categories should
+ * still be ordered by which reading feels more central to the role. This
+ * scoring (vs. the earlier first-match-wins) is what gives icon selection
+ * more diversity: an agent whose description leans heavily into one
+ * category's vocabulary no longer loses to an earlier rule that happens to
+ * match on a single incidental word.
  */
 const AGENT_ICON_RULES: { icon: MaterialIconType; keywords: string[] }[] = [
-  {
-    icon: "gavel",
-    keywords: ["legal", "juridique", "contrat", "contract", "compliance", "conformité", "droit", "law"],
-  },
-  {
-    icon: "shield",
-    keywords: ["sécurité", "securite", "security", "secure", "vulnérab", "vulnerab", "threat", "menace", "pentest"],
-  },
-  {
-    icon: "support_agent",
-    keywords: ["support", "assistance", "helpdesk", "help desk", "service client", "customer service", "sav"],
-  },
-  {
-    icon: "translate",
-    keywords: ["traduc", "translat", "langue", "language"],
-  },
-  {
-    icon: "payments",
-    keywords: ["finance", "financ", "facture", "invoice", "budget", "comptab", "accounting", "paiement", "payment"],
-  },
+  // ── Engineering / IT ──────────────────────────────────────────────────
   {
     icon: "code",
     keywords: [
@@ -60,30 +51,81 @@ const AGENT_ICON_RULES: { icon: MaterialIconType; keywords: string[] }[] = [
       "github",
       "software",
       "logiciel",
-      "devops",
       "ingénieur",
       "engineer",
+      "api",
     ],
+  },
+  {
+    icon: "cloud",
+    keywords: ["cloud", "devops", "kubernetes", "infrastructure", "infra", "déploiement", "deployment", "serveur"],
   },
   {
     icon: "database",
     keywords: ["base de données", "database", "sql", "entrepôt de données", "data warehouse"],
   },
   {
+    icon: "architecture",
+    keywords: ["architecture", "conception technique", "technical design", "urbanisation", "schéma technique"],
+  },
+  {
+    icon: "bug_report",
+    keywords: ["test", "qa", "qualité logicielle", "bug", "anomalie", "recette", "non-régression", "regression"],
+  },
+  {
+    icon: "shield",
+    keywords: [
+      "sécurité",
+      "securite",
+      "security",
+      "secure",
+      "cybersécurité",
+      "vulnérab",
+      "vulnerab",
+      "threat",
+      "menace",
+      "pentest",
+    ],
+  },
+  {
+    icon: "sync_alt",
+    keywords: ["intégration", "integration", "synchronis", "sync", "etl", "flux de données", "data pipeline"],
+  },
+
+  // ── Data / Analysis ───────────────────────────────────────────────────
+  {
     icon: "analytics",
     keywords: ["analytic", "analyse", "statistiq", "statistic", "dashboard", "kpi", "métrique", "metric"],
   },
   {
-    icon: "campaign",
-    keywords: ["marketing", "campagne", "campaign", "publicité", "advertis", "réseaux sociaux", "social media"],
+    icon: "table_chart",
+    keywords: ["tableur", "spreadsheet", "excel", "reporting", "rapport chiffré", "tableau de données"],
   },
   {
-    icon: "groups",
-    keywords: ["rh", "ressources humaines", "recrut", "recruit", "onboarding", "talent"],
+    icon: "find_in_page",
+    keywords: ["recherche documentaire", "document search", "rag", "corpus", "base documentaire", "knowledge base"],
   },
   {
     icon: "travel_explore",
-    keywords: ["recherche", "research", "veille", "explorat", "investigat"],
+    keywords: ["veille", "market research", "recherche", "research", "explorat", "investigat", "innovation"],
+  },
+
+  // ── Writing / Documents / Media ───────────────────────────────────────
+  {
+    icon: "edit_note",
+    keywords: ["rédac", "writ", "draft", "contenu", "content", "blog", "article"],
+  },
+  {
+    icon: "summarize",
+    keywords: ["résum", "summar", "synthèse", "synthesis"],
+  },
+  {
+    icon: "translate",
+    keywords: ["traduc", "translat", "langue", "language"],
+  },
+  {
+    icon: "description",
+    keywords: ["document", "documentation", "rapport", "report", "compte rendu"],
   },
   {
     icon: "picture_as_pdf",
@@ -94,49 +136,137 @@ const AGENT_ICON_RULES: { icon: MaterialIconType; keywords: string[] }[] = [
     keywords: ["présentation", "presentation", "slide", "powerpoint", "ppt"],
   },
   {
+    icon: "image",
+    keywords: ["image", "photo", "visuel", "design graphique"],
+  },
+  {
     icon: "video_file",
     keywords: ["vidéo", "video"],
   },
   {
     icon: "audio_file",
-    keywords: ["audio", "podcast", "voix", "voice"],
+    keywords: ["audio", "podcast", "voix", "voice", "transcription"],
   },
   {
-    icon: "image",
-    keywords: ["image", "photo", "visuel"],
+    icon: "folder",
+    keywords: ["fichier", "file", "classement", "gestion documentaire", "archivage"],
+  },
+
+  // ── Office / Productivity ─────────────────────────────────────────────
+  {
+    icon: "mail",
+    keywords: ["email", "e-mail", "courriel"],
   },
   {
     icon: "edit_calendar",
     keywords: ["planning", "calendar", "calendrier", "schedul", "rendez-vous", "réunion", "meeting"],
   },
   {
-    icon: "mail",
-    keywords: ["email", "e-mail", "courriel"],
+    icon: "assignment",
+    keywords: [
+      "gestion de projet",
+      "project management",
+      "tâche",
+      "planification de projet",
+      "jalons",
+      "milestone",
+      // "pilote"/"piloter"/"pilotage" are French business jargon for project
+      // steering ("comité de pilotage", "piloter un projet") — nothing to do
+      // with aviation, and squarely relevant to an ESN (#2076 discussion).
+      "pilote",
+      "piloter",
+      "pilotage",
+      "chef de projet",
+    ],
   },
   {
-    icon: "summarize",
-    keywords: ["résum", "summar", "synthèse", "synthesis"],
+    icon: "check_circle",
+    keywords: ["checklist", "suivi de tâches", "task tracking", "to-do", "todo"],
   },
   {
-    icon: "edit_note",
-    keywords: ["rédac", "writ", "draft", "contenu", "content", "blog", "article"],
+    icon: "history",
+    keywords: ["historique", "history", "traçabilité", "audit trail", "journal des événements", "log"],
+  },
+  {
+    icon: "map",
+    keywords: ["voyage", "travel", "déplacement professionnel", "itinéraire", "itinerary", "note de frais mission"],
+  },
+  {
+    icon: "forum",
+    keywords: ["assistant conversationnel", "conversational assistant", "questions réponses", "faq"],
+  },
+
+  // ── Support / Operations ──────────────────────────────────────────────
+  {
+    icon: "support_agent",
+    keywords: ["support", "assistance", "helpdesk", "help desk", "service client", "customer service", "sav"],
+  },
+  {
+    icon: "build",
+    keywords: ["outils internes", "internal tooling", "maintenance", "dépannage", "troubleshoot"],
+  },
+
+  // ── HR ─────────────────────────────────────────────────────────────────
+  {
+    icon: "groups",
+    keywords: ["rh", "ressources humaines", "recrut", "recruit", "onboarding", "talent"],
+  },
+  {
+    icon: "school",
+    keywords: ["formation", "training", "apprentissage", "e-learning", "montée en compétence", "upskilling"],
+  },
+
+  // ── Finance ────────────────────────────────────────────────────────────
+  {
+    icon: "payments",
+    keywords: ["finance", "financ", "budget", "comptab", "accounting", "paiement", "payment", "trésorerie"],
+  },
+  {
+    icon: "receipt_long",
+    keywords: ["facture", "invoice", "facturation", "billing", "note de frais"],
+  },
+  {
+    icon: "shopping_cart",
+    keywords: ["achat", "procurement", "fournisseur", "supplier", "approvisionnement", "commande"],
+  },
+
+  // ── Legal / Compliance ────────────────────────────────────────────────
+  {
+    icon: "gavel",
+    keywords: ["legal", "juridique", "contrat", "contract", "droit", "law"],
   },
   {
     icon: "admin_panel_settings",
-    keywords: ["admin", "gouvernance", "governance", "politique", "policy"],
+    keywords: ["conformité", "compliance", "gouvernance", "governance", "politique interne", "policy", "audit"],
+  },
+
+  // ── Sales / Marketing ─────────────────────────────────────────────────
+  {
+    icon: "handshake",
+    keywords: ["commercial", "vente", "sales", "négociation", "negotiation", "relation client", "account management"],
   },
   {
-    icon: "search",
-    keywords: ["search", "rechercher", "lookup", "requête"],
+    icon: "request_quote",
+    keywords: ["devis", "quote", "appel d'offres", "rfp", "avant-vente", "proposition commerciale"],
+  },
+  {
+    icon: "campaign",
+    keywords: ["marketing", "campagne", "campaign", "publicité", "advertis", "réseaux sociaux", "social media"],
   },
 ];
+
+function scoreRule(keywords: string[], haystack: string): number {
+  return keywords.reduce((score, keyword) => score + (haystack.includes(keyword) ? 1 : 0), 0);
+}
 
 /**
  * Guess a Material Symbol for an agent card from its name, role, and
  * description — a best-effort visual hint, not a guarantee of relevance.
  *
+ * Each category is scored by how many of its distinct keywords match; the
+ * highest score wins (ties keep the earlier category in `AGENT_ICON_RULES`).
  * Falls back to `fallback` (normally the site's configured default agent
- * icon) when no keyword rule matches.
+ * icon) when every category scores zero.
  */
 export function guessAgentIcon(
   displayName: string,
@@ -145,6 +275,12 @@ export function guessAgentIcon(
   fallback: MaterialIconType,
 ): MaterialIconType {
   const haystack = `${displayName} ${role} ${description}`.toLowerCase();
-  const match = AGENT_ICON_RULES.find((rule) => rule.keywords.some((keyword) => haystack.includes(keyword)));
-  return match?.icon ?? fallback;
+  let best: { icon: MaterialIconType; score: number } | undefined;
+  for (const rule of AGENT_ICON_RULES) {
+    const score = scoreRule(rule.keywords, haystack);
+    if (score > 0 && (!best || score > best.score)) {
+      best = { icon: rule.icon, score };
+    }
+  }
+  return best?.icon ?? fallback;
 }

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1655,6 +1655,8 @@ export type ManagedAgentInstanceSummary = {
   template_id: string;
   display_name: string;
   description?: string | null;
+  /** Short one-line summary of what this agent does, distinct from the longer `description` — shown on the agent card so a teammate can recall the agent's purpose without reading the full description. Server-set to `display_name` at enrollment until independently edited (#2076). */
+  role: string;
   status: "enabled" | "disabled";
   /** Platform-forced suspension reason (#1975, RFC §3.9), or null when the instance is not suspended. Distinct from `status` (the editor's enable/disable toggle): a suspended instance is hidden from chat-only members and shows editors a warning with a locked enable toggle. One of capability_unavailable / capability_access_revoked / capability_config_invalid. */
   suspension_reason?: SuspensionReason | null;
@@ -1693,6 +1695,8 @@ export type CreateAgentInstanceRequest = {
   template_id: string;
   display_name: string;
   description?: string | null;
+  /** Optional short one-line summary of what this agent does. Defaults to `display_name` when omitted (#2076). */
+  role?: string | null;
   /** Optional initial values for the template's tunable fields. Keys must match ManagedAgentFieldSpec.key values from the template. Unknown keys are ignored. Known values are validated against the declared field type and constraints. */
   tuning_field_values?: {
     [key: string]:
@@ -1717,6 +1721,8 @@ export type CreateAgentInstanceRequest = {
 export type UpdateAgentInstanceRequest = {
   display_name?: string | null;
   description?: string | null;
+  /** Short one-line summary of what this agent does. Omit to leave the current role unchanged (#2076). */
+  role?: string | null;
   /** Set to 'enabled' or 'disabled' to toggle the instance. None leaves the current status unchanged. */
   status?: ("enabled" | "disabled") | null;
   /** Replaces the stored field values for this instance. Keys must match ManagedAgentFieldSpec.key values frozen at enrollment. Unknown keys are ignored. Known values are validated against the declared field type and constraints. Omit the field to leave existing values unchanged; pass null to clear the stored agent tuning values. */

--- a/apps/frontend/src/styles/index.css
+++ b/apps/frontend/src/styles/index.css
@@ -94,6 +94,16 @@ body {
    * silently fell back to the browser default serif); use the real Geist token so every
    * inherited-font surface matches. */
   font-family: var(--font-family-base);
+  /* Interface chrome (titles, labels, avatar initials, counters...) never
+   * shows the i-beam cursor. Reactivated explicitly only for real inputs and
+   * long-form reading zones — never the other way around. */
+  user-select: none;
+}
+
+input,
+textarea,
+[contenteditable] {
+  user-select: text;
 }
 
 [data-color="primary"] {

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -273,6 +273,12 @@ The control plane is a **pure proxy** for these values — it does not interpret
 - `agent_instance_id` — primary identifier
 - `team_id`, `template_id`
 - `display_name`, `description`, `status`
+- `role: str` — **added 2026-07-23 (#2076).** Short one-line summary of what
+  the agent does, distinct from the longer `description`; shown on the agent
+  card. Independently settable via `CreateAgentInstanceRequest.role` /
+  `UpdateAgentInstanceRequest.role` (both optional); server-defaults to
+  `display_name` when omitted at creation, and is left unchanged on update
+  when omitted.
 - ~~`effective_chat_options: EffectiveChatOptions`~~ — **REMOVED 2026-07-11 (CAPAB-01 #1976).** `EffectiveChatOptions` is retired; chat controls are a session-prep projection shipped on `ExecutionPreparation.chat_controls`, not a listing-surface field. The composer fetches them via an eager prepare-execution at chat open. See RFC AGENT-CAPABILITY-RFC §3.3/§3.7.
 - `created_at`, `updated_at`, `created_by`
 - `tuning_field_values: dict[str, TuningValue]` — frozen snapshot of user-set


### PR DESCRIPTION
## Summary

Full redesign of the agent card, per an agreed mockup, plus a few adjacent UI polish fixes done alongside it:

- **Agent role field** (backend contract change): `ManagedAgentTuning.role` existed but was always server-set to `display_name` and never independently editable or exposed. Now a real field — `CreateAgentInstanceRequest.role` / `UpdateAgentInstanceRequest.role` (both optional, default to `display_name` / leave unchanged), exposed on `ManagedAgentInstanceSummary`, editable in the agent create/edit form. Regenerated the OpenAPI-derived frontend client per the repo's mandatory generated-client rule. Documented in `CONTROL-PLANE-PRODUCT-CONTRACT.md`.
- **Card layout**: new label-small origin·template line above the agent name ("fred-agents · Generalist", raw `source_runtime_id`), new role line below the name.
- **Toolbar restructure**: edit/enable-toggle grouped bottom-left; a dedicated Chat button bottom-right (icon `reviews`, "Chat"/"Discuter") replaces the whole-card click-to-chat interaction — visible to every user, not just `canManageAgents`.
- **Icon guessing**: the card's icon is now picked by a deterministic keyword heuristic over the agent's name/role/description (e.g. "legal contract review" → `gavel`, "customer support" → `support_agent`), falling back to the site's configured default icon when nothing matches. Chosen over an LLM-based guess for this iteration: instant, free, deterministic, no new backend call or storage field.
- **Chat button hover polish** (two rounds of feedback): default border uses the neutral `--outline` token; hover keeps the animated gradient border but no longer lightens the button's dark interior (Button's own outlined-hover state layer was painting over the gradient) and switches text/icon to `on-surface`; border width is reserved at the hover width (2px) at all times with the rest-state 1px line drawn via an inset `box-shadow`, so the button never shifts on hover (it has no fixed width).
- **Adjacent fixes**: page-wide `user-select: none` by default (design-system rule), reactivated for inputs/textareas/contenteditable and long-form reading zones; `TeamCard` tooltip no longer clipped by the card's `overflow: hidden`; `Button.tsx` now forwards `className` (previously silently dropped).

Fixes #2076

## Test plan
- [x] Backend: `make code-quality` + `make test` (493 tests) — clean
- [x] Frontend: `make code-quality` + `make test` (530 tests, including new unit tests for the icon-guessing heuristic) — clean
- [ ] Manual check in the running dev stack: create/edit an agent with a role, confirm it displays and saves; confirm the Chat button navigates and doesn't shift on hover; confirm icon guessing picks a sensible icon for a few sample names/roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)