### PR TITLE
feat(MIGR-01.01): configurable upload warning banner on upload surfaces (#2077)

### DIFF
--- a/apps/control-plane-backend/config/configuration.yaml
+++ b/apps/control-plane-backend/config/configuration.yaml
@@ -60,6 +60,14 @@ policies:
   purge_catalog_path: ./conversation_policy_catalog.yaml
 
 platform:
+  # Optional deployer-configured banner shown on upload surfaces (document
+  # upload drawer, chat attachments). Omit the whole block to show nothing.
+  # frontend:
+  #   upload_warning:
+  #     severity: warning # info | warning | error | success
+  #     messages:
+  #       en: "Do not upload classified documents."
+  #       fr: "Ne téléversez pas de documents classifiés."
   # Runtime pod references only. Managed agent instance enrollment is DB-backed.
   knowledge_flow_base_url: http://127.0.0.1:8111/knowledge-flow/v1
   runtime_catalog_sources:

--- a/apps/control-plane-backend/config/configuration_prod.yaml
+++ b/apps/control-plane-backend/config/configuration_prod.yaml
@@ -81,13 +81,13 @@ policies:
   purge_catalog_path: ./conversation_policy_catalog.yaml
 
 platform:
-  # Banner shown on upload surfaces (document upload drawer, chat attachments).
-  frontend:
-    upload_warning:
-      severity: warning
-      messages:
-        en: "Do not upload sensitive or classified documents."
-        fr: "Ne téléversez pas de documents sensibles ou classifiés."
+  # # Banner shown on upload surfaces (document upload drawer, chat attachments).
+  # frontend:
+  #   upload_warning:
+  #     severity: warning
+  #     messages:
+  #       en: "Do not upload sensitive or classified documents."
+  #       fr: "Ne téléversez pas de documents sensibles ou classifiés."
   # Runtime pod references only. Managed agent instance enrollment is DB-backed.
   knowledge_flow_base_url: http://127.0.0.1:8111/knowledge-flow/v1
   runtime_catalog_sources:

--- a/apps/control-plane-backend/config/configuration_prod.yaml
+++ b/apps/control-plane-backend/config/configuration_prod.yaml
@@ -81,6 +81,13 @@ policies:
   purge_catalog_path: ./conversation_policy_catalog.yaml
 
 platform:
+  # Banner shown on upload surfaces (document upload drawer, chat attachments).
+  frontend:
+    upload_warning:
+      severity: warning
+      messages:
+        en: "Do not upload sensitive or classified documents."
+        fr: "Ne téléversez pas de documents sensibles ou classifiés."
   # Runtime pod references only. Managed agent instance enrollment is DB-backed.
   knowledge_flow_base_url: http://127.0.0.1:8111/knowledge-flow/v1
   runtime_catalog_sources:

--- a/apps/control-plane-backend/config/schema/configuration.schema.json
+++ b/apps/control-plane-backend/config/schema/configuration.schema.json
@@ -119,6 +119,18 @@
       "properties": {
         "feature_flags": {
           "$ref": "#/$defs/FrontendFeatureFlags"
+        },
+        "upload_warning": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/UploadWarning"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional banner shown on upload surfaces (document upload drawer, chat attachments). Omit to show nothing."
         }
       },
       "title": "FrontendBootstrapConfig",
@@ -1099,6 +1111,34 @@
         }
       },
       "title": "TemporalSchedulerConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "UploadWarning": {
+      "description": "Deployer-configured banner shown on upload surfaces (MIGR-01.01).\n\nPorted from the main-branch `Properties.uploadWarning` (agentic-backend):\nlets a deployment display a localized notice (e.g. legal/classification\nreminder) wherever users upload files \u2014 document upload drawer and chat\nattachments. Omit the whole block to show nothing.",
+      "properties": {
+        "severity": {
+          "default": "info",
+          "description": "Visual severity variant of the banner.",
+          "enum": [
+            "info",
+            "warning",
+            "error",
+            "success"
+          ],
+          "title": "Severity",
+          "type": "string"
+        },
+        "messages": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Locale \u2192 message map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+          "title": "Messages",
+          "type": "object"
+        }
+      },
+      "title": "UploadWarning",
       "type": "object",
       "additionalProperties": false
     },

--- a/apps/control-plane-backend/control_plane_backend/config/models.py
+++ b/apps/control-plane-backend/control_plane_backend/config/models.py
@@ -70,10 +70,36 @@ class FrontendFeatureFlags(BaseModel):
     enableElecWarfare: bool = False
 
 
+class UploadWarning(BaseModel):
+    """Deployer-configured banner shown on upload surfaces (MIGR-01.01).
+
+    Ported from the main-branch `Properties.uploadWarning` (agentic-backend):
+    lets a deployment display a localized notice (e.g. legal/classification
+    reminder) wherever users upload files — document upload drawer and chat
+    attachments. Omit the whole block to show nothing.
+    """
+
+    severity: Literal["info", "warning", "error", "success"] = Field(
+        default="info",
+        description="Visual severity variant of the banner.",
+    )
+    messages: dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → message map (e.g. {"en": "...", "fr": "..."}).',
+    )
+
+
 class FrontendBootstrapConfig(BaseModel):
     """Static frontend bootstrap configuration served by control-plane."""
 
     feature_flags: FrontendFeatureFlags = Field(default_factory=FrontendFeatureFlags)
+    upload_warning: UploadWarning | None = Field(
+        default=None,
+        description=(
+            "Optional banner shown on upload surfaces (document upload drawer, "
+            "chat attachments). Omit to show nothing."
+        ),
+    )
 
 
 class RuntimeCatalogSourceConfig(BaseModel):

--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -13,6 +13,7 @@ from control_plane_backend.config.models import (
     FrontendFeatureFlags,
     ManagedAgentFieldSpec,
     ManagedAgentTuning,
+    UploadWarning,
 )
 from control_plane_backend.product.prompt_category import PromptCategory
 from control_plane_backend.teams.schemas import Team, TeamWithPermissions
@@ -62,6 +63,17 @@ class FrontendBootstrap(BaseModel):
     gcu_version: str | None = None
     feature_flags: FrontendFeatureFlags
     permissions: PermissionSummary
+    upload_warning: UploadWarning | None = Field(
+        default=None,
+        description=(
+            "Deployer-configured banner for upload surfaces (document upload "
+            "drawer, chat attachments), from `platform.frontend.upload_warning` "
+            "(MIGR-01.01). `None` when the deployment configures none — the "
+            "frontend then renders nothing. Deliberately on the authenticated "
+            "bootstrap, not the pre-auth `FrontendConfig`: upload surfaces only "
+            "render post-auth, and `FrontendConfig` stays minimal."
+        ),
+    )
 
 
 class FrontendUserAuthConfig(BaseModel):

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -316,6 +316,7 @@ async def build_frontend_bootstrap(
         gcu_version=deps.configuration.app.gcu_version,
         feature_flags=deps.configuration.platform.frontend.feature_flags,
         permissions=permissions,
+        upload_warning=deps.configuration.platform.frontend.upload_warning,
     )
 
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -267,7 +267,9 @@
       "processingDone": "Done",
       "processingFailed": "Failed",
       "processingFast": "Fast processing",
-      "processingPrepare": "Preparing processing"
+      "processingPrepare": "Preparing processing",
+      "uploadWarningConfirm": "I understand",
+      "uploadWarningTitle": "Before attaching files"
     },
     "composerActions": {
       "dialogAria": "Chat actions",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -267,7 +267,9 @@
       "processingDone": "Terminé",
       "processingFailed": "Échec",
       "processingFast": "Traitement rapide",
-      "processingPrepare": "Préparation du traitement"
+      "processingPrepare": "Préparation du traitement",
+      "uploadWarningConfirm": "J'ai compris",
+      "uploadWarningTitle": "Avant d'ajouter des fichiers"
     },
     "composerActions": {
       "dialogAria": "Actions de conversation",

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -27,11 +27,13 @@ import { TraceDetailDrawer } from "@shared/molecules/ThoughtTrace/TraceDetailDra
 import { TraceDrawerProvider } from "@shared/molecules/ThoughtTrace/traceDrawerContext";
 import { findTraceEntry, traceEntryKey, type TraceEntry } from "../../../utils/traceUtils";
 import { ComposerActionsMenu } from "@shared/molecules/ComposerActionsMenu/ComposerActionsMenu";
+import { UploadWarningAckDialog } from "@shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { CapabilitySidePanelHost } from "../../../features/capabilities/CapabilitySidePanelHost";
 import { ComposerControlSlot } from "../../../features/capabilities/ComposerControlSlot";
 import { selectSidePanelOpenRequest } from "../../../features/capabilities/sidePanelOpenRequestSlice";
 import { useManagedChat } from "./useManagedChat";
+import { useUploadWarningAcknowledgement } from "../../../core/hooks/useUploadWarningAcknowledgement";
 import { useFrontendBootstrap } from "../../../../hooks/useFrontendBootstrap";
 import { useGetTeamQuery } from "../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
@@ -157,10 +159,26 @@ export default function ManagedChatPage() {
     );
   };
 
+  // First-file gate: while the deployer-configured upload warning is
+  // unacknowledged, adds from both entry points (picker and drop) are parked
+  // here and only forwarded once the user accepts the dialog. Cancel drops them.
+  const { requiresAcknowledgement, acknowledge } = useUploadWarningAcknowledgement();
+  const [pendingAttachments, setPendingAttachments] = useState<{ files: File[]; source: "picker" | "drop" } | null>(
+    null,
+  );
+
+  const addAttachments = (files: File[], source: "picker" | "drop") => {
+    if (requiresAcknowledgement) {
+      setPendingAttachments({ files, source });
+      return;
+    }
+    chat.handleAddAttachments(files, source);
+  };
+
   const handleFilesSelected = (files: FileList | null) => {
     if (!allowChatAttachments) return;
     const selected = Array.from(files ?? []);
-    if (selected.length > 0) chat.handleAddAttachments(selected, "picker");
+    if (selected.length > 0) addAttachments(selected, "picker");
   };
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
@@ -176,7 +194,7 @@ export default function ManagedChatPage() {
     event.preventDefault();
     setDragActive(false);
     const files = Array.from(event.dataTransfer.files);
-    if (files.length > 0) chat.handleAddAttachments(files, "drop");
+    if (files.length > 0) addAttachments(files, "drop");
   };
 
   const composer = (
@@ -345,6 +363,15 @@ export default function ManagedChatPage() {
         />
         <TraceDetailDrawer entry={selectedTraceEntry} onClose={() => setSelectedTraceKey(null)} />
         {isAdmin && <DebugRawDrawer open={debugOpen} onClose={() => setDebugOpen(false)} messages={chat.messages} />}
+        <UploadWarningAckDialog
+          open={pendingAttachments !== null}
+          onConfirm={() => {
+            acknowledge();
+            if (pendingAttachments) chat.handleAddAttachments(pendingAttachments.files, pendingAttachments.source);
+            setPendingAttachments(null);
+          }}
+          onCancel={() => setPendingAttachments(null)}
+        />
       </div>
     </TraceDrawerProvider>
   );

--- a/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.module.css
@@ -1,3 +1,7 @@
+.uploadWarning {
+  margin-bottom: var(--spacing-xs);
+}
+
 .list {
   display: flex;
   flex-direction: column;

--- a/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
 import IconButton from "@shared/atoms/IconButton/IconButton";
+import UploadWarningBanner from "@shared/molecules/UploadWarningBanner/UploadWarningBanner";
 import { InlineDrawer } from "../InlineDrawer/InlineDrawer";
 import { MarkdownPreviewModal } from "../MarkdownPreviewModal/MarkdownPreviewModal";
 import type { SessionAttachment } from "@rework/types/attachments";
@@ -74,6 +75,7 @@ export function SessionAttachmentsDrawer({
         width="460px"
         layout="push"
       >
+        <UploadWarningBanner className={styles.uploadWarning} />
         <div className={styles.list}>
           {isLoading && attachments.length === 0 ? (
             <div className={styles.empty}>{t("chatbot.sessionAttachments.loading")}</div>

--- a/apps/frontend/src/rework/components/shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog.tsx
@@ -1,0 +1,61 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useTranslation } from "react-i18next";
+import { ConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialog";
+import { useLocalizedUploadWarning } from "../../../../core/hooks/useLocalizedUploadWarning";
+
+interface UploadWarningAckDialogProps {
+  open: boolean;
+  /** Called after the user accepted the notice — proceed with the pending files. */
+  onConfirm: () => void;
+  /** Called when the user dismissed the notice — drop the pending files. */
+  onCancel: () => void;
+}
+
+/**
+ * Blocking one-time acknowledgement of the deployer-configured upload warning.
+ *
+ * Why this component exists:
+ * - chat attachments have no persistent surface where a passive banner would
+ *   reliably be seen *before* the first file is attached, so the notice is
+ *   shown as a dialog the user must accept once
+ *   (`useUploadWarningAcknowledgement` persists the acceptance)
+ * - reuses `ConfirmationDialog` so it looks like every other confirmation
+ *
+ * How to use it:
+ * - open it when a file add is pending and `requiresAcknowledgement` is true;
+ *   on confirm, call `acknowledge()` and proceed with the held files
+ *
+ * Example:
+ * - `<UploadWarningAckDialog open={pending !== null} onConfirm={...} onCancel={...} />`
+ */
+export function UploadWarningAckDialog({ open, onConfirm, onCancel }: UploadWarningAckDialogProps) {
+  const { t } = useTranslation();
+  const { uploadWarningMessage } = useLocalizedUploadWarning();
+
+  if (!uploadWarningMessage) return null;
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title={t("chatbot.attachments.uploadWarningTitle")}
+      message={uploadWarningMessage}
+      confirmLabel={t("chatbot.attachments.uploadWarningConfirm")}
+      cancelLabel={t("common.cancel")}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/apps/frontend/src/rework/components/shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog.tsx
@@ -14,6 +14,7 @@
 
 import { useTranslation } from "react-i18next";
 import { ConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialog";
+import UploadWarningBanner from "@shared/molecules/UploadWarningBanner/UploadWarningBanner";
 import { useLocalizedUploadWarning } from "../../../../core/hooks/useLocalizedUploadWarning";
 
 interface UploadWarningAckDialogProps {
@@ -51,7 +52,9 @@ export function UploadWarningAckDialog({ open, onConfirm, onCancel }: UploadWarn
     <ConfirmationDialog
       open={open}
       title={t("chatbot.attachments.uploadWarningTitle")}
-      message={uploadWarningMessage}
+      // The notice itself renders as the shared severity-styled banner (icon +
+      // accent), not as plain dialog text — same visual as the upload drawer.
+      details={<UploadWarningBanner />}
       confirmLabel={t("chatbot.attachments.uploadWarningConfirm")}
       cancelLabel={t("common.cancel")}
       onConfirm={onConfirm}

--- a/apps/frontend/src/rework/components/shared/molecules/UploadWarningBanner/UploadWarningBanner.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/UploadWarningBanner/UploadWarningBanner.module.css
@@ -22,7 +22,7 @@
   background: var(--surface-container);
   padding: var(--spacing-xs) var(--spacing-s);
   color: var(--on-surface);
-  font: var(--font-body-small);
+  font: var(--font-body-medium);
 }
 
 /* Same severity → accent mapping as Toast, for cross-surface consistency. */

--- a/apps/frontend/src/rework/components/shared/molecules/UploadWarningBanner/UploadWarningBanner.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/UploadWarningBanner/UploadWarningBanner.module.css
@@ -1,0 +1,52 @@
+/* Copyright Thales 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+  border-left: 3px solid var(--banner-accent);
+  border-radius: var(--radius-xs);
+  background: var(--surface-container);
+  padding: var(--spacing-xs) var(--spacing-s);
+  color: var(--on-surface);
+  font: var(--font-body-small);
+}
+
+/* Same severity → accent mapping as Toast, for cross-surface consistency. */
+.banner[data-severity="success"] {
+  --banner-accent: var(--success);
+}
+.banner[data-severity="error"] {
+  --banner-accent: var(--error);
+}
+.banner[data-severity="warning"] {
+  --banner-accent: var(--warning);
+}
+.banner[data-severity="info"] {
+  --banner-accent: var(--secondary);
+}
+
+.icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--banner-accent);
+  font-size: 1rem;
+}
+
+.message {
+  align-self: center;
+  white-space: pre-line;
+}

--- a/apps/frontend/src/rework/components/shared/molecules/UploadWarningBanner/UploadWarningBanner.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/UploadWarningBanner/UploadWarningBanner.tsx
@@ -1,0 +1,67 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Icon from "@shared/atoms/Icon/Icon";
+import type { IconType } from "@shared/utils/Type";
+import { useLocalizedUploadWarning } from "../../../../core/hooks/useLocalizedUploadWarning";
+import styles from "./UploadWarningBanner.module.css";
+
+const severityIcons: Record<string, IconType> = {
+  info: "info",
+  warning: "warning",
+  error: "error",
+  success: "check_circle",
+};
+
+interface UploadWarningBannerProps {
+  className?: string;
+}
+
+/**
+ * Render the deployer-configured upload warning banner when one is available.
+ *
+ * Why this component exists:
+ * - upload-related surfaces (document upload drawer, chat attachments) must
+ *   share one banner so the notice stays visually consistent while locale
+ *   resolution remains centralized in `useLocalizedUploadWarning`
+ * - renders nothing when the deployment configures no warning — callers can
+ *   place it unconditionally
+ * - ported from the main-branch `UploadWarningAlert` (MIGR-01.01), restyled
+ *   for the rework design system (no MUI)
+ *
+ * How to use it:
+ * - place it where an upload warning should appear; pass `className` for
+ *   local layout adjustments
+ *
+ * Example:
+ * - `<UploadWarningBanner />`
+ */
+export default function UploadWarningBanner({ className }: UploadWarningBannerProps) {
+  const { uploadWarning, uploadWarningMessage } = useLocalizedUploadWarning();
+
+  if (!uploadWarning || !uploadWarningMessage) {
+    return null;
+  }
+
+  const severity = uploadWarning.severity ?? "info";
+
+  return (
+    <div className={className ? `${styles.banner} ${className}` : styles.banner} data-severity={severity} role="alert">
+      <span className={styles.icon} aria-hidden>
+        <Icon category="outlined" type={severityIcons[severity] ?? "info"} />
+      </span>
+      <span className={styles.message}>{uploadWarningMessage}</span>
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.initialFiles.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.initialFiles.test.tsx
@@ -40,6 +40,8 @@ vi.mock("react-dropzone", () => ({
 vi.mock("@shared/utils/Portal", () => ({ Portal: ({ children }: { children: React.ReactNode }) => children }));
 vi.mock("@shared/molecules/Toast/ToastProvider", () => ({ useToast: () => ({}) }));
 vi.mock("@shared/molecules/Select/Select", () => ({ default: () => null }));
+// Not under test here — and its bootstrap query (RTK) would need a Redux Provider.
+vi.mock("@shared/molecules/UploadWarningBanner/UploadWarningBanner", () => ({ default: () => null }));
 vi.mock("@hooks/useTeamCapabilities.ts", () => ({ useTeamCapabilities: () => ({ canUpdateResources: true }) }));
 vi.mock("../../../../../slices/streamDocumentUpload", () => ({ streamUploadOrProcessDocument: vi.fn() }));
 vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({}));

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx
@@ -22,6 +22,7 @@ import Icon from "@shared/atoms/Icon/Icon";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import Select from "@shared/molecules/Select/Select";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
+import UploadWarningBanner from "@shared/molecules/UploadWarningBanner/UploadWarningBanner";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
 import { streamUploadOrProcessDocument, type ScheduledTask } from "../../../../../slices/streamDocumentUpload";
 import { IngestionProcessingProfile } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
@@ -259,6 +260,7 @@ export function DocumentUploadDrawer({
             />
           </div>
           <div className={styles.body}>
+            <UploadWarningBanner />
             <div className={styles.field}>
               <label className={styles.label}>{t("documentLibrary.ingestionMode")}</label>
               <Select<"upload" | "process">

--- a/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.test.ts
+++ b/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.test.ts
@@ -1,0 +1,50 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pins the locale-fallback contract of the upload warning banner
+// (MIGR-01.01): active language first, then "en", then hidden — so a
+// deployment configuring only "en" still shows its notice to "fr" users, and
+// a deployment configuring nothing renders nothing anywhere.
+
+import { describe, expect, it } from "vitest";
+import type { UploadWarning } from "../../../slices/controlPlane/controlPlaneOpenApi";
+import { resolveUploadWarningMessage } from "./useLocalizedUploadWarning";
+
+const warning: UploadWarning = {
+  severity: "warning",
+  messages: { en: "Do not upload classified documents.", fr: "Ne téléversez pas de documents classifiés." },
+};
+
+describe("resolveUploadWarningMessage", () => {
+  it("picks the message matching the active language", () => {
+    expect(resolveUploadWarningMessage(warning, "fr")).toBe("Ne téléversez pas de documents classifiés.");
+  });
+
+  it("strips the region subtag from i18next language tags", () => {
+    expect(resolveUploadWarningMessage(warning, "fr-FR")).toBe("Ne téléversez pas de documents classifiés.");
+  });
+
+  it("falls back to en when the active language has no entry", () => {
+    expect(resolveUploadWarningMessage(warning, "de")).toBe("Do not upload classified documents.");
+  });
+
+  it("returns null when neither the language nor en is configured", () => {
+    expect(resolveUploadWarningMessage({ severity: "info", messages: { fr: "..." } }, "de")).toBeNull();
+  });
+
+  it("returns null when no warning is configured", () => {
+    expect(resolveUploadWarningMessage(null, "fr")).toBeNull();
+    expect(resolveUploadWarningMessage({ severity: "info" }, "fr")).toBeNull();
+  });
+});

--- a/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.test.ts
+++ b/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, it } from "vitest";
 import type { UploadWarning } from "../../../slices/controlPlane/controlPlaneOpenApi";
 import { resolveUploadWarningMessage } from "./useLocalizedUploadWarning";
+import { uploadWarningSignature } from "./useUploadWarningAcknowledgement";
 
 const warning: UploadWarning = {
   severity: "warning",
@@ -46,5 +47,23 @@ describe("resolveUploadWarningMessage", () => {
   it("returns null when no warning is configured", () => {
     expect(resolveUploadWarningMessage(null, "fr")).toBeNull();
     expect(resolveUploadWarningMessage({ severity: "info" }, "fr")).toBeNull();
+  });
+});
+
+// The chat-attachments acknowledgement is stored against this signature: it
+// must be stable for an unchanged config (ack survives reloads) and change
+// whenever the deployer edits the notice (everyone is re-prompted).
+describe("uploadWarningSignature", () => {
+  it("is stable for an identical warning", () => {
+    expect(uploadWarningSignature(warning)).toBe(uploadWarningSignature({ ...warning }));
+  });
+
+  it("changes when the message content changes", () => {
+    const edited: UploadWarning = { ...warning, messages: { ...warning.messages, en: "New rules apply." } };
+    expect(uploadWarningSignature(edited)).not.toBe(uploadWarningSignature(warning));
+  });
+
+  it("changes when the severity changes", () => {
+    expect(uploadWarningSignature({ ...warning, severity: "error" })).not.toBe(uploadWarningSignature(warning));
   });
 });

--- a/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.ts
+++ b/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.ts
@@ -1,0 +1,70 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useFrontendBootstrap } from "../../../hooks/useFrontendBootstrap";
+import type { UploadWarning } from "../../../slices/controlPlane/controlPlaneOpenApi";
+
+type LocalizedUploadWarning = {
+  uploadWarning: UploadWarning | null;
+  uploadWarningMessage: string | null;
+};
+
+/**
+ * Resolve the warning message for an i18next language tag ("fr-FR" → "fr"),
+ * falling back to "en", then to nothing (banner hidden).
+ *
+ * Exported separately so the fallback contract is unit-testable without
+ * mocking the bootstrap query or i18next.
+ */
+export function resolveUploadWarningMessage(
+  uploadWarning: UploadWarning | null,
+  language: string | undefined,
+): string | null {
+  if (!uploadWarning?.messages) return null;
+  return uploadWarning.messages[language?.split("-")[0] ?? "en"] ?? uploadWarning.messages["en"] ?? null;
+}
+
+/**
+ * Resolve the deployer-configured upload warning for the current locale.
+ *
+ * Why this hook exists:
+ * - document uploads and chat attachments both display the same
+ *   platform-managed banner (`platform.frontend.upload_warning`, served on
+ *   `/frontend/bootstrap`) and must not duplicate locale fallback logic
+ * - ported from the main-branch `useLocalizedUploadWarning` (MIGR-01.01),
+ *   re-sourced from the control-plane bootstrap instead of agentic-backend
+ *   properties
+ *
+ * How to use it:
+ * - call inside a component, render the banner only when both `uploadWarning`
+ *   and `uploadWarningMessage` are non-null — `UploadWarningBanner` does this
+ *
+ * Example:
+ * - `const { uploadWarning, uploadWarningMessage } = useLocalizedUploadWarning();`
+ */
+export function useLocalizedUploadWarning(): LocalizedUploadWarning {
+  const { i18n } = useTranslation();
+  const { bootstrap } = useFrontendBootstrap();
+  const uploadWarning = bootstrap?.upload_warning ?? null;
+
+  return useMemo(
+    () => ({
+      uploadWarning,
+      uploadWarningMessage: resolveUploadWarningMessage(uploadWarning, i18n.language),
+    }),
+    [i18n.language, uploadWarning],
+  );
+}

--- a/apps/frontend/src/rework/core/hooks/useUploadWarningAcknowledgement.ts
+++ b/apps/frontend/src/rework/core/hooks/useUploadWarningAcknowledgement.ts
@@ -1,0 +1,70 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback } from "react";
+import { useLocalStorageState } from "../../../hooks/useLocalStorageState";
+import type { UploadWarning } from "../../../slices/controlPlane/controlPlaneOpenApi";
+import { useLocalizedUploadWarning } from "./useLocalizedUploadWarning";
+
+type UploadWarningAcknowledgement = {
+  /** True when a warning is configured and this browser has not acknowledged it yet. */
+  requiresAcknowledgement: boolean;
+  /** Persist the acknowledgement so the dialog is not shown again. */
+  acknowledge: () => void;
+};
+
+/**
+ * Stable signature of the configured warning, locale-independent.
+ *
+ * Exported separately so the re-prompt contract is unit-testable: an
+ * acknowledgement is stored against this signature, so editing the warning in
+ * deployment config (message or severity) re-prompts every user, while a mere
+ * UI locale switch does not.
+ */
+export function uploadWarningSignature(uploadWarning: UploadWarning): string {
+  return JSON.stringify({ severity: uploadWarning.severity ?? "info", messages: uploadWarning.messages ?? {} });
+}
+
+/**
+ * One-time acknowledgement of the deployer-configured upload warning.
+ *
+ * Why this hook exists:
+ * - chat attachments show the warning as a blocking dialog on the first file
+ *   add (unlike the passive banner on the document upload drawer), and that
+ *   dialog must not re-appear once acknowledged
+ * - the acknowledgement is per-browser (localStorage), keyed on the warning
+ *   content — a deployer changing the notice re-prompts everyone
+ *
+ * How to use it:
+ * - when `requiresAcknowledgement` is true, hold the pending files and open
+ *   `UploadWarningAckDialog`; call `acknowledge()` on confirm, then proceed
+ *
+ * Example:
+ * - `const { requiresAcknowledgement, acknowledge } = useUploadWarningAcknowledgement();`
+ */
+export function useUploadWarningAcknowledgement(): UploadWarningAcknowledgement {
+  const { uploadWarning, uploadWarningMessage } = useLocalizedUploadWarning();
+  const [acknowledgedSignature, setAcknowledgedSignature] = useLocalStorageState<string | null>(
+    "uploadWarningAck",
+    null,
+  );
+
+  const signature = uploadWarning ? uploadWarningSignature(uploadWarning) : null;
+  const acknowledge = useCallback(() => setAcknowledgedSignature(signature), [setAcknowledgedSignature, signature]);
+
+  return {
+    requiresAcknowledgement: uploadWarningMessage !== null && signature !== acknowledgedSignature,
+    acknowledge,
+  };
+}

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1480,6 +1480,14 @@ export type PermissionSummary = {
   /** OpenFGA-derived platform-observer flag (organization `platform_observer` relation, checked directly). Grants read-only platform observability surfaces without full platform-admin rights. */
   is_platform_observer?: boolean;
 };
+export type UploadWarning = {
+  /** Visual severity variant of the banner. */
+  severity?: "info" | "warning" | "error" | "success";
+  /** Locale → message map (e.g. {"en": "...", "fr": "..."}). */
+  messages?: {
+    [key: string]: string;
+  };
+};
 export type FrontendBootstrap = {
   current_user: UserSummary;
   active_team: TeamWithPermissions;
@@ -1487,6 +1495,8 @@ export type FrontendBootstrap = {
   gcu_version?: string | null;
   feature_flags: FrontendFeatureFlags;
   permissions: PermissionSummary;
+  /** Deployer-configured banner for upload surfaces (document upload drawer, chat attachments), from `platform.frontend.upload_warning` (MIGR-01.01). `None` when the deployment configures none — the frontend then renders nothing. Deliberately on the authenticated bootstrap, not the pre-auth `FrontendConfig`: upload surfaces only render post-auth, and `FrontendConfig` stays minimal. */
+  upload_warning?: UploadWarning | null;
 };
 export type FrontendUserAuthConfig = {
   enabled: boolean;

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -12472,6 +12472,43 @@
                           "title": "FrontendFeatureFlags",
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "upload_warning": {
+                          "anyOf": [
+                            {
+                              "description": "Deployer-configured banner shown on upload surfaces (MIGR-01.01).\n\nPorted from the main-branch `Properties.uploadWarning` (agentic-backend):\nlets a deployment display a localized notice (e.g. legal/classification\nreminder) wherever users upload files \u2014 document upload drawer and chat\nattachments. Omit the whole block to show nothing.",
+                              "properties": {
+                                "severity": {
+                                  "default": "info",
+                                  "description": "Visual severity variant of the banner.",
+                                  "enum": [
+                                    "info",
+                                    "warning",
+                                    "error",
+                                    "success"
+                                  ],
+                                  "title": "Severity",
+                                  "type": "string"
+                                },
+                                "messages": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Locale \u2192 message map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                  "title": "Messages",
+                                  "type": "object"
+                                }
+                              },
+                              "title": "UploadWarning",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Optional banner shown on upload surfaces (document upload drawer, chat attachments). Omit to show nothing."
                         }
                       },
                       "title": "FrontendBootstrapConfig",
@@ -14390,6 +14427,43 @@
                           "title": "FrontendFeatureFlags",
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "upload_warning": {
+                          "anyOf": [
+                            {
+                              "description": "Deployer-configured banner shown on upload surfaces (MIGR-01.01).\n\nPorted from the main-branch `Properties.uploadWarning` (agentic-backend):\nlets a deployment display a localized notice (e.g. legal/classification\nreminder) wherever users upload files \u2014 document upload drawer and chat\nattachments. Omit the whole block to show nothing.",
+                              "properties": {
+                                "severity": {
+                                  "default": "info",
+                                  "description": "Visual severity variant of the banner.",
+                                  "enum": [
+                                    "info",
+                                    "warning",
+                                    "error",
+                                    "success"
+                                  ],
+                                  "title": "Severity",
+                                  "type": "string"
+                                },
+                                "messages": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Locale \u2192 message map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                  "title": "Messages",
+                                  "type": "object"
+                                }
+                              },
+                              "title": "UploadWarning",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Optional banner shown on upload surfaces (document upload drawer, chat attachments). Omit to show nothing."
                         }
                       },
                       "title": "FrontendBootstrapConfig",

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -1708,6 +1708,15 @@ applications:
       scheduler: *cp-scheduler
       storage:   *cp-storage
       platform:
+        # Optional deployer-configured banner shown on upload surfaces
+        # (document upload drawer, chat attachments). Message resolved from
+        # the user's locale, "en" fallback. Omit the block to show nothing.
+        # frontend:
+        #   upload_warning:
+        #     severity: warning # info | warning | error | success
+        #     messages:
+        #       en: "Do not upload sensitive or classified documents."
+        #       fr: "Ne téléversez pas de documents sensibles ou classifiés."
         knowledge_flow_base_url: *kf-url
         runtime_catalog_sources:
           - runtime_id: fred-agents

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -115,6 +115,9 @@ Phase 3a uses one control-plane-owned bootstrap payload:
     - optional Terms of Use / CGU gating switch exposed by deployment config
   - `feature_flags`
   - `permissions`
+  - `upload_warning`
+    - optional deployer-configured upload notice (severity + locale→message
+      map) shown on upload surfaces — see Contract Note §23 (MIGR-01.01)
 
 `FrontendBootstrap` must not carry deployment branding labels. Static branding
 and frontend display strings (`siteDisplayName`, `siteTitle`, `siteSubtitle`,
@@ -1325,3 +1328,27 @@ propagates verbatim (the uniform-422 convention of §17). Mismatched
 422 before any pod call. Files addressed to a capability that is not active in
 the save are ignored, mirroring the config-values policy. Responses and
 authorization (`CAN_UPDATE_AGENTS`) are identical to the JSON routes.
+
+## 23. Contract Notes — upload warning banner (MIGR-01.01, 2026-07-23, #2077)
+
+`FrontendBootstrap` gains one optional field, `upload_warning`
+(`UploadWarning`: `severity: info|warning|error|success` + `messages: {locale
+→ string}`), sourced from control-plane deployment config
+`platform.frontend.upload_warning`. When set, the frontend renders one shared
+banner (`UploadWarningBanner`) on upload surfaces — the document upload
+drawer and the chat session-attachments drawer — resolving the message from
+the active i18next locale with `en` fallback. `null`/omitted → nothing
+rendered, the pre-#2077 behavior.
+
+Ported from the main-branch `Properties.uploadWarning` (#1597, #1634), whose
+serving surface (agentic-backend frontend properties) no longer exists on
+swift.
+
+Boundary rationale (§3.1): this is **not** a branding label — it is a
+deployer *policy/compliance notice* (e.g. "do not upload classified
+documents"), structured (severity + locale map), which the static
+`config.json` `properties` surface (`Record<string, string>`) cannot express.
+It follows the `gcu_version` precedent: deployment-config-owned policy
+exposed on the authenticated bootstrap. Deliberately not on the pre-auth
+`FrontendConfig`, which stays minimal — upload surfaces only render
+post-auth.


### PR DESCRIPTION

Port of the main-branch uploadWarning feature (#1597, #1634) to swift. Deployers can display a localized, severity-levelled notice on upload surfaces via platform.frontend.upload_warning in control-plane config:

- control-plane: UploadWarning model (severity + locale->message map) on FrontendBootstrapConfig, exposed on the authenticated FrontendBootstrap (not the pre-auth FrontendConfig, which stays minimal); JSON schema and chart values.schema.json regenerated
- frontend: useLocalizedUploadWarning hook (locale resolution with "en" fallback, unit-tested) + shared UploadWarningBanner molecule (rework design system, Toast severity accent mapping), rendered in DocumentUploadDrawer and SessionAttachmentsDrawer
- config: active block in configuration_prod.yaml, commented examples in configuration.yaml and deploy/charts/fred/values.yaml
- contract: CONTROL-PLANE-PRODUCT-CONTRACT.md §3.1 amended + note §23 (policy notice, not a branding label)

# Pull Request

> **Read this before you type anything.**
>
> Opening a PR is the _last_ step, not the first. If you designed this alone,
> implemented it without sharing the plan, and are now hoping the review will
> validate the approach — stop. Close this tab. Go read
> [`docs/swift/platform/DEVELOPER_CONTRACT.md`](../docs/swift/platform/DEVELOPER_CONTRACT.md)
> and come back when the steps below are already done.
>
> This is not process theater. Every question below exists because something
> went wrong when it was skipped. Fill them in honestly. A short honest answer
> beats a long evasive one every time.

---

## 1. What problem does this solve — and where is it tracked?

<!-- ID from docs/swift/data/id-legend.yaml (e.g. S1, CP-2, M1-F.3).
     If there is no ID, explain why this work exists at all. -->

**ID:** <!-- S1 / CP-2 / … / "no ID — mechanical fix because …" -->

**Problem in one sentence:**

**Backlog ref:** <!-- link to the [ ] checkbox in the relevant backlog file -->

---

## 2. Before you wrote a single line of code

This section cannot be skipped. If the answer to any question is "no" or
"I didn't", explain why — do not leave it blank.

**RFC written?**

<!-- For any design choice, schema change, new endpoint, or new component:
     paste the link to the RFC in docs/swift/rfc/.
     For a purely mechanical fix (one-function bug, typo, missing field
     already agreed on): write "not required — mechanical fix" and explain. -->

**Plan presented to the team before implementation?**

<!-- Did you share what you were going to build, which files you'd touch,
     which tests you'd add, which docs you'd update — and wait for a
     confirmation before starting? Yes / No + one line of context. -->

**Confirmation received?**

<!-- Who confirmed ("yes go ahead" / "ok" / "looks good")?
     If you were explicitly told "implement immediately", say so. -->

---

## 3. What you built

<!-- Be concrete. Not "updated the service" — say which function, which model,
     which endpoint, which component, and what it now does differently.
     Two or three sentences is enough. Ten vague words is not. -->

---

## 4. Proof of quality

**Tests added or updated:**

<!-- List exact test function names and the file they live in.
     If you added none, explain why none were needed. -->

| Test | File | What it covers |
| ---- | ---- | -------------- |
|      |      |                |

**`make code-quality` output (paste the last line or "all checks passed"):**

```

```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```

```

**`make test` output (paste the summary line — pass count, 0 failures):**

```

```

If you touched multiple packages, paste one block per package.

---

## 5. Docs updated

Work through this line by line. If an item does not apply, write "n/a" and say why.

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    |              |
| New behaviour, API field, or contract change                      |              |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) |              |
| UX component implemented or visual status changed                 |              |
| Phase progress row exists for this area                           |              |
| WORKPLAN sprint item finished                                     |              |
| Code and a design doc now diverge                                 |              |

---

## 6. Close-out statement

<!--
Copy the exact block from the end of your implementation session.
If you don't have one, write it now — and wonder why you don't have it.
-->

```
## Task close-out
- Code:
- Tests:
- Docs updated:
- Backlog:
- Skipped steps:
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

**How do we roll back?**
