### PR TITLE
Agent card: more-menu, Duplicate, and rich info tooltip

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -930,7 +930,41 @@
       "edit": "Edit",
       "noDescription": "No description yet.",
       "suspended": "Suspended — a capability this agent uses is broken or unavailable. Edit the agent to fix it.",
-      "suspendedToggleLocked": "This agent is suspended. Fix its capabilities in the edit form before re-enabling it."
+      "suspendedToggleLocked": "This agent is suspended. Fix its capabilities in the edit form before re-enabling it.",
+      "duplicate": "Duplicate",
+      "delete": "Delete",
+      "tooltip": {
+        "label": "Agent details",
+        "origin": "Origin",
+        "template": "Template",
+        "created": "Created",
+        "updated": "Last update"
+      },
+      "duplicateDialog": {
+        "title": "Duplicate this agent",
+        "nameLabel": "New agent name",
+        "cancel": "Cancel",
+        "confirm": "Duplicate"
+      },
+      "deleteDialog": {
+        "title": "Delete this agent?",
+        "message": "\"{{name}}\" will be permanently removed from this team. This action is irreversible.",
+        "confirm": "Delete",
+        "cancel": "Cancel"
+      },
+      "duplicateSuccess": "{{agent}} duplicated",
+      "duplicateError": "Failed to duplicate the {{agent}}",
+      "deleteSuccess": "{{agent}} deleted",
+      "deleteError": "Failed to delete the {{agent}}",
+      "createSuccess": "{{agent}} created",
+      "createError": "Failed to create the {{agent}}",
+      "updateSuccess": "{{agent}} updated",
+      "updateError": "Failed to update the {{agent}}",
+      "statusEnabled": "enabled",
+      "statusDisabled": "disabled",
+      "toggleSuccess": "{{agent}} {{status}}",
+      "unexpectedError": "An unexpected error occurred.",
+      "missingTeamId": "Missing team id in route."
     },
     "analytics": {
       "activeUsers": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -930,7 +930,41 @@
       "edit": "Modifier",
       "noDescription": "Pas encore de description.",
       "suspended": "Suspendu — une capacité utilisée par cet agent est défectueuse ou indisponible. Modifiez l'agent pour corriger le problème.",
-      "suspendedToggleLocked": "Cet agent est suspendu. Corrigez ses capacités dans le formulaire d'édition avant de le réactiver."
+      "suspendedToggleLocked": "Cet agent est suspendu. Corrigez ses capacités dans le formulaire d'édition avant de le réactiver.",
+      "duplicate": "Dupliquer",
+      "delete": "Supprimer",
+      "tooltip": {
+        "label": "Détails de l'agent",
+        "origin": "Origine",
+        "template": "Template",
+        "created": "Création",
+        "updated": "Dernière MAJ"
+      },
+      "duplicateDialog": {
+        "title": "Dupliquer cet agent",
+        "nameLabel": "Nom du nouvel agent",
+        "cancel": "Annuler",
+        "confirm": "Dupliquer"
+      },
+      "deleteDialog": {
+        "title": "Supprimer cet agent ?",
+        "message": "« {{name}} » sera définitivement supprimé de cette équipe. Cette action est irréversible.",
+        "confirm": "Supprimer",
+        "cancel": "Annuler"
+      },
+      "duplicateSuccess": "{{agent}} dupliqué",
+      "duplicateError": "Échec de la duplication : {{agent}}",
+      "deleteSuccess": "{{agent}} supprimé",
+      "deleteError": "Échec de la suppression : {{agent}}",
+      "createSuccess": "{{agent}} créé",
+      "createError": "Échec de la création : {{agent}}",
+      "updateSuccess": "{{agent}} mis à jour",
+      "updateError": "Échec de la mise à jour : {{agent}}",
+      "statusEnabled": "activé",
+      "statusDisabled": "désactivé",
+      "toggleSuccess": "{{agent}} {{status}}",
+      "unexpectedError": "Une erreur inattendue s'est produite.",
+      "missingTeamId": "Identifiant d'équipe manquant dans la route."
     },
     "analytics": {
       "activeUsers": {

--- a/apps/frontend/src/rework/components/pages/PromptsPage/PromptsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/PromptsPage/PromptsPage.tsx
@@ -27,6 +27,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { getQueryUiState } from "@core/utils/queryUiState.ts";
+import { userDisplayName } from "@core/utils/userDisplayName.ts";
 import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import {
@@ -50,16 +51,6 @@ type FormState = {
   text: string;
 };
 const emptyForm: FormState = { name: "", description: "", category: "other", tags: [], text: "" };
-
-/** Human display for a resolved user: full name, else username, else the raw uid (#1952 pattern). */
-function userDisplayName(
-  uid: string,
-  summary: { first_name?: string | null; last_name?: string | null; username?: string } | undefined,
-): string {
-  if (!summary) return uid;
-  const fullName = [summary.first_name, summary.last_name].filter(Boolean).join(" ");
-  return fullName || summary.username || uid;
-}
 
 export default function PromptsPage() {
   const { teamId } = useParams<{ teamId: string }>();

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -24,9 +24,9 @@ import type {
   AgentTemplateSummary,
   ManagedAgentFieldSpec,
   ManagedAgentInstanceSummary,
-  UserSummary,
 } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
 import { useUsersByIdsQuery } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements.ts";
+import { userDisplayName } from "@core/utils/userDisplayName.ts";
 import { TuningFieldRenderer } from "./TuningFieldRenderer.tsx";
 import { CapabilityCard } from "./CapabilityCard/CapabilityCard.tsx";
 import styles from "./AgentFormBody.module.css";
@@ -54,13 +54,6 @@ function routeField(field: ManagedAgentFieldSpec): "prompts" | "settings" | "cha
   if (g === "prompts") return "prompts";
   if (g === "chat") return "chat";
   return "settings";
-}
-
-/** Human display for a resolved user: full name, else username, else the raw uid (#1952). */
-function userDisplayName(uid: string, summary: UserSummary | undefined): string {
-  if (!summary) return uid;
-  const fullName = [summary.first_name, summary.last_name].filter(Boolean).join(" ");
-  return fullName || summary.username || uid;
 }
 
 function formatRelativeDate(dateStr: string | null | undefined): string {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/DuplicateAgentDialog/DuplicateAgentDialog.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/DuplicateAgentDialog/DuplicateAgentDialog.module.css
@@ -1,0 +1,39 @@
+.overlay {
+  display: flex;
+  position: fixed;
+  justify-content: center;
+  align-items: center;
+  z-index: 1300;
+  inset: 0;
+  background-color: var(--scrim);
+}
+
+.dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  box-shadow: var(--shadow-s);
+  border-radius: var(--radius-m);
+  background-color: var(--surface-container-high);
+  width: min(400px, 90vw);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  padding: var(--spacing-m);
+}
+
+.title {
+  margin: 0;
+  color: var(--on-surface);
+  font: var(--font-title-medium);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-m) var(--spacing-m);
+}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/DuplicateAgentDialog/DuplicateAgentDialog.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/DuplicateAgentDialog/DuplicateAgentDialog.tsx
@@ -1,0 +1,103 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import Button from "@shared/atoms/Button/Button.tsx";
+import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
+import { Portal } from "@shared/utils/Portal.tsx";
+import styles from "./DuplicateAgentDialog.module.css";
+
+interface DuplicateAgentDialogProps {
+  open: boolean;
+  /** The source agent's current display name, prefilled as the starting point. */
+  initialName: string;
+  isSubmitting?: boolean;
+  onCancel: () => void;
+  onConfirm: (newName: string) => void;
+}
+
+export default function DuplicateAgentDialog({
+  open,
+  initialName,
+  isSubmitting = false,
+  onCancel,
+  onConfirm,
+}: DuplicateAgentDialogProps) {
+  const { t } = useTranslation();
+  const [name, setName] = useState(initialName);
+
+  // Reset to the source name each time the dialog reopens (e.g. for a
+  // different agent, or reopened after a cancel).
+  useEffect(() => {
+    if (open) setName(initialName);
+  }, [open, initialName]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const trimmedName = name.trim();
+  const canConfirm = trimmedName.length > 0 && !isSubmitting;
+
+  return (
+    <Portal id="modal-portal">
+      <div className={styles.overlay} onClick={onCancel}>
+        <div
+          className={styles.dialog}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="duplicate-agent-dialog-title"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className={styles.body}>
+            <p id="duplicate-agent-dialog-title" className={styles.title}>
+              {t("rework.agentCard.duplicateDialog.title")}
+            </p>
+            <TextInput
+              label={t("rework.agentCard.duplicateDialog.nameLabel")}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canConfirm) onConfirm(trimmedName);
+              }}
+            />
+          </div>
+          <div className={styles.actions}>
+            <Button color="on-surface" variant="outlined" size="medium" onClick={onCancel}>
+              {t("rework.agentCard.duplicateDialog.cancel")}
+            </Button>
+            <Button
+              color="primary"
+              variant="filled"
+              size="medium"
+              disabled={!canConfirm}
+              onClick={() => onConfirm(trimmedName)}
+            >
+              {t("rework.agentCard.duplicateDialog.confirm")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -23,9 +23,16 @@ import { useFrontendBootstrap } from "../../../../hooks/useFrontendBootstrap.ts"
 import { useFrontendProperties } from "../../../../hooks/useFrontendProperties.ts";
 import { useGetTeamQuery } from "../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
-import { type AgentFormPayload, default as AgentFormModal } from "./AgentFormModal/AgentFormModal.tsx";
+import {
+  type AgentFormPayload,
+  buildAgentFormSubmitPayload,
+  extractCapabilityConfigValues,
+  default as AgentFormModal,
+} from "./AgentFormModal/AgentFormModal.tsx";
+import DuplicateAgentDialog from "./DuplicateAgentDialog/DuplicateAgentDialog.tsx";
 import TeamAgentEmptyState from "./TeamAgentEmptyState/TeamAgentEmptyState.tsx";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice.tsx";
+import { useUsersByIdsQuery } from "../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import {
   type CreateAgentInstanceRequest,
   type ManagedAgentInstanceSummary,
@@ -69,7 +76,9 @@ function buildAgentSaveFormData(
 const hasAssetFiles = (assetFiles: Record<string, Record<string, File>>): boolean =>
   Object.values(assetFiles).some((slots) => Object.keys(slots).length > 0);
 
-function extractApiErrorDetail(error: unknown): string {
+/** Returns undefined (rather than a hardcoded fallback string) when no usable
+ *  detail is found — callers supply their own translated fallback. */
+function extractApiErrorDetail(error: unknown): string | undefined {
   if (typeof error !== "object" || error === null) return String(error);
   const data = (error as Record<string, unknown>).data;
   if (typeof data === "object" && data !== null) {
@@ -86,7 +95,7 @@ function extractApiErrorDetail(error: unknown): string {
     }
   }
   const msg = (error as Record<string, unknown>).message;
-  return typeof msg === "string" ? msg : "An unexpected error occurred.";
+  return typeof msg === "string" ? msg : undefined;
 }
 
 /**
@@ -107,6 +116,7 @@ export default function TeamAgentsPage() {
   const isPersonalTeam = teamId === activeTeam?.id;
   const [isEnrollOpen, setIsEnrollOpen] = useState(false);
   const [editingInstance, setEditingInstance] = useState<ManagedAgentInstanceSummary | null>(null);
+  const [duplicatingInstance, setDuplicatingInstance] = useState<ManagedAgentInstanceSummary | null>(null);
 
   const { data: fetchedTeam } = useGetTeamQuery({ teamId: teamId || "" }, { skip: !teamId || isPersonalTeam });
   const team = isPersonalTeam ? activeTeam : fetchedTeam;
@@ -130,6 +140,18 @@ export default function TeamAgentsPage() {
     { teamId: teamId || "" },
     { skip: !teamId || !canManageAgents },
   );
+
+  // Batched once for the whole list (not one query per card, #2096) — the
+  // agent card's info tooltip shows created_by/updated_by display names.
+  const auditUids = Array.from(
+    new Set(
+      managedInstances
+        .flatMap((instance) => [instance.created_by, instance.updated_by])
+        .filter((uid): uid is string => Boolean(uid)),
+    ),
+  );
+  const { data: auditUsers = [] } = useUsersByIdsQuery({ ids: auditUids }, { skip: auditUids.length === 0 });
+  const auditUserById = new Map(auditUsers.map((summary) => [summary.id, summary]));
 
   const [createManagedInstance, { isLoading: isCreatingInstance }] =
     usePostTeamAgentInstanceControlPlaneV1TeamsTeamIdAgentInstancesPostMutation();
@@ -173,13 +195,13 @@ export default function TeamAgentsPage() {
       } else {
         await createManagedInstance({ teamId, createAgentInstanceRequest: request }).unwrap();
       }
-      showSuccess({ summary: `${agentsNicknameSingular} created` });
+      showSuccess({ summary: t("rework.agentCard.createSuccess", { agent: agentsNicknameSingular }) });
       setIsEnrollOpen(false);
       await refetchInstances();
     } catch (error: unknown) {
       showError({
-        summary: `Failed to create ${agentsNicknameSingular.toLowerCase()}`,
-        detail: extractApiErrorDetail(error),
+        summary: t("rework.agentCard.createError", { agent: agentsNicknameSingular.toLowerCase() }),
+        detail: extractApiErrorDetail(error) ?? t("rework.agentCard.unexpectedError"),
       });
     }
   };
@@ -217,13 +239,13 @@ export default function TeamAgentsPage() {
           updateAgentInstanceRequest: request,
         }).unwrap();
       }
-      showSuccess({ summary: `${agentsNicknameSingular} updated` });
+      showSuccess({ summary: t("rework.agentCard.updateSuccess", { agent: agentsNicknameSingular }) });
       setEditingInstance(null);
       await refetchInstances();
     } catch (error: unknown) {
       showError({
-        summary: `Failed to update ${agentsNicknameSingular.toLowerCase()}`,
-        detail: extractApiErrorDetail(error),
+        summary: t("rework.agentCard.updateError", { agent: agentsNicknameSingular.toLowerCase() }),
+        detail: extractApiErrorDetail(error) ?? t("rework.agentCard.unexpectedError"),
       });
     }
   };
@@ -237,13 +259,69 @@ export default function TeamAgentsPage() {
         agentInstanceId: instance.agent_instance_id,
         updateAgentInstanceRequest: { status: newStatus },
       }).unwrap();
-      showSuccess({ summary: `${agentsNicknameSingular} ${newStatus}` });
+      const statusLabel = t(
+        newStatus === "enabled" ? "rework.agentCard.statusEnabled" : "rework.agentCard.statusDisabled",
+      );
+      showSuccess({
+        summary: t("rework.agentCard.toggleSuccess", { agent: agentsNicknameSingular, status: statusLabel }),
+      });
       await refetchInstances();
     } catch (error: unknown) {
       const err = error as { data?: { detail?: string }; message?: string };
       showError({
-        summary: `Failed to update ${agentsNicknameSingular.toLowerCase()}`,
+        summary: t("rework.agentCard.updateError", { agent: agentsNicknameSingular.toLowerCase() }),
         detail: err?.data?.detail || err?.message || String(error),
+      });
+    }
+  };
+
+  const handleDuplicate = async (source: ManagedAgentInstanceSummary, newName: string) => {
+    if (!teamId) return;
+    const template = availableTemplates.find((tpl) => tpl.template_id === source.template_id);
+    // Reuse the same payload-building as the normal enroll form (#2096) —
+    // correct capability filtering against the current template state —
+    // rather than hand-rebuilding a parallel, easier-to-get-subtly-wrong
+    // CreateAgentInstanceRequest straight from the source instance's stored
+    // fields. Not reusing `handleEnroll` itself: it always closes/resets the
+    // *enroll* modal's own state, which is wrong for the duplicate dialog.
+    const payload = buildAgentFormSubmitPayload(
+      {
+        templateId: source.template_id,
+        displayName: newName,
+        role: source.role,
+        description: source.description ?? "",
+        tuningValues: (source.tuning_field_values as Record<string, unknown>) ?? {},
+        selectedCapabilityIds: source.selected_capability_ids ?? [],
+        capabilityConfigValues: extractCapabilityConfigValues(source.capability_config),
+        capabilityAssetFiles: {},
+        capabilityBlockingErrors: {},
+      },
+      template,
+    );
+    const request: CreateAgentInstanceRequest = {
+      template_id: payload.templateId,
+      display_name: payload.displayName,
+      role: payload.role || undefined,
+      description: payload.description || undefined,
+      tuning_field_values:
+        Object.keys(payload.tuningFieldValues).length > 0
+          ? (payload.tuningFieldValues as AgentRequestTuningFieldValues)
+          : undefined,
+      capability_ids: payload.templateHasCapabilities ? payload.selectedCapabilityIds : undefined,
+      capability_config_values:
+        payload.templateHasCapabilities && Object.keys(payload.capabilityConfigValues).length > 0
+          ? (payload.capabilityConfigValues as AgentRequestCapabilityConfigValues)
+          : undefined,
+    };
+    try {
+      await createManagedInstance({ teamId, createAgentInstanceRequest: request }).unwrap();
+      showSuccess({ summary: t("rework.agentCard.duplicateSuccess", { agent: agentsNicknameSingular }) });
+      setDuplicatingInstance(null);
+      await refetchInstances();
+    } catch (error: unknown) {
+      showError({
+        summary: t("rework.agentCard.duplicateError", { agent: agentsNicknameSingular.toLowerCase() }),
+        detail: extractApiErrorDetail(error) ?? t("rework.agentCard.unexpectedError"),
       });
     }
   };
@@ -252,21 +330,28 @@ export default function TeamAgentsPage() {
     if (!teamId) return;
     showConfirmationDialog({
       criticalAction: true,
-      title: `Delete ${agentsNicknameSingular.toLowerCase()}?`,
-      message: `Remove "${instance.display_name}" from this team?`,
+      title: t("rework.agentCard.deleteDialog.title"),
+      message: t("rework.agentCard.deleteDialog.message", { name: instance.display_name }),
+      confirmButtonLabel: t("rework.agentCard.deleteDialog.confirm"),
+      cancelButtonLabel: t("rework.agentCard.deleteDialog.cancel"),
+      // Same inverted emphasis as "Leave team" — Cancel stays the visually
+      // dominant filled button, Delete drops to a low-emphasis text button.
+      cancelVariant: "filled",
+      cancelColor: "primary",
+      confirmVariant: "text",
       onConfirm: async () => {
         try {
           await deleteManagedInstance({
             teamId,
             agentInstanceId: instance.agent_instance_id,
           }).unwrap();
-          showSuccess({ summary: `${agentsNicknameSingular} deleted` });
+          showSuccess({ summary: t("rework.agentCard.deleteSuccess", { agent: agentsNicknameSingular }) });
           setEditingInstance(null);
           await refetchInstances();
         } catch (error: unknown) {
           const err = error as { data?: { detail?: string }; message?: string };
           showError({
-            summary: `Failed to delete ${agentsNicknameSingular.toLowerCase()}`,
+            summary: t("rework.agentCard.deleteError", { agent: agentsNicknameSingular.toLowerCase() }),
             detail: err?.data?.detail || err?.message || String(error),
           });
         }
@@ -275,7 +360,7 @@ export default function TeamAgentsPage() {
   };
 
   if (!teamId) {
-    return <div className={styles.pageError}>Missing team id in route.</div>;
+    return <div className={styles.pageError}>{t("rework.agentCard.missingTeamId")}</div>;
   }
 
   const isControlPlaneUnavailable =
@@ -352,8 +437,11 @@ export default function TeamAgentsPage() {
                   teamId={teamId}
                   canManageAgents={canManageAgents}
                   offline={templatesUnavailable}
+                  auditUserById={auditUserById}
                   onEdit={() => setEditingInstance(instance)}
                   onToggleEnabled={() => handleToggleEnabled(instance)}
+                  onDuplicate={() => setDuplicatingInstance(instance)}
+                  onDelete={() => handleDelete(instance)}
                 />
               );
             })}
@@ -379,6 +467,16 @@ export default function TeamAgentsPage() {
         }}
         onSubmit={editingInstance ? handleEdit : handleEnroll}
         onDelete={editingInstance ? () => handleDelete(editingInstance) : undefined}
+      />
+
+      <DuplicateAgentDialog
+        open={duplicatingInstance !== null}
+        initialName={duplicatingInstance?.display_name ?? ""}
+        isSubmitting={isCreatingInstance}
+        onCancel={() => setDuplicatingInstance(null)}
+        onConfirm={(newName) => {
+          if (duplicatingInstance) void handleDuplicate(duplicatingInstance, newName);
+        }}
       />
     </div>
   );

--- a/apps/frontend/src/rework/components/shared/atoms/MenuItem/MenuItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/MenuItem/MenuItem.module.scss
@@ -23,6 +23,15 @@
     --item-color: var(--on-surface-disabled);
     --item-bg: var(--state-surface-main-disabled);
   }
+
+  &[data-destructive="true"]:not([data-disabled="true"]) {
+    --item-color: var(--error);
+
+    &[data-focused="true"],
+    &:hover {
+      --item-bg: var(--state-error-hover);
+    }
+  }
 }
 
 .state-layer {

--- a/apps/frontend/src/rework/components/shared/atoms/MenuItem/MenuItem.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/MenuItem/MenuItem.tsx
@@ -25,6 +25,8 @@ export interface MenuItemProps extends ComponentPropsWithRef<"li"> {
   selected?: boolean;
   focused?: boolean;
   disabled?: boolean;
+  /** Renders the label/icon in the error color (e.g. a "Delete" action). */
+  destructive?: boolean;
 }
 
 function MenuItem({
@@ -36,6 +38,7 @@ function MenuItem({
   selected = false,
   focused = false,
   disabled = false,
+  destructive = false,
   onClick,
   id: providedId,
   ref, // La ref arrive ici
@@ -56,6 +59,7 @@ function MenuItem({
       data-selected={selected}
       data-focused={focused}
       data-disabled={disabled}
+      data-destructive={destructive}
       tabIndex={focused ? 0 : -1}
       onClick={disabled ? undefined : onClick}
     >

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.module.scss
@@ -29,3 +29,12 @@
   visibility: visible;
   opacity: 1;
 }
+
+/* Rich content (e.g. a multi-row info panel) sizes to its own content instead
+ * of hugging a single nowrap line, and drops the small text-hint padding —
+ * the content itself owns its internal spacing. */
+.tooltip-content-rich {
+  padding: 0;
+  overflow: hidden;
+  white-space: normal;
+}

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
@@ -16,11 +16,15 @@ import { cloneElement, isValidElement, useId, type ReactElement, type ReactNode 
 import styles from "./Tooltip.module.scss";
 
 interface TooltipProps {
-  text: string;
+  text?: string;
+  /** Rich content instead of a plain text hint (e.g. a multi-row info panel).
+   *  Unlike `text`, the tooltip widens to fit and wraps instead of forcing a
+   *  single nowrap line. Takes precedence over `text` when both are set. */
+  content?: ReactNode;
   children: ReactNode;
 }
 
-export const Tooltip = ({ text, children }: TooltipProps) => {
+export const Tooltip = ({ text, content, children }: TooltipProps) => {
   const tooltipId = useId();
   // Single-element children get aria-describedby wired to the tooltip text so
   // screen readers announce it for both hover and keyboard focus (the CSS
@@ -29,12 +33,14 @@ export const Tooltip = ({ text, children }: TooltipProps) => {
   const child = isValidElement(children)
     ? cloneElement(children as ReactElement<{ "aria-describedby"?: string }>, { "aria-describedby": tooltipId })
     : children;
+  const contentClasses = [styles["tooltip-content"]];
+  if (content) contentClasses.push(styles["tooltip-content-rich"]);
 
   return (
     <span className={styles["tooltip-wrapper"]}>
       {child}
-      <span id={tooltipId} className={styles["tooltip-content"]} role="tooltip">
-        {text}
+      <span id={tooltipId} className={contentClasses.join(" ")} role="tooltip">
+        {content ?? text}
       </span>
     </span>
   );

--- a/apps/frontend/src/rework/components/shared/molecules/Menu/Menu.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Menu/Menu.tsx
@@ -82,6 +82,7 @@ const MenuInternal = <T,>({
             description={option.description}
             icon={option.icon}
             disabled={option.disabled}
+            destructive={option.destructive}
             selected={isSelected}
             focused={isFocused}
             onClick={() => {

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
@@ -60,6 +60,14 @@
   gap: var(--spacing-m);
 }
 
+/* Pushed flush to the card's top-right corner (#2096); does not stretch to
+ * the row's full height like its siblings (the icon / name+role block). */
+.moreMenu {
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-left: auto;
+}
+
 .agentIcon {
   display: flex;
   flex-shrink: 0;
@@ -81,16 +89,6 @@
   justify-content: center;
   gap: var(--spacing-3xs);
   min-width: 0;
-}
-
-/* Origin · template, e.g. "fred-agents · Generalist" — raw source_runtime_id,
-   not a prettified label (#2076). */
-.agentOrigin {
-  overflow: hidden;
-  color: var(--on-surface-muted);
-  font: var(--font-label-small);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .agentName {
@@ -141,20 +139,69 @@
   font: var(--font-body-medium);
 }
 
-/* ── Actions row — edit/toggle grouped left, Chat flush right (#2076) ───────── */
+/* ── Actions row — info icon flush left, Chat flush right (#2096) ──────────── */
 
 .actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   gap: var(--spacing-xs);
   padding: 0 var(--spacing-s) var(--spacing-s);
 }
 
-.actionsLeft {
+/* ── Info tooltip content (#2096) — Origin/Template/Created/Updated ─────────
+ * Each label hugs its own text (no shared column width across rows — the
+ * mockup's per-row label boxes are visibly different widths); the value
+ * pushes to the tooltip's right edge and the tooltip itself widens to fit
+ * (Tooltip.module.scss's `.tooltip-content-rich` drops the nowrap/fixed
+ * sizing), so a long author name is never clipped. */
+.infoTooltip {
   display: flex;
-  gap: var(--spacing-3xs);
-  margin-right: auto;
+  flex-direction: column;
+  min-width: 12rem;
+}
+
+.infoRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-m);
+  border-bottom: 1px solid var(--outline-muted);
+  padding: var(--spacing-2xs) var(--spacing-s);
+  min-height: 2rem;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.infoLabel {
+  color: var(--on-surface-muted);
+  font: var(--font-label-medium);
+  white-space: nowrap;
+}
+
+.infoValue {
+  overflow: hidden;
+  color: var(--on-surface);
+  font: var(--font-body-medium);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.infoValueStacked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  color: var(--on-surface);
+  font: var(--font-body-medium);
+  text-align: right;
+}
+
+.infoValueDate {
+  color: var(--on-surface-muted);
+  font: var(--font-label-small);
 }
 
 .chatLink {

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
@@ -15,14 +15,18 @@
 import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu.tsx";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
 import { materialIcons, type MaterialIconType } from "@shared/utils/Type.ts";
 import { guessAgentIcon } from "@shared/utils/agentIcon.ts";
+import { userDisplayName } from "@core/utils/userDisplayName.ts";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useFrontendProperties } from "../../../../../hooks/useFrontendProperties.ts";
-import { ManagedAgentInstanceSummary } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
+import { ManagedAgentInstanceSummary, UserSummary } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
 import styles from "./AgentCard.module.scss";
+
+type MoreMenuAction = "edit" | "toggle" | "duplicate" | "delete";
 
 export interface AgentCardProps {
   instance: ManagedAgentInstanceSummary;
@@ -32,8 +36,25 @@ export interface AgentCardProps {
   teamId?: string;
   canManageAgents: boolean;
   offline?: boolean;
+  /** Resolved audit users for `created_by`/`updated_by`, batched once for the
+   *  whole list by the caller rather than one query per card. */
+  auditUserById?: Map<string, UserSummary>;
   onEdit: () => void;
   onToggleEnabled: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}
+
+function formatShortDate(dateStr: string | null | undefined): string | undefined {
+  if (!dateStr) return undefined;
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return undefined;
+  const datePart = date.toLocaleDateString();
+  // Fixed 24h "HH:MM" (zero-padded), independent of locale — toLocaleTimeString's
+  // padding/12h-vs-24h choice varies by browser and locale.
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${datePart} - ${hours}:${minutes}`;
 }
 
 export default function AgentCard({
@@ -43,8 +64,11 @@ export default function AgentCard({
   teamId,
   canManageAgents,
   offline = false,
+  auditUserById,
   onEdit,
   onToggleEnabled,
+  onDuplicate,
+  onDelete,
 }: AgentCardProps) {
   const { agentIconName } = useFrontendProperties();
   const { t } = useTranslation();
@@ -53,7 +77,7 @@ export default function AgentCard({
   // chat affordance) and its enable toggle is LOCKED — the fix is in settings.
   const isSuspended = !!instance.suspension_reason;
   const isEnabled = !offline && !isSuspended && instance.status === "enabled";
-  const toggleTooltip = isSuspended
+  const toggleLabel = isSuspended
     ? t("rework.agentCard.suspendedToggleLocked")
     : isEnabled
       ? t("rework.agentCard.deactivate")
@@ -67,9 +91,50 @@ export default function AgentCard({
     ? (agentIconName as MaterialIconType)
     : "smart_toy";
   const iconName = guessAgentIcon(instance.display_name, instance.role, instance.description ?? "", defaultIcon);
-  // Raw source_runtime_id, not a prettified label (e.g. "fred-agents"), per
-  // the agent card redesign (#2076).
-  const origin = [runtimeId, templateDisplayName].filter(Boolean).join(" · ");
+
+  const createdByName = instance.created_by
+    ? userDisplayName(instance.created_by, auditUserById?.get(instance.created_by))
+    : undefined;
+  const updatedByName = instance.updated_by
+    ? userDisplayName(instance.updated_by, auditUserById?.get(instance.updated_by))
+    : undefined;
+  const createdAt = formatShortDate(instance.created_at);
+  const updatedAt = formatShortDate(instance.updated_at);
+
+  const infoTooltipContent = (
+    <div className={styles.infoTooltip}>
+      {runtimeId && (
+        <div className={styles.infoRow}>
+          <span className={styles.infoLabel}>{t("rework.agentCard.tooltip.origin")}</span>
+          <span className={styles.infoValue}>{runtimeId}</span>
+        </div>
+      )}
+      {templateDisplayName && (
+        <div className={styles.infoRow}>
+          <span className={styles.infoLabel}>{t("rework.agentCard.tooltip.template")}</span>
+          <span className={styles.infoValue}>{templateDisplayName}</span>
+        </div>
+      )}
+      {createdByName && (
+        <div className={styles.infoRow}>
+          <span className={styles.infoLabel}>{t("rework.agentCard.tooltip.created")}</span>
+          <span className={styles.infoValueStacked}>
+            <span>{createdByName}</span>
+            {createdAt && <span className={styles.infoValueDate}>{createdAt}</span>}
+          </span>
+        </div>
+      )}
+      {updatedByName && (
+        <div className={styles.infoRow}>
+          <span className={styles.infoLabel}>{t("rework.agentCard.tooltip.updated")}</span>
+          <span className={styles.infoValueStacked}>
+            <span>{updatedByName}</span>
+            {updatedAt && <span className={styles.infoValueDate}>{updatedAt}</span>}
+          </span>
+        </div>
+      )}
+    </div>
+  );
 
   const chatButton = (
     <Button
@@ -84,6 +149,15 @@ export default function AgentCard({
     </Button>
   );
 
+  const handleMoreMenuSelect = (action: MoreMenuAction) => {
+    if (action === "edit") onEdit();
+    else if (action === "toggle") {
+      if (isSuspended) return;
+      onToggleEnabled();
+    } else if (action === "duplicate") onDuplicate();
+    else if (action === "delete") onDelete();
+  };
+
   return (
     <div className={styles.agentCard} data-enabled={isEnabled}>
       <div className={styles.agentInfo}>
@@ -92,10 +166,50 @@ export default function AgentCard({
             <Icon category={"outlined"} type={iconName} />
           </div>
           <div className={styles.agentIdentity}>
-            {origin && <div className={styles.agentOrigin}>{origin}</div>}
             <div className={styles.agentName}>{instance.display_name}</div>
             <div className={styles.agentRole}>{instance.role}</div>
           </div>
+          {canManageAgents && (
+            <div className={styles.moreMenu}>
+              <IconButtonMenu<MoreMenuAction>
+                iconButton={{
+                  color: "on-surface",
+                  variant: "icon",
+                  size: "medium",
+                  icon: { category: "outlined", type: "more_vert" },
+                }}
+                options={[
+                  {
+                    key: "edit",
+                    value: "edit",
+                    label: t("rework.agentCard.edit"),
+                    icon: { category: "outlined", type: "edit" },
+                  },
+                  {
+                    key: "toggle",
+                    value: "toggle",
+                    label: toggleLabel,
+                    icon: { category: "outlined", type: isEnabled ? "visibility_off" : "visibility" },
+                    disabled: isSuspended,
+                  },
+                  {
+                    key: "duplicate",
+                    value: "duplicate",
+                    label: t("rework.agentCard.duplicate"),
+                    icon: { category: "outlined", type: "content_copy" },
+                  },
+                  {
+                    key: "delete",
+                    value: "delete",
+                    label: t("rework.agentCard.delete"),
+                    icon: { category: "outlined", type: "delete" },
+                    destructive: true,
+                  },
+                ]}
+                onSelect={handleMoreMenuSelect}
+              />
+            </div>
+          )}
         </div>
         <div className={styles.agentDescription}>{instance.description || t("rework.agentCard.noDescription")}</div>
       </div>
@@ -110,35 +224,15 @@ export default function AgentCard({
       )}
 
       <div className={styles.actions}>
-        {canManageAgents && (
-          <div className={styles.actionsLeft}>
-            <Tooltip text={toggleTooltip}>
-              <IconButton
-                color="on-surface"
-                variant="icon"
-                size="medium"
-                // A suspended instance has a LOCKED enable toggle (#1975, RFC §3.9):
-                // the fix is in the edit form, not a re-enable. Disable it so an
-                // editor cannot toggle a broken agent back into the catalog.
-                disabled={isSuspended}
-                icon={{ category: "outlined", type: isEnabled ? "visibility" : "visibility_off" }}
-                onClick={() => {
-                  if (isSuspended) return;
-                  onToggleEnabled();
-                }}
-              />
-            </Tooltip>
-            <Tooltip text={t("rework.agentCard.edit")}>
-              <IconButton
-                color="on-surface"
-                variant="icon"
-                size="medium"
-                icon={{ category: "outlined", type: "edit" }}
-                onClick={onEdit}
-              />
-            </Tooltip>
-          </div>
-        )}
+        <Tooltip content={infoTooltipContent}>
+          <IconButton
+            color="on-surface-retreat"
+            variant="icon"
+            size="medium"
+            icon={{ category: "outlined", type: "info" }}
+            aria-label={t("rework.agentCard.tooltip.label")}
+          />
+        </Tooltip>
         {isEnabled && teamId ? (
           <Link to={`/team/${teamId}/managed-chat/${instance.agent_instance_id}`} className={styles.chatLink}>
             {chatButton}

--- a/apps/frontend/src/rework/core/utils/userDisplayName.ts
+++ b/apps/frontend/src/rework/core/utils/userDisplayName.ts
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { IconProps } from "@shared/atoms/Icon/Icon.tsx";
-
-export interface OptionModel<T = string> {
-  value: T;
-  label: string;
-  key: string;
-  icon?: IconProps;
-  disabled?: boolean;
-  description?: string;
-  /** Renders the item's label/icon in the error color (e.g. a "Delete" action). */
-  destructive?: boolean;
+/** Human display for a resolved user: full name, else username, else the raw uid (#1952 pattern). */
+export function userDisplayName(
+  uid: string,
+  summary: { first_name?: string | null; last_name?: string | null; username?: string } | undefined,
+): string {
+  if (!summary) return uid;
+  const fullName = [summary.first_name, summary.last_name].filter(Boolean).join(" ");
+  return fullName || summary.username || uid;
 }

--- a/apps/frontend/src/styles/colors-state-semantic.css
+++ b/apps/frontend/src/styles/colors-state-semantic.css
@@ -50,6 +50,14 @@
   --state-on-success-container-focused: color-mix(in srgb, var(--on-success-container), transparent 84%);
   --state-on-success-container-selected: color-mix(in srgb, var(--on-success-container), transparent 84%);
 
+  /* Tint of --error itself (not --on-error) — for a destructive element whose
+     own text/icon color IS --error on a transparent/neutral surface (e.g. a
+     "Delete" menu item), not one sitting on a solid --error fill. */
+  --state-error-hover: color-mix(in srgb, var(--error), transparent 92%);
+  --state-error-pressed: color-mix(in srgb, var(--error), transparent 88%);
+  --state-error-focused: color-mix(in srgb, var(--error), transparent 84%);
+  --state-error-selected: color-mix(in srgb, var(--error), transparent 84%);
+
   --state-on-error-hover: color-mix(in srgb, var(--on-error), transparent 92%);
   --state-on-error-pressed: color-mix(in srgb, var(--on-error), transparent 88%);
   --state-on-error-focused: color-mix(in srgb, var(--on-error), transparent 84%);

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -688,26 +688,28 @@ _(none yet)_
 **Location:** `src/rework/components/shared/organisms/AgentCard/AgentCard.tsx`
 **Status:** `Functional`
 
-Displays one managed agent instance. Enabled cards are wrapped by `TeamAgentsPage` in a `<Link>` to the managed-chat route. On hover: descriptive content blurs, a "Start Chat" overlay appears, and the border plays a rotating conic-gradient animation. Footer action buttons (Settings, Delete) stay unblurred so they remain accessible during the hover state. Disabled cards render with muted colours and no hover effects, driven by a `data-enabled` CSS custom-property cascade.
+Displays one managed agent instance. Current layout (#2096, superseding the #2076 toolbar-restructure pass):
+
+- Header row: icon, name, role (short one-liner) — and, only for users who can manage agents in the team, a `⋮` **more menu** flush to the top-right (`IconButtonMenu`), containing Edit, Activate/Deactivate, Duplicate, and Delete (rendered in the error color via `MenuItem`'s new `destructive` prop).
+- Description (3-line clamp).
+- Suspension/catalog warning banner, when applicable.
+- Footer row: an always-visible `i` **info icon** (bottom-left, not gated on any permission) that reveals a rich instant-hover `Tooltip` above it — Origin (raw `source_runtime_id`) and Template on their own rows, plus Created-by/Last-updated-by (name + short date, only shown when set) — and the **Chat** button (bottom-right), disabled unless the instance is enabled.
+- The origin/template line that used to sit under the agent name (#2076) is gone from the card body entirely — it only lives in the info tooltip now.
+- **Duplicate** opens `DuplicateAgentDialog` (name field prefilled with the source's name); confirming rebuilds a `CreateAgentInstanceRequest` from the source instance via the same `buildAgentFormSubmitPayload`/`extractCapabilityConfigValues` helpers the edit form uses (correct capability filtering against the live template), then calls the normal create endpoint — no backend change.
+- **Delete** reuses `TeamAgentsPage`'s existing `handleDelete` (previously only reachable from inside the edit modal) via the same `ConfirmationDialog`, with the same inverted emphasis as the "Leave team" dialog: Cancel is `filled`/primary (visually dominant, the safe choice), Delete is `text`/error (low emphasis).
+- The `Tooltip` atom gained an optional `content: ReactNode` prop (alongside the existing `text: string`) for this rich variant — sizes to content instead of forcing a single nowrap line, same hover/`:focus-within`/above-anchor positioning as every other tooltip in the app.
+- Disabled cards render with muted colours, driven by the existing `data-enabled` CSS custom-property cascade (unchanged by #2096).
+- The Chat button's hover treatment (rotating conic-gradient border) is unchanged from #2076.
 
 #### Open UX issues
 
-- **Gradient animation colours** — the conic-gradient uses hardcoded hex stops (`#65e0f6`, `#9299ff`, `#e1c39c`, `#d665b4`). These are intentional branding colours not in the design token system. Confirm with designer whether they should be tokenised or kept as-is.
-
-- **Status badge — `color-mix`** — uses `color-mix(in srgb, var(--success) 12%, transparent)` for the badge background. Verify browser support aligns with deployment targets (Chrome 111+, Firefox 113+).
-
-- **Disabled card affordance** — renders with `cursor: default` and dimmed icon. Confirm whether a `not-allowed` cursor or a muted overlay label (e.g. "Disabled") would better communicate non-interactivity to end users.
-
-- **Card height** — no `min-height` set; height is driven by content. Validate grid row alignment when instances have very short vs. very long descriptions.
-
-- **"Start Chat" label** — uses i18n key `rework.agentCard.startChat`. Confirm translation exists in all supported locales.
+- Not yet design-reviewed against a live stack. First functional pass only.
+- **Gradient animation colours** — the Chat button's conic-gradient uses hardcoded hex stops (`#65e0f6`, `#9299ff`, `#e1c39c`, `#d665b4`). Intentional branding colours not in the design token system — confirm with designer whether they should be tokenised or kept as-is.
 
 #### Resolved
 
-- **Gradient animation + "Start Chat" overlay restored** — the rotating conic-gradient border and blur/overlay hover interaction from the develop branch were lost in the agentic-pod migration. Both are restored in `AgentCard.module.scss`.
-- **`data-enabled` CSS cascade restored** — enabled/disabled state drives name colour, icon opacity, and background via CSS custom properties, matching develop branch behaviour.
+- **Toolbar restructure (#2076)** — edit/toggle icon buttons moved from a persistent bottom-left pair into the top-right more-menu (#2096); the whole-card click-to-chat interaction was already removed in #2076 in favour of the explicit Chat button.
 - **Extracted to reusable organism** — card logic was previously inlined (575 lines) in `TeamAgentsPage.tsx`. Now in `shared/organisms/AgentCard/` with a clean prop interface against `ManagedAgentInstanceSummary`.
-- **Whole-card click** — enabled cards are wrapped in `<Link>`; action buttons call `e.stopPropagation()` so they don't trigger navigation.
 
 ---
 


### PR DESCRIPTION
## Summary
- **More menu (top-right `⋮`)** replaces the persistent bottom-left Edit/Deactivate buttons — visible only to users who can manage agents in the team. Contains Edit, Activate/Deactivate, Duplicate, and Delete (rendered in the error color).
- **Duplicate** opens a small dialog (name field prefilled with the source agent's name); confirming rebuilds a create request from the source instance's template/tuning/capabilities (reusing the edit form's own payload-building helpers for correct capability filtering) and calls the existing create endpoint — no backend change.
- **Delete** is now reachable directly from the card (previously only from inside the edit modal), with a confirmation dialog stating the action is irreversible, same inverted button emphasis as the "Leave team" dialog (Cancel = filled/primary, Delete = text/error).
- **Info tooltip** — the origin/template line that used to sit under the agent name is gone from the card body; an always-visible `i` icon (bottom-left, next to Chat) reveals it instantly on hover instead, split into Origin/Template rows plus Created-by/Last-updated-by (name, date, and time — `date - HH:MM`).

## Supporting changes
- `Tooltip` gains an optional rich `content` prop (alongside the existing plain-text `text`), sized to its content instead of forcing a single nowrap line.
- `Menu`/`MenuItem`/`OptionModel` gain a `destructive` item style (error-colored text/icon + matching hover tint); added the missing `--state-error-hover`/`-pressed`/`-focused`/`-selected` tokens this needed.
- The `userDisplayName` helper (previously duplicated in `AgentFormBody.tsx` and `PromptsPage.tsx`) is extracted to a shared util, now used by a third caller.
- Every user-facing string this touched — including several pre-existing hardcoded-English toasts in `TeamAgentsPage.tsx` (create/update/toggle/delete success and error messages, the generic API-error fallback, the missing-team-id page error) — now goes through i18n (en/fr).

## Tracking
Issue #2096.

## Test plan
- [x] `make code-quality` (tsc/prettier/eslint)
- [x] `make test` — 597 passed
- [ ] Manual: more-menu visibility per role, Duplicate flow, Delete flow, info tooltip hover/sizing with a long author name, French locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)