### PR TITLE
fix: improve banner text legibility over custom banner images

### DIFF
--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -10,6 +10,7 @@
  * Height matches MarketplaceNavbar (56px) so switching contexts doesn't jump. */
 .bannerContainer {
   display: flex;
+  position: relative;
   align-items: flex-end;
   border-radius: 0 0 var(--radius-s) var(--radius-s);
   background-position: center;
@@ -18,12 +19,34 @@
   height: 56px;
 }
 
+/* Legibility scrim: a subtle dark gradient rising from the bottom edge keeps
+ * the white banner text and icons readable over light or busy custom banner
+ * images (`banner_image_url`), while barely dimming the darker brand-gradient
+ * fallback. Anchored to the bottom so it only touches the strip where the
+ * team name sits, leaving the top of the image clean. */
+.bannerContainer::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.2) 45%, transparent 75%);
+  pointer-events: none;
+  content: "";
+}
+
 .teamNameContainer {
   display: flex;
+  position: relative;
   justify-content: space-between;
   align-items: end;
+  z-index: 1;
   width: 100%;
   font: var(--font-title-medium);
+}
+
+/* Small drop shadow on the team name, on top of the scrim, so the white text
+ * stays crisp even against a light patch of a custom banner image. */
+.teamName {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
 }
 
 .navigationContainer {

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -7,7 +7,9 @@
 }
 
 /* Background and text colour are set inline from the configured team asset.
- * Height matches MarketplaceNavbar (56px) so switching contexts doesn't jump. */
+ * The team banner is intentionally taller than the marketplace/admin headers
+ * (88px vs 56px) to give the team identity more presence — matching the
+ * original design. */
 .bannerContainer {
   display: flex;
   position: relative;
@@ -16,7 +18,7 @@
   background-position: center;
   background-size: cover;
   padding: 0 var(--spacing-xs) var(--spacing-xs) var(--spacing-s);
-  height: 56px;
+  height: 88px;
 }
 
 /* Legibility scrim: a subtle dark gradient rising from the bottom edge keeps


### PR DESCRIPTION
Closes #2097

## Problem

The team/space banner (`TeamContentNavbar`) renders the team name and action icons in **white** (`bannerColor.onSolid`). When a team sets a custom `banner_image_url` whose lower edge is light or busy, the white text sits on a light background and becomes unreadable — e.g. "Espace personnel" disappears over a light-purple custom banner.

## Fix

CSS-only change in `TeamContentNavbar.module.scss`:

- **Bottom scrim** — a `::before` pseudo-element with a dark gradient rising from the bottom edge (`rgba(0,0,0,0.5)` → transparent at 75%). It darkens only the strip where the text sits, leaving the top of the custom image clean and barely touching the darker brand-gradient fallback. This is what guarantees legibility over *any* uploaded image.
- **Text-shadow** — `0 1px 3px rgba(0,0,0,0.55)` on the team name for extra crispness on top of the scrim.
- `.teamNameContainer` gets `position: relative; z-index: 1` so text/icons layer above the scrim.

No TSX, API, contract, or generated-client changes.

## Verification

`cd apps/frontend && make code-quality` — tsc + prettier + eslint all pass.