### PR TITLE
Chat sidebar: team role shield badge, session list redesign + agent grouping

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1313,8 +1313,10 @@
       },
       "chatList": {
         "emptyManaged": "No conversations yet. Start a new chat with a managed agent.",
+        "groupByAgent": "Group by agent",
         "loading": "Loading...",
-        "title": "Chat"
+        "title": "Chat",
+        "unknownAgent": "Unknown agent"
       },
       "marketplace": {
         "menu": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1313,8 +1313,10 @@
       },
       "chatList": {
         "emptyManaged": "Aucune conversation pour l'instant. Démarrez un chat avec un agent géré.",
+        "groupByAgent": "Grouper par agent",
         "loading": "Chargement...",
-        "title": "Conversations"
+        "title": "Conversations",
+        "unknownAgent": "Agent inconnu"
       },
       "marketplace": {
         "menu": {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
@@ -81,6 +81,19 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
 
   const [registerSession] = usePostTeamSessionControlPlaneV1TeamsTeamIdSessionsPostMutation();
   const [refreshSession] = usePatchTeamSessionControlPlaneV1TeamsTeamIdSessionsSessionIdPatchMutation();
+  // Bumps the session's activity timestamp (tile date + chat-list ordering) —
+  // called both at send time (so the tile jumps to the top the moment the
+  // user hits Enter) and again when the turn completes.
+  const touchSessionActivity = useCallback(
+    (sid: string) => {
+      refreshSession({
+        teamId,
+        sessionId: sid,
+        updateSessionRequest: { updated_at: new Date().toISOString() },
+      }).catch(() => {});
+    },
+    [refreshSession, teamId],
+  );
 
   const bindSessionId = useCallback(
     (sid: string) => {
@@ -137,13 +150,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     lang,
     flushPendingWrites: flushSessionWrites,
     onBindDraftAgentToSessionId: bindSessionId,
-    onTurnPersisted: (sid) => {
-      refreshSession({
-        teamId,
-        sessionId: sid,
-        updateSessionRequest: { updated_at: new Date().toISOString() },
-      }).catch(() => {});
-    },
+    onTurnPersisted: touchSessionActivity,
     onAwaitingHuman: (event) => setPendingHitl(event),
     onError: (msg) => showError({ summary: "Agent error", detail: msg }),
   });
@@ -280,6 +287,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
             },
           }
         : undefined;
+    touchSessionActivity(sid);
     send(
       text,
       sid,
@@ -311,6 +319,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     bindSessionId,
     registerSession,
     trackSessionWrite,
+    touchSessionActivity,
     send,
   ]);
 

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.module.scss
@@ -25,7 +25,7 @@
 }
 
 .tooltip-wrapper:hover .tooltip-content,
-.tooltip-wrapper:focus-within .tooltip-content {
+.tooltip-wrapper:has(:focus-visible) .tooltip-content {
   visibility: visible;
   opacity: 1;
 }

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
@@ -28,8 +28,10 @@ export const Tooltip = ({ text, content, children }: TooltipProps) => {
   const tooltipId = useId();
   // Single-element children get aria-describedby wired to the tooltip text so
   // screen readers announce it for both hover and keyboard focus (the CSS
-  // already reveals the tooltip on :focus-within) — without this, role="tooltip"
-  // alone isn't programmatically linked to the element it describes.
+  // already reveals the tooltip on :has(:focus-visible) — not :focus-within,
+  // which would also fire on the lingering focus a mouse click leaves behind)
+  // — without this, role="tooltip" alone isn't programmatically linked to the
+  // element it describes.
   const child = isValidElement(children)
     ? cloneElement(children as ReactElement<{ "aria-describedby"?: string }>, { "aria-describedby": tooltipId })
     : children;

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -70,6 +70,22 @@
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
 }
 
+/* Shield glyph prefixing the role label when the user holds team_admin —
+ * same glyph/color/size as the TeamSelectionItem admin badge, without its
+ * circular background/outline (#2100 follow-up). */
+.roleLabelWithIcon {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3xs);
+}
+
+.roleLabelAdminIcon {
+  display: inline-flex;
+  height: 1.33em; /* match .teamRoleLabel's line-height so the row stays the same height with or without the icon */
+  color: var(--secondary);
+  font-size: 12px;
+}
+
 .navigationContainer {
   display: flex;
   flex-direction: column;

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -26,6 +26,7 @@ import { useSelectedTeam } from "../../../../../../hooks/useSelectedTeam.ts";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
 import { hasElevatedTeamRole } from "@hooks/teamCapabilities.ts";
 import { IconType } from "@shared/utils/Type.ts";
+import Icon from "@shared/atoms/Icon/Icon.tsx";
 
 /**
  * Team-scoped sidebar section — the second vertical bar.
@@ -76,13 +77,25 @@ export default function TeamContentNavbar() {
   const relationsLoaded = !!selectedTeam && "my_relations" in selectedTeam;
   const roleLabel = (() => {
     const priority: Record<string, number> = { team_admin: 0, team_editor: 1, team_analyst: 2 };
-    const heldRoles = (selectedTeam?.my_relations ?? []).filter((relation) => relation in priority);
-    if (heldRoles.length === 0) return t("rework.teamRoles.team_member");
-    return heldRoles
+    const heldRoles = (selectedTeam?.my_relations ?? [])
+      .filter((relation) => relation in priority)
       .slice()
-      .sort((a, b) => priority[a] - priority[b])
-      .map((relation) => t(`rework.teamRoles.${relation}`))
-      .join(" · ");
+      .sort((a, b) => priority[a] - priority[b]);
+    if (heldRoles.length === 0) return t("rework.teamRoles.team_member");
+    const labelText = heldRoles.map((relation) => t(`rework.teamRoles.${relation}`)).join(" · ");
+    // team_admin sorts first (priority 0), so when held it's always the
+    // opening token of `labelText` — the shield only needs to prefix the
+    // whole string, same glyph as the TeamSelectionItem admin badge (#2100)
+    // minus its circular background/outline.
+    if (heldRoles[0] !== "team_admin") return labelText;
+    return (
+      <span className={styles.roleLabelWithIcon}>
+        <span className={styles.roleLabelAdminIcon} aria-hidden="true">
+          <Icon category="outlined" type="shield" filled />
+        </span>
+        {labelText}
+      </span>
+    );
   })();
   const showRoleLabel = !isPersonalTeam && !!selectedTeam?.is_member && relationsLoaded;
 

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: hidden;
 }
 
 .chatListHeader {
@@ -10,7 +9,7 @@
   justify-content: space-between;
   align-items: center;
   padding: var(--spacing-xs) var(--spacing-m);
-  height: 2rem;
+  min-height: 2rem;
   color: var(--on-surface-retreat);
   font: var(--font-body-small);
 }
@@ -20,6 +19,13 @@
   flex-direction: column;
   padding: 0 var(--spacing-xs) var(--spacing-xs);
   overflow-y: auto;
+}
+
+/* Sub-list header shown above each agent's conversations when grouping is on. */
+.groupHeader {
+  padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-2xs);
+  color: var(--primary);
+  font: var(--font-label-small);
 }
 
 .chatListPlaceholder {

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.tsx
@@ -12,44 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import {
   useDeleteTeamSessionControlPlaneV1TeamsTeamIdSessionsSessionIdDeleteMutation,
+  useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery,
   useGetTeamSessionsControlPlaneV1TeamsTeamIdSessionsGetQuery,
 } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import { ChatListItem } from "./ChatListItem/ChatListItem.tsx";
 import styles from "./ChatList.module.scss";
+
+type Session = NonNullable<
+  ReturnType<typeof useGetTeamSessionsControlPlaneV1TeamsTeamIdSessionsGetQuery>["data"]
+>[number];
 
 interface ChatListProps {
   teamId?: string;
 }
 
-function formatRelativeDate(dateStr: string | undefined): string {
+// "12/03/26 - 13:03" — fixed DD/MM/YY - HH:mm, not locale-dependent
+// (unlike `toLocaleDateString()`, which flips day/month order in en-US).
+function formatSessionDate(dateStr: string | undefined): string {
   if (!dateStr) return "";
   const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = String(date.getFullYear()).slice(-2);
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${day}/${month}/${year} - ${hours}:${minutes}`;
 }
 
 export default function ChatList({ teamId }: ChatListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [groupByAgent, setGroupByAgent] = useState(false);
 
   const { data: sessions, isLoading } = useGetTeamSessionsControlPlaneV1TeamsTeamIdSessionsGetQuery(
     { teamId: teamId! },
     { skip: !teamId, pollingInterval: 30_000 },
   );
+  const { data: agentInstances } = useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery(
+    { teamId: teamId! },
+    { skip: !teamId },
+  );
+  const agentNameByInstanceId = new Map(
+    agentInstances?.map((instance) => [instance.agent_instance_id, instance.display_name]),
+  );
 
   const [deleteSession] = useDeleteTeamSessionControlPlaneV1TeamsTeamIdSessionsSessionIdDeleteMutation();
 
-  const isEmpty = !isLoading && (!sessions || sessions.length === 0);
+  const managedSessions = (sessions ?? []).filter((session): session is Session & { agent_instance_id: string } =>
+    Boolean(session.agent_instance_id),
+  );
+  const isEmpty = !isLoading && managedSessions.length === 0;
 
   const handleDelete = (sessionId: string, href: string) => async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -63,26 +82,61 @@ export default function ChatList({ teamId }: ChatListProps) {
     }
   };
 
+  const renderItem = (session: Session & { agent_instance_id: string }, showAgentName: boolean) => {
+    const href = `/team/${teamId}/managed-chat/${session.agent_instance_id}?session=${session.session_id}`;
+    return (
+      <ChatListItem
+        key={session.session_id}
+        sessionId={session.session_id}
+        href={href}
+        label={session.title || session.session_id.slice(0, 8) + "…"}
+        agentName={showAgentName ? agentNameByInstanceId.get(session.agent_instance_id) : undefined}
+        dateLabel={formatSessionDate(session.updated_at)}
+        onDelete={handleDelete(session.session_id, href)}
+      />
+    );
+  };
+
+  const groups = groupByAgent
+    ? Array.from(
+        managedSessions
+          .reduce((byAgent, session) => {
+            const agentName =
+              agentNameByInstanceId.get(session.agent_instance_id) ?? t("rework.sidebar.chatList.unknownAgent");
+            (byAgent.get(agentName) ?? byAgent.set(agentName, []).get(agentName)!).push(session);
+            return byAgent;
+          }, new Map<string, (Session & { agent_instance_id: string })[]>())
+          .entries(),
+      ).sort(([a], [b]) => a.localeCompare(b, undefined, { sensitivity: "base" }))
+    : null;
+
   return (
     <div className={styles.chatListContainer} data-team-id={teamId}>
-      <div className={styles.chatListHeader}>{t("rework.sidebar.chatList.title")}</div>
+      <div className={styles.chatListHeader}>
+        {t("rework.sidebar.chatList.title")}
+        <Tooltip text={t("rework.sidebar.chatList.groupByAgent")}>
+          <IconButton
+            color={groupByAgent ? "primary" : "on-surface-retreat"}
+            variant="icon"
+            size="small"
+            icon={{ category: "outlined", type: "category", filled: groupByAgent }}
+            aria-pressed={groupByAgent}
+            aria-label={t("rework.sidebar.chatList.groupByAgent")}
+            onClick={() => setGroupByAgent((value) => !value)}
+          />
+        </Tooltip>
+      </div>
       <div className={styles.chatListItems}>
         {isLoading && <div className={styles.chatListPlaceholder}>{t("rework.sidebar.chatList.loading")}</div>}
         {isEmpty && <div className={styles.chatListPlaceholder}>{t("rework.sidebar.chatList.emptyManaged")}</div>}
-        {sessions?.map((session) => {
-          if (!session.agent_instance_id) return null;
-          const href = `/team/${teamId}/managed-chat/${session.agent_instance_id}?session=${session.session_id}`;
-          return (
-            <ChatListItem
-              key={session.session_id}
-              sessionId={session.session_id}
-              href={href}
-              label={session.title || session.session_id.slice(0, 8) + "…"}
-              dateLabel={formatRelativeDate(session.updated_at)}
-              onDelete={handleDelete(session.session_id, href)}
-            />
-          );
-        })}
+        {groups
+          ? groups.map(([agentName, groupSessions]) => (
+              <div key={agentName}>
+                <div className={styles.groupHeader}>{agentName}</div>
+                {groupSessions.map((session) => renderItem(session, false))}
+              </div>
+            ))
+          : managedSessions.map((session) => renderItem(session, true))}
       </div>
     </div>
   );

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.module.scss
@@ -5,7 +5,7 @@
   gap: var(--spacing-xs);
   cursor: pointer;
   border-radius: var(--radius-s);
-  padding: var(--spacing-2xs) var(--spacing-2xs) var(--spacing-2xs) var(--spacing-m);
+  padding: var(--spacing-xs) var(--spacing-2xs) var(--spacing-xs) var(--spacing-xs);
   min-height: 2.5rem;
   color: var(--on-surface);
   text-decoration: none;
@@ -37,8 +37,12 @@
 }
 
 .date {
-  color: var(--on-surface-retreat);
+  color: var(--on-surface-muted);
   font: var(--font-label-small);
+}
+
+.agentName {
+  color: var(--primary);
 }
 
 .chatActions {

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.tsx
@@ -21,11 +21,12 @@ interface ChatListItemProps {
   sessionId: string;
   href: string;
   label: string;
+  agentName?: string;
   dateLabel?: string;
   onDelete: (e: React.MouseEvent) => void;
 }
 
-export function ChatListItem({ sessionId, href, label, dateLabel, onDelete }: ChatListItemProps) {
+export function ChatListItem({ sessionId, href, label, agentName, dateLabel, onDelete }: ChatListItemProps) {
   const location = useLocation();
   const isSelected = location.search.includes(`session=${sessionId}`);
 
@@ -33,7 +34,13 @@ export function ChatListItem({ sessionId, href, label, dateLabel, onDelete }: Ch
     <Link to={href} className={styles.chatItemContainer} data-selected={isSelected}>
       <div className={styles.chatDescription}>
         <div className={styles.title}>{label}</div>
-        {dateLabel && <div className={styles.date}>{dateLabel}</div>}
+        {(agentName || dateLabel) && (
+          <div className={styles.date}>
+            {agentName && <span className={styles.agentName}>{agentName}</span>}
+            {agentName && dateLabel && " · "}
+            {dateLabel}
+          </div>
+        )}
       </div>
       <span className={styles.chatActions}>
         <DeleteIconButton size="small" onClick={onDelete} />

--- a/apps/frontend/src/rework/components/shared/utils/Type.ts
+++ b/apps/frontend/src/rework/components/shared/utils/Type.ts
@@ -132,6 +132,7 @@ export const materialIcons = [
   "handshake",
   "request_quote",
   "history",
+  "category",
 ] as const;
 
 export type MaterialIconType = (typeof materialIcons)[number];

--- a/apps/frontend/src/rework/core/hooks/useChatSse.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.ts
@@ -225,6 +225,12 @@ export function useChatSse(
         }
 
         case "final": {
+          // `final` is the only reliable end-of-turn signal on this stream (see
+          // agent_app.py's `execute_stream` docstring) — the contract's
+          // `turn_persisted` event is defined but never actually emitted, so the
+          // session's activity timestamp/list position must be refreshed here
+          // instead of waiting on that dead event.
+          onTurnPersisted?.(sessionId);
           // Authoritative frame — replaces any accumulated delta at the same rank.
           const rank = deltaRankRef.current ?? rankRef.current++;
           const parts: ChatMessage["parts"] = [{ type: "text", text: event.content ?? "" }];

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -882,7 +882,12 @@ Helps a user recognize their role in each team they belong to.
   labels (already shown as chips in the Members table). Falls back to
   "Membre" when no elevated role is held. Not shown for the personal space,
   or for a non-member merely browsing a public/marketplace team pre-join
-  (`selectedTeam.is_member`).
+  (`selectedTeam.is_member`). When `team_admin` is held (always the first
+  token — roles are priority-sorted, admin first), the same Shield glyph as
+  the `TeamSelectionItem` badge (`color: secondary`, 12px) prefixes the
+  label, without that badge's circular background/outline — inline, `gap:
+  var(--spacing-3xs)`. Personal-space admin has no equivalent yet (the role
+  label itself isn't shown there) — left for a follow-up task.
 - Backend: new `TeamWithPermissions.my_relations` field — see
   `CONTROL-PLANE-PRODUCT-CONTRACT.md` §26 for why `permissions` alone
   couldn't reliably answer "is this user actually team_analyst".


### PR DESCRIPTION
## Summary

- Team role banner (`TeamContentNavbar`) now prefixes the role label with the same admin Shield glyph used on the `TeamSelectionItem` avatar badge, minus its circular background/outline, whenever the user holds `team_admin` (#2100 follow-up).
- Chat/session list (`ChatList`/`ChatListItem`) redesign: tile padding aligned with the header, agent name shown before an absolute `DD/MM/YY - HH:mm` date, new icon-button toggle to group conversations by agent (alphabetical, with a small per-agent sub-header).
- Fixed the session's activity timestamp never updating live — it depended on an SSE event (`turn_persisted`) the runtime never actually emits; now triggered on `final` and at send time instead.
- Fixed the shared `Tooltip` atom staying open after a mouse click leaves the trigger (`:focus-within` → `:has(:focus-visible)`), benefiting every tooltip in the app.

## Test plan

- [ ] `make code-quality` (tsc + prettier + eslint) — passes
- [ ] Open a team you're admin of, confirm the Shield icon appears before "Administrateur" in the banner role label
- [ ] Open the chat sidebar, confirm tile alignment with the "Conversations" header
- [ ] Send a message in a resumed old conversation, confirm the tile's date updates and it jumps to the top immediately on hitting Enter
- [ ] Toggle "Group by agent", confirm alphabetical per-agent grouping and that tiles hide the agent name while grouped
- [ ] Hover the group-by-agent button, confirm the tooltip appears instantly and closes when the mouse leaves after a click

## Tracking

- #2100 (admin shield badge — banner role label prefix)
- #2115 (chat session list polish + the two bug fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)