### PR TITLE
consolidation 24-07: observability fixes (JWT issuer, capabilities perf, erasure) + frontend fixes

### DIFF
--- a/apps/control-plane-backend/alembic/versions/a5b6c7d8e9f0_add_session_metadata_source_runtime_id.py
+++ b/apps/control-plane-backend/alembic/versions/a5b6c7d8e9f0_add_session_metadata_source_runtime_id.py
@@ -1,0 +1,70 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add session_metadata.source_runtime_id
+
+Erasure resolves a session's runtime by re-reading the (mutable-lifetime)
+agent_instance row for its source_runtime_id. Once the instance is deleted
+that lookup returns None forever, permanently blocking runtime checkpoint/
+history erasure (issue #2089, FRED-2.0.2-RGPD-READY-RFC §7). source_runtime_id
+is immutable after instance creation and names a platform-config-level
+runtime catalog entry, not instance-row data, so capturing it once on the
+session at create_session time removes the dependency on the instance row
+still existing. Backfilled here for every row whose agent_instance_id still
+resolves to a live instance; rows whose instance was already deleted before
+this migration stay NULL (unrecoverable regardless of fix shape — the
+instance -> source mapping is already gone).
+
+Revision ID: a5b6c7d8e9f0
+Revises: a4b5c6d7e8f9
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b6c7d8e9f0"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = (
+    "a4b5c6d7e8f9"  # pragma: allowlist secret
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "session_metadata",
+        sa.Column("source_runtime_id", sa.String(), nullable=True),
+    )
+    # Backfill from agent_instance for every session whose instance is still
+    # enrolled — the common case, since this bug only affects instances
+    # deleted before the fix ships.
+    op.execute(
+        """
+        UPDATE session_metadata
+        SET source_runtime_id = agent_instance.source_runtime_id
+        FROM agent_instance
+        WHERE session_metadata.agent_instance_id = agent_instance.agent_instance_id
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("session_metadata", "source_runtime_id")

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -22,6 +22,7 @@ enforces the `capability#can_manage` gate, and delegates the writes. Kept out of
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Mapping
 
@@ -46,6 +47,7 @@ from control_plane_backend.capabilities.enablement import (
     set_capability_personal_scope,
 )
 from control_plane_backend.capabilities.impact import (
+    CapabilityImpact,
     compute_capability_impact,
     preview_revoke_impact,
     resolve_availability_for_team,
@@ -146,6 +148,66 @@ async def _read_personal_scope(rebac: RebacEngine, capability_id: str) -> Person
     return "default"
 
 
+async def _build_enablement_item(
+    entry: CapabilityCatalogEntry,
+    *,
+    rebac: RebacEngine,
+    total_team_count: int,
+    total_personal_space_count: int,
+    impact: Mapping[str, CapabilityImpact],
+) -> CapabilityEnablementItem:
+    """Build one row's ReBAC-derived fields (#2089).
+
+    The 4 lookups below are independent `lookup_subjects` reads on different
+    relations of the same capability — gathering them turns 4 sequential
+    OpenFGA round-trips per row into 1.
+    """
+
+    (
+        default_on,
+        enabled_team_ids,
+        disabled_team_ids,
+        personal_scope,
+    ) = await asyncio.gather(
+        _is_default_on(rebac, entry.id),
+        _teams_with_relation(rebac, entry.id, RelationType.ENABLED),
+        _teams_with_relation(rebac, entry.id, RelationType.DISABLED),
+        _read_personal_scope(rebac, entry.id),
+    )
+    entry_impact = impact.get(entry.id)
+    return CapabilityEnablementItem(
+        id=entry.id,
+        name=entry.name,
+        version=entry.version,
+        icon=entry.icon,
+        team_scope=entry.team_scope,
+        default_on=default_on,
+        enabled_team_ids=enabled_team_ids,
+        disabled_team_ids=disabled_team_ids,
+        total_team_count=total_team_count,
+        total_personal_space_count=total_personal_space_count,
+        personal_scope=personal_scope,
+        team_settings_fields=list(entry.team_settings_fields),
+        kind=entry.kind,
+        suspended_instances=entry_impact.suspended_instances if entry_impact else 0,
+        health_unknown_instances=(
+            entry_impact.skipped_unreachable if entry_impact else 0
+        ),
+        suspended_instance_details=(
+            [
+                ImpactedInstanceSummary(
+                    agent_instance_id=item.agent_instance_id,
+                    team_id=item.team_id,
+                    display_name=item.display_name,
+                )
+                for item in entry_impact.instances
+            ]
+            if entry_impact
+            else []
+        ),
+    )
+
+
 async def list_capability_enablement(
     *, user: KeycloakUser, deps: ProductServiceDependencies
 ) -> CapabilityEnablementList:
@@ -153,64 +215,53 @@ async def list_capability_enablement(
 
     rebac = _rebac(deps)
     # Aggregate-list read gate: `can_manage` is org-admin, so probe it on the
-    # organization singleton via the same admin relation.
+    # organization singleton via the same admin relation. Kept before every
+    # other step below — authorization must resolve before any of this
+    # request's work runs.
     await _require_manage_any(rebac, user)
 
-    catalog = await aggregate_capability_catalog(deps)
-    # Platform-wide denominators, fetched once for the whole list — they are the
-    # same for every capability: collaborative teams for default-on inheritance
-    # (§8.5), personal spaces (= users) for personal-class access (§8.4).
-    total_team_count = await count_all_collaborative_teams(deps.team_dependencies)
-    total_personal_space_count = await count_all_personal_spaces(deps.team_dependencies)
-    # Resting health for the WHOLE catalog in one pass (#1975): one ReBAC
-    # `ListObjects` per team holding instances plus one template fetch per pod,
-    # rather than a lookup per row. Admin-only screen, so the extra round-trips
-    # buy the most accurate answer available. `collect_instances` names the
-    # broken agents inline so the health-column drill-down (which agents, in
-    # which team) needs no second endpoint — the derivation already walked every
-    # instance, so naming them is a list append, not another pass.
-    impact = await compute_capability_impact(deps, collect_instances=True)
-    items: list[CapabilityEnablementItem] = []
-    for entry in catalog.values():
-        items.append(
-            CapabilityEnablementItem(
-                id=entry.id,
-                name=entry.name,
-                version=entry.version,
-                icon=entry.icon,
-                team_scope=entry.team_scope,
-                default_on=await _is_default_on(rebac, entry.id),
-                enabled_team_ids=await _teams_with_relation(
-                    rebac, entry.id, RelationType.ENABLED
-                ),
-                disabled_team_ids=await _teams_with_relation(
-                    rebac, entry.id, RelationType.DISABLED
-                ),
-                total_team_count=total_team_count,
-                total_personal_space_count=total_personal_space_count,
-                personal_scope=await _read_personal_scope(rebac, entry.id),
-                team_settings_fields=list(entry.team_settings_fields),
-                kind=entry.kind,
-                suspended_instances=(
-                    impact[entry.id].suspended_instances if entry.id in impact else 0
-                ),
-                health_unknown_instances=(
-                    impact[entry.id].skipped_unreachable if entry.id in impact else 0
-                ),
-                suspended_instance_details=(
-                    [
-                        ImpactedInstanceSummary(
-                            agent_instance_id=item.agent_instance_id,
-                            team_id=item.team_id,
-                            display_name=item.display_name,
-                        )
-                        for item in impact[entry.id].instances
-                    ]
-                    if entry.id in impact
-                    else []
-                ),
+    # Lazy import breaks the product.service ↔ capabilities import cycle, same
+    # reason `catalog.py`/`impact.py` defer their own product.service imports.
+    from control_plane_backend.product.service import _template_fetch_scope
+
+    # These 4 steps are mutually independent (none consumes another's result),
+    # so run them concurrently instead of one after another (#2089). Platform-
+    # wide denominators (collaborative teams for default-on inheritance §8.5,
+    # personal spaces for personal-class access §8.4) and resting health
+    # (#1975: one ReBAC `ListObjects` per team holding instances, `collect_instances`
+    # names the broken agents inline so the health-column drill-down needs no
+    # second endpoint) all fold into the same gather as the catalog fetch.
+    # `_template_fetch_scope()` de-dupes the pod `/agents/templates` fetch that
+    # `aggregate_capability_catalog` and `compute_capability_impact` would
+    # otherwise each make independently (#2089).
+    with _template_fetch_scope():
+        (
+            catalog,
+            total_team_count,
+            total_personal_space_count,
+            impact,
+        ) = await asyncio.gather(
+            aggregate_capability_catalog(deps),
+            count_all_collaborative_teams(deps.team_dependencies),
+            count_all_personal_spaces(deps.team_dependencies),
+            compute_capability_impact(deps, collect_instances=True),
+        )
+    # Per-row ReBAC reads are independent across rows too (#2089) — gather
+    # every row's build instead of awaiting them one at a time.
+    items = list(
+        await asyncio.gather(
+            *(
+                _build_enablement_item(
+                    entry,
+                    rebac=rebac,
+                    total_team_count=total_team_count,
+                    total_personal_space_count=total_personal_space_count,
+                    impact=impact,
+                )
+                for entry in catalog.values()
             )
         )
+    )
     items.sort(key=lambda item: item.id)
     return CapabilityEnablementList(items=items)
 

--- a/apps/control-plane-backend/control_plane_backend/models/session_metadata_models.py
+++ b/apps/control-plane-backend/control_plane_backend/models/session_metadata_models.py
@@ -23,6 +23,12 @@ class SessionMetadataRow(Base):
     agent_instance_id: Mapped[str | None] = mapped_column(
         String, nullable=True, index=True
     )
+    # Captured once at create_session from the (then-live) agent instance's
+    # source_runtime_id — immutable, config-level runtime catalog key. Lets
+    # erasure resolve the owning runtime even after agent_instance_id's row is
+    # later deleted (issue #2089, FRED-2.0.2-RGPD-READY-RFC §7). NULL for rows
+    # created before this column existed.
+    source_runtime_id: Mapped[str | None] = mapped_column(String, nullable=True)
     user_id: Mapped[str | None] = mapped_column(String, nullable=True)
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import contextvars
 import hashlib
 import json
 import logging
@@ -371,7 +373,60 @@ async def build_frontend_config(deps: ProductServiceDependencies) -> FrontendCon
     )
 
 
+# Request-scoped memoization for `_fetch_runtime_templates` (#2089). Several
+# independent read paths inside one `GET /admin/capabilities` call
+# (`aggregate_capability_catalog`'s two fetches + `compute_capability_impact`'s
+# `_available_capability_ids_by_source`) each fetch the SAME pod's
+# `/agents/templates` with the SAME `include_non_public` flag — a real,
+# uncached HTTP round-trip every time. A `ContextVar` (not a parameter
+# threaded through every function in the chain — that would ripple the
+# signature into `aggregate_capability_catalog`, `compute_capability_impact`,
+# `_available_capabilities_for_source`, `_agent_capabilities_for_source`, and
+# `_available_capability_ids_by_source`, breaking every test double that
+# monkeypatches one of those with a fixed signature) lets a caller opt one
+# request into de-duplication via `_template_fetch_scope()` without changing
+# any signature in the chain; callers that never enter the scope (every other
+# caller, and any test that mocks `_fetch_runtime_templates` wholesale) are
+# unaffected — `.get()` returns the default `None` and every fetch behaves
+# exactly as before.
+_template_fetch_cache_var: contextvars.ContextVar[
+    "dict[tuple[str, bool], asyncio.Future[list[_RuntimeTemplatePayload]]] | None"
+] = contextvars.ContextVar("_template_fetch_cache_var", default=None)
+
+
+@contextlib.contextmanager
+def _template_fetch_scope():
+    """De-duplicate `_fetch_runtime_templates` calls made inside this scope (#2089).
+
+    Storing the in-flight `Future` (not the eventual result) closes the race
+    where two concurrent callers both miss the cache and both fetch — the
+    second awaits the first's future instead of starting its own request.
+    """
+
+    token = _template_fetch_cache_var.set({})
+    try:
+        yield
+    finally:
+        _template_fetch_cache_var.reset(token)
+
+
 async def _fetch_runtime_templates(
+    base_url: str, include_non_public: bool = False
+) -> list[_RuntimeTemplatePayload]:
+    cache = _template_fetch_cache_var.get()
+    if cache is not None:
+        key = (base_url, include_non_public)
+        future = cache.get(key)
+        if future is None:
+            future = asyncio.ensure_future(
+                _fetch_runtime_templates_uncached(base_url, include_non_public)
+            )
+            cache[key] = future
+        return await future
+    return await _fetch_runtime_templates_uncached(base_url, include_non_public)
+
+
+async def _fetch_runtime_templates_uncached(
     base_url: str, include_non_public: bool = False
 ) -> list[_RuntimeTemplatePayload]:
     url = f"{base_url.rstrip('/')}/agents/templates"

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -3339,10 +3339,21 @@ async def create_session(
     Example:
     - `item = await create_session(user, team_id, request, deps)`
     """
+    source_runtime_id: str | None = None
+    if request.agent_instance_id is not None:
+        # Capture the instance's source_runtime_id now, while it is certainly
+        # live, so a later agent-instance deletion can never strand erasure's
+        # runtime resolution for this session (issue #2089, RFC §7).
+        instance = await deps.get_agent_instance_store().get_for_team(
+            request.agent_instance_id, team_id
+        )
+        if instance is not None:
+            source_runtime_id = instance.source_runtime_id
     record = SessionMetadataRecord(
         session_id=request.session_id,
         team_id=team_id,
         agent_instance_id=request.agent_instance_id,
+        source_runtime_id=source_runtime_id,
         user_id=user.uid,
         title=request.title,
     )

--- a/apps/control-plane-backend/control_plane_backend/sessions/erasure_service.py
+++ b/apps/control-plane-backend/control_plane_backend/sessions/erasure_service.py
@@ -164,6 +164,7 @@ class ConversationErasureService:
         base_url, resolve_error = await self._resolve_runtime_base_url(
             team_id=team_id,
             agent_instance_id=session.agent_instance_id,
+            source_runtime_id=session.source_runtime_id,
         )
         if base_url is None:
             for store in (STORE_CHECKPOINT, STORE_HISTORY):
@@ -248,37 +249,50 @@ class ConversationErasureService:
         *,
         team_id: TeamId,
         agent_instance_id: str | None,
+        source_runtime_id: str | None,
     ) -> tuple[str | None, str | None]:
         """Resolve the server-side runtime `base_url` for a session's runtime.
+
+        `source_runtime_id` names a platform-config-level runtime catalog entry
+        (`runtime_catalog_sources`), not agent-instance-row data — it is
+        immutable once an instance is created. Prefer the copy captured on the
+        session at `create_session` time, so a *later* agent-instance deletion
+        can never strand this resolution (issue #2089, RFC §7: the instance row
+        used to be the *only* path here, and it does not survive the instance
+        being unenrolled). Fall back to a live instance lookup only for rows
+        that predate this column.
 
         Returns `(base_url, None)` on success, or `(None, error)` when the
         runtime cannot be resolved — no `agent_instance_id`, an unknown
         instance, or a disabled/missing runtime source. Callers record the
         error rather than guessing a runtime (A0).
         """
-        if agent_instance_id is None:
-            return None, "unresolved runtime: session has no agent_instance_id"
+        resolved_source_id = source_runtime_id
+        if resolved_source_id is None:
+            if agent_instance_id is None:
+                return None, "unresolved runtime: session has no agent_instance_id"
 
-        instance = await self._deps.get_agent_instance_store().get_for_team(
-            agent_instance_id, team_id
-        )
-        if instance is None:
-            return None, (
-                f"unresolved runtime: agent instance {agent_instance_id!r} "
-                "not found for team"
+            instance = await self._deps.get_agent_instance_store().get_for_team(
+                agent_instance_id, team_id
             )
+            if instance is None:
+                return None, (
+                    f"unresolved runtime: agent instance {agent_instance_id!r} "
+                    "not found for team"
+                )
+            resolved_source_id = instance.source_runtime_id
 
         source = next(
             (
                 s
                 for s in self._deps.configuration.platform.runtime_catalog_sources
-                if s.runtime_id == instance.source_runtime_id and s.enabled
+                if s.runtime_id == resolved_source_id and s.enabled
             ),
             None,
         )
         if source is None:
             return None, (
-                f"unresolved runtime: source {instance.source_runtime_id!r} "
+                f"unresolved runtime: source {resolved_source_id!r} "
                 "is disabled or missing"
             )
         return source.base_url, None

--- a/apps/control-plane-backend/control_plane_backend/sessions/store.py
+++ b/apps/control-plane-backend/control_plane_backend/sessions/store.py
@@ -39,6 +39,7 @@ class SessionMetadataRecord:
         agent_instance_id: str | None,
         user_id: str | None,
         title: str | None,
+        source_runtime_id: str | None = None,
         context_prompt_ids: list[str] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
@@ -46,6 +47,7 @@ class SessionMetadataRecord:
         self.session_id = session_id
         self.team_id = team_id
         self.agent_instance_id = agent_instance_id
+        self.source_runtime_id = source_runtime_id
         self.user_id = user_id
         self.title = title
         self.context_prompt_ids = context_prompt_ids or []
@@ -60,6 +62,7 @@ def _row_to_record(
         session_id=row.session_id,
         team_id=TeamId(row.team_id),
         agent_instance_id=row.agent_instance_id,
+        source_runtime_id=row.source_runtime_id,
         user_id=row.user_id,
         title=row.title,
         context_prompt_ids=context_prompt_ids or [],
@@ -136,6 +139,7 @@ class SessionMetadataStore:
             session_id=record.session_id,
             team_id=str(record.team_id),
             agent_instance_id=record.agent_instance_id,
+            source_runtime_id=record.source_runtime_id,
             user_id=record.user_id,
             title=record.title,
             created_at=record.created_at or now,

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -38,6 +38,7 @@ from control_plane_backend.product.dependencies import (
     ProductServiceDependencies,
     build_product_service_dependencies,
 )
+from control_plane_backend.product.schemas import CreateSessionRequest
 from control_plane_backend.product.service import (
     _delete_knowledge_flow_attachment,
     _RuntimeTemplatePayload,
@@ -242,6 +243,16 @@ class _FakeSessionMetadataStore:
 
     def __init__(self, records: list[SessionMetadataRecord] | None = None) -> None:
         self._records: list[SessionMetadataRecord] = list(records or [])
+
+    async def create(self, record: SessionMetadataRecord) -> SessionMetadataRecord:
+        from control_plane_backend.sessions.store import (
+            SessionMetadataAlreadyExistsError,
+        )
+
+        if any(r.session_id == record.session_id for r in self._records):
+            raise SessionMetadataAlreadyExistsError(record.session_id)
+        self._records.append(record)
+        return record
 
     async def update_last_activity(
         self,
@@ -2463,6 +2474,61 @@ async def test_delete_team_session_returns_404_for_other_user_session(
     assert store._records[0].title == "Owned by Alice"
 
 
+@pytest.mark.asyncio
+async def test_create_session_persists_source_runtime_id_from_live_instance() -> None:
+    """`create_session` must capture `source_runtime_id` from the (currently
+    live) agent instance, so erasure can later resolve the runtime even if the
+    instance is deleted before the session is (issue #2089, RFC §7)."""
+    session_store = _FakeSessionMetadataStore([])
+    deps = _build_erasure_deps(
+        session_store,
+        _FakeSessionAttachmentStore([]),
+        agent_instance_store=_FakeAgentInstanceStore(
+            [
+                _make_record(
+                    agent_instance_id="instance-1", source_runtime_id="runtime-a"
+                )
+            ]
+        ),
+    )
+
+    await product_service.create_session(
+        KeycloakUser(uid="admin", username="admin", roles=[]),
+        TeamId("personal"),
+        CreateSessionRequest(
+            session_id="session-1", agent_instance_id="instance-1", title="New chat"
+        ),
+        deps,
+    )
+
+    assert len(session_store._records) == 1
+    assert session_store._records[0].source_runtime_id == "runtime-a"
+
+
+@pytest.mark.asyncio
+async def test_create_session_leaves_source_runtime_id_none_without_agent_instance() -> (
+    None
+):
+    """No `agent_instance_id` on the request → no instance lookup, no
+    `source_runtime_id` — matches a personal-space session with no managed
+    agent bound yet."""
+    session_store = _FakeSessionMetadataStore([])
+    deps = _build_erasure_deps(
+        session_store,
+        _FakeSessionAttachmentStore([]),
+        agent_instance_store=_FakeAgentInstanceStore([]),
+    )
+
+    await product_service.create_session(
+        KeycloakUser(uid="admin", username="admin", roles=[]),
+        TeamId("personal"),
+        CreateSessionRequest(session_id="session-1", title="New chat"),
+        deps,
+    )
+
+    assert session_store._records[0].source_runtime_id is None
+
+
 def _patch_runtime_erase_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make erase_session's runtime step succeed for HTTP delete tests.
 
@@ -2474,7 +2540,11 @@ def _patch_runtime_erase_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     async def _resolve(
-        self: Any, *, team_id: Any, agent_instance_id: Any
+        self: Any,
+        *,
+        team_id: Any,
+        agent_instance_id: Any,
+        source_runtime_id: Any = None,
     ) -> tuple[str, None]:
         return "http://runtime-a.internal", None
 
@@ -3274,6 +3344,72 @@ async def test_erase_session_runtime_instance_not_found_records_ok_false_no_http
     # Retry-safety: metadata retained (deleted last, only on full success).
     assert by_store["session_metadata"].ok is False
     assert receipt.ok is False
+
+
+@pytest.mark.asyncio
+async def test_erase_session_survives_agent_instance_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #2089 / RFC §7 regression: deleting an agent instance must not
+    permanently block erasure of sessions that used it.
+
+    Reproduces the live bug exactly: an agent instance is deleted (its
+    `agent_instance_store` row is gone, unlike
+    `test_erase_session_runtime_instance_not_found_records_ok_false_no_http`
+    above, which covers the still-permanent case of a pre-migration session
+    with no stored `source_runtime_id`). Here the session carries the
+    `source_runtime_id` captured at `create_session` time, so
+    `_resolve_runtime_base_url` must resolve the runtime from that stored
+    value instead of re-deriving it from the now-deleted instance row —
+    erasure converges instead of leaving the session permanently un-erasable.
+    """
+    from control_plane_backend.sessions.erasure_service import (
+        ConversationErasureService,
+    )
+
+    session_store = _FakeSessionMetadataStore(
+        [
+            SessionMetadataRecord(
+                session_id="session-1",
+                team_id=TeamId("personal"),
+                agent_instance_id="instance-1",
+                source_runtime_id="runtime-a",
+                user_id="admin",
+                title="Session on a since-deleted agent instance",
+            )
+        ]
+    )
+    runtime_calls: list[tuple[str, dict[str, str]]] = []
+    monkeypatch.setattr(
+        "control_plane_backend.sessions.erasure_service.httpx.AsyncClient",
+        _make_runtime_client(runtime_calls),
+    )
+    deps = _build_erasure_deps(
+        session_store,
+        _FakeSessionAttachmentStore([]),
+        # The agent instance is gone (unenrolled) — empty store, exactly like
+        # a real deleted instance: `get_for_team` returns None.
+        agent_instance_store=_FakeAgentInstanceStore([]),
+        configuration=_runtime_config(runtime_id="runtime-a"),
+    )
+    receipt = await ConversationErasureService(deps).erase_session(
+        team_id=TeamId("personal"),
+        session_id="session-1",
+        user_id="admin",
+        authorization="Bearer test-token",
+    )
+
+    # The runtime WAS resolved (from the session's stored source_runtime_id)
+    # and its checkpoint/history WERE actually purged — not just skipped.
+    assert len(runtime_calls) == 2
+    by_store = {r.store: r for r in receipt.stores}
+    assert by_store["runtime_checkpoint"].ok is True
+    assert by_store["runtime_history"].ok is True
+    assert by_store["session_metadata"].ok is True
+    assert receipt.ok is True
+    # Convergence: the erase actually completes and the row is gone — this is
+    # the part that never happened before the fix (it retried forever).
+    assert session_store._records == []
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -847,11 +847,13 @@
           "actions": "Actions"
         },
         "enabledTeams": {
-          "teams": "{{count}} team(s)",
+          "teams_one": "{{count}} team",
+          "teams_other": "{{count}} teams",
           "inheritedHint": "Enabled for all teams by default. Teams that opted out are already subtracted.",
           "unknown": "Unknown",
           "unknownHint": "Enabled for all teams by default, but the team directory is unavailable so the exact count cannot be resolved.",
-          "personal": "{{count}} personal space(s)",
+          "personal_one": "{{count}} personal space",
+          "personal_other": "{{count}} personal spaces",
           "personalUnknown": "personal spaces"
         },
         "health": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -847,11 +847,13 @@
           "actions": "Actions"
         },
         "enabledTeams": {
-          "teams": "{{count}} équipe(s)",
+          "teams_one": "{{count}} équipe",
+          "teams_other": "{{count}} équipes",
           "inheritedHint": "Activée par défaut pour toutes les équipes. Les équipes qui s'en sont exclues sont déjà déduites.",
           "unknown": "Inconnu",
           "unknownHint": "Activée par défaut pour toutes les équipes, mais l'annuaire des équipes est indisponible : le nombre exact ne peut pas être déterminé.",
-          "personal": "{{count}} espace(s) personnel(s)",
+          "personal_one": "{{count}} espace personnel",
+          "personal_other": "{{count}} espaces personnels",
           "personalUnknown": "espaces personnels"
         },
         "health": {

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.module.css
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.module.css
@@ -88,23 +88,40 @@
   font: var(--font-label-small);
 }
 
+/* Pill badge — same visual language as the team-role chips
+ * (TeamSettingsMembersTable's .roleChip): outlined pill, label-small type.
+ * Static here (no hover/active state) since these are counts, not controls. */
 .count {
-  color: var(--on-surface);
-  font: var(--font-body-medium);
+  border: 0.5px solid var(--outline-variant);
+  border-radius: 999px;
+  background: var(--surface-container-highest);
+  padding: var(--spacing-3xs) var(--spacing-xs);
+  color: var(--on-surface-retreat);
+  font: var(--font-label-small);
+  white-space: nowrap;
 }
 
 /* Team reach and personal-space reach are different denominators, so they get
- * one line each rather than an inline "A + B" that reads as a single count. */
+ * their own badge each rather than an inline "A + B" that reads as a single
+ * count. Row, not a column stack, so the two short badges sit side by side.
+ * `nowrap` + the column's widened `1.6fr` (CapabilitiesPage.tsx) keep them on
+ * one line instead of falling back to a two-line stack. */
 .countStack {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
+  gap: var(--spacing-3xs);
 }
 
 /* Muted like the neutral health cell: this is an absent value, not a number. */
 .countUnknown {
+  border: 0.5px solid var(--outline-variant);
+  border-radius: 999px;
+  background: var(--surface-container-highest);
+  padding: var(--spacing-3xs) var(--spacing-xs);
   color: var(--on-surface-muted);
-  font: var(--font-body-medium);
+  font: var(--font-label-small);
+  white-space: nowrap;
 }
 
 /* The DataTable cell is a left-aligning flex row, so cell content sits hard

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
@@ -209,7 +209,9 @@ export default function CapabilitiesPage() {
     },
     {
       label: t("rework.admin.capabilities.col.enabledTeams"),
-      size: "1fr",
+      // Wider than the other 1fr columns: the two reach badges (teams,
+      // personal spaces) need to sit side by side on one line, not wrap.
+      size: "1.6fr",
       cellRenderer: (cap) => {
         const count = enabledTeamCount(cap);
         const personal = personalSpaceCount(cap);

--- a/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { PropsWithChildren, ReactNode, useEffect, useId, useRef } from "react";
+import { PropsWithChildren, ReactNode, useCallback, useEffect, useId, useRef } from "react";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { useInlineDrawerResize } from "./useInlineDrawerResize";
 import styles from "./InlineDrawer.module.css";
@@ -87,19 +87,34 @@ export function InlineDrawer({
       ? `min(${width}, 45vw)`
       : width;
 
+  // Blur before telling the host to close: closing sets aria-hidden={true} on
+  // `aside` (below), and if the currently focused element is still inside it
+  // at that point, the browser blocks the aria-hidden change and logs
+  // "Blocked aria-hidden on an element because its descendant retained
+  // focus." Blurring synchronously, before `onClose` triggers the state
+  // update, guarantees focus has already left the subtree by the time React
+  // commits `aria-hidden="true"`.
+  const handleClose = useCallback(() => {
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && drawerRef.current?.contains(active)) {
+      active.blur();
+    }
+    onClose();
+  }, [onClose]);
+
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") handleClose();
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [open, onClose]);
+  }, [open, handleClose]);
 
   return (
     <>
       {layout === "overlay" && (
-        <div className={styles.backdrop} data-open={open} aria-hidden={!open} onClick={onClose} />
+        <div className={styles.backdrop} data-open={open} aria-hidden={!open} onClick={handleClose} />
       )}
       <aside
         ref={drawerRef}
@@ -133,7 +148,7 @@ export function InlineDrawer({
                 size="small"
                 icon={{ category: "outlined", type: "close" }}
                 aria-label="Close panel"
-                onClick={onClose}
+                onClick={handleClose}
               />
             </div>
           </div>

--- a/apps/frontend/src/rework/components/shared/molecules/PieChart/PieChart.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/PieChart/PieChart.module.scss
@@ -14,6 +14,8 @@
   flex: 1;
   justify-content: center;
   align-items: center;
+  width: 100%;
+  max-width: 320px;
 }
 
 .header {

--- a/apps/frontend/src/rework/components/shared/molecules/PieChart/PieChart.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PieChart/PieChart.tsx
@@ -59,7 +59,7 @@ export default function PieChart({ title, rows, emptyMessage, isLoading, isError
 
       {!!rows.length && (
         <div className={styles.chartArea}>
-          <ResponsiveContainer width={320} height={220}>
+          <ResponsiveContainer width="100%" height={220}>
             <RechartsPieChart>
               <Pie data={rows} dataKey="value" nameKey="label" cx="50%" cy="50%" outerRadius={80} strokeWidth={0}>
                 {rows.map((_, i) => (

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
@@ -93,8 +93,9 @@ export function RichInputField({
   const resize = () => {
     const el = textareaRef.current;
     if (!el) return;
+    const preCollapseScrollTop = el.scrollTop;
     el.style.height = "auto";
-    const overflowing = el.scrollHeight >= maxHeight;
+    const overflowing = el.scrollHeight > maxHeight;
     el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
     el.style.overflowY = overflowing ? "auto" : "hidden";
     // Collapsing to "auto" above shrinks the box for one tick; while it's
@@ -103,9 +104,12 @@ export function RichInputField({
     // height. Restoring the real height never resets it, so a paste or long
     // line leaves the box permanently scrolled a few pixels down — with
     // overflow hidden that reads as the top of the text being clipped, not
-    // scrollable. Force it back: 0 when everything fits, scrolled to the
-    // caret's end when the content exceeds maxHeight.
-    el.scrollTop = overflowing ? el.scrollHeight : 0;
+    // scrollable. When everything fits there's nothing to scroll, so 0 is
+    // always correct. When it overflows, forcing scrollHeight (the bottom)
+    // on every keystroke fights the user editing earlier in the draft — restore
+    // the scrollTop captured before the collapse instead, so the view only
+    // moves when the browser's own caret-follow would have moved it anyway.
+    el.scrollTop = overflowing ? preCollapseScrollTop : 0;
   };
 
   // Reset height when value is cleared externally.

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
@@ -94,9 +94,18 @@ export function RichInputField({
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    const next = Math.min(el.scrollHeight, maxHeight);
-    el.style.height = `${next}px`;
-    el.style.overflowY = next >= maxHeight ? "auto" : "hidden";
+    const overflowing = el.scrollHeight >= maxHeight;
+    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    el.style.overflowY = overflowing ? "auto" : "hidden";
+    // Collapsing to "auto" above shrinks the box for one tick; while it's
+    // shrunk, the browser's native caret-follow can assign scrollTop a
+    // nonzero value to keep the caret in view against that tiny transient
+    // height. Restoring the real height never resets it, so a paste or long
+    // line leaves the box permanently scrolled a few pixels down — with
+    // overflow hidden that reads as the top of the text being clipped, not
+    // scrollable. Force it back: 0 when everything fits, scrolled to the
+    // caret's end when the content exceeds maxHeight.
+    el.scrollTop = overflowing ? el.scrollHeight : 0;
   };
 
   // Reset height when value is cleared externally.
@@ -106,6 +115,7 @@ export function RichInputField({
       if (el) {
         el.style.height = "auto";
         el.style.overflowY = "hidden";
+        el.scrollTop = 0;
       }
     }
   }, [value]);

--- a/apps/knowledge-flow-backend/config/configuration_prod.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_prod.yaml
@@ -239,7 +239,13 @@ security:
   user:
     enabled: true
     client_id: "app"
-    realm_url: "http://app-keycloak:8080/realms/app"
+    # Must be browser-reachable: tokens validated here are issued client-side
+    # by keycloak-js against this same URL, so it must match the browser's
+    # issuer exactly (soft "JWT issuer mismatch" warning otherwise, oidc.py).
+    # "app-keycloak" only resolves inside the docker-compose network.
+    # security.m2m.realm_url above stays docker-internal (backend-to-Keycloak only).
+    # Mirrors control-plane-backend/config/configuration_prod.yaml's split.
+    realm_url: "http://localhost:8080/realms/app"
   authorized_origins:
     - "http://localhost:5173"
   rebac:

--- a/docs/swift/data/id-legend.yaml
+++ b/docs/swift/data/id-legend.yaml
@@ -1249,6 +1249,12 @@ items:
       additive DOC-RENAME and DOC-TAGS document features.
       Deferred follow-ups (not in 2.0.2): member-removal task emission; real-conversation
       evaluation execution + cancel; evaluation authz gap (EVAL-01).
+      2026-07-24 bug fix (RFC §7, issue #2089): deleting an agent instance permanently
+      blocked erasure of any session that had used it — runtime resolution depended solely
+      on the (now-deleted) agent_instance row, so the checkpoint/history erase failed forever
+      and the purge queue retried without ever converging (visibly flagged `stalled` after 5
+      attempts, but never actually erased). Fixed by capturing source_runtime_id on
+      session_metadata at create_session time so resolution survives instance deletion.
 
   - id: CTRLP-13
     title: "RGPD lifecycle completion — observable erasure for member removal + idle expiry"

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -465,6 +465,13 @@ Will contain: session title (user-editable or auto-generated), creation timestam
 
 Session metadata is created by control-plane at `prepare-execution` time or on first turn. It is never stored in `fred-runtime`.
 
+`session_metadata` also carries an internal-only `source_runtime_id` (captured from the
+agent instance at `create_session` time, immutable, never returned by any API model). It
+lets `ConversationErasureService` resolve the owning runtime for checkpoint/history erasure
+even after the session's `agent_instance_id` row is later deleted — resolving solely through
+the live instance row let an agent-instance deletion permanently block erasure of any session
+that had used it (issue #2089, `FRED-2.0.2-RGPD-READY-RFC.md` §7).
+
 Until control-plane session metadata is implemented, the sidebar omits session listing. The intentional placeholder (no session list in sidebar) is acceptable. Adding a session list before the backend is ready is not.
 
 **Checkpoint State — owned by `fred-runtime` checkpointer**

--- a/docs/swift/rfc/FRED-2.0.2-RGPD-READY-RFC.md
+++ b/docs/swift/rfc/FRED-2.0.2-RGPD-READY-RFC.md
@@ -232,3 +232,70 @@ No schema change is required: `ErasureReason` already enumerates
 Team-wide deletion and bulk conversation deletion remain out of scope (no such flow exists).
 Evaluation-side deferrals (real-conversation execution + cancel, evaluation authz) remain
 tracked under EVAL-01/EVAL-03, not here.
+
+---
+
+## 7. Amendment — runtime resolution survives agent-instance deletion (bug fix)
+
+**Status:** shipped 2026-07-24. Found live via the `live-observability-session` skill
+(issue #2089), not a regression on this branch — present since 2.0.2 shipped.
+
+### 7.1 Problem
+
+DoD-1 promises erasure is retry-safe and converges: "no store is left orphaned and no queue
+entry is stuck." That promise silently broke for one path: `DELETE
+/teams/{team_id}/agent-instances/{id}` is an unconditional local metadata delete (§3 "unbinding
+is a local metadata deletion rather than a runtime call") — it does not check for sessions still
+referencing the instance, and never touches the runtime's checkpoint/history stores.
+`ConversationErasureService._resolve_runtime_base_url` resolved a session's runtime **only** by
+re-reading the agent instance row live (`get_for_team(agent_instance_id, team_id)`) to recover
+its `source_runtime_id`. Once the instance is deleted, that lookup returns `None` forever — a
+*permanent* condition — but the erasure fan-out treated it like any other (potentially
+transient) resolution error: `runtime_checkpoint`/`runtime_history` erasure fails,
+`receipt.ok` never becomes `True`, and per §2.1 the `session_metadata` row (and every other
+already-erased store's guarantee) is retained so the erase stays "retryable." The retry is real
+(`LifecycleManagerWorkflow` reschedules every 10 minutes, §3) and visibly escalates to a
+`stalled` task after `ERASURE_STALL_AFTER_ATTEMPTS` (5) attempts — so an admin does eventually
+see it flagged — but nothing in the retry path can ever re-resolve the runtime, so the erasure
+never actually converges and the flagged item never clears. Reproduced live twice: delete an
+agent instance, delete a conversation that used it, erase always comes back incomplete.
+
+Confirmed the runtime-side checkpoint/history data is not torn down by instance deletion either
+— `unenroll_agent_instance` never calls the runtime — so this is a genuine, permanent data leak
+against the RGPD guarantee, not a cosmetic retry-count issue.
+
+### 7.2 Fix
+
+The failure was never really "the runtime is unresolvable" — `source_runtime_id` names a
+platform-config-level runtime catalog entry (`runtime_catalog_sources`), not a property of the
+instance row itself, and it is immutable after instance creation (`update_agent_instance` never
+changes it). The only thing that made resolution fail permanently was routing it exclusively
+through a row that a later, unrelated action (instance deletion) is allowed to delete.
+
+**`session_metadata` gains a nullable `source_runtime_id` column**, captured once at
+`create_session` time by resolving the (then-certainly-live) agent instance, alongside the
+existing `agent_instance_id`. `_resolve_runtime_base_url` now resolves the runtime source **from
+the session's own stored `source_runtime_id` when present**, falling back to the live
+agent-instance lookup only for pre-migration rows that predate the column. Runtime resolution no
+longer depends on the agent-instance row surviving the conversation's own lifetime — deleting an
+instance can no longer orphan erasure for sessions that used it. "Unresolved runtime" now means
+what §2.1/A0 always intended it to mean: the runtime *source itself* (the config entry) is gone
+or disabled — a real, rare, still-permanent-and-still-reported condition — never "some unrelated
+row got deleted."
+
+This is additive and backward compatible: existing rows get `source_runtime_id = NULL` and keep
+today's (already-broken, pre-existing) behavior for instances deleted *before* this migration
+ships — those are unrecoverable regardless of fix shape, since the instance→source mapping is
+already gone. The migration backfills `source_runtime_id` for every row whose `agent_instance_id`
+still resolves to a live instance at migration time, closing the gap retroactively wherever
+possible.
+
+Deliberately not pursued: relocating the runtime delete into `unenroll_agent_instance` (cascade
+at delete time, candidate (b) considered) — it would add synchronous multi-session fan-out to a
+delete endpoint and a race against concurrent session erasure, for no benefit once resolution no
+longer depends on the instance row. Also not pursued: treating an unresolved runtime as
+already-erased (candidate (a)) — verified live that the runtime-side rows are not torn down by
+instance deletion, so that path would have silently converted a visible, retryable leak into an
+invisible, permanent one. The existing `ERASURE_STALL_AFTER_ATTEMPTS` visibility escalation
+(§6-adjacent, `erasure_tasks.py`) stays as-is — it already does its one job (surface a wedged
+fan-out to an admin); this fix is what lets the retry it flags actually succeed.


### PR DESCRIPTION
## Summary

Fixes found and verified live during a 2026-07-24 observability session (full Fred stack + fred-agent-evaluator + fred-samples), tracked on #2089, plus a batch of small frontend fixes landed on the same branch in parallel.

**Backend / observability fixes (closes #2089):**
- `fix: split knowledge-flow-backend user/m2m Keycloak realm_url` — mirrors control-plane-backend's existing split; fixes a soft `[AUTH] JWT issuer mismatch` warning firing on every authenticated frontend request.
- `perf(CTRLP): parallelize GET /admin/capabilities read fan-out` — collapses an unparallelized 5-lookups-per-capability × 33-capability sequential fan-out plus a duplicate pod-template HTTP fetch; ~570ms → ~230-340ms, verified live pre/post-restart.
- `fix(CTRLP-12): survive agent-instance deletion during conversation erasure` — `session_metadata.source_runtime_id` is now captured at session-creation time (new nullable column + migration `a5b6c7d8e9f0`) instead of re-resolved live from the (possibly now-deleted) agent-instance row, so erasure of a conversation no longer gets stuck retrying forever once its agent instance is deleted. New RFC amendment: `FRED-2.0.2-RGPD-READY-RFC.md` §7.

**Frontend fixes:**
- `fix(FRONT): reset composer scrollTop after auto-grow` — fixes clipped/hidden chat-composer text.
- `fix(FRONT): blur focus before InlineDrawer sets aria-hidden on close` — accessibility fix, avoids focusing a hidden element.
- `fix(FRONT): render Admin Capabilities enabled-teams reach as badges` — UI clarity fix on the admin capabilities page.
- `fix(FRONT): stop hardcoding PieChart ResponsiveContainer width/height` — makes the PieChart component responsive.

**Remaining open items from the same session** (design decisions, not included here — tracked separately on #2092):
- ReBAC audit-noise on `GET /teams` (`authz.relation.granted` re-emitted on every listing, not just on real grants)
- No dedicated audit-log entry for agent-instance deletion
- `ContextVar`/`GeneratorExit` bug in the shared `fred_runtime.react.react_runtime` library (found on a fred-samples ReAct sub-agent)

## Test plan

- [x] `make test` — 504 passed (apps/control-plane-backend), including 3 new tests (`test_erase_session_survives_agent_instance_deletion` and others)
- [x] `make code-quality` clean
- [x] Live-verified all three backend fixes against the running dev stack (JWT warning gone, `/admin/capabilities` latency confirmed dropped post-restart, erasure fix confirmed to apply to new sessions — pre-existing orphaned test rows remain stuck by design, no backfill source available)
- [x] Frontend fixes: manual browser verification pending (developer to confirm)

Closes #2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)