### PR TITLE
Agent form rework: header, template picker, 4-tab body + usage_statement

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/cli/client.py
+++ b/apps/control-plane-backend/control_plane_backend/cli/client.py
@@ -326,6 +326,7 @@ class ControlPlaneApiClient:
         *,
         template_id: str,
         display_name: str,
+        usage_statement: str,
         description: str | None = None,
     ) -> ManagedAgentInstanceSummary:
         """Enroll one discovered template as a managed agent instance."""
@@ -334,6 +335,7 @@ class ControlPlaneApiClient:
             template_id=template_id,
             display_name=display_name,
             description=description,
+            usage_statement=usage_statement,
         )
         payload = self._get_json_payload(
             "POST",

--- a/apps/control-plane-backend/control_plane_backend/cli/main.py
+++ b/apps/control-plane-backend/control_plane_backend/cli/main.py
@@ -1312,7 +1312,9 @@ def run_command(
 
     if command == "/enroll":
         if not args:
-            raise ValueError("Usage: /enroll <template_id> [display_name]")
+            raise ValueError(
+                "Usage: /enroll <template_id> [display_name] [usage_statement]"
+            )
         team_id = _resolve_team_id(ctx, None)
         template_id = args[0]
         templates = ctx.state.known_templates or ctx.client.list_agent_templates(
@@ -1327,11 +1329,13 @@ def run_command(
                 f"Unknown template_id {template_id!r}. Run /templates first for the current team."
             )
         display_name = args[1] if len(args) > 1 else template.display_name
+        usage_statement = args[2] if len(args) > 2 else template.description
         created = ctx.client.enroll_agent_instance(
             team_id,
             template_id=template.template_id,
             display_name=display_name,
             description=template.description,
+            usage_statement=usage_statement,
         )
         ctx.state.known_instances = ctx.client.list_agent_instances(team_id)
         _print_model_json(

--- a/apps/control-plane-backend/control_plane_backend/config/models.py
+++ b/apps/control-plane-backend/control_plane_backend/config/models.py
@@ -164,6 +164,18 @@ class ManagedAgentTuning(BaseModel):
 
     role: str = Field(..., min_length=1)
     description: str = Field(..., min_length=1)
+    usage_statement: str = Field(
+        default="",
+        description=(
+            "User-authored statement of the intended use case for this agent "
+            "instance (purpose, target users/impacted parties, data handled, "
+            "outputs, error impact) — used to screen for platform/organization "
+            "risk (#2105). Defaults to '' so pre-#2105 rows without this key in "
+            "their stored tuning_json still deserialize; the product-facing "
+            "requiredness is enforced by the API layer (CreateAgentInstanceRequest "
+            "and the agent form), not by this default."
+        ),
+    )
     tags: list[str] = Field(default_factory=list)
     fields: list[ManagedAgentFieldSpec] = Field(default_factory=list)
     # The MCP tuning trio (mcp_servers / selected_mcp_server_ids /

--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -195,6 +195,19 @@ class ManagedAgentInstanceSummary(BaseModel):
             "until independently edited (#2076)."
         ),
     )
+    usage_statement: str = Field(
+        default="",
+        description=(
+            "User-authored intended-use statement (purpose, target/impacted "
+            "users, data handled, outputs, error impact) captured in the "
+            "agent form's Engagement tab, used to screen for platform/"
+            "organization risk (#2105). Empty for agents enrolled before "
+            "#2105 until independently edited — required at creation and "
+            "enforced by the agent edit form on save, but omittable on "
+            "`UpdateAgentInstanceRequest` (like `role`) so partial updates "
+            "such as the enable/disable toggle are unaffected."
+        ),
+    )
     status: Literal["enabled", "disabled"]
     suspension_reason: SuspensionReason | None = Field(
         default=None,
@@ -535,6 +548,16 @@ class CreateAgentInstanceRequest(BaseModel):
             "Defaults to `display_name` when omitted (#2076)."
         ),
     )
+    usage_statement: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Required intended-use statement (purpose, target/impacted users, "
+            "data handled, outputs, error impact) — used to screen for "
+            "platform/organization risk (#2105). Hard-required at creation, "
+            "unlike the optional `role`."
+        ),
+    )
     tuning_field_values: dict[str, TuningValue] | None = Field(
         default=None,
         description=(
@@ -578,6 +601,19 @@ class UpdateAgentInstanceRequest(BaseModel):
         description=(
             "Short one-line summary of what this agent does. Omit to leave "
             "the current role unchanged (#2076)."
+        ),
+    )
+    usage_statement: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Intended-use statement (#2105). Omit to leave the current value "
+            "unchanged — same convention as `role`, so partial updates like "
+            "the enable/disable toggle (which PATCHes only `status`) are not "
+            "forced to resupply it. The agent edit form always submits it "
+            "(enforced client-side, same as `display_name`), so in practice "
+            "every full-form save keeps this current, including for agents "
+            "enrolled before #2105 whose stored value starts out empty."
         ),
     )
     status: Literal["enabled", "disabled"] | None = Field(

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -1979,6 +1979,7 @@ def _record_to_summary(
         display_name=record.display_name,
         description=record.description,
         role=record.tuning.role,
+        usage_statement=record.tuning.usage_statement,
         status="enabled" if record.enabled else "disabled",
         suspension_reason=(
             SuspensionReason(record.suspension_reason)
@@ -2258,6 +2259,7 @@ async def enroll_agent_instance(
         update={
             "role": request.role or request.display_name,
             "description": request.description or request.display_name,
+            "usage_statement": request.usage_statement,
         }
     )
     if request.tuning_field_values:
@@ -2494,6 +2496,14 @@ async def update_agent_instance(
         # branch above already ran for the same request.
         new_tuning = (new_tuning or record.tuning).model_copy(
             update={"role": request.role}
+        )
+
+    if request.usage_statement is not None:
+        # Same "None means unchanged" convention as role above (#2105) — the
+        # agent edit form always submits it, so this only stays None for
+        # partial-update callers like the enable/disable toggle.
+        new_tuning = (new_tuning or record.tuning).model_copy(
+            update={"usage_statement": request.usage_statement}
         )
 
     updated = await store.update(

--- a/apps/control-plane-backend/tests/test_capability_selection_1974.py
+++ b/apps/control-plane-backend/tests/test_capability_selection_1974.py
@@ -286,6 +286,7 @@ async def test_enroll_persists_pod_validated_envelopes_verbatim(
             "/control-plane/v1/teams/personal/agent-instances",
             headers={"Authorization": "Bearer user-token"},
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Echo with capabilities",
                 "capability_ids": ["demo_echo"],
@@ -331,6 +332,7 @@ async def test_enroll_unknown_capability_id_is_typed_422(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Bad selection",
                 "capability_ids": ["ghost"],
@@ -355,6 +357,7 @@ async def test_enroll_config_for_unselected_capability_is_ignored(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Selective",
                 "capability_ids": ["demo_echo"],
@@ -392,6 +395,7 @@ async def test_enroll_propagates_pod_422_wording(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Missing asset",
                 "capability_ids": ["demo_echo"],
@@ -429,6 +433,7 @@ async def test_enroll_no_selection_materializes_only_granted_defaults(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Default selection",
             },
@@ -460,6 +465,7 @@ async def test_enroll_hidden_template_is_404_not_500(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Should not exist for this team",
             },
@@ -481,6 +487,7 @@ async def test_enroll_no_selection_with_rebac_disabled_takes_all_defaults(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "ReBAC disabled",
             },
@@ -513,6 +520,7 @@ async def test_enroll_no_selection_rejected_when_no_default_capability_is_usable
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Toolless agent",
             },
@@ -536,6 +544,7 @@ async def test_enroll_explicit_selection_denied_by_rebac_is_403(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "Deliberate but denied",
                 "capability_ids": ["demo_echo"],

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -1416,6 +1416,7 @@ async def test_team_agent_instances_returns_managed_identity(
             "display_name": "Echo Team Agent",
             "description": "Managed echo agent",
             "role": "Echo Team Agent",
+            "usage_statement": "",
             "status": "enabled",
             "created_by": "internal-admin",
             "tuning_field_values": {},
@@ -1604,7 +1605,11 @@ async def test_agent_instance_mutations_require_can_update_agents(
         # enroll
         await client.post(
             "/control-plane/v1/teams/fredlab/agent-instances",
-            json={"template_id": "runtime-a:foo", "display_name": "x"},
+            json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
+                "template_id": "runtime-a:foo",
+                "display_name": "x",
+            },
         )
         assert captured["perms"] == [TeamPermission.CAN_UPDATE_AGENTS]
         # delete
@@ -2077,6 +2082,7 @@ async def test_enroll_agent_instance_creates_db_record(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "My Echo Agent",
                 "description": "A test echo agent",
@@ -2136,6 +2142,7 @@ async def test_enroll_agent_instance_unreachable_runtime_returns_503(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "My Echo Agent",
                 "description": "A test echo agent",
@@ -4498,6 +4505,7 @@ async def test_enroll_agent_instance_returns_404_for_unknown_runtime(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "unknown-runtime:some-agent",
                 "display_name": "Agent",
             },
@@ -4523,7 +4531,11 @@ async def test_enroll_agent_instance_returns_400_for_malformed_template_id(
     ) as client:
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
-            json={"template_id": "no-colon-here", "display_name": "Agent"},
+            json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
+                "template_id": "no-colon-here",
+                "display_name": "Agent",
+            },
         )
 
     assert resp.status_code == 400
@@ -5477,6 +5489,7 @@ async def test_enroll_agent_instance_stores_provided_field_values(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "My Echo",
                 "tuning_field_values": {"persona": "You are a helpful assistant."},
@@ -5528,6 +5541,7 @@ async def test_enroll_agent_instance_silently_drops_unknown_field_keys(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.echo",
                 "display_name": "My Echo",
                 "tuning_field_values": {
@@ -5578,6 +5592,7 @@ async def test_enroll_agent_instance_rejects_invalid_tuning_value_type_and_range
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.validated",
                 "display_name": "Validated Echo",
                 "tuning_field_values": {
@@ -6013,6 +6028,7 @@ async def test_enroll_agent_instance_stores_mcp_server_selection(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.mcp",
                 "display_name": "MCP Instance",
                 "capability_ids": [_MCP_SEARCH_ID],
@@ -6085,7 +6101,11 @@ async def test_enrolling_internal_template_is_admin_only(
             enabled=True,
         )
     ]
-    body = {"template_id": "runtime-a:rags.sample.mcp", "display_name": "x"}
+    body = {
+        "template_id": "runtime-a:rags.sample.mcp",
+        "display_name": "x",
+        "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
+    }
 
     # Keycloak `admin` role but no OpenFGA `platform_admin` relation: the hidden
     # template resolves to nothing -> 404 (as if it did not exist).
@@ -6251,6 +6271,7 @@ async def test_enroll_agent_instance_stores_mcp_config_values(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.mcp",
                 "display_name": "MCP Instance",
                 "capability_ids": [_MCP_SEARCH_ID],
@@ -6321,6 +6342,7 @@ async def test_enroll_agent_instance_rejects_unknown_mcp_server_id(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.mcp",
                 "display_name": "MCP Instance",
                 "capability_ids": ["mcp-unknown"],
@@ -7000,6 +7022,7 @@ async def test_enroll_agent_instance_rejects_unknown_prompt_token(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.validated",
                 "display_name": "Bad Prompt Agent",
                 "tuning_field_values": {
@@ -7051,6 +7074,7 @@ async def test_enroll_agent_instance_accepts_valid_prompt_tokens(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.validated",
                 "display_name": "Good Prompt Agent",
                 "tuning_field_values": {
@@ -7103,6 +7127,7 @@ async def test_enroll_agent_instance_accepts_prompt_with_code_braces(
         resp = await client.post(
             "/control-plane/v1/teams/personal/agent-instances",
             json={
+                "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.validated",
                 "display_name": "Code Prompt Agent",
                 "tuning_field_values": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1555,6 +1555,10 @@
           }
         },
         "noTemplates": "No agent templates available — start a runtime pod.",
+        "templateBrowser": {
+          "title": "Select an agent template",
+          "subtitle": "Each template is designed and optimized to create an agent for a specific mission."
+        },
         "promptField": {
           "pickFromLibrary": "Pick from library",
           "removeTagAria": "Remove {{tag}}",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1552,6 +1552,11 @@
           "role": {
             "label": "Role",
             "placeholder": "Describe the {{agentsNicknameSingular}}'s role"
+          },
+          "usageStatement": {
+            "label": "Use case",
+            "explanation": "Clearly describe the use cases you plan to address with this agent.",
+            "placeholder": "Purpose, target users, impacted parties, data handled, outputs/deliverables, impact if the agent errs..."
           }
         },
         "noTemplates": "No agent templates available — start a runtime pod.",
@@ -1567,10 +1572,10 @@
         },
         "sections": {
           "aria": "Form sections",
-          "chat": "Chat",
+          "general": "General",
           "prompts": "Prompts",
-          "settings": "Settings",
-          "tools": "Tools"
+          "tools": "Tools",
+          "commitments": "Commitments"
         },
         "selectPlaceholder": "Select an option",
         "suspended": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1575,6 +1575,8 @@
           "accessRevoked": "Your team's access to a capability it uses was revoked ({{capabilities}}). Untick it and re-save the agent, or contact a platform administrator.",
           "configInvalid": "The parameters of a capability it uses are no longer valid. Reset them and re-save the agent to fix it, or contact a platform administrator."
         },
+        "subtitle": "Team: {{team}}",
+        "subtitleWithTemplate": "Team: {{team}} · Template: {{template}}",
         "templateUnavailable": "Template unavailable — field definitions may be incomplete.",
         "titleCreate": "Create a new {{agentsNicknameSingular}}",
         "titleEdit": "Edit {{agent}}",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1552,6 +1552,11 @@
           "role": {
             "label": "Rôle",
             "placeholder": "Décrivez le rôle de {{agentsNicknameSingular}}"
+          },
+          "usageStatement": {
+            "label": "Cas d'usage",
+            "explanation": "Décrivez clairement les cas d'usage que vous envisagez de traiter grâce à cet agent.",
+            "placeholder": "Finalité, utilisateurs cibles, acteurs impactés, données exploitées, productions/livrables, impacts en cas d'erreur de l'agent..."
           }
         },
         "noTemplates": "Aucun modèle d'agent disponible — démarrez un pod runtime.",
@@ -1567,10 +1572,10 @@
         },
         "sections": {
           "aria": "Sections du formulaire",
-          "chat": "Discussion",
+          "general": "Général",
           "prompts": "Prompts",
-          "settings": "Paramètres",
-          "tools": "Outils"
+          "tools": "Outils",
+          "commitments": "Engagement"
         },
         "selectPlaceholder": "Sélectionner une option",
         "suspended": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1555,6 +1555,10 @@
           }
         },
         "noTemplates": "Aucun modèle d'agent disponible — démarrez un pod runtime.",
+        "templateBrowser": {
+          "title": "Sélectionner un template d'agent",
+          "subtitle": "Chaque template permet de créer un agent pensé et optimisé pour une mission spécifique."
+        },
         "promptField": {
           "pickFromLibrary": "Choisir depuis la bibliothèque",
           "removeTagAria": "Retirer {{tag}}",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1575,6 +1575,8 @@
           "accessRevoked": "L'accès de votre équipe à une capacité qu'il utilise a été révoqué ({{capabilities}}). Décochez-la et réenregistrez l'agent, ou contactez un administrateur de la plateforme.",
           "configInvalid": "Les paramètres d'une capacité qu'il utilise ne sont plus valides. Réinitialisez-les et réenregistrez l'agent pour corriger le problème, ou contactez un administrateur de la plateforme."
         },
+        "subtitle": "Équipe : {{team}}",
+        "subtitleWithTemplate": "Équipe : {{team}} · Template : {{template}}",
         "templateUnavailable": "Modèle indisponible — les définitions de champs peuvent être incomplètes.",
         "titleCreate": "Créer un nouveau {{agentsNicknameSingular}}",
         "titleEdit": "Editer {{agent}}",

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.module.css
@@ -29,31 +29,6 @@
   text-transform: uppercase;
 }
 
-.contextBar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-s);
-  border-radius: var(--radius-s);
-  background: var(--surface-container-low);
-  padding: var(--spacing-s) var(--spacing-m);
-}
-
-.contextName {
-  color: var(--on-surface);
-  font: var(--font-title-small);
-}
-
-.contextCategory {
-  border-radius: 999px;
-  background: var(--secondary-container);
-  padding: 2px 10px;
-  color: var(--on-secondary-container);
-  font: var(--font-label-small);
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
 .templateUnavailableNotice {
   margin: 0;
   border-radius: var(--radius-s);

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -31,29 +31,34 @@ import { TuningFieldRenderer } from "./TuningFieldRenderer.tsx";
 import { CapabilityCard } from "./CapabilityCard/CapabilityCard.tsx";
 import styles from "./AgentFormBody.module.css";
 
-export type SectionKey = "prompts" | "settings" | "chat" | "tools";
+export type SectionKey = "general" | "prompts" | "tools" | "commitments";
 
-const SECTION_ORDER: SectionKey[] = ["prompts", "settings", "chat", "tools"];
+const SECTION_ORDER: SectionKey[] = ["general", "prompts", "tools", "commitments"];
 
 const SECTION_LABEL_KEYS: Record<SectionKey, string> = {
+  general: "rework.teams.formAgent.sections.general",
   prompts: "rework.teams.formAgent.sections.prompts",
-  settings: "rework.teams.formAgent.sections.settings",
-  chat: "rework.teams.formAgent.sections.chat",
   tools: "rework.teams.formAgent.sections.tools",
+  commitments: "rework.teams.formAgent.sections.commitments",
 };
 
 const SECTION_ICONS: Record<SectionKey, { category: "outlined"; type: IconType }> = {
+  general: { category: "outlined", type: "tune" },
   prompts: { category: "outlined", type: "edit_note" },
-  settings: { category: "outlined", type: "tune" },
-  chat: { category: "outlined", type: "forum" },
   tools: { category: "outlined", type: "build" },
+  commitments: { category: "outlined", type: "shield" },
 };
 
-function routeField(field: ManagedAgentFieldSpec): "prompts" | "settings" | "chat" {
+/**
+ * Only `ui.group === "Prompts"` gets its own tab; every other declared group
+ * (Settings, Credentials, Document reading, Mindmap, Grounding, Comparison,
+ * Fallback, ...) folds into "General" alongside name/role/description. This
+ * keeps the 4-tab layout compatible with the existing template `ui.group`
+ * taxonomy without requiring any template-side changes.
+ */
+function routeField(field: ManagedAgentFieldSpec): "prompts" | "general" {
   const g = (field.ui?.group ?? "").toLowerCase().trim();
-  if (g === "prompts") return "prompts";
-  if (g === "chat") return "chat";
-  return "settings";
+  return g === "prompts" ? "prompts" : "general";
 }
 
 function formatRelativeDate(dateStr: string | null | undefined): string {
@@ -78,6 +83,7 @@ type AgentFormBodyProps = {
   displayName: string;
   role: string;
   description: string;
+  usageStatement: string;
   tuningFieldValues: Record<string, unknown>;
   /** Explicit list of active capability ids ([] = none active). */
   selectedCapabilityIds: string[];
@@ -95,6 +101,7 @@ type AgentFormBodyProps = {
   onDisplayNameChange: (v: string) => void;
   onRoleChange: (v: string) => void;
   onDescriptionChange: (v: string) => void;
+  onUsageStatementChange: (v: string) => void;
   onTuningChange: (key: string, value: unknown) => void;
   onCapabilitySelectionChange: (ids: string[]) => void;
   onCapabilityConfigChange: (capabilityId: string, key: string, value: unknown) => void;
@@ -109,6 +116,7 @@ export function AgentFormBody({
   displayName,
   role,
   description,
+  usageStatement,
   tuningFieldValues,
   selectedCapabilityIds,
   capabilityConfigValues,
@@ -123,6 +131,7 @@ export function AgentFormBody({
   onDisplayNameChange,
   onRoleChange,
   onDescriptionChange,
+  onUsageStatementChange,
   onTuningChange,
   onCapabilitySelectionChange,
   onCapabilityConfigChange,
@@ -182,24 +191,20 @@ export function AgentFormBody({
 
   const visibleFields = (selectedTemplate?.default_tuning_fields ?? []).filter((f) => !f.ui?.hide);
   const promptFields = visibleFields.filter((f) => routeField(f) === "prompts");
-  const settingsFields = visibleFields.filter((f) => routeField(f) === "settings");
-  const chatFields = visibleFields.filter((f) => routeField(f) === "chat");
-
-  const fieldsBySection: Record<"prompts" | "settings" | "chat", ManagedAgentFieldSpec[]> = {
-    prompts: promptFields,
-    settings: settingsFields,
-    chat: chatFields,
-  };
+  const generalFields = visibleFields.filter((f) => routeField(f) === "general");
 
   const visibleSections = SECTION_ORDER.filter((s) => {
     if (s === "tools") return capabilities.length > 0;
-    return fieldsBySection[s].length > 0;
+    if (s === "prompts") return promptFields.length > 0;
+    return true; // general and commitments always have content
   });
 
-  const effectiveSection = visibleSections.includes(activeSection) ? activeSection : (visibleSections[0] ?? "settings");
+  const effectiveSection = visibleSections.includes(activeSection) ? activeSection : (visibleSections[0] ?? "general");
   const activeSectionIndex = Math.max(0, visibleSections.indexOf(effectiveSection));
 
   const nameError = submitAttempted && !displayName.trim() ? t("rework.teams.formAgent.fields.name.label") : undefined;
+  const usageStatementError =
+    submitAttempted && !usageStatement.trim() ? t("rework.teams.formAgent.fields.usageStatement.label") : undefined;
 
   // Effective value (current input or declared default) of every tuning field,
   // across sections — drives `ui.visible_when` even when the gating field lives
@@ -255,95 +260,105 @@ export function AgentFormBody({
 
       {!templateMissing && (
         <>
-          <TextInput
-            label={t("rework.teams.formAgent.fields.name.label")}
-            value={displayName}
-            onChange={(e) => onDisplayNameChange(e.target.value)}
-            maxLength={255}
-            required
-            disabled={isSubmitting}
-            error={nameError}
-          />
-          <TextInput
-            label={t("rework.teams.formAgent.fields.role.label")}
-            placeholder={displayName}
-            value={role}
-            onChange={(e) => onRoleChange(e.target.value)}
-            maxLength={255}
-            disabled={isSubmitting}
-          />
-          <TextArea
-            label={t("rework.teams.formAgent.fields.description.label")}
-            value={description}
-            onChange={(e) => onDescriptionChange(e.target.value)}
-            rows={3}
-            maxLength={500}
-            disabled={isSubmitting}
-          />
+          <div className={styles.tabStrip}>
+            <ButtonGroup
+              key={visibleSections.join(",")}
+              size="medium"
+              color="secondary"
+              variant="radio"
+              fullWidth
+              aria-label={t("rework.teams.formAgent.sections.aria")}
+              selectedIndex={activeSectionIndex}
+              onSelectedIndexChange={(i) => onSectionChange(visibleSections[i] as SectionKey)}
+              items={visibleSections.map((s) => ({
+                label: t(SECTION_LABEL_KEYS[s]),
+                icon: SECTION_ICONS[s],
+                hasError: errorSections.has(s),
+                onClick: () => onSectionChange(s),
+              }))}
+            />
+          </div>
 
-          {visibleSections.length > 0 && (
-            <>
-              <div className={styles.tabStrip}>
-                <ButtonGroup
-                  key={visibleSections.join(",")}
-                  size="small"
-                  color="secondary"
-                  variant="tabs"
-                  aria-label={t("rework.teams.formAgent.sections.aria")}
-                  selectedIndex={activeSectionIndex}
-                  onSelectedIndexChange={(i) => onSectionChange(visibleSections[i] as SectionKey)}
-                  items={visibleSections.map((s) => ({
-                    label: t(SECTION_LABEL_KEYS[s]),
-                    icon: SECTION_ICONS[s],
-                    hasError: errorSections.has(s),
-                    onClick: () => onSectionChange(s),
-                  }))}
-                />
-              </div>
-
-              {errorSections.size > 0 && (
-                <div className={styles.validationBanner} role="alert">
-                  {t("rework.teams.formAgent.validation.requiredFields")}
-                </div>
-              )}
-
-              <div className={styles.sectionContent}>
-                {effectiveSection === "prompts" && renderFieldList(promptFields)}
-                {effectiveSection === "settings" && renderFieldList(settingsFields)}
-                {effectiveSection === "chat" && renderFieldList(chatFields)}
-                {effectiveSection === "tools" && capabilities.length > 0 && (
-                  <ul className={styles.toolsList}>
-                    {capabilities.map((capability) => {
-                      const checked = selectedCapabilityIds.includes(capability.id);
-                      const toggle = () => {
-                        const next = checked
-                          ? selectedCapabilityIds.filter((id) => id !== capability.id)
-                          : [...selectedCapabilityIds, capability.id];
-                        onCapabilitySelectionChange(next);
-                      };
-                      return (
-                        <CapabilityCard
-                          key={capability.id}
-                          capability={capability}
-                          teamId={teamId}
-                          checked={checked}
-                          disabled={isSubmitting}
-                          configValues={capabilityConfigValues[capability.id] ?? {}}
-                          assetFiles={capabilityAssetFiles[capability.id] ?? {}}
-                          onToggle={toggle}
-                          onConfigChange={(key, val) => onCapabilityConfigChange(capability.id, key, val)}
-                          onAssetFileChange={(slotKey, file) =>
-                            onCapabilityAssetFileChange(capability.id, slotKey, file)
-                          }
-                          onBlockingErrorChange={(message) => onCapabilityBlockingErrorChange(capability.id, message)}
-                        />
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
-            </>
+          {errorSections.size > 0 && (
+            <div className={styles.validationBanner} role="alert">
+              {t("rework.teams.formAgent.validation.requiredFields")}
+            </div>
           )}
+
+          <div className={styles.sectionContent}>
+            {effectiveSection === "general" && (
+              <>
+                <TextInput
+                  label={t("rework.teams.formAgent.fields.name.label")}
+                  value={displayName}
+                  onChange={(e) => onDisplayNameChange(e.target.value)}
+                  maxLength={255}
+                  required
+                  disabled={isSubmitting}
+                  error={nameError}
+                />
+                <TextInput
+                  label={t("rework.teams.formAgent.fields.role.label")}
+                  placeholder={displayName}
+                  value={role}
+                  onChange={(e) => onRoleChange(e.target.value)}
+                  maxLength={255}
+                  disabled={isSubmitting}
+                />
+                <TextArea
+                  label={t("rework.teams.formAgent.fields.description.label")}
+                  value={description}
+                  onChange={(e) => onDescriptionChange(e.target.value)}
+                  rows={3}
+                  maxLength={500}
+                  disabled={isSubmitting}
+                />
+                {renderFieldList(generalFields)}
+              </>
+            )}
+            {effectiveSection === "prompts" && renderFieldList(promptFields)}
+            {effectiveSection === "tools" && capabilities.length > 0 && (
+              <ul className={styles.toolsList}>
+                {capabilities.map((capability) => {
+                  const checked = selectedCapabilityIds.includes(capability.id);
+                  const toggle = () => {
+                    const next = checked
+                      ? selectedCapabilityIds.filter((id) => id !== capability.id)
+                      : [...selectedCapabilityIds, capability.id];
+                    onCapabilitySelectionChange(next);
+                  };
+                  return (
+                    <CapabilityCard
+                      key={capability.id}
+                      capability={capability}
+                      teamId={teamId}
+                      checked={checked}
+                      disabled={isSubmitting}
+                      configValues={capabilityConfigValues[capability.id] ?? {}}
+                      assetFiles={capabilityAssetFiles[capability.id] ?? {}}
+                      onToggle={toggle}
+                      onConfigChange={(key, val) => onCapabilityConfigChange(capability.id, key, val)}
+                      onAssetFileChange={(slotKey, file) => onCapabilityAssetFileChange(capability.id, slotKey, file)}
+                      onBlockingErrorChange={(message) => onCapabilityBlockingErrorChange(capability.id, message)}
+                    />
+                  );
+                })}
+              </ul>
+            )}
+            {effectiveSection === "commitments" && (
+              <TextArea
+                label={t("rework.teams.formAgent.fields.usageStatement.label")}
+                explanation={t("rework.teams.formAgent.fields.usageStatement.explanation")}
+                placeholder={t("rework.teams.formAgent.fields.usageStatement.placeholder")}
+                value={usageStatement}
+                onChange={(e) => onUsageStatementChange(e.target.value)}
+                rows={8}
+                required
+                disabled={isSubmitting}
+                error={usageStatementError}
+              />
+            )}
+          </div>
         </>
       )}
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -243,14 +243,9 @@ export function AgentFormBody({
         tabIndex={-1}
         readOnly
       />
-      {selectedTemplate ? (
-        <div className={styles.contextBar}>
-          <span className={styles.contextName}>{selectedTemplate.display_name}</span>
-          {selectedTemplate.category && <span className={styles.contextCategory}>{selectedTemplate.category}</span>}
-        </div>
-      ) : templateMissing ? (
+      {templateMissing && (
         <p className={styles.templateUnavailableNotice}>{t("rework.teams.formAgent.templateUnavailable")}</p>
-      ) : null}
+      )}
 
       {suspensionMessage && (
         <div className={styles.suspensionBanner} role="alert">

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.module.css
@@ -3,9 +3,8 @@
   flex-direction: column;
   gap: var(--spacing-l);
   margin: 1rem auto;
-  box-shadow: var(--shadow-l);
   border-radius: var(--radius-l);
-  background: var(--surface-container-lowest);
+  background: var(--surface-main);
   padding: var(--spacing-l);
   width: min(52rem, calc(100vw - 2rem));
 }
@@ -21,19 +20,6 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-m);
-}
-
-.modalIcon {
-  display: flex;
-  flex-shrink: 0;
-  justify-content: center;
-  align-items: center;
-  border-radius: 999px;
-  background: var(--primary-container);
-  width: 3.25rem;
-  height: 3.25rem;
-  color: var(--primary);
-  font-size: 1.75rem;
 }
 
 .modalTitleBlock {
@@ -58,10 +44,6 @@
   justify-content: flex-end;
   align-items: center;
   gap: var(--spacing-xs);
-}
-
-.modalActionsBack {
-  margin-right: auto;
 }
 
 .modalContent {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.test.ts
@@ -28,13 +28,14 @@ const EMPTY_CAPABILITY_STATE = {
 };
 
 describe("buildAgentFormSubmitPayload", () => {
-  it("trims display name, role, and description on create submit", () => {
+  it("trims display name, role, description, and usage statement on create submit", () => {
     const payload = buildAgentFormSubmitPayload(
       {
         templateId: "runtime:agent",
         displayName: "  DT Aegis  ",
         role: "  Guardian  ",
         description: "  Guardrails  ",
+        usageStatement: "  Screens inbound requests for policy violations.  ",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
       },
@@ -45,6 +46,7 @@ describe("buildAgentFormSubmitPayload", () => {
       displayName: "DT Aegis",
       role: "Guardian",
       description: "Guardrails",
+      usageStatement: "Screens inbound requests for policy violations.",
     });
   });
 
@@ -55,6 +57,7 @@ describe("buildAgentFormSubmitPayload", () => {
         displayName: "Agent",
         role: "",
         description: "",
+        usageStatement: "",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
         selectedCapabilityIds: ["ghost-cap"],
@@ -75,6 +78,7 @@ describe("buildAgentFormSubmitPayload", () => {
         displayName: "Agent",
         role: "",
         description: "",
+        usageStatement: "",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
         // "gone" is not advertised; "unselected" is advertised but not ticked.
@@ -100,6 +104,7 @@ describe("buildAgentFormSubmitPayload", () => {
         displayName: "Agent",
         role: "",
         description: "",
+        usageStatement: "",
         tuningValues: {},
         ...EMPTY_CAPABILITY_STATE,
         selectedCapabilityIds: ["knowledge-flow-mcp-text"],

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import Button from "@shared/atoms/Button/Button.tsx";
-import Icon from "@shared/atoms/Icon/Icon.tsx";
 import { FullPageModal } from "@shared/molecules/FullPageModal/FullPageModal.tsx";
-import { IconType } from "@shared/utils/Type.ts";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFrontendProperties } from "../../../../../hooks/useFrontendProperties.ts";
@@ -159,7 +157,7 @@ export default function AgentFormModal({
   onDelete,
 }: AgentFormModalProps) {
   const { t, i18n } = useTranslation();
-  const { agentsNicknameSingular, agentIconName } = useFrontendProperties();
+  const { agentsNicknameSingular } = useFrontendProperties();
 
   // step 1 = choose template, step 2 = configure. Edit mode always starts at 2.
   const [step, setStep] = useState<1 | 2>(1);
@@ -304,34 +302,23 @@ export default function AgentFormModal({
       ? t("rework.teams.formAgent.titleEdit", { agent: editInstance?.display_name ?? "" })
       : t("rework.teams.formAgent.titleCreate", { agentsNicknameSingular });
 
+  const teamLabel = teamName || t("rework.sidebar.team.userTeam");
+  const subtitle = selectedTemplate
+    ? t("rework.teams.formAgent.subtitleWithTemplate", { team: teamLabel, template: selectedTemplate.display_name })
+    : t("rework.teams.formAgent.subtitle", { team: teamLabel });
+
   return (
-    <FullPageModal isOpen={isOpen} onClose={onClose} id="agent-form-modal">
+    <FullPageModal isOpen={isOpen} onClose={onClose} id="agent-form-modal" background="container">
       <div className={styles.modalCard}>
         <div className={styles.modalHeader}>
           <div className={styles.modalPresentation}>
-            <span className={styles.modalIcon}>
-              <Icon category="outlined" type={agentIconName as IconType} filled={true} />
-            </span>
             <div className={styles.modalTitleBlock}>
               <div className={styles.modalTitle}>{title}</div>
-              <div className={styles.modalSubtitle}>{teamName || t("rework.sidebar.team.userTeam")}</div>
+              <div className={styles.modalSubtitle}>{subtitle}</div>
             </div>
           </div>
 
           <div className={styles.modalActions}>
-            {mode === "create" && step === 2 && (
-              <div className={styles.modalActionsBack}>
-                <Button
-                  color="on-surface"
-                  variant="text"
-                  size="medium"
-                  icon={{ category: "outlined", type: "arrow_back" }}
-                  onClick={() => setStep(1)}
-                >
-                  {t("rework.back")}
-                </Button>
-              </div>
-            )}
             <Button color="primary" variant="text" size="medium" onClick={onClose}>
               {t("rework.cancel")}
             </Button>

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormModal.tsx
@@ -31,6 +31,7 @@ export type AgentFormPayload = {
   displayName: string;
   role: string;
   description: string;
+  usageStatement: string;
   tuningFieldValues: Record<string, unknown>;
   /** Explicit list of active capability ids ([] = none active). */
   selectedCapabilityIds: string[];
@@ -70,6 +71,7 @@ type FormState = {
   displayName: string;
   role: string;
   description: string;
+  usageStatement: string;
   tuningValues: Record<string, unknown>;
   selectedCapabilityIds: string[];
   capabilityConfigValues: Record<string, Record<string, unknown>>;
@@ -79,11 +81,10 @@ type FormState = {
   capabilityBlockingErrors: Record<string, string | null>;
 };
 
+/** Mirrors AgentFormBody's routeField — only "Prompts" gets its own tab, everything else lands in "general". */
 function sectionOfField(field: ManagedAgentFieldSpec): SectionKey {
   const g = (field.ui?.group ?? "").toLowerCase().trim();
-  if (g === "prompts") return "prompts";
-  if (g === "chat") return "chat";
-  return "settings";
+  return g === "prompts" ? "prompts" : "general";
 }
 
 /**
@@ -120,6 +121,7 @@ export function buildAgentFormSubmitPayload(
     displayName: form.displayName.trim(),
     role: form.role.trim(),
     description: form.description.trim(),
+    usageStatement: form.usageStatement.trim(),
     tuningFieldValues: form.tuningValues,
     selectedCapabilityIds: effectiveCapabilityIds,
     capabilityConfigValues: effectiveCapabilityConfig,
@@ -167,6 +169,7 @@ export default function AgentFormModal({
     displayName: "",
     role: "",
     description: "",
+    usageStatement: "",
     tuningValues: {},
     selectedCapabilityIds: [],
     capabilityConfigValues: {},
@@ -174,12 +177,12 @@ export default function AgentFormModal({
     capabilityBlockingErrors: {},
   });
   const [submitAttempted, setSubmitAttempted] = useState(false);
-  const [activeSection, setActiveSection] = useState<SectionKey>("settings");
+  const [activeSection, setActiveSection] = useState<SectionKey>("general");
 
   useEffect(() => {
     if (!isOpen) {
       setSubmitAttempted(false);
-      setActiveSection("settings");
+      setActiveSection("general");
       return;
     }
     if (mode === "edit" && editInstance) {
@@ -188,6 +191,7 @@ export default function AgentFormModal({
         displayName: editInstance.display_name,
         role: editInstance.role,
         description: editInstance.description ?? "",
+        usageStatement: editInstance.usage_statement ?? "",
         tuningValues: (editInstance.tuning_field_values as Record<string, unknown>) ?? {},
         selectedCapabilityIds: editInstance.selected_capability_ids ?? [],
         // capability_config stores the {schema_version, config} envelope per id;
@@ -203,6 +207,7 @@ export default function AgentFormModal({
         displayName: "",
         role: "",
         description: "",
+        usageStatement: "",
         tuningValues: {},
         selectedCapabilityIds: [],
         capabilityConfigValues: {},
@@ -226,13 +231,14 @@ export default function AgentFormModal({
       displayName: tpl?.display_name ?? "",
       role: "",
       description: tpl?.description_by_lang?.[lang] ?? tpl?.description ?? "",
+      usageStatement: "",
       tuningValues: defaultTuningValues,
       selectedCapabilityIds: [],
       capabilityConfigValues: {},
       capabilityAssetFiles: {},
       capabilityBlockingErrors: {},
     });
-    setActiveSection("settings");
+    setActiveSection("general");
     setSubmitAttempted(false);
     setStep(2);
   };
@@ -278,17 +284,35 @@ export default function AgentFormModal({
   // A capability config widget may block the save (e.g. ppt_filler while its
   // mandatory template is missing, #1903) — only ACTIVE capabilities count.
   const capabilityBlocked = form.selectedCapabilityIds.some((id) => !!form.capabilityBlockingErrors[id]);
-  const isFormValid = !!form.templateId && !!form.displayName.trim() && !missingRequired && !capabilityBlocked;
+  const isFormValid =
+    !!form.templateId &&
+    !!form.displayName.trim() &&
+    !!form.usageStatement.trim() &&
+    !missingRequired &&
+    !capabilityBlocked;
   const canSave = isFormValid && !isSubmitting;
 
   const errorSections = new Set<SectionKey>(
-    submitAttempted ? requiredFields.filter((f) => !form.tuningValues[f.key]).map((f) => sectionOfField(f)) : [],
+    submitAttempted
+      ? [
+          ...requiredFields.filter((f) => !form.tuningValues[f.key]).map((f) => sectionOfField(f)),
+          ...(!form.displayName.trim() ? (["general"] as const) : []),
+          ...(!form.usageStatement.trim() ? (["commitments"] as const) : []),
+        ]
+      : [],
   );
 
   const handleSubmit = async () => {
     setSubmitAttempted(true);
     if (!canSave) {
-      const firstErrorSection = (["prompts", "settings", "chat"] as const).find((s) => {
+      const firstErrorSection = (["general", "prompts", "commitments"] as const).find((s) => {
+        if (s === "general") {
+          return (
+            !form.displayName.trim() ||
+            requiredFields.some((f) => !form.tuningValues[f.key] && sectionOfField(f) === "general")
+          );
+        }
+        if (s === "commitments") return !form.usageStatement.trim();
         return requiredFields.some((f) => !form.tuningValues[f.key] && sectionOfField(f) === s);
       });
       if (firstErrorSection) setActiveSection(firstErrorSection);
@@ -346,6 +370,7 @@ export default function AgentFormModal({
               displayName={form.displayName}
               role={form.role}
               description={form.description}
+              usageStatement={form.usageStatement}
               tuningFieldValues={form.tuningValues}
               selectedCapabilityIds={form.selectedCapabilityIds}
               capabilityConfigValues={form.capabilityConfigValues}
@@ -360,6 +385,7 @@ export default function AgentFormModal({
               onDisplayNameChange={(v) => setForm((prev) => ({ ...prev, displayName: v }))}
               onRoleChange={(v) => setForm((prev) => ({ ...prev, role: v }))}
               onDescriptionChange={(v) => setForm((prev) => ({ ...prev, description: v }))}
+              onUsageStatementChange={(v) => setForm((prev) => ({ ...prev, usageStatement: v }))}
               onTuningChange={handleTuningChange}
               onCapabilitySelectionChange={(ids) => setForm((prev) => ({ ...prev, selectedCapabilityIds: ids }))}
               onCapabilityConfigChange={handleCapabilityConfigChange}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/CapabilityCard/CapabilityCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/CapabilityCard/CapabilityCard.module.css
@@ -34,7 +34,7 @@
 
 .name {
   color: var(--on-surface);
-  font: var(--font-label-medium);
+  font: var(--font-body-large);
 }
 
 /* Emphasis only — same font metrics as .name so toggling never shifts the list */
@@ -45,7 +45,7 @@
 
 .description {
   color: var(--on-surface-retreat);
-  font: var(--font-body-small);
+  font: var(--font-body-medium);
 }
 
 /* Sub-form revealed when the capability is active and declares config_fields */

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/CapabilityCard/CapabilityCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/CapabilityCard/CapabilityCard.module.css
@@ -18,9 +18,20 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-s);
+  /* Inset by the card's border-width so this full-bleed background's own
+     curve lines up with the border's inner edge — relying on the parent's
+     overflow: hidden alone to clip a square corner here leaves a visible
+     seam/thinning right on the arc, worse once :hover repaints the border.
+     All four corners when it's the only child (no config sub-form below);
+     top corners only when a sub-form follows. */
+  border-radius: calc(var(--radius-s) - 1px);
   background: var(--surface-container-low);
   padding: var(--spacing-s) var(--spacing-m);
   user-select: none;
+}
+
+.header:not(:last-child) {
+  border-radius: calc(var(--radius-s) - 1px) calc(var(--radius-s) - 1px) 0 0;
 }
 
 .meta {
@@ -54,6 +65,9 @@
   flex-direction: column;
   gap: var(--spacing-m);
   border-top: 1px solid var(--outline-muted);
+  /* Same inset-radius reasoning as .header — this is always the card's
+     last child when present, so only the bottom corners need it. */
+  border-radius: 0 0 calc(var(--radius-s) - 1px) calc(var(--radius-s) - 1px);
   background: var(--surface-container);
   padding: var(--spacing-m);
 }

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateBrowser/TemplateBrowser.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateBrowser/TemplateBrowser.module.css
@@ -2,6 +2,25 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-m);
+  border-radius: var(--radius-s);
+  background: var(--surface-container-high);
+  padding: var(--spacing-s) var(--spacing-m) var(--spacing-m);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+}
+
+.title {
+  color: var(--on-surface);
+  font: var(--font-title-medium);
+}
+
+.subtitle {
+  color: var(--on-surface-retreat);
+  font: var(--font-body-medium);
 }
 
 .filter {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateBrowser/TemplateBrowser.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateBrowser/TemplateBrowser.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: var(--spacing-m);
   border-radius: var(--radius-s);
-  background: var(--surface-container-high);
+  background: var(--surface-container-low);
   padding: var(--spacing-s) var(--spacing-m) var(--spacing-m);
 }
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateBrowser/TemplateBrowser.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateBrowser/TemplateBrowser.tsx
@@ -43,6 +43,11 @@ export function TemplateBrowser({ templates, selectedId, onSelect }: TemplateBro
 
   return (
     <div className={styles.browser}>
+      <div className={styles.header}>
+        <div className={styles.title}>{t("rework.teams.formAgent.templateBrowser.title")}</div>
+        <div className={styles.subtitle}>{t("rework.teams.formAgent.templateBrowser.subtitle")}</div>
+      </div>
+
       {podIds.length > 1 && (
         <div className={styles.filter}>
           <ButtonGroup

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
@@ -14,6 +14,7 @@
 
 .card:hover:not([data-unavailable="true"]):not([data-selected="true"]) {
   border-color: var(--outline);
+  background: var(--state-on-surface-hover);
 }
 
 .card[data-selected="true"] {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
@@ -2,11 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2xs);
-  transition:
-    border-color 0.15s,
-    background-color 0.15s;
   cursor: pointer;
-  border: 2px solid var(--outline-muted);
+  border: 1px solid var(--outline-muted);
   border-radius: var(--radius-m);
   background: var(--surface-container);
   padding: var(--spacing-m);
@@ -16,7 +13,7 @@
 }
 
 .card:hover:not([data-unavailable="true"]):not([data-selected="true"]) {
-  border-color: var(--outline);
+  border-color: var(--outline-retreat);
   background: var(--surface-container-high);
 }
 
@@ -30,10 +27,12 @@
   cursor: not-allowed;
 }
 
-.cardHeader {
+.cardFooter {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-top: auto;
+  padding-top: var(--spacing-2xs);
 }
 
 .category {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
@@ -14,12 +14,12 @@
 
 .card:hover:not([data-unavailable="true"]):not([data-selected="true"]) {
   border-color: var(--outline-retreat);
-  background: var(--surface-container-high);
+  background: var(--surface-container);
 }
 
 .card[data-selected="true"] {
   border-color: var(--primary);
-  background: var(--surface-container-low);
+  background: var(--surface-container);
 }
 
 .card[data-unavailable="true"] {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
@@ -38,22 +38,21 @@
 .category {
   color: var(--on-surface-muted);
   font: var(--font-label-small);
-  font-size: 11px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .name {
   color: var(--primary);
-  font: var(--font-title-small);
+  font: var(--font-body-large);
 }
 
 .description {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   overflow: hidden;
-  color: var(--on-surface-retreat);
-  font: var(--font-body-small);
+  color: var(--on-surface);
+  font: var(--font-body-medium);
   -webkit-box-orient: vertical;
 }
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
@@ -3,9 +3,9 @@
   flex-direction: column;
   gap: var(--spacing-2xs);
   cursor: pointer;
-  border: 1px solid var(--outline-muted);
+  border: 1px solid var(--outline-retreat);
   border-radius: var(--radius-m);
-  background: var(--surface-container);
+  background: transparent;
   padding: var(--spacing-m);
   width: 100%;
   min-height: 8rem;
@@ -13,13 +13,11 @@
 }
 
 .card:hover:not([data-unavailable="true"]):not([data-selected="true"]) {
-  border-color: var(--outline-retreat);
-  background: var(--surface-container);
+  border-color: var(--outline);
 }
 
 .card[data-selected="true"] {
   border-color: var(--primary);
-  background: var(--surface-container);
 }
 
 .card[data-unavailable="true"] {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.module.css
@@ -36,12 +36,8 @@
   align-items: center;
 }
 
-.categoryPill {
-  align-self: flex-start;
-  border-radius: 999px;
-  background: var(--secondary-container);
-  padding: 2px 10px;
-  color: var(--on-secondary-container);
+.category {
+  color: var(--on-surface-muted);
   font: var(--font-label-small);
   font-size: 11px;
   letter-spacing: 0.04em;
@@ -49,7 +45,7 @@
 }
 
 .name {
-  color: var(--on-surface);
+  color: var(--primary);
   font: var(--font-title-small);
 }
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.tsx
@@ -36,12 +36,12 @@ export function TemplateCard({ template, selected, onSelect }: TemplateCardProps
       onClick={onSelect}
       disabled={unavailable}
     >
-      <div className={styles.cardHeader}>
+      <span className={styles.name}>{template.display_name}</span>
+      {description && <span className={styles.description}>{description}</span>}
+      <div className={styles.cardFooter}>
         {template.category && <span className={styles.category}>{template.category}</span>}
         <span className={styles.podLabel}>{template.source_runtime_id}</span>
       </div>
-      <span className={styles.name}>{template.display_name}</span>
-      {description && <span className={styles.description}>{description}</span>}
     </button>
   );
 }

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TemplateCard/TemplateCard.tsx
@@ -37,7 +37,7 @@ export function TemplateCard({ template, selected, onSelect }: TemplateCardProps
       disabled={unavailable}
     >
       <div className={styles.cardHeader}>
-        {template.category && <span className={styles.categoryPill}>{template.category}</span>}
+        {template.category && <span className={styles.category}>{template.category}</span>}
         <span className={styles.podLabel}>{template.source_runtime_id}</span>
       </div>
       <span className={styles.name}>{template.display_name}</span>

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -171,6 +171,7 @@ export default function TeamAgentsPage() {
       display_name: payload.displayName,
       role: payload.role || undefined,
       description: payload.description || undefined,
+      usage_statement: payload.usageStatement,
       tuning_field_values:
         Object.keys(payload.tuningFieldValues).length > 0
           ? (payload.tuningFieldValues as AgentRequestTuningFieldValues)
@@ -212,6 +213,7 @@ export default function TeamAgentsPage() {
       display_name: payload.displayName,
       role: payload.role || undefined,
       description: payload.description || undefined,
+      usage_statement: payload.usageStatement,
       tuning_field_values:
         Object.keys(payload.tuningFieldValues).length > 0
           ? (payload.tuningFieldValues as AgentRequestTuningFieldValues)
@@ -290,6 +292,7 @@ export default function TeamAgentsPage() {
         displayName: newName,
         role: source.role,
         description: source.description ?? "",
+        usageStatement: source.usage_statement ?? "",
         tuningValues: (source.tuning_field_values as Record<string, unknown>) ?? {},
         selectedCapabilityIds: source.selected_capability_ids ?? [],
         capabilityConfigValues: extractCapabilityConfigValues(source.capability_config),
@@ -303,6 +306,7 @@ export default function TeamAgentsPage() {
       display_name: payload.displayName,
       role: payload.role || undefined,
       description: payload.description || undefined,
+      usage_statement: payload.usageStatement,
       tuning_field_values:
         Object.keys(payload.tuningFieldValues).length > 0
           ? (payload.tuningFieldValues as AgentRequestTuningFieldValues)

--- a/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroup.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroup.module.scss
@@ -5,4 +5,8 @@
   background-color: var(--surface-container);
   padding: var(--spacing-2xs);
   width: fit-content;
+
+  &[data-full-width="true"] {
+    width: 100%;
+  }
 }

--- a/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroup.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroup.tsx
@@ -31,6 +31,8 @@ interface ButtonGroupProps {
   variant: "radio" | "tabs";
   /** Accessible name for the group (radiogroup/tablist both need one). */
   "aria-label": string;
+  /** Stretches the group and its items to fill the parent's width instead of the default fit-content pill. */
+  fullWidth?: boolean;
   defaultSelectedIndex?: number;
   /** When provided, turns the component into a controlled tab strip. */
   selectedIndex?: number;
@@ -43,6 +45,7 @@ export default function ButtonGroup({
   color,
   variant,
   "aria-label": ariaLabel,
+  fullWidth = false,
   defaultSelectedIndex = 0,
   selectedIndex,
   onSelectedIndexChange,
@@ -124,6 +127,7 @@ export default function ButtonGroup({
   return (
     <div
       className={styles["button-group"]}
+      data-full-width={fullWidth}
       role={variant === "radio" ? "radiogroup" : "tablist"}
       aria-label={ariaLabel}
     >
@@ -137,6 +141,7 @@ export default function ButtonGroup({
           size={size}
           color={item.color ?? color}
           variant={variant}
+          fullWidth={fullWidth}
           selected={index === resolvedIndex}
           tabIndex={index === resolvedIndex ? 0 : -1}
           onClick={(e) => selectIndex(index, e)}

--- a/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroupItem/ButtonGroupItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroupItem/ButtonGroupItem.module.scss
@@ -74,6 +74,14 @@
     }
   }
 
+  &[data-full-width="true"] {
+    flex: 1;
+
+    .stateLayer {
+      width: 100%;
+    }
+  }
+
   @each $name, $scheme in $color-schemes {
     &[data-color="#{$name}"] {
       &:active .stateLayer:not([data-selected="true"]) {

--- a/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroupItem/ButtonGroupItem.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/ButtonGroup/ButtonGroupItem/ButtonGroupItem.tsx
@@ -34,6 +34,8 @@ export interface ButtonGroupItemPrivateProps {
   selected: boolean;
   /** Drives ARIA role/state: a mutually-exclusive "radio" pick or a "tabs" strip. */
   variant: "radio" | "tabs";
+  /** Stretches this item to share the group's full width equally with its siblings. */
+  fullWidth?: boolean;
 }
 
 export default function ButtonGroupItem({
@@ -44,6 +46,7 @@ export default function ButtonGroupItem({
   size,
   hasError,
   variant,
+  fullWidth,
   ref,
   ...props
 }: ButtonGroupItemProps & ButtonGroupItemPrivateProps) {
@@ -53,6 +56,7 @@ export default function ButtonGroupItem({
       className={styles.buttonGroupItem}
       data-color={color}
       data-size={size}
+      data-full-width={fullWidth}
       role={variant === "radio" ? "radio" : "tab"}
       aria-checked={variant === "radio" ? selected : undefined}
       aria-selected={variant === "tabs" ? selected : undefined}

--- a/apps/frontend/src/rework/components/shared/atoms/MenuItem/MenuItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/MenuItem/MenuItem.module.scss
@@ -7,7 +7,7 @@
   --padding-left: var(--spacing-m);
 
   &:has(.icon-wrapper) {
-    --padding-left: var(--spacing-xs);
+    --padding-left: var(--spacing-s);
   }
 
   &[data-focused="true"]:not([data-disabled="true"]),

--- a/apps/frontend/src/rework/components/shared/molecules/FullPageModal/FullPageModal.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/FullPageModal/FullPageModal.module.scss
@@ -10,4 +10,8 @@
   width: 100%;
   height: 100%;
   overflow-y: auto;
+
+  &[data-background="container"] {
+    background: var(--surface-container);
+  }
 }

--- a/apps/frontend/src/rework/components/shared/molecules/FullPageModal/FullPageModal.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/FullPageModal/FullPageModal.tsx
@@ -21,13 +21,15 @@ interface FullPageModalProps {
   onClose: () => void;
   children: ReactNode;
   id: string;
+  /** Backdrop background token. Defaults to "main" (--surface-main). */
+  background?: "main" | "container";
 }
 
 export interface ModalInteractionProps {
   close: () => void;
 }
 
-export const FullPageModal = ({ isOpen, onClose, children, id }: FullPageModalProps) => {
+export const FullPageModal = ({ isOpen, onClose, children, id, background = "main" }: FullPageModalProps) => {
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
@@ -49,7 +51,14 @@ export const FullPageModal = ({ isOpen, onClose, children, id }: FullPageModalPr
 
   return (
     <Portal id="modal-portal">
-      <div role="dialog" aria-modal="true" aria-labelledby={`${id}-title`} className={styles.modal} data-state="open">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${id}-title`}
+        className={styles.modal}
+        data-state="open"
+        data-background={background}
+      >
         {children}
       </div>
     </Portal>

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
@@ -61,10 +61,16 @@
 }
 
 /* Pushed flush to the card's top-right corner (#2096); does not stretch to
- * the row's full height like its siblings (the icon / name+role block). */
+ * the row's full height like its siblings (the icon / name+role block).
+ * .agentInfo's own padding (--spacing-m) would sit it further from the
+ * corner than the .actions row's info button (--spacing-s) sits from its
+ * own corner — the negative top/right margin below closes that gap so both
+ * corner buttons read at the same distance from the card edge. */
 .moreMenu {
   flex-shrink: 0;
   align-self: flex-start;
+  margin-top: calc(var(--spacing-s) - var(--spacing-m));
+  margin-right: calc(var(--spacing-s) - var(--spacing-m));
   margin-left: auto;
 }
 

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.tsx
@@ -173,7 +173,7 @@ export default function AgentCard({
             <div className={styles.moreMenu}>
               <IconButtonMenu<MoreMenuAction>
                 iconButton={{
-                  color: "on-surface",
+                  color: "on-surface-retreat",
                   variant: "icon",
                   size: "medium",
                   icon: { category: "outlined", type: "more_vert" },

--- a/apps/frontend/src/rework/features/pipeline/usePipelineRun.ts
+++ b/apps/frontend/src/rework/features/pipeline/usePipelineRun.ts
@@ -123,6 +123,7 @@ export function usePipelineRun(scenario: Scenario): PipelineRun {
           createAgentInstanceRequest: {
             template_id: template.template_id,
             display_name: "Self-test (auto)",
+            usage_statement: "Automated internal self-test pipeline run — not a production agent.",
             ...(tuningFieldValues ? { tuning_field_values: tuningFieldValues } : {}),
           },
         }).unwrap();

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1680,6 +1680,8 @@ export type ManagedAgentInstanceSummary = {
   description?: string | null;
   /** Short one-line summary of what this agent does, distinct from the longer `description` — shown on the agent card so a teammate can recall the agent's purpose without reading the full description. Server-set to `display_name` at enrollment until independently edited (#2076). */
   role: string;
+  /** User-authored intended-use statement (purpose, target/impacted users, data handled, outputs, error impact) captured in the agent form's Engagement tab, used to screen for platform/organization risk (#2105). Empty for agents enrolled before #2105 until independently edited — required at creation and enforced by the agent edit form on save, but omittable on `UpdateAgentInstanceRequest` (like `role`) so partial updates such as the enable/disable toggle are unaffected. */
+  usage_statement?: string;
   status: "enabled" | "disabled";
   /** Platform-forced suspension reason (#1975, RFC §3.9), or null when the instance is not suspended. Distinct from `status` (the editor's enable/disable toggle): a suspended instance is hidden from chat-only members and shows editors a warning with a locked enable toggle. One of capability_unavailable / capability_access_revoked / capability_config_invalid. */
   suspension_reason?: SuspensionReason | null;
@@ -1720,6 +1722,8 @@ export type CreateAgentInstanceRequest = {
   description?: string | null;
   /** Optional short one-line summary of what this agent does. Defaults to `display_name` when omitted (#2076). */
   role?: string | null;
+  /** Required intended-use statement (purpose, target/impacted users, data handled, outputs, error impact) — used to screen for platform/organization risk (#2105). Hard-required at creation, unlike the optional `role`. */
+  usage_statement: string;
   /** Optional initial values for the template's tunable fields. Keys must match ManagedAgentFieldSpec.key values from the template. Unknown keys are ignored. Known values are validated against the declared field type and constraints. */
   tuning_field_values?: {
     [key: string]:
@@ -1746,6 +1750,8 @@ export type UpdateAgentInstanceRequest = {
   description?: string | null;
   /** Short one-line summary of what this agent does. Omit to leave the current role unchanged (#2076). */
   role?: string | null;
+  /** Intended-use statement (#2105). Omit to leave the current value unchanged — same convention as `role`, so partial updates like the enable/disable toggle (which PATCHes only `status`) are not forced to resupply it. The agent edit form always submits it (enforced client-side, same as `display_name`), so in practice every full-form save keeps this current, including for agents enrolled before #2105 whose stored value starts out empty. */
+  usage_statement?: string | null;
   /** Set to 'enabled' or 'disabled' to toggle the instance. None leaves the current status unchanged. */
   status?: ("enabled" | "disabled") | null;
   /** Replaces the stored field values for this instance. Keys must match ManagedAgentFieldSpec.key values frozen at enrollment. Unknown keys are ignored. Known values are validated against the declared field type and constraints. Omit the field to leave existing values unchanged; pass null to clear the stored agent tuning values. */
@@ -1871,6 +1877,8 @@ export type PromptPromoteRequest = {
 export type ManagedAgentTuning = {
   role: string;
   description: string;
+  /** User-authored statement of the intended use case for this agent instance (purpose, target users/impacted parties, data handled, outputs, error impact) — used to screen for platform/organization risk (#2105). Defaults to '' so pre-#2105 rows without this key in their stored tuning_json still deserialize; the product-facing requiredness is enforced by the API layer (CreateAgentInstanceRequest and the agent form), not by this default. */
+  usage_statement?: string;
   tags?: string[];
   fields?: ManagedAgentFieldSpec[];
   /** Capability activation policy (#1974, RFC AGENT-CAPABILITY §3.8). None means inherit the template default selection; [] means activate no capabilities; a non-empty list means activate exactly that set. Validated at save time against the capabilities the instance's bound pod advertises (unknown ids -> HTTP 422). */

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -282,6 +282,19 @@ The control plane is a **pure proxy** for these values — it does not interpret
   `UpdateAgentInstanceRequest.role` (both optional); server-defaults to
   `display_name` when omitted at creation, and is left unchanged on update
   when omitted.
+- `usage_statement: str` — **added 2026-07-24 (#2105).** User-authored
+  statement of the agent's intended use (purpose, target/impacted users,
+  data handled, outputs, error impact), captured by the agent form's
+  Engagement tab and used to screen for platform/organization risk. Stored
+  inside the `ManagedAgentTuning` JSON blob (`tuning_json` column) like
+  `role`/`description` — no dedicated DB column, no migration.
+  Hard-required (`min_length=1`) on `CreateAgentInstanceRequest`. Optional
+  on `UpdateAgentInstanceRequest` (omit = leave unchanged, same convention
+  as `role`) so partial updates that don't touch content — e.g. the
+  enable/disable toggle, which PATCHes only `status` — are unaffected.
+  Requiredness for pre-#2105 agents (whose stored value defaults to `""`)
+  is enforced by the agent edit form blocking Save when empty, the same
+  pattern already used for `display_name`, not by the API contract itself.
 - ~~`effective_chat_options: EffectiveChatOptions`~~ — **REMOVED 2026-07-11 (CAPAB-01 #1976).** `EffectiveChatOptions` is retired; chat controls are a session-prep projection shipped on `ExecutionPreparation.chat_controls`, not a listing-surface field. The composer fetches them via an eager prepare-execution at chat open. See RFC AGENT-CAPABILITY-RFC §3.3/§3.7.
 - `created_at`, `updated_at`, `created_by`
 - `tuning_field_values: dict[str, TuningValue]` — frozen snapshot of user-set

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -929,6 +929,7 @@ Header reorg (#2102, 2026-07-24, first pass of a broader rework — more changes
 - **Field grouping** — `ui.group` groups fields under labeled sections; ungrouped fields appear first.
 - **MCP tools section** — read-only list of tools advertised by the selected template (display_name or id + require_tools).
 - **Header reorg** (#2102) — avatar, back button, and context bar (template name + category pill) removed; team + template now shown as one subtitle line under the title.
+- **Template browser container** (#2103) — pod filter + card grid now sit inside a titled `--surface-container-high` container ("Sélectionner un template d'agent" + explanatory subtitle, i18n'd). Card name now `--primary`-colored; category label (e.g. "REACT") is plain muted text, no longer a colored pill.
 - **Metadata footer** — created_by + relative date shown in edit mode when `created_by` is set.
 - **Inline validation** — `submitAttempted` gates required-field errors; no toast for validation.
 - **State isolation** — `FormState` resets fully on modal close; template change resets tuning values.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -904,21 +904,28 @@ _(none — design approved at implementation)_
 **Location:** `src/rework/components/pages/TeamAgentsPage/AgentFormModal/`
 **Status:** `Functional`
 
-Complete create / edit modal for managed agent instances. Refactored per `docs/rfc/AGENT-INSTANCE-FORM-RFC.md` into a clean sub-component tree:
+Complete create / edit modal for managed agent instances, organized as a clean sub-component tree:
 
 - `AgentFormModal.tsx` — modal shell + `FormState` ownership; no field rendering
-- `AgentFormBody.tsx` — controlled form body; create or edit layout
+- `AgentFormBody.tsx` — controlled form body; 4-tab layout, create or edit
 - `TemplateBrowser/` — responsive card grid for template selection
-- `TemplateCard/` — single selectable card with category pill, name, clamped description
+- `TemplateCard/` — single selectable card with category label, name, clamped description
 - `TuningFieldRenderer.tsx` — handles all field types: string, number/integer, boolean (`SwitchRow`), enum (design-system `Select` molecule), secret (password+reveal), url, array (`TagInput` molecule), prompt/multiline (`TextArea`)
 
-Create mode: template browser → display name → description → tuning fields (grouped by `ui.group`) → MCP tools (read-only list). Edit mode: same editable fields → metadata footer (created_by · relative date).
+Step 1: template browser. Step 2: a full-width `ButtonGroup` tab strip (`variant="radio"`, `size="medium"` — same pattern as the theme/language pickers in `UserSettingsPage.tsx`) with 4 top-level tabs (#2105, 2026-07-24):
 
-Header reorg (#2102, 2026-07-24, first pass of a broader rework — more changes to this page tracked in follow-up issues): dropped the agent icon/avatar and the back button; merged the team name and selected template name into one subtitle line (`"Équipe : <team> · Template : <template>"`, i18n'd — template segment omitted until a template is picked, or in edit mode if the original template is missing); dropped the in-body context bar (template name + category pill). Page backdrop now `--surface-container`, form card `--surface-main`, no drop shadow — scoped to this modal only via `FullPageModal`'s new `background` prop (other `FullPageModal` consumers unchanged).
+- **Général** — Nom, Rôle, Description, plus every tuning field whose `ui.group` is not `"Prompts"` (the pre-#2105 catch-all "Settings" tab content — `Settings`, `Credentials`, `Document reading`, `Mindmap`, `Grounding`, `Comparison`, `Fallback`, ... — verified against real `fred-agents` templates). No template-side (`ui.group`) changes; purely a frontend regrouping.
+- **Prompts** — every `ui.group == "Prompts"` field, unchanged content.
+- **Outils** — capability cards, unchanged content. Hidden when the template has none.
+- **Engagement** — new required "Cas d'usage" field (large `TextArea`, label + explanation + placeholder), persisted as `ManagedAgentInstanceSummary.usage_statement` (screens agent purpose for platform/org risk).
+
+Edit mode: same 4 tabs → metadata footer (created_by · relative date) → delete button.
+
+Header reorg (#2102, 2026-07-24): dropped the agent icon/avatar and the back button; merged the team name and selected template name into one subtitle line (`"Équipe : <team> · Template : <template>"`, i18n'd — template segment omitted until a template is picked, or in edit mode if the original template is missing); dropped the in-body context bar (template name + category pill). Page backdrop `--surface-container`, form card `--surface-main`, no drop shadow — scoped to this modal only via `FullPageModal`'s new `background` prop (other `FullPageModal` consumers unchanged).
 
 #### Open UX issues
 
-- **Tuning field groups** — flat scroll within modal; no accordion. Decide if needed for agents with many fields.
+- **Tuning field groups** — flat scroll within the Général tab; no accordion. Decide if needed for agents with many fields.
 - **Template browser on mobile** — grid collapses to single column below ~480px; confirm whether list layout is preferable.
 - **Single-template auto-select** — single available template is auto-selected; browser is still shown. Decide if it should collapse directly to step 2 immediately.
 
@@ -926,12 +933,13 @@ Header reorg (#2102, 2026-07-24, first pass of a broader rework — more changes
 
 - **Template browser** — replaced raw `<select>` with responsive card grid; selected state uses `--primary` border.
 - **All field types** — secret, url, prompt, number/integer, enum, boolean (`SwitchRow`), multiline all implemented.
-- **Field grouping** — `ui.group` groups fields under labeled sections; ungrouped fields appear first.
+- **Field grouping** — `ui.group` groups fields under labeled sections; ungrouped fields land in Général.
 - **MCP tools section** — read-only list of tools advertised by the selected template (display_name or id + require_tools).
 - **Header reorg** (#2102) — avatar, back button, and context bar (template name + category pill) removed; team + template now shown as one subtitle line under the title.
-- **Template browser container** (#2103) — pod filter + card grid now sit inside a titled `--surface-container-high` container ("Sélectionner un template d'agent" + explanatory subtitle, i18n'd). Card name now `--primary`-colored; category label (e.g. "REACT") is plain muted text, no longer a colored pill.
+- **Template browser container** (#2103) — pod filter + card grid sit inside a titled `--surface-container-low` container ("Sélectionner un template d'agent" + explanatory subtitle, i18n'd). Card border 1px `--outline-muted` (`--outline-retreat` on hover, no transition), background fixed `--surface-container` in every state (no hover/selected shift), category/pod labels moved to a card footer. Card name `--font-body-large`/`--primary`, description `--font-body-medium`/`--on-surface`, category/pod labels `--font-label-small`/`--on-surface-muted`.
+- **4-tab restructure + Engagement field** (#2105) — see above.
 - **Metadata footer** — created_by + relative date shown in edit mode when `created_by` is set.
-- **Inline validation** — `submitAttempted` gates required-field errors; no toast for validation.
+- **Inline validation** — `submitAttempted` gates required-field errors, including displayName (Général tab) and usage_statement (Engagement tab); no toast for validation.
 - **State isolation** — `FormState` resets fully on modal close; template change resets tuning values.
 
 ---

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -912,13 +912,15 @@ Complete create / edit modal for managed agent instances. Refactored per `docs/r
 - `TemplateCard/` — single selectable card with category pill, name, clamped description
 - `TuningFieldRenderer.tsx` — handles all field types: string, number/integer, boolean (`SwitchRow`), enum (design-system `Select` molecule), secret (password+reveal), url, array (`TagInput` molecule), prompt/multiline (`TextArea`)
 
-Create mode: template browser → display name → description → tuning fields (grouped by `ui.group`) → MCP tools (read-only list). Edit mode: context bar (template name + category) → same editable fields → metadata footer (created_by · relative date).
+Create mode: template browser → display name → description → tuning fields (grouped by `ui.group`) → MCP tools (read-only list). Edit mode: same editable fields → metadata footer (created_by · relative date).
+
+Header reorg (#2102, 2026-07-24, first pass of a broader rework — more changes to this page tracked in follow-up issues): dropped the agent icon/avatar and the back button; merged the team name and selected template name into one subtitle line (`"Équipe : <team> · Template : <template>"`, i18n'd — template segment omitted until a template is picked, or in edit mode if the original template is missing); dropped the in-body context bar (template name + category pill). Page backdrop now `--surface-container`, form card `--surface-main`, no drop shadow — scoped to this modal only via `FullPageModal`'s new `background` prop (other `FullPageModal` consumers unchanged).
 
 #### Open UX issues
 
 - **Tuning field groups** — flat scroll within modal; no accordion. Decide if needed for agents with many fields.
 - **Template browser on mobile** — grid collapses to single column below ~480px; confirm whether list layout is preferable.
-- **Single-template auto-select** — single available template is auto-selected; browser is still shown. Decide if it should collapse to a context bar immediately.
+- **Single-template auto-select** — single available template is auto-selected; browser is still shown. Decide if it should collapse directly to step 2 immediately.
 
 #### Resolved
 
@@ -926,7 +928,7 @@ Create mode: template browser → display name → description → tuning fields
 - **All field types** — secret, url, prompt, number/integer, enum, boolean (`SwitchRow`), multiline all implemented.
 - **Field grouping** — `ui.group` groups fields under labeled sections; ungrouped fields appear first.
 - **MCP tools section** — read-only list of tools advertised by the selected template (display_name or id + require_tools).
-- **Edit mode context bar** — template name + category pill; no interaction.
+- **Header reorg** (#2102) — avatar, back button, and context bar (template name + category pill) removed; team + template now shown as one subtitle line under the title.
 - **Metadata footer** — created_by + relative date shown in edit mode when `created_by` is set.
 - **Inline validation** — `submitAttempted` gates required-field errors; no toast for validation.
 - **State isolation** — `FormState` resets fully on modal close; template change resets tuning values.


### PR DESCRIPTION
## Summary

Multi-pass rework of the agent creation/edit form (`AgentFormModal` and its sub-components), plus small consistency fixes to shared components discovered along the way.

- **#2102 — Header reorg**: drop the avatar/icon and the back button; merge team + template into one subtitle line; drop the in-body template/category context bar. Page backdrop `--surface-container`, form card `--surface-main`, no drop shadow — scoped to this modal only via a new `FullPageModal` `background` prop.
- **#2103 — Template picker**: pod filter + card grid now sit inside a titled `--surface-container-low` container. `TemplateCard` restyle: transparent background with a hover state layer, 1px `--outline-retreat`/`--outline` border, typography tokens (name `body-large`/`--primary`, description `body-medium`/`--on-surface`, category/pod labels `label-small`/`--on-surface-muted`), category/pod moved to a footer, plus a corner-rendering fix on `CapabilityCard` (rounded full-bleed children instead of clipped-by-parent).
- **#2105 — 4-tab restructure + `usage_statement`**: the form body moves to a full-width `ButtonGroup` tab strip (Général / Prompts / Outils / Engagement). Général absorbs every non-Prompts tuning field (no template `ui.group` changes). New required "Cas d'usage" field, added end-to-end: `ManagedAgentTuning`/`ManagedAgentInstanceSummary`/`Create·UpdateAgentInstanceRequest` (stored in the existing `tuning_json` blob, no DB migration), CLI, duplicate-agent flow, self-test pipeline, OpenAPI regen.
- **#2096 follow-ups**: agent card more-menu icon color + corner spacing to match the info button; shared `MenuItem` icon-row `padding-left` token fix (8px → 12px, affects every icon-led menu in the app, not just this one).

## Test plan

- [x] `make code-quality` (backend + frontend) — clean
- [x] `make test` — backend 505/505, frontend 597/597
- [x] Manual Playwright pass: create/edit flows, 4-tab navigation, required-field validation (displayName + usage_statement), enable/disable toggle (confirms `usage_statement` staying optional on `UpdateAgentInstanceRequest` doesn't break the partial-PATCH toggle), duplicate flow, light + dark themes
- [ ] Dimitri: please double-check the `usage_statement` contract treatment (dated `CONTROL-PLANE-PRODUCT-CONTRACT.md` entry, no separate RFC — same precedent as `role` #2076) matches what you'd want given its platform-safety framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)