### PR TITLE
Team role badges: admin shield on avatars, role label in team banner

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/teams/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/schemas.py
@@ -176,6 +176,14 @@ class TeamRetentionView(BaseModel):
 
 class TeamWithPermissions(Team):
     permissions: list[TeamPermission] = Field(default_factory=list)
+    # The caller's own raw role relations on this team (team_admin/_editor/
+    # _analyst/_member — the same set `TeamMember.relations` exposes for other
+    # members). `permissions` alone cannot answer "does this user hold
+    # team_analyst" reliably: can_run_evaluations/can_manage_evaluation_corpus
+    # are also granted to team_admin via the FGA union, so a plain admin would
+    # look like an analyst too. Frontend team-role badges (#2100) need this
+    # unambiguous.
+    my_relations: list[UserTeamRelation] = Field(default_factory=list)
     # CTRLP-12 (RFC §3.B): resolved per-team retention (platform cap vs team
     # value). None for system/personal teams, which have no team-editable
     # retention (personal deletes use the platform `personal_delete_grace`).

--- a/apps/control-plane-backend/control_plane_backend/teams/service.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/service.py
@@ -459,9 +459,13 @@ async def create_team(
     permissions = await _get_team_permissions_for_user(
         rebac, user, team_id, consistency_token
     )
+    my_relations = list(await _get_user_roles_in_team(rebac, team_id, user.uid))
     retention = await _resolve_team_retention_view(team_id, deps)
     return TeamWithPermissions(
-        **teams[0].model_dump(), permissions=permissions, retention=retention
+        **teams[0].model_dump(),
+        permissions=permissions,
+        my_relations=my_relations,
+        retention=retention,
     )
 
 
@@ -521,9 +525,13 @@ async def get_team_by_id(
         team_id,
         consistency_token,
     )
+    my_relations = list(await _get_user_roles_in_team(rebac, team_id, user.uid))
     retention = await _resolve_team_retention_view(team_id, deps)
     return TeamWithPermissions(
-        **teams[0].model_dump(), permissions=permissions, retention=retention
+        **teams[0].model_dump(),
+        permissions=permissions,
+        my_relations=my_relations,
+        retention=retention,
     )
 
 
@@ -631,9 +639,13 @@ async def update_team(
         team_id,
         consistency_token,
     )
+    my_relations = list(await _get_user_roles_in_team(rebac, team_id, user.uid))
     retention = await _resolve_team_retention_view(team_id, deps)
     return TeamWithPermissions(
-        **teams[0].model_dump(), permissions=permissions, retention=retention
+        **teams[0].model_dump(),
+        permissions=permissions,
+        my_relations=my_relations,
+        retention=retention,
     )
 
 

--- a/apps/control-plane-backend/control_plane_backend/teams/system.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/system.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from fred_core import JoiningMode, KeycloakUser, TeamPermission
 from fred_core.common import TeamId, personal_team_id
 
-from control_plane_backend.teams.schemas import Team, TeamWithPermissions
+from control_plane_backend.teams.schemas import (
+    Team,
+    TeamWithPermissions,
+    UserTeamRelation,
+)
 
 
 async def build_personal_team(
@@ -59,6 +63,12 @@ async def build_personal_team(
             TeamPermission("can_update_resources"),
             TeamPermission("can_update_agents"),
         ],
+        # Matches the hardcoded `permissions` above rather than a live
+        # `_get_user_roles_in_team` lookup: the owner's `team_editor` tuple
+        # only self-heals on read (REBAC.md "Personal teams"), so a fresh
+        # personal team with zero prior activity may not have it persisted
+        # yet — the literal is what this DTO already unconditionally promises.
+        my_relations=[UserTeamRelation.TEAM_EDITOR],
         max_resources_storage_size=personal_max_resources_storage_size,
         current_resources_storage_size=current_size,
     )

--- a/apps/control-plane-backend/tests/test_import_export_users.py
+++ b/apps/control-plane-backend/tests/test_import_export_users.py
@@ -209,6 +209,24 @@ class _FakeTeamRebac:
             }
         return set()
 
+    # `_get_user_roles_in_team` (now also called from `TeamWithPermissions`
+    # builders, #2100) reads the literal persisted tuple rather than the
+    # computed TEAM_MEMBER relation — mirror that against this fake's own
+    # relation log instead of `team_admins`.
+    async def has_direct_relation(
+        self,
+        subject: RebacReference,
+        relation: RelationType,
+        resource: RebacReference,
+        **_kw: Any,
+    ) -> bool:
+        return any(
+            r.subject.id == subject.id
+            and r.relation == relation
+            and str(r.resource.id) == str(resource.id)
+            for r in self.team_relations
+        )
+
 
 class _SpyNoopRebac(NoopRebacEngine):
     """The real production no-op engine (`NoopRebacEngine`), spied on rather

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -1297,6 +1297,7 @@ async def test_get_personal_team_returns_shared_system_team_contract() -> None:
             "can_update_resources",
             "can_update_agents",
         ],
+        "my_relations": ["team_editor"],
         "max_resources_storage_size": 5368709120,
         "current_resources_storage_size": 0,
     }

--- a/apps/control-plane-backend/tests/test_team_member_roles.py
+++ b/apps/control-plane-backend/tests/test_team_member_roles.py
@@ -33,15 +33,15 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from control_plane_backend.scheduler.policies.policy_models import (
+    ConversationPolicyCatalog,
+)
 from control_plane_backend.teams.schemas import (
     GrantTeamMemberRoleRequest,
     TeamAdminConstraintError,
     TeamMemberLastRoleError,
     TeamMemberRoleNotHeldError,
     UserTeamRelation,
-)
-from control_plane_backend.scheduler.policies.policy_models import (
-    ConversationPolicyCatalog,
 )
 from control_plane_backend.teams.service import (
     get_team_by_id,

--- a/apps/control-plane-backend/tests/test_team_member_roles.py
+++ b/apps/control-plane-backend/tests/test_team_member_roles.py
@@ -40,7 +40,11 @@ from control_plane_backend.teams.schemas import (
     TeamMemberRoleNotHeldError,
     UserTeamRelation,
 )
+from control_plane_backend.scheduler.policies.policy_models import (
+    ConversationPolicyCatalog,
+)
 from control_plane_backend.teams.service import (
+    get_team_by_id,
     grant_team_member_role,
     list_team_members_unfiltered,
     remove_team_member,
@@ -112,6 +116,40 @@ class _FakeRebac:
         held = self.roles.get(uid, set())
         return any(role.value == relation.value for role in held)
 
+    async def has_permission(
+        self, subject, permission: TeamPermission, resource, **kwargs
+    ) -> bool:
+        # Mirrors schema.fga's team-type permission unions closely enough for
+        # `get_team_by_id`'s `_get_team_permissions_for_user` call — real
+        # `public` grants (unauthenticated can_read) are not modeled since no
+        # test here exercises a non-member caller.
+        held = self.roles.get(subject.id, set())
+        elevated = {
+            UserTeamRelation.TEAM_ADMIN,
+            UserTeamRelation.TEAM_EDITOR,
+            UserTeamRelation.TEAM_ANALYST,
+        }
+        is_member = bool(held & elevated) or UserTeamRelation.TEAM_MEMBER in held
+        is_admin = UserTeamRelation.TEAM_ADMIN in held
+        is_editor = UserTeamRelation.TEAM_EDITOR in held
+        is_analyst = UserTeamRelation.TEAM_ANALYST in held
+        return {
+            TeamPermission.CAN_READ: is_member,
+            TeamPermission.CAN_UPDATE_INFO: is_admin,
+            TeamPermission.CAN_UPDATE_RESOURCES: is_editor,
+            TeamPermission.CAN_UPDATE_AGENTS: is_editor,
+            TeamPermission.CAN_READ_MEMEBERS: is_member,
+            TeamPermission.CAN_ADMINISTER_MEMBERS: is_admin,
+            TeamPermission.CAN_ADMINISTER_EDITORS: is_admin,
+            TeamPermission.CAN_ADMINISTER_ANALYSTS: is_admin,
+            TeamPermission.CAN_ADMINISTER_ADMINS: is_admin,
+            TeamPermission.CAN_READ_CONVERSATIONS: is_member,
+            TeamPermission.CAN_USE_TEAM_AGENTS: is_member,
+            TeamPermission.CAN_RUN_EVALUATIONS: is_analyst or is_admin,
+            TeamPermission.CAN_MANAGE_EVALUATION_CORPUS: is_analyst or is_admin,
+            TeamPermission.CAN_READ_CONVERSATIONS_FOR_EVALUATION: is_analyst,
+        }.get(permission, False)
+
     async def add_relation(self, relation: Relation, **kwargs: object) -> None:
         uid = relation.subject.id
         self.roles.setdefault(uid, set()).add(UserTeamRelation(relation.relation.value))
@@ -151,6 +189,7 @@ def _deps(
     get_session_store: Any = cast(Any, object),
     get_purge_queue_store: Any = cast(Any, object),
     search_users: Any = cast(Any, _no_search_users),
+    get_policy_catalog: Any = cast(Any, object),
 ):
     from control_plane_backend.teams.dependencies import TeamServiceDependencies
 
@@ -165,7 +204,7 @@ def _deps(
         get_content_store=cast(Any, object),
         get_session_store=get_session_store,
         get_purge_queue_store=get_purge_queue_store,
-        get_policy_catalog=cast(Any, object),
+        get_policy_catalog=get_policy_catalog,
         get_users_by_ids=cast(Any, _no_users_by_ids),
         search_users=search_users,
         run_lifecycle_manager_once_in_memory=cast(Any, lambda _i: object()),
@@ -467,6 +506,29 @@ async def test_list_team_members_reports_every_held_role() -> None:
         UserTeamRelation.TEAM_ANALYST,
     ]
     assert by_id["phil"] == [UserTeamRelation.TEAM_EDITOR]
+
+
+@pytest.mark.asyncio
+async def test_get_team_by_id_reports_callers_own_relations() -> None:
+    """#2100: `TeamWithPermissions.my_relations` must report the caller's own
+    raw roles, unambiguously distinguishing e.g. a plain team_admin from an
+    admin who is ALSO team_analyst — something `permissions` alone cannot do,
+    since can_run_evaluations/can_manage_evaluation_corpus are granted to
+    both team_analyst and team_admin (schema.fga union)."""
+    rebac = _FakeRebac(
+        roles={"caller": {UserTeamRelation.TEAM_ADMIN, UserTeamRelation.TEAM_ANALYST}}
+    )
+
+    team = await get_team_by_id(
+        _user(),
+        TeamId("fredlab"),
+        _deps(rebac, "fredlab", get_policy_catalog=ConversationPolicyCatalog),
+    )
+
+    assert set(team.my_relations) == {
+        UserTeamRelation.TEAM_ADMIN,
+        UserTeamRelation.TEAM_ANALYST,
+    }
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -9,15 +9,18 @@
 /* Background and text colour are set inline from the configured team asset.
  * The team banner is intentionally taller than the marketplace/admin headers
  * (88px vs 56px) to give the team identity more presence — matching the
- * original design. */
+ * original design. Column layout (#2100): the name/gear row sits at the top,
+ * the role label at the bottom — `justify-content: space-between` spaces the
+ * two rows across the fixed height without needing to size either by hand. */
 .bannerContainer {
   display: flex;
   position: relative;
-  align-items: flex-end;
+  flex-direction: column;
+  justify-content: space-between;
   border-radius: 0 0 var(--radius-s) var(--radius-s);
   background-position: center;
   background-size: cover;
-  padding: 0 var(--spacing-xs) var(--spacing-xs) var(--spacing-s);
+  padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-xs) var(--spacing-s);
   height: 88px;
 }
 
@@ -35,19 +38,35 @@
   content: "";
 }
 
+/* Fixed to the gear IconButton's own height ("small" = 2rem) so the row's
+ * height — and therefore the top-aligned team name's vertical position —
+ * never changes depending on whether the gear icon is actually rendered
+ * (it's hidden while `inSettings`). Without this, the name shifted up when
+ * settings opened, because the row shrank to the text's own shorter height. */
 .teamNameContainer {
   display: flex;
   position: relative;
   justify-content: space-between;
-  align-items: end;
+  align-items: start;
   z-index: 1;
   width: 100%;
+  min-height: 2rem;
   font: var(--font-title-medium);
 }
 
 /* Small drop shadow on the team name, on top of the scrim, so the white text
  * stays crisp even against a light patch of a custom banner image. */
 .teamName {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+/* Roles the current user holds on this team, e.g. "Admin · Analyst" or
+ * "Member" (#2100) — bottom-left of the banner, below the name/gear row. */
+.teamRoleLabel {
+  position: relative;
+  z-index: 1;
+  color: inherit;
+  font: var(--font-label-medium);
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
 }
 

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -80,6 +80,33 @@ export default function TeamContentNavbar() {
   const usageBase = `/team/${teamId}/usage`;
   const inUsage = !!teamId && pathname.startsWith(usageBase);
 
+  // #2100: which roles the current user holds on this team, "Admin · Analyst"
+  // style — `permissions` alone cannot answer this (can_run_evaluations/
+  // can_manage_evaluation_corpus are granted to team_analyst AND team_admin,
+  // so it can't tell a plain admin from an admin who is also analyst), hence
+  // the dedicated `my_relations` field. Not shown for the personal space (not
+  // a team with "roles" in this sense) or for a non-member merely browsing a
+  // public/marketplace team pre-join.
+  //
+  // `selectedTeam` can transiently be the bootstrap-cached summary (plain
+  // `Team`, no `my_relations` key at all) before the dedicated per-team fetch
+  // resolves — same gap `TeamSettingsPage` already guards against for
+  // `permissions`. Without this check the banner renders with the incomplete
+  // summary (it mounts earlier than the settings page) and shows the "no
+  // elevated role" fallback for every user until the real fetch lands.
+  const relationsLoaded = !!selectedTeam && "my_relations" in selectedTeam;
+  const roleLabel = (() => {
+    const priority: Record<string, number> = { team_admin: 0, team_editor: 1, team_analyst: 2 };
+    const heldRoles = (selectedTeam?.my_relations ?? []).filter((relation) => relation in priority);
+    if (heldRoles.length === 0) return t("rework.teamRoles.team_member");
+    return heldRoles
+      .slice()
+      .sort((a, b) => priority[a] - priority[b])
+      .map((relation) => t(`rework.teamRoles.${relation}`))
+      .join(" · ");
+  })();
+  const showRoleLabel = !isPersonalTeam && !!selectedTeam?.is_member && relationsLoaded;
+
   const navigationItems: NavigationMenuItemProps[] = [
     {
       type: "link",
@@ -210,6 +237,7 @@ export default function TeamContentNavbar() {
             </span>
           )}
         </div>
+        {showRoleLabel && <span className={styles.teamRoleLabel}>{roleLabel}</span>}
       </div>
       <div className={styles.navigationContainer}>
         {inSettings ? (

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionItem/TeamSelectionItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionItem/TeamSelectionItem.module.scss
@@ -114,3 +114,19 @@
   height: 8px;
   pointer-events: none;
 }
+
+.adminBadge {
+  display: flex;
+  position: absolute;
+  right: 8px;
+  bottom: 2px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background-color: var(--surface-container-lowest);
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+  color: var(--secondary);
+  font-size: 12px;
+}

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionItem/TeamSelectionItem.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionItem/TeamSelectionItem.tsx
@@ -34,6 +34,9 @@ interface TeamSelectionItemProps {
   avatarColor?: TeamColor;
   icon?: IconProps;
   activityDot?: boolean;
+  /** Shown bottom-right of the avatar when the current user is team_admin
+   *  of this team (#2100). */
+  adminBadge?: boolean;
 }
 
 export default function TeamSelectionItem({
@@ -45,6 +48,7 @@ export default function TeamSelectionItem({
   avatarColor,
   icon = { category: "outlined", type: "groups", filled: true },
   activityDot = false,
+  adminBadge = false,
 }: TeamSelectionItemProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [tooltipStyle, setTooltipStyle] = useState<CSSProperties>({});
@@ -113,6 +117,11 @@ export default function TeamSelectionItem({
         </div>
       </Link>
       {activityDot && <span className={styles.activityDot} aria-hidden="true" />}
+      {adminBadge && (
+        <span className={styles.adminBadge} aria-hidden="true">
+          <Icon category="outlined" type="shield" filled />
+        </span>
+      )}
       {isVisible &&
         createPortal(
           <span id={tooltipId} role="tooltip" className={styles.teamTooltip} style={tooltipStyle}>

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionNavbar.tsx
@@ -41,6 +41,7 @@ export default function TeamSelectionNavbar() {
 
   const personalTeamId = activeTeam?.id ?? "personal";
   const collaborativeTeams = availableTeams.filter((team) => team.id !== personalTeamId && team.is_member);
+  const currentUserId = KeyCloakService.GetUserId();
   // Shape-based check, not a comparison against personalTeamId: activeTeam.id
   // resolves from "personal" to "personal-<uid>" once bootstrap loads, but the
   // pathname only follows if something re-navigates. A prefix match against a
@@ -84,6 +85,7 @@ export default function TeamSelectionNavbar() {
               selected={pathname.startsWith(`/team/${team.id}`)}
               imgUrl={team.banner_image_url ?? (defaultTeamAvatarFile ? `/images/${defaultTeamAvatarFile}` : undefined)}
               avatarName={team.name}
+              adminBadge={!!currentUserId && (team.admins ?? []).some((admin) => admin.id === currentUserId)}
             />
           );
         })}

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1399,6 +1399,7 @@ export type TeamPermission =
   | "can_run_evaluations"
   | "can_manage_evaluation_corpus"
   | "can_read_conversations_for_evaluation";
+export type UserTeamRelation = "team_admin" | "team_editor" | "team_analyst" | "team_member";
 export type RetentionFieldView = {
   platform_max?: string | null;
   team_value?: string | null;
@@ -1422,6 +1423,7 @@ export type TeamWithPermissions = {
   max_resources_storage_size?: number | null;
   current_resources_storage_size?: number | null;
   permissions?: TeamPermission[];
+  my_relations?: UserTeamRelation[];
   retention?: TeamRetentionView | null;
 };
 export type UserDetails = {
@@ -1459,7 +1461,6 @@ export type BodyUploadTeamBannerControlPlaneV1TeamsTeamIdBannerPost = {
   /** Banner image file (max 5MB, JPEG/PNG/WebP) */
   file: string;
 };
-export type UserTeamRelation = "team_admin" | "team_editor" | "team_analyst" | "team_member";
 export type TeamMember = {
   type?: "user";
   relations: UserTeamRelation[];

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -1427,3 +1427,41 @@ reaches a settings surface, scoped by their existing per-section capability
 gates (a plain member sees a read-only Members list plus a new "Leave team"
 action; elevated roles keep today's full panel plus the same action). No new
 `TeamPermission` was added — see RFC Part 9 §45 for why.
+
+## 26. Contract Notes — #2100, `TeamWithPermissions.my_relations`
+
+**New field, additive only.** `TeamWithPermissions` (`GET /teams/{team_id}`,
+`create_team`, `update_team`, and the bootstrap's `active_team`) gains
+`my_relations: list[UserTeamRelation]` — the caller's own raw role relations
+on that team (`team_admin`/`team_editor`/`team_analyst`/`team_member`), the
+same set already exposed for other members via `TeamMember.relations`.
+
+**Why `permissions` alone was not enough:** `can_run_evaluations` and
+`can_manage_evaluation_corpus` are granted to both `team_analyst` and
+`team_admin` (schema.fga union), so a plain `team_admin` with no explicit
+`team_analyst` grant would already show those permissions — deriving an
+"Analyst" role badge from `permissions` would mislabel every admin as an
+analyst too. `team_admin` (`can_administer_admins`) and `team_editor`
+(`can_update_agents`) remain independently and reliably derivable from
+`permissions`, but `my_relations` is now the single unambiguous source for
+all three, used by the frontend's team-role display (§ below).
+
+Personal teams report the fixed literal `["team_editor"]` (matching their
+already-hardcoded `permissions`) rather than a live ReBAC lookup — see
+`teams/system.py::build_personal_team`.
+
+**Frontend:**
+
+- `TeamSelectionItem` (left team rail): a 14×14 Shield badge (bottom-right of
+  the avatar) appears when the current user is listed in that team's
+  `admins` (`Team.admins`, already present — no new data needed for this
+  part; `my_relations` is not involved here since the rail only needs a
+  boolean, not the full role set).
+- `TeamContentNavbar` (team banner): the name/gear row moves to the top of
+  the banner; a new bottom-left label lists every role the user holds,
+  joined by " · " (e.g. "Administrateur · Analyste"), reusing the existing
+  `rework.teamRoles.*` i18n labels, falling back to "Membre" when no
+  elevated role is held. Hidden for the personal space and for a non-member
+  merely browsing a public/marketplace team pre-join (`is_member`).
+
+`controlPlaneOpenApi.ts` regenerated (`make update-control-plane-api`).

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -812,6 +812,40 @@ deliberate risk-reduction pattern, not the default hierarchy.
 
 ---
 
+### `TeamContentNavbar` banner / `TeamSelectionItem` — team role badges (#2100)
+
+**Location:** `src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx`,
+`src/rework/components/shared/layouts/Sidebar/TeamSelectionNavbar/TeamSelectionItem/TeamSelectionItem.tsx`
+**Status:** `Functional`
+
+Helps a user recognize their role in each team they belong to.
+
+- **Left team rail (`TeamSelectionItem`, `teamAvatarContainer`):** a 14×14
+  Shield icon badge (`color: secondary`, 2px `surface-container-lowest`
+  outline forming a clean cutout against the avatar underneath — same
+  technique as the existing `activityDot`) appears bottom-right of a team's
+  avatar (`right: 8px; bottom: 2px`) when the current user is admin of that
+  team. Derived client-side from `Team.admins` (`admin.id === currentUserId`)
+  — no `my_relations` needed here, just a boolean.
+- **Team banner (`TeamContentNavbar`):** `.bannerContainer` is now a column
+  (`justify-content: space-between`) instead of a single bottom-aligned row —
+  the team name + settings gear move to the top, and a new bottom-left label
+  lists every role the user holds, joined by " · " (e.g.
+  "Administrateur · Analyste"), reusing the existing `rework.teamRoles.*`
+  labels (already shown as chips in the Members table). Falls back to
+  "Membre" when no elevated role is held. Not shown for the personal space,
+  or for a non-member merely browsing a public/marketplace team pre-join
+  (`selectedTeam.is_member`).
+- Backend: new `TeamWithPermissions.my_relations` field — see
+  `CONTROL-PLANE-PRODUCT-CONTRACT.md` §26 for why `permissions` alone
+  couldn't reliably answer "is this user actually team_analyst".
+
+#### Open UX issues
+
+- Not yet design-reviewed. First functional pass only.
+
+---
+
 ### `Toast` / `ToastProvider`
 
 **Location:** `src/rework/components/shared/molecules/Toast/Toast.tsx`


### PR DESCRIPTION
## Summary

Helps a user recognize their role in each team they belong to.

- **Admin shield badge** — in the left team-selection rail, a Shield icon badge (`secondary` color, `surface-container-lowest` backdrop) appears on a team's avatar when the current user is `team_admin` of that team. Derived client-side from `Team.admins` (already in the bootstrap payload) — no new data needed for this part.
- **Role label in the team banner** — the name/gear row stays pinned to the top of the banner regardless of settings mode (previously shifted depending on whether the gear icon was rendered); a new bottom-left label lists every role the user holds, joined by " · " (e.g. "Administrateur · Analyste"), reusing the existing `rework.teamRoles.*` labels. Plain members see "Membre". Hidden for the personal space and for a non-member browsing a public/marketplace team pre-join.

## Backend contract change

`TeamWithPermissions` gains `my_relations: list[UserTeamRelation]` — the caller's own raw role relations, mirroring `TeamMember.relations` already exposed for other members. `permissions` alone can't reliably answer "is this user actually team_analyst": `can_run_evaluations`/`can_manage_evaluation_corpus` are granted to both `team_analyst` and `team_admin` via the FGA union, so a plain admin would look like an analyst too. Added everywhere `TeamWithPermissions` is constructed (`get_team_by_id`, `create_team`, `update_team`, `build_personal_team`); client regenerated.

## Tracking

Issue #2100.

## Test plan

- [x] `make code-quality` (backend: ruff/bandit/basedpyright; frontend: tsc/prettier/eslint)
- [x] `make test` — backend 505 passed, frontend 597 passed
- [x] Manually verified against a live local stack (all services restarted)
- [ ] Design review of badge/label placement and sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)