### PR TITLE
Team members table: fill height + pagination, relocate Leave team button

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -390,6 +390,7 @@
   "dataTable": {
     "pagination": {
       "first": "First page",
+      "itemsPerPage": "Items per page",
       "last": "Last page",
       "next": "Next page",
       "pageNumber": "Page {{page}}",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -392,6 +392,7 @@
       "first": "First page",
       "last": "Last page",
       "next": "Next page",
+      "pageNumber": "Page {{page}}",
       "prev": "Previous page",
       "totalItems": "{{count}} items"
     }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -389,9 +389,11 @@
   },
   "dataTable": {
     "pagination": {
+      "first": "First page",
+      "last": "Last page",
       "next": "Next page",
-      "page": "page {{page}} / {{pageCount}}",
-      "prev": "Previous page"
+      "prev": "Previous page",
+      "totalItems": "{{count}} items"
     }
   },
   "dialogs": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -387,6 +387,13 @@
     "vectorTableTitle": "Documents with vectors",
     "vectorsColumn": "Vectors"
   },
+  "dataTable": {
+    "pagination": {
+      "next": "Next page",
+      "page": "page {{page}} / {{pageCount}}",
+      "prev": "Previous page"
+    }
+  },
   "dialogs": {
     "cancel": "Cancel"
   },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -392,6 +392,7 @@
       "first": "Première page",
       "last": "Dernière page",
       "next": "Page suivante",
+      "pageNumber": "Page {{page}}",
       "prev": "Page précédente",
       "totalItems": "{{count}} éléments"
     }

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -390,6 +390,7 @@
   "dataTable": {
     "pagination": {
       "first": "Première page",
+      "itemsPerPage": "Items par page",
       "last": "Dernière page",
       "next": "Page suivante",
       "pageNumber": "Page {{page}}",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -389,9 +389,11 @@
   },
   "dataTable": {
     "pagination": {
+      "first": "Première page",
+      "last": "Dernière page",
       "next": "Page suivante",
-      "page": "page {{page}} / {{pageCount}}",
-      "prev": "Page précédente"
+      "prev": "Page précédente",
+      "totalItems": "{{count}} éléments"
     }
   },
   "dialogs": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -387,6 +387,13 @@
     "vectorTableTitle": "Documents avec vecteurs",
     "vectorsColumn": "Vecteurs"
   },
+  "dataTable": {
+    "pagination": {
+      "next": "Page suivante",
+      "page": "page {{page}} / {{pageCount}}",
+      "prev": "Page précédente"
+    }
+  },
   "dialogs": {
     "cancel": "Annuler"
   },

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -82,15 +82,3 @@
   display: flex;
   padding: var(--spacing-xs) 0 var(--spacing-xs) var(--spacing-xs);
 }
-
-/* Anchored to the bottom of the settings menu column (`.navigationContainer`
- * is a full-height flex column), full width minus a 16px gutter each side. */
-.leave-team-container {
-  display: flex;
-  margin-top: auto;
-  padding: 0 var(--spacing-m) var(--spacing-m);
-}
-
-.leave-team-button {
-  width: 100%;
-}

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -21,19 +21,11 @@ import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import Button from "@shared/atoms/Button/Button.tsx";
 import Separator from "@shared/atoms/Separator/Separator.tsx";
 import ChatList from "@shared/organisms/ChatList/ChatList.tsx";
-import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
-import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
-import { useMutationAction } from "@core/hooks/useMutationAction.ts";
 import { useFrontendProperties } from "../../../../../../hooks/useFrontendProperties.ts";
 import { useSelectedTeam } from "../../../../../../hooks/useSelectedTeam.ts";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
 import { hasElevatedTeamRole } from "@hooks/teamCapabilities.ts";
 import { IconType } from "@shared/utils/Type.ts";
-import { KeyCloakService } from "../../../../../../security/KeycloakService";
-import {
-  useListTeamMembersQuery,
-  useRemoveTeamMemberMutation,
-} from "../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 
 /**
  * Team-scoped sidebar section — the second vertical bar.
@@ -54,23 +46,10 @@ export default function TeamContentNavbar() {
   const navigate = useNavigate();
   const { teamId, isPersonalTeam, selectedTeam, canOpenTeamSettings, bannerColor, bannerStyle } = useSelectedTeam();
   const capabilities = useTeamCapabilities(selectedTeam);
-  const { canUpdateAgents, canUpdateInfo, canAdministerAdmins } = capabilities;
-  const { showConfirmationDialog } = useConfirmationDialog();
-  const { notifyApiError } = useApiErrorToast();
-  const { runMutationAction } = useMutationAction();
-  const [removeTeamMember] = useRemoveTeamMemberMutation();
+  const { canUpdateAgents, canUpdateInfo } = capabilities;
 
   const settingsBase = `/team/${teamId}/settings`;
   const inSettings = !!teamId && pathname.startsWith(settingsBase);
-
-  // Only an admin can ever be blocked from leaving (the "at least one
-  // team_admin" invariant, AUTHZ-09) — skip the lookup for everyone else.
-  const { data: teamMembers } = useListTeamMembersQuery(
-    { teamId: teamId ?? "" },
-    { skip: !inSettings || !teamId || !canAdministerAdmins },
-  );
-  const adminCount = teamMembers?.filter((member) => member.relations.includes("team_admin")).length ?? 0;
-  const isLastAdmin = canAdministerAdmins && adminCount <= 1;
 
   // The personal space has no team-admin permission to gate a settings icon on
   // (`canOpenTeamSettings` is always false there — OBSERV-02 / BACKLOG.md §7b),
@@ -175,34 +154,6 @@ export default function TeamContentNavbar() {
     });
   }
 
-  const handleLeaveTeam = () => {
-    if (!teamId || isLastAdmin) return;
-    showConfirmationDialog({
-      title: t("rework.teamSettings.leaveTeam.title"),
-      message: t("rework.teamSettings.leaveTeam.message", { teamName: selectedTeam?.name ?? "" }),
-      confirmButtonLabel: t("rework.teamSettings.leaveTeam.confirmLabel"),
-      criticalAction: true,
-      cancelVariant: "filled",
-      cancelColor: "primary",
-      confirmVariant: "text",
-      onConfirm: async () => {
-        const userId = KeyCloakService.GetUserId();
-        if (!userId) return;
-        await runMutationAction({
-          action: () => removeTeamMember({ teamId, userId }).unwrap(),
-          onError: (error) =>
-            notifyApiError(error, {
-              summary: t("rework.teamSettings.leaveTeam.errors.summary"),
-              fallbackDetail: t("rework.teamSettings.leaveTeam.errors.fallbackDetail"),
-              forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
-              conflictDetail: t("rework.teamSettings.members.errors.lastOwnerDetail"),
-            }),
-          onSuccess: () => navigate("/team/personal/agents"),
-        });
-      },
-    });
-  };
-
   return (
     <div className={styles.teamContentNavbarContainer}>
       <div className={styles.bannerContainer} style={bannerStyle}>
@@ -254,19 +205,6 @@ export default function TeamContentNavbar() {
               </Button>
             </span>
             <NavigationMenu items={settingsItems} />
-            <span className={styles["leave-team-container"]}>
-              <Button
-                color={"error"}
-                variant={"filled"}
-                size={"medium"}
-                disabled={isLastAdmin}
-                title={isLastAdmin ? t("rework.teamSettings.leaveTeam.lastAdminTooltip") : undefined}
-                onClick={handleLeaveTeam}
-                className={styles["leave-team-button"]}
-              >
-                {t("rework.teamSettings.navigation.leaveTeam")}
-              </Button>
-            </span>
           </>
         ) : inUsage ? (
           // Same focused-view treatment as settings: the usage dashboard

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -1,11 +1,21 @@
+/* Flex column so the footer (when present) always sits at the very bottom —
+ * `.datatable-body` is the one that grows/scrolls; the footer never moves. */
 .datatable-container {
-  display: grid;
-  grid-template-columns: var(--grid-layout);
-  grid-auto-rows: minmax(min-content, auto);
-  align-content: start;
+  display: flex;
+  flex-direction: column;
   border-radius: var(--spacing-xs);
   background-color: var(--datatable-background-color);
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.datatable-body {
+  display: grid;
+  grid-template-columns: var(--grid-layout);
+  grid-auto-rows: minmax(min-content, auto);
+  flex: 1;
+  align-content: start;
   min-height: 0;
   overflow: auto;
 }
@@ -55,12 +65,9 @@
 
 .datatable-footer {
   display: flex;
-  position: sticky;
-  bottom: 0;
-  grid-column: 1 / -1;
+  flex-shrink: 0;
   justify-content: space-between;
   align-items: center;
-  z-index: 1;
   border-top: 1px solid var(--surface-container-highest);
   background-color: var(--datatable-background-color);
   height: 3.75rem;

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -95,6 +95,12 @@
 /* Fixed width (not just min-width) so the neighbouring nav buttons don't
  * shift horizontally as the page number's digit count changes. */
 .footer-page-label {
-  width: 4.5rem;
+  width: 3.5rem;
   text-align: center;
+}
+
+/* Extra breathing room on top of the footer's own gap, so the rows-per-page
+ * picker doesn't read as glued to the "Items per page" label/nav buttons. */
+.footer-rows-per-page-select {
+  margin-right: var(--spacing-xs);
 }

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -58,17 +58,24 @@
   position: sticky;
   bottom: 0;
   grid-column: 1 / -1;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  gap: var(--spacing-xs);
   z-index: 1;
   border-top: 1px solid var(--surface-container-highest);
   background-color: var(--datatable-background-color);
-  padding: var(--spacing-2xs) var(--spacing-xs);
+  padding: 0 var(--spacing-s);
+  height: 3.75rem;
+}
+
+.datatable-footer-left,
+.datatable-footer-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
 }
 
 .footer-label {
   color: var(--on-surface-retreat);
-  font: var(--font-label-medium);
+  font: var(--font-body-medium);
   white-space: nowrap;
 }

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -84,3 +84,10 @@
   font: var(--font-body-medium);
   white-space: nowrap;
 }
+
+/* Fixed width (not just min-width) so the neighbouring nav buttons don't
+ * shift horizontally as the page number's digit count changes. */
+.footer-page-label {
+  width: 4.5rem;
+  text-align: center;
+}

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -63,15 +63,20 @@
   z-index: 1;
   border-top: 1px solid var(--surface-container-highest);
   background-color: var(--datatable-background-color);
-  padding: 0 var(--spacing-s);
   height: 3.75rem;
 }
 
-.datatable-footer-left,
+.datatable-footer-left {
+  display: flex;
+  align-items: center;
+  padding-left: var(--spacing-m);
+}
+
 .datatable-footer-right {
   display: flex;
   align-items: center;
-  gap: var(--spacing-s);
+  gap: var(--spacing-xs);
+  padding-right: var(--spacing-m);
 }
 
 .footer-label {

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -52,3 +52,23 @@
 .first-column-inset .datatable-cell:first-child {
   padding-left: var(--spacing-l);
 }
+
+.datatable-footer {
+  display: flex;
+  position: sticky;
+  bottom: 0;
+  grid-column: 1 / -1;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-xs);
+  z-index: 1;
+  border-top: 1px solid var(--surface-container-highest);
+  background-color: var(--datatable-background-color);
+  padding: var(--spacing-2xs) var(--spacing-xs);
+}
+
+.footer-label {
+  color: var(--on-surface-retreat);
+  font: var(--font-label-medium);
+  white-space: nowrap;
+}

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.test.tsx
@@ -69,63 +69,61 @@ function rowValues(): string[] {
   return Array.from(container.querySelectorAll('[class*="datatable-row"] span')).map((el) => el.textContent ?? "");
 }
 
+function footer(): Element | null {
+  return container.querySelector('[class*="datatable-footer"]');
+}
+
+/** [rowsPerPageSelect, firstPage, prevPage, nextPage, lastPage] */
+function footerButtons(): HTMLButtonElement[] {
+  return Array.from(footer()?.querySelectorAll("button") ?? []);
+}
+
 describe("DataTable", () => {
   it("renders every row with no footer when pageSize is omitted", () => {
     render(<DataTable columns={columns} data={makeRows(45)} />);
     expect(rowValues()).toHaveLength(45);
-    expect(container.querySelector('[class*="datatable-footer"]')).toBeNull();
+    expect(footer()).toBeNull();
   });
 
-  it("hides the pagination footer when every row fits on one page", () => {
+  it("shows a persistent footer with the total item count even when every row fits on one page", () => {
     render(<DataTable columns={columns} data={makeRows(10)} pageSize={20} />);
     expect(rowValues()).toHaveLength(10);
-    expect(container.querySelector('[class*="datatable-footer"]')).toBeNull();
+    const [, first, prev, next, last] = footerButtons();
+    expect(footer()?.textContent).toContain("10");
+    expect(first.hasAttribute("disabled")).toBe(true);
+    expect(prev.hasAttribute("disabled")).toBe(true);
+    expect(next.hasAttribute("disabled")).toBe(true);
+    expect(last.hasAttribute("disabled")).toBe(true);
   });
 
-  it("shows only the first page's rows and a footer when data exceeds pageSize", () => {
+  it("shows only the first page's rows, the current page number, and the total count", () => {
     render(<DataTable columns={columns} data={makeRows(45)} pageSize={20} />);
     expect(rowValues()).toEqual(makeRows(20).map((r) => String(r.id)));
-    const footer = container.querySelector('[class*="datatable-footer"]');
-    expect(footer).not.toBeNull();
+    expect(footer()?.textContent).toContain("45");
+    expect(footer()?.textContent).toContain("1");
   });
 
-  it("navigates to the next/previous page and disables buttons at the ends", () => {
+  it("navigates next/prev/first/last, disabling the relevant buttons at each end", () => {
     render(<DataTable columns={columns} data={makeRows(45)} pageSize={20} />);
-    const [prev, next] = Array.from(container.querySelectorAll("button"));
+    const [, first, prev, next, last] = footerButtons();
+    expect(first.hasAttribute("disabled")).toBe(true);
     expect(prev.hasAttribute("disabled")).toBe(true);
     expect(next.hasAttribute("disabled")).toBe(false);
+    expect(last.hasAttribute("disabled")).toBe(false);
 
     click(next);
-    expect(rowValues()).toEqual([
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31",
-      "32",
-      "33",
-      "34",
-      "35",
-      "36",
-      "37",
-      "38",
-      "39",
-      "40",
-    ]);
+    expect(rowValues()[0]).toBe("21");
+    expect(rowValues()).toHaveLength(20);
+    expect(first.hasAttribute("disabled")).toBe(false);
     expect(prev.hasAttribute("disabled")).toBe(false);
 
-    click(next);
+    click(last);
     expect(rowValues()).toEqual(["41", "42", "43", "44", "45"]);
     expect(next.hasAttribute("disabled")).toBe(true);
+    expect(last.hasAttribute("disabled")).toBe(true);
 
-    click(prev);
-    click(prev);
+    click(first);
     expect(rowValues()[0]).toBe("1");
+    expect(prev.hasAttribute("disabled")).toBe(true);
   });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import DataTable, { DataTableColumn } from "./DataTable.tsx";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key} ${JSON.stringify(opts)}` : key),
+  }),
+}));
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+interface Row {
+  id: number;
+}
+
+const columns: DataTableColumn<Row>[] = [{ label: "Id", cellRenderer: (row) => <span>{row.id}</span> }];
+
+function makeRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function click(el: Element | null) {
+  act(() => {
+    el?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+function rowValues(): string[] {
+  return Array.from(container.querySelectorAll('[class*="datatable-row"] span')).map((el) => el.textContent ?? "");
+}
+
+describe("DataTable", () => {
+  it("renders every row with no footer when pageSize is omitted", () => {
+    render(<DataTable columns={columns} data={makeRows(45)} />);
+    expect(rowValues()).toHaveLength(45);
+    expect(container.querySelector('[class*="datatable-footer"]')).toBeNull();
+  });
+
+  it("hides the pagination footer when every row fits on one page", () => {
+    render(<DataTable columns={columns} data={makeRows(10)} pageSize={20} />);
+    expect(rowValues()).toHaveLength(10);
+    expect(container.querySelector('[class*="datatable-footer"]')).toBeNull();
+  });
+
+  it("shows only the first page's rows and a footer when data exceeds pageSize", () => {
+    render(<DataTable columns={columns} data={makeRows(45)} pageSize={20} />);
+    expect(rowValues()).toEqual(makeRows(20).map((r) => String(r.id)));
+    const footer = container.querySelector('[class*="datatable-footer"]');
+    expect(footer).not.toBeNull();
+  });
+
+  it("navigates to the next/previous page and disables buttons at the ends", () => {
+    render(<DataTable columns={columns} data={makeRows(45)} pageSize={20} />);
+    const [prev, next] = Array.from(container.querySelectorAll("button"));
+    expect(prev.hasAttribute("disabled")).toBe(true);
+    expect(next.hasAttribute("disabled")).toBe(false);
+
+    click(next);
+    expect(rowValues()).toEqual([
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31",
+      "32",
+      "33",
+      "34",
+      "35",
+      "36",
+      "37",
+      "38",
+      "39",
+      "40",
+    ]);
+    expect(prev.hasAttribute("disabled")).toBe(false);
+
+    click(next);
+    expect(rowValues()).toEqual(["41", "42", "43", "44", "45"]);
+    expect(next.hasAttribute("disabled")).toBe(true);
+
+    click(prev);
+    click(prev);
+    expect(rowValues()[0]).toBe("1");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -83,22 +83,24 @@ export default function DataTable<T>({
         { "--grid-layout": tableGridLayout, "--datatable-background-color": backgroundColor } as React.CSSProperties
       }
     >
-      {columns.map((column) => (
-        <div className={`${styles["datatable-cell"]} ${styles["datatable-cell-header"]}`} key={column.label}>
-          <span className={styles["header-content"]}>{column.label}</span>
-        </div>
-      ))}
-      {pageData.map((line, lineIndex) => (
-        <div className={styles["datatable-row"]} key={`row-${lineIndex}`}>
-          {columns.map((column) => {
-            return (
-              <div className={styles["datatable-cell"]} key={column.label}>
-                {column.cellRenderer(line)}
-              </div>
-            );
-          })}
-        </div>
-      ))}
+      <div className={styles["datatable-body"]}>
+        {columns.map((column) => (
+          <div className={`${styles["datatable-cell"]} ${styles["datatable-cell-header"]}`} key={column.label}>
+            <span className={styles["header-content"]}>{column.label}</span>
+          </div>
+        ))}
+        {pageData.map((line, lineIndex) => (
+          <div className={styles["datatable-row"]} key={`row-${lineIndex}`}>
+            {columns.map((column) => {
+              return (
+                <div className={styles["datatable-cell"]} key={column.label}>
+                  {column.cellRenderer(line)}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
       {paginationEnabled && (
         <div className={styles["datatable-footer"]}>
           <div className={styles["datatable-footer-left"]}>

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -109,16 +109,19 @@ export default function DataTable<T>({
             </span>
           </div>
           <div className={styles["datatable-footer-right"]}>
-            <Select<number>
-              size="small"
-              compact
-              value={rowsPerPage}
-              options={rowsPerPageOptions}
-              onChange={(value) => {
-                setRowsPerPage(value);
-                setPage(0);
-              }}
-            />
+            <div className={styles["footer-rows-per-page-select"]}>
+              <Select<number>
+                size="small"
+                compact
+                value={rowsPerPage}
+                options={rowsPerPageOptions}
+                onChange={(value) => {
+                  setRowsPerPage(value);
+                  setPage(0);
+                }}
+              />
+            </div>
+            <span className={styles["footer-label"]}>{t("dataTable.pagination.itemsPerPage")}</span>
             <IconButton
               color="on-surface"
               variant="icon"

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import styles from "./DataTable.module.scss";
-import React from "react";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 
 interface DataTableProps<T> {
   columns: DataTableColumn<T>[];
@@ -22,6 +24,8 @@ interface DataTableProps<T> {
   /** Extra left inset on the first column (header + every row), for tables
    *  whose content otherwise sits flush against the table's left edge. */
   firstColumnInset?: boolean;
+  /** Rows per page. Omit to render every row with no pagination (default). */
+  pageSize?: number;
 }
 
 export interface DataTableColumn<T> {
@@ -35,7 +39,18 @@ export default function DataTable<T>({
   data,
   backgroundColor = "var(--surface-container)",
   firstColumnInset = false,
+  pageSize,
 }: DataTableProps<T>) {
+  const { t } = useTranslation();
+  const [page, setPage] = useState(0);
+
+  const pageCount = pageSize ? Math.max(1, Math.ceil(data.length / pageSize)) : 1;
+  // Clamped rather than reset-on-change: if a row is removed and the current
+  // page no longer exists, fall back to the new last page instead of jumping
+  // the user back to page 1.
+  const currentPage = Math.min(page, pageCount - 1);
+  const pageData = pageSize ? data.slice(currentPage * pageSize, currentPage * pageSize + pageSize) : data;
+
   const tableGridLayout = columns
     .map((column) => {
       return column.size ? `${column.size}` : "1fr";
@@ -57,7 +72,7 @@ export default function DataTable<T>({
           <span className={styles["header-content"]}>{column.label}</span>
         </div>
       ))}
-      {data.map((line, lineIndex) => (
+      {pageData.map((line, lineIndex) => (
         <div className={styles["datatable-row"]} key={`row-${lineIndex}`}>
           {columns.map((column) => {
             return (
@@ -68,6 +83,31 @@ export default function DataTable<T>({
           })}
         </div>
       ))}
+      {pageSize && pageCount > 1 && (
+        <div className={styles["datatable-footer"]}>
+          <IconButton
+            color="on-surface"
+            variant="icon"
+            size="xs"
+            icon={{ category: "outlined", type: "chevron_left" }}
+            aria-label={t("dataTable.pagination.prev")}
+            disabled={currentPage <= 0}
+            onClick={() => setPage(currentPage - 1)}
+          />
+          <span className={styles["footer-label"]}>
+            {t("dataTable.pagination.page", { page: currentPage + 1, pageCount })}
+          </span>
+          <IconButton
+            color="on-surface"
+            variant="icon"
+            size="xs"
+            icon={{ category: "outlined", type: "chevron_right" }}
+            aria-label={t("dataTable.pagination.next")}
+            disabled={currentPage >= pageCount - 1}
+            onClick={() => setPage(currentPage + 1)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -109,6 +109,7 @@ export default function DataTable<T>({
             </span>
           </div>
           <div className={styles["datatable-footer-right"]}>
+            <span className={styles["footer-label"]}>{t("dataTable.pagination.itemsPerPage")}</span>
             <div className={styles["footer-rows-per-page-select"]}>
               <Select<number>
                 size="small"
@@ -121,7 +122,6 @@ export default function DataTable<T>({
                 }}
               />
             </div>
-            <span className={styles["footer-label"]}>{t("dataTable.pagination.itemsPerPage")}</span>
             <IconButton
               color="on-surface"
               variant="icon"

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -109,6 +109,7 @@ export default function DataTable<T>({
           <div className={styles["datatable-footer-right"]}>
             <Select<number>
               size="medium"
+              compact
               value={rowsPerPage}
               options={rowsPerPageOptions}
               onChange={(value) => {
@@ -134,7 +135,9 @@ export default function DataTable<T>({
               disabled={currentPage <= 0}
               onClick={() => setPage(currentPage - 1)}
             />
-            <span className={styles["footer-label"]}>{currentPage + 1}</span>
+            <span className={`${styles["footer-label"]} ${styles["footer-page-label"]}`}>
+              {t("dataTable.pagination.pageNumber", { page: currentPage + 1 })}
+            </span>
             <IconButton
               color="on-surface"
               variant="icon"

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -110,7 +110,7 @@ export default function DataTable<T>({
           </div>
           <div className={styles["datatable-footer-right"]}>
             <Select<number>
-              size="medium"
+              size="small"
               compact
               value={rowsPerPage}
               options={rowsPerPageOptions}

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -16,6 +16,10 @@ import styles from "./DataTable.module.scss";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import Select from "@shared/molecules/Select/Select.tsx";
+import { OptionModel } from "@models/Option.model.ts";
+
+const ROWS_PER_PAGE_OPTIONS = [20, 50, 100];
 
 interface DataTableProps<T> {
   columns: DataTableColumn<T>[];
@@ -24,7 +28,9 @@ interface DataTableProps<T> {
   /** Extra left inset on the first column (header + every row), for tables
    *  whose content otherwise sits flush against the table's left edge. */
   firstColumnInset?: boolean;
-  /** Rows per page. Omit to render every row with no pagination (default). */
+  /** Enables pagination and sets the initial rows-per-page (should be one of
+   *  `ROWS_PER_PAGE_OPTIONS`). Omit to render every row with no pagination
+   *  bar (default) — existing call sites are unaffected. */
   pageSize?: number;
 }
 
@@ -34,6 +40,12 @@ export interface DataTableColumn<T> {
   cellRenderer?: (element: T) => React.ReactNode;
 }
 
+const rowsPerPageOptions: OptionModel<number>[] = ROWS_PER_PAGE_OPTIONS.map((n) => ({
+  value: n,
+  label: String(n),
+  key: String(n),
+}));
+
 export default function DataTable<T>({
   columns,
   data,
@@ -42,14 +54,18 @@ export default function DataTable<T>({
   pageSize,
 }: DataTableProps<T>) {
   const { t } = useTranslation();
+  const paginationEnabled = pageSize !== undefined;
   const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(pageSize ?? ROWS_PER_PAGE_OPTIONS[0]);
 
-  const pageCount = pageSize ? Math.max(1, Math.ceil(data.length / pageSize)) : 1;
+  const pageCount = paginationEnabled ? Math.max(1, Math.ceil(data.length / rowsPerPage)) : 1;
   // Clamped rather than reset-on-change: if a row is removed and the current
   // page no longer exists, fall back to the new last page instead of jumping
   // the user back to page 1.
   const currentPage = Math.min(page, pageCount - 1);
-  const pageData = pageSize ? data.slice(currentPage * pageSize, currentPage * pageSize + pageSize) : data;
+  const pageData = paginationEnabled
+    ? data.slice(currentPage * rowsPerPage, currentPage * rowsPerPage + rowsPerPage)
+    : data;
 
   const tableGridLayout = columns
     .map((column) => {
@@ -83,29 +99,61 @@ export default function DataTable<T>({
           })}
         </div>
       ))}
-      {pageSize && pageCount > 1 && (
+      {paginationEnabled && (
         <div className={styles["datatable-footer"]}>
-          <IconButton
-            color="on-surface"
-            variant="icon"
-            size="xs"
-            icon={{ category: "outlined", type: "chevron_left" }}
-            aria-label={t("dataTable.pagination.prev")}
-            disabled={currentPage <= 0}
-            onClick={() => setPage(currentPage - 1)}
-          />
-          <span className={styles["footer-label"]}>
-            {t("dataTable.pagination.page", { page: currentPage + 1, pageCount })}
-          </span>
-          <IconButton
-            color="on-surface"
-            variant="icon"
-            size="xs"
-            icon={{ category: "outlined", type: "chevron_right" }}
-            aria-label={t("dataTable.pagination.next")}
-            disabled={currentPage >= pageCount - 1}
-            onClick={() => setPage(currentPage + 1)}
-          />
+          <div className={styles["datatable-footer-left"]}>
+            <span className={styles["footer-label"]}>
+              {t("dataTable.pagination.totalItems", { count: data.length })}
+            </span>
+          </div>
+          <div className={styles["datatable-footer-right"]}>
+            <Select<number>
+              size="medium"
+              value={rowsPerPage}
+              options={rowsPerPageOptions}
+              onChange={(value) => {
+                setRowsPerPage(value);
+                setPage(0);
+              }}
+            />
+            <IconButton
+              color="on-surface"
+              variant="icon"
+              size="medium"
+              icon={{ category: "outlined", type: "first_page" }}
+              aria-label={t("dataTable.pagination.first")}
+              disabled={currentPage <= 0}
+              onClick={() => setPage(0)}
+            />
+            <IconButton
+              color="on-surface"
+              variant="icon"
+              size="medium"
+              icon={{ category: "outlined", type: "chevron_left" }}
+              aria-label={t("dataTable.pagination.prev")}
+              disabled={currentPage <= 0}
+              onClick={() => setPage(currentPage - 1)}
+            />
+            <span className={styles["footer-label"]}>{currentPage + 1}</span>
+            <IconButton
+              color="on-surface"
+              variant="icon"
+              size="medium"
+              icon={{ category: "outlined", type: "chevron_right" }}
+              aria-label={t("dataTable.pagination.next")}
+              disabled={currentPage >= pageCount - 1}
+              onClick={() => setPage(currentPage + 1)}
+            />
+            <IconButton
+              color="on-surface"
+              variant="icon"
+              size="medium"
+              icon={{ category: "outlined", type: "last_page" }}
+              aria-label={t("dataTable.pagination.last")}
+              disabled={currentPage >= pageCount - 1}
+              onClick={() => setPage(pageCount - 1)}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
@@ -272,9 +272,11 @@ export default function Select<T>({
           document.body,
         )}
 
-      <span className={styles["error-message"]} id={`${baseId}-error`}>
-        {error && <>{error}</>}
-      </span>
+      {(!compact || error) && (
+        <span className={styles["error-message"]} id={`${baseId}-error`}>
+          {error && <>{error}</>}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/LeaveTeamButton/LeaveTeamButton.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/LeaveTeamButton/LeaveTeamButton.tsx
@@ -1,0 +1,92 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import Button from "@shared/atoms/Button/Button.tsx";
+import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
+import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
+import { useMutationAction } from "@core/hooks/useMutationAction.ts";
+import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
+import { KeyCloakService } from "../../../../../../../security/KeycloakService";
+import { TeamWithPermissions } from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
+import {
+  useListTeamMembersQuery,
+  useRemoveTeamMemberMutation,
+} from "../../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
+
+interface LeaveTeamButtonProps {
+  team: TeamWithPermissions;
+}
+
+/**
+ * AUTHZ-09 self-service "leave team" action. Disabled for the last remaining
+ * team_admin (the "at least one admin" invariant, shared with #1985).
+ */
+export default function LeaveTeamButton({ team }: LeaveTeamButtonProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { showConfirmationDialog } = useConfirmationDialog();
+  const { notifyApiError } = useApiErrorToast();
+  const { runMutationAction } = useMutationAction();
+  const { canAdministerAdmins } = useTeamCapabilities(team);
+  const [removeTeamMember] = useRemoveTeamMemberMutation();
+
+  // Only an admin can ever be blocked from leaving — skip the lookup for
+  // everyone else.
+  const { data: teamMembers } = useListTeamMembersQuery({ teamId: team.id }, { skip: !canAdministerAdmins });
+  const adminCount = teamMembers?.filter((member) => member.relations.includes("team_admin")).length ?? 0;
+  const isLastAdmin = canAdministerAdmins && adminCount <= 1;
+
+  const handleLeaveTeam = () => {
+    if (isLastAdmin) return;
+    showConfirmationDialog({
+      title: t("rework.teamSettings.leaveTeam.title"),
+      message: t("rework.teamSettings.leaveTeam.message", { teamName: team.name ?? "" }),
+      confirmButtonLabel: t("rework.teamSettings.leaveTeam.confirmLabel"),
+      criticalAction: true,
+      cancelVariant: "filled",
+      cancelColor: "primary",
+      confirmVariant: "text",
+      onConfirm: async () => {
+        const userId = KeyCloakService.GetUserId();
+        if (!userId) return;
+        await runMutationAction({
+          action: () => removeTeamMember({ teamId: team.id, userId }).unwrap(),
+          onError: (error) =>
+            notifyApiError(error, {
+              summary: t("rework.teamSettings.leaveTeam.errors.summary"),
+              fallbackDetail: t("rework.teamSettings.leaveTeam.errors.fallbackDetail"),
+              forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
+              conflictDetail: t("rework.teamSettings.members.errors.lastOwnerDetail"),
+            }),
+          onSuccess: () => navigate("/team/personal/agents"),
+        });
+      },
+    });
+  };
+
+  return (
+    <Button
+      color="error"
+      variant="filled"
+      size="medium"
+      disabled={isLastAdmin}
+      title={isLastAdmin ? t("rework.teamSettings.leaveTeam.lastAdminTooltip") : undefined}
+      onClick={handleLeaveTeam}
+    >
+      {t("rework.teamSettings.navigation.leaveTeam")}
+    </Button>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.module.scss
@@ -2,12 +2,22 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-m);
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
 .team-settings-members-header {
   display: flex;
+  flex-shrink: 0;
   justify-content: space-between;
+  align-items: center;
+}
+
+.team-settings-members-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-l);
 }
 
 .team-settings-members-header-title {
@@ -17,5 +27,7 @@
   font: var(--font-title-large);
 }
 
-.team-settings-members-content {
+.team-settings-members-table-wrapper {
+  flex: 1;
+  min-height: 0;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import TeamSettingsMembersTable from "./TeamSettingsMembersTable/TeamSettingsMembersTable.tsx";
+import LeaveTeamButton from "./LeaveTeamButton/LeaveTeamButton.tsx";
 import Autocomplete from "@shared/molecules/Autocomplete/Autocomplete.tsx";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -54,7 +55,10 @@ export default function TeamSettingsMembers({ team }: TeamSettingsMembersProps) 
   return (
     <div className={styles["team-settings-members-container"]}>
       <div className={styles["team-settings-members-header"]}>
-        <div className={styles["team-settings-members-header-title"]}>{t("rework.teamSettings.members.title")}</div>
+        <div className={styles["team-settings-members-header-left"]}>
+          <div className={styles["team-settings-members-header-title"]}>{t("rework.teamSettings.members.title")}</div>
+          <LeaveTeamButton team={team} />
+        </div>
         {can_administer_members && (
           <Autocomplete<UserSummary>
             textInput={{
@@ -71,7 +75,9 @@ export default function TeamSettingsMembers({ team }: TeamSettingsMembersProps) 
           ></Autocomplete>
         )}
       </div>
-      <TeamSettingsMembersTable team={team} />
+      <div className={styles["team-settings-members-table-wrapper"]}>
+        <TeamSettingsMembersTable team={team} />
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -238,5 +238,5 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
     handleRemoveMember,
   ]);
 
-  return <DataTable columns={columns} data={sortedMembers} firstColumnInset />;
+  return <DataTable columns={columns} data={sortedMembers} firstColumnInset pageSize={20} />;
 }

--- a/apps/frontend/src/rework/components/shared/utils/Type.ts
+++ b/apps/frontend/src/rework/components/shared/utils/Type.ts
@@ -69,6 +69,8 @@ export const materialIcons = [
   "image",
   "chevron_right",
   "chevron_left",
+  "first_page",
+  "last_page",
   "close",
   "cloud_off",
   "edit_note",

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -771,7 +771,8 @@ existing call sites that never set `item.color` are unaffected.
 ### `TeamContentNavbar` / `TeamSettingsPage` — self-service team leave (AUTHZ-09)
 
 **Location:** `src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx`,
-`src/rework/components/pages/TeamSettingsPage/TeamSettingsPage.tsx`
+`src/rework/components/pages/TeamSettingsPage/TeamSettingsPage.tsx`,
+`src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/LeaveTeamButton/LeaveTeamButton.tsx`
 **Status:** `Functional`
 
 The team-settings gear icon (previously `canAdministerAdmins`-gated, admin
@@ -788,14 +789,16 @@ sees inside scales with their role:
   true for everyone) to a new `hasElevatedTeamRole` helper
   (`teamCapabilities.ts`), since it isn't part of the plain-member baseline.
 
-**New: "Leave team" button.** Full-width, `16px` side gutter, anchored to
-the bottom of the settings sidebar (`margin-top: auto` inside the existing
-full-height flex column) below the section list — `filled` / `error`
-`Button`. Disabled with an explanatory `title` tooltip only for a team's
-sole remaining `team_admin` (computed client-side from the members list
-already fetched for the table; the backend's last-admin invariant is the
-actual source of truth and still applies server-side regardless). Confirms
-via `ConfirmationDialog`, then redirects to `/team/personal/agents`.
+**"Leave team" button (relocated 2026-07-24, #2108).** No longer in the
+settings sidebar — now a `filled` / `error` `Button` (`LeaveTeamButton.tsx`)
+rendered inline in the Members section header, `24px` to the right of the
+"Membres" page title (`.team-settings-members-header-left`, `gap:
+var(--spacing-l)`), so it only appears on the Members section, not on
+Parameters/Activity/Evaluations. Disabled with an explanatory `title`
+tooltip only for a team's sole remaining `team_admin` (computed client-side
+from the members list; the backend's last-admin invariant is the actual
+source of truth and still applies server-side regardless). Confirms via
+`ConfirmationDialog`, then redirects to `/team/personal/agents`.
 
 #### `ConfirmationDialog` — per-call button emphasis override
 
@@ -807,6 +810,37 @@ dialog is the first consumer to invert the usual emphasis — `Annuler` =
 filled (the safe, reversible choice stays visually dominant), `Quitter` =
 text + error (the destructive choice is low-emphasis, M3 "Text" tier) — a
 deliberate risk-reduction pattern, not the default hierarchy.
+
+#### Open UX issues
+
+- Not yet design-reviewed. First functional pass only.
+
+---
+
+### `DataTable` — opt-in pagination, `TeamSettingsMembers` full-height layout (#2108)
+
+**Location:** `src/rework/components/shared/molecules/DataTable/DataTable.tsx`,
+`src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx`
+**Status:** `Functional`
+
+`DataTable` gained an optional `pageSize` prop. Omitted (the default), it
+renders exactly as before — every consumer that doesn't pass it
+(`AdminTeamsPage`, `MigrationPage`, `CapabilitiesPage`) is unaffected. When
+set, the table slices `data` to one page, adds a sticky pagination footer
+(prev/next `IconButton`s + "page x / y" label — same "chevron + label"
+pattern as `ResourcePagination` in the resource browser), and hides the
+footer entirely when everything fits on a single page (`data.length <=
+pageSize`), matching `ResourcePagination`'s `total > PAGE_SIZE` convention.
+New i18n keys: top-level `dataTable.pagination.{prev,next,page}`.
+
+`TeamSettingsMembersTable` is the first consumer, at `pageSize={20}`.
+
+The Members section (`TeamSettingsMembers.module.scss`) is now a full-height
+flex column (`height: 100%` from the already-24px-padded `.teamSettingsPage`
+shell): the header row is fixed height, and the table wrapper takes
+`flex: 1; min-height: 0` so the table's bottom edge sits exactly `24px`
+above the viewport bottom, scrolling internally past `pageSize` rows on very
+short viewports rather than growing the page.
 
 #### Open UX issues
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -826,14 +826,25 @@ deliberate risk-reduction pattern, not the default hierarchy.
 `DataTable` gained an optional `pageSize` prop. Omitted (the default), it
 renders exactly as before — every consumer that doesn't pass it
 (`AdminTeamsPage`, `MigrationPage`, `CapabilitiesPage`) is unaffected. When
-set, the table slices `data` to one page, adds a sticky pagination footer
-(prev/next `IconButton`s + "page x / y" label — same "chevron + label"
-pattern as `ResourcePagination` in the resource browser), and hides the
-footer entirely when everything fits on a single page (`data.length <=
-pageSize`), matching `ResourcePagination`'s `total > PAGE_SIZE` convention.
-New i18n keys: top-level `dataTable.pagination.{prev,next,page}`.
+set, the table slices `data` to one page and renders a persistent pagination
+footer, height `3.75rem` — same height as a table row — with two flex
+containers:
 
-`TeamSettingsMembersTable` is the first consumer, at `pageSize={20}`.
+- **Left:** total item count (`{{count}} items/éléments`, `body-medium`,
+  `on-surface-retreat`).
+- **Right**, left to right: a rows-per-page `Select` (20/50/100, our own
+  molecule, not MUI), then `IconButton` (`medium`, `icon` variant,
+  `on-surface`) first-page / previous-page, the current page number
+  (`body-medium`, `on-surface-retreat`), then next-page / last-page. All four
+  nav buttons disable at their respective bound (first/prev at page 1,
+  next/last at the last page) — the footer itself never hides, even when
+  every row fits on one page, so the count and page-size control stay
+  reachable. New icons `first_page`/`last_page` added to the app's Material
+  Symbols allow-list (`shared/utils/Type.ts`). New i18n keys: top-level
+  `dataTable.pagination.{first,prev,next,last,totalItems}`.
+
+`TeamSettingsMembersTable` is the first consumer, at an initial `pageSize={20}`
+(the rows-per-page `Select` lets the user switch to 50/100 from there).
 
 The Members section (`TeamSettingsMembers.module.scss`) is now a full-height
 flex column (`height: 100%` from the already-24px-padded `.teamSettingsPage`


### PR DESCRIPTION
## Summary
- The Members section table now fills the available height (stopping 24px from the viewport bottom) instead of shrinking to content height.
- `DataTable` gains an opt-in pagination footer (total count, rows-per-page select 20/50/100, first/prev/page-number/next/last nav) — existing consumers (`AdminTeamsPage`, `MigrationPage`, `CapabilitiesPage`) are unaffected since it's opt-in via a new `pageSize` prop.
- The footer is pinned to the very bottom of the table regardless of row count (flex layout fix), height matches a table row, fully i18n'd (fr/en).
- "Leave team" button relocated from the settings sidebar (previously visible on every settings section) to inline in the Members section header, 24px right of the title — extracted into its own `LeaveTeamButton` component.

## Test plan
- [x] `make code-quality` (tsc + prettier + eslint) passes
- [x] `make test` — 601/601 passing, including new `DataTable` pagination tests
- [ ] Manual check in the browser: Members page for a team, verify table height/pagination/button placement, and rows-per-page 20/50/100 switching

Closes #2108. Continues #2085 (AUTHZ-09) for the button relocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)