### PR TITLE
Team members: bulk add-members dialog with role picker (#2117)

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1538,11 +1538,6 @@
           "updateRoleDetail": "Could not update member role.",
           "updateRoleSummary": "Failed to update role"
         },
-        "revokeRoleDialog": {
-          "confirmLabel": "Remove role",
-          "message": "Remove the {{role}} role from {{name}}?",
-          "title": "Remove a role"
-        },
         "table": {
           "actions": "Actions",
           "deleteAction": "Delete",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1519,6 +1519,8 @@
           "buttonLabel": "Add members",
           "cancel": "Cancel",
           "confirm": "Add",
+          "pendingListEmpty": "No user selected yet",
+          "pendingListHeader": "Members to add to the team",
           "removeAria": "Remove {{name}} from the list",
           "searchPlaceholder": "Enter a name, first name, or user ID",
           "subtitle": "Users will be added to the team immediately",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1515,10 +1515,18 @@
     },
     "teamSettings": {
       "members": {
-        "addMember": {
-          "placeholder": "Invite users"
+        "addMembersDialog": {
+          "buttonLabel": "Add members",
+          "cancel": "Cancel",
+          "confirm": "Add",
+          "removeAria": "Remove {{name}} from the list",
+          "searchPlaceholder": "Enter a name, first name, or user ID",
+          "subtitle": "Users will be added to the team immediately",
+          "title": "Add new members"
         },
         "errors": {
+          "addDetail": "Could not add this user to the team.",
+          "addSummary": "Failed to add member",
           "forbiddenDetail": "You are not allowed to perform this action.",
           "lastOwnerDetail": "A team must keep at least one admin.",
           "removeMemberDetail": "Could not remove team member.",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1530,6 +1530,8 @@
           "addDetail": "Could not add this user to the team.",
           "addSummary": "Failed to add member",
           "forbiddenDetail": "You are not allowed to perform this action.",
+          "grantDetail": "{{name}} was added, but the {{role}} role could not be granted.",
+          "grantSummary": "Failed to grant a role",
           "lastOwnerDetail": "A team must keep at least one admin.",
           "removeMemberDetail": "Could not remove team member.",
           "removeMemberSummary": "Failed to remove member",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1538,6 +1538,11 @@
           "updateRoleDetail": "Could not update member role.",
           "updateRoleSummary": "Failed to update role"
         },
+        "revokeRoleDialog": {
+          "confirmLabel": "Remove role",
+          "message": "Remove the {{role}} role from {{name}}?",
+          "title": "Remove a role"
+        },
         "table": {
           "actions": "Actions",
           "deleteAction": "Delete",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -393,7 +393,7 @@
       "itemsPerPage": "Items per page",
       "last": "Last page",
       "next": "Next page",
-      "pageNumber": "Page {{page}}",
+      "pageNumber": "Page {{page}} of {{pageCount}}",
       "prev": "Previous page",
       "totalItems": "{{count}} items"
     }

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1515,10 +1515,18 @@
     },
     "teamSettings": {
       "members": {
-        "addMember": {
-          "placeholder": "Inviter des utilisateurs"
+        "addMembersDialog": {
+          "buttonLabel": "Ajouter des membres",
+          "cancel": "Annuler",
+          "confirm": "Ajouter",
+          "removeAria": "Retirer {{name}} de la liste",
+          "searchPlaceholder": "Entrer un nom, prénom ou ID utilisateur",
+          "subtitle": "Les utilisateurs seront immédiatement ajoutés à l'équipe",
+          "title": "Ajouter de nouveaux membres"
         },
         "errors": {
+          "addDetail": "Impossible d'ajouter cet utilisateur à l'équipe.",
+          "addSummary": "Échec de l'ajout du membre",
           "forbiddenDetail": "Vous n'avez pas les droits pour effectuer cette action.",
           "lastOwnerDetail": "Une équipe doit conserver au moins un administrateur.",
           "removeMemberDetail": "Impossible de supprimer ce membre de l'équipe.",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1538,11 +1538,6 @@
           "updateRoleDetail": "Impossible de mettre à jour le rôle du membre.",
           "updateRoleSummary": "Échec de la mise à jour du rôle"
         },
-        "revokeRoleDialog": {
-          "confirmLabel": "Retirer le rôle",
-          "message": "Retirer le rôle {{role}} à {{name}} ?",
-          "title": "Retirer un rôle"
-        },
         "table": {
           "actions": "Actions",
           "deleteAction": "Supprimer",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1519,6 +1519,8 @@
           "buttonLabel": "Ajouter des membres",
           "cancel": "Annuler",
           "confirm": "Ajouter",
+          "pendingListEmpty": "Aucun utilisateur sélectionné pour l'instant",
+          "pendingListHeader": "Membres à ajouter à l'équipe",
           "removeAria": "Retirer {{name}} de la liste",
           "searchPlaceholder": "Entrer un nom, prénom ou ID utilisateur",
           "subtitle": "Les utilisateurs seront immédiatement ajoutés à l'équipe",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1538,6 +1538,11 @@
           "updateRoleDetail": "Impossible de mettre à jour le rôle du membre.",
           "updateRoleSummary": "Échec de la mise à jour du rôle"
         },
+        "revokeRoleDialog": {
+          "confirmLabel": "Retirer le rôle",
+          "message": "Retirer le rôle {{role}} à {{name}} ?",
+          "title": "Retirer un rôle"
+        },
         "table": {
           "actions": "Actions",
           "deleteAction": "Supprimer",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1530,6 +1530,8 @@
           "addDetail": "Impossible d'ajouter cet utilisateur à l'équipe.",
           "addSummary": "Échec de l'ajout du membre",
           "forbiddenDetail": "Vous n'avez pas les droits pour effectuer cette action.",
+          "grantDetail": "{{name}} a été ajouté(e), mais le rôle {{role}} n'a pas pu lui être attribué.",
+          "grantSummary": "Échec de l'attribution d'un rôle",
           "lastOwnerDetail": "Une équipe doit conserver au moins un administrateur.",
           "removeMemberDetail": "Impossible de supprimer ce membre de l'équipe.",
           "removeMemberSummary": "Échec de la suppression du membre",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -390,10 +390,10 @@
   "dataTable": {
     "pagination": {
       "first": "Première page",
-      "itemsPerPage": "Items par page",
+      "itemsPerPage": "Éléments par page",
       "last": "Dernière page",
       "next": "Page suivante",
-      "pageNumber": "Page {{page}}",
+      "pageNumber": "Page {{page}} sur {{pageCount}}",
       "prev": "Page précédente",
       "totalItems": "{{count}} éléments"
     }

--- a/apps/frontend/src/rework/components/shared/atoms/Button/Button.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/Button/Button.module.scss
@@ -44,7 +44,10 @@
     }
 
     &.btn-outlined {
-      --btn-border: #{map.get($scheme, "main")};
+      // M3: the outlined variant's border is always the neutral `outline`
+      // token, regardless of `color` — only the label/state-layer take the
+      // scheme's color. Matches IconButton's outlined variant.
+      --btn-border: var(--outline);
       --btn-text-color: #{map.get($scheme, "main")};
 
       &:hover:not(:disabled) {

--- a/apps/frontend/src/rework/components/shared/atoms/IconButton/IconButton.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/IconButton/IconButton.module.scss
@@ -46,7 +46,10 @@
     }
 
     &.btn-outlined {
-      --btn-border: #{map.get($scheme, "main")};
+      // M3: the outlined variant's border is always the neutral `outline`
+      // token, regardless of `color` — only the icon/state-layer take the
+      // scheme's color. Matches Button's outlined variant.
+      --btn-border: var(--outline);
       --btn-text-color: #{map.get($scheme, "main")};
 
       &:hover:not(:disabled) {

--- a/apps/frontend/src/rework/components/shared/atoms/IconButton/IconButton.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/IconButton/IconButton.tsx
@@ -18,13 +18,14 @@ import { ComponentPropsWithoutRef } from "react";
 import Icon, { IconProps } from "@shared/atoms/Icon/Icon.tsx";
 
 export interface IconButtonProps extends ComponentPropsWithoutRef<"button"> {
-  color: ColorTheme;
+  /** Defaults to "on-surface-retreat" — the app's baseline icon-button color. */
+  color?: ColorTheme;
   variant: IconButtonVariant;
   size: ComponentSize;
   icon: IconProps;
 }
 
-export default function IconButton({ color, variant, size, icon, ...props }: IconButtonProps) {
+export default function IconButton({ color = "on-surface-retreat", variant, size, icon, ...props }: IconButtonProps) {
   const buttonClasses = [styles.btn, styles[`btn-${color}`], styles[`btn-${size}`], styles[`btn-${variant}`]];
 
   return (

--- a/apps/frontend/src/rework/components/shared/atoms/TextInput/TextInput.module.scss
+++ b/apps/frontend/src/rework/components/shared/atoms/TextInput/TextInput.module.scss
@@ -73,6 +73,13 @@
   font: var(--font-body-medium);
 }
 
+/* Compact fields have no hint/error/counter text — drop the container
+ * entirely rather than leaving an empty row, so the field's rendered
+ * height is exactly the input's. */
+.input[data-compact="true"] .information {
+  display: none;
+}
+
 .hint {
   min-width: 0;
   overflow-wrap: break-word;

--- a/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Autocomplete from "./Autocomplete.tsx";
+import type { OptionModel } from "@models/Option.model.ts";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function input(): HTMLInputElement {
+  return container.querySelector("input") as HTMLInputElement;
+}
+
+function pressKey(key: string) {
+  act(() => {
+    input().dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+}
+
+function focusedLabel(): string | null {
+  const el = container.querySelector('[role="option"][data-focused="true"]');
+  return el ? el.textContent : null;
+}
+
+// Object-valued options (like a real candidate user record) are the case
+// that motivated keying Menu's item id off `option.key` instead of
+// `option.value` — a plain string/number `value` would happen to work
+// either way.
+interface Candidate {
+  id: string;
+  name: string;
+}
+
+function options(): OptionModel<Candidate>[] {
+  return [
+    { key: "1", value: { id: "1", name: "Alice" }, label: "Alice" },
+    { key: "2", value: { id: "2", name: "Bob" }, label: "Bob" },
+    { key: "3", value: { id: "3", name: "Carla" }, label: "Carla" },
+  ];
+}
+
+describe("Autocomplete keyboard navigation", () => {
+  it("focuses the first option by default once the menu is open with results", () => {
+    render(
+      <Autocomplete<Candidate>
+        textInput={{ placeholder: "Search" }}
+        minQueryLength={0}
+        options={options()}
+        onSelect={vi.fn()}
+      />,
+    );
+    act(() => {
+      input().focus();
+    });
+
+    expect(focusedLabel()).toBe("Alice");
+  });
+
+  it("ArrowDown/ArrowUp move the focused option, wrapping at each end", () => {
+    render(
+      <Autocomplete<Candidate>
+        textInput={{ placeholder: "Search" }}
+        minQueryLength={0}
+        options={options()}
+        onSelect={vi.fn()}
+      />,
+    );
+    act(() => {
+      input().focus();
+    });
+
+    pressKey("ArrowDown");
+    expect(focusedLabel()).toBe("Bob");
+
+    pressKey("ArrowDown");
+    expect(focusedLabel()).toBe("Carla");
+
+    pressKey("ArrowDown");
+    expect(focusedLabel()).toBe("Alice"); // wraps
+
+    pressKey("ArrowUp");
+    expect(focusedLabel()).toBe("Carla"); // wraps the other way
+  });
+
+  it("Enter selects the currently focused option, clears the query, and closes the menu", () => {
+    const onSelect = vi.fn();
+    render(
+      <Autocomplete<Candidate>
+        textInput={{ placeholder: "Search" }}
+        minQueryLength={0}
+        options={options()}
+        onSelect={onSelect}
+      />,
+    );
+    act(() => {
+      input().focus();
+    });
+
+    pressKey("ArrowDown"); // -> Bob
+    pressKey("Enter");
+
+    expect(onSelect).toHaveBeenCalledWith({ id: "2", name: "Bob" });
+    expect(input().value).toBe("");
+    expect(container.querySelector('[data-open="true"]')).toBeNull();
+  });
+
+  it("resets the focused option back to the first one on the next keystroke", () => {
+    render(
+      <Autocomplete<Candidate>
+        textInput={{ placeholder: "Search" }}
+        minQueryLength={0}
+        options={options()}
+        onSelect={vi.fn()}
+      />,
+    );
+    act(() => {
+      input().focus();
+    });
+    pressKey("ArrowDown");
+    expect(focusedLabel()).toBe("Bob");
+
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setter.call(input(), "a");
+      input().dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(focusedLabel()).toBe("Alice");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.tsx
@@ -15,7 +15,7 @@
 import styles from "./Autocomplete.module.scss";
 import TextInput, { TextInputProps } from "@shared/atoms/TextInput/TextInput.tsx";
 import Menu from "@shared/molecules/Menu/Menu.tsx";
-import { useEffect, useId, useState } from "react";
+import { KeyboardEvent as ReactKeyboardEvent, useEffect, useId, useState } from "react";
 import { OptionModel } from "@models/Option.model.ts";
 
 interface AutocompleteProps<T> {
@@ -45,6 +45,14 @@ export default function Autocomplete<T>({
   // alone can't tell a fresh open from one that was just dismissed).
   const [dismissed, setDismissed] = useState(false);
   const [queryValue, setQueryValue] = useState("");
+  // Virtual focus (aria-activedescendant pattern, same as Select): DOM focus
+  // stays on the input, arrow keys move this index and Enter selects it.
+  // Reset on every keystroke/focus rather than reactively on `options`
+  // itself — `options` is a brand new array reference on nearly every
+  // parent render (a `.filter()`/`.map()` result), not just when the
+  // candidate list actually changes, and resetting off of it would keep
+  // stomping on the user's own up/down navigation mid-browse.
+  const [activeIndex, setActiveIndex] = useState(0);
   const baseId = useId();
 
   const isOpen = isFocused && !dismissed && queryValue.trim().length >= minQueryLength;
@@ -63,6 +71,54 @@ export default function Autocomplete<T>({
     onFieldValueChange?.(queryValue);
   }, [queryValue]);
 
+  // Walks past disabled options in `delta`'s direction; if every option is
+  // disabled, the active index doesn't move.
+  const moveActive = (delta: number) => {
+    if (options.length === 0) return;
+    setActiveIndex((prev) => {
+      const base = prev < 0 ? 0 : prev;
+      let next = base;
+      for (let i = 0; i < options.length; i++) {
+        next = (next + delta + options.length) % options.length;
+        if (!options[next]?.disabled) return next;
+      }
+      return prev;
+    });
+  };
+
+  const selectOption = (value: T) => {
+    setDismissed(true);
+    onSelect(value);
+    setQueryValue("");
+  };
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        moveActive(1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        moveActive(-1);
+        break;
+      case "Enter": {
+        const option = options[activeIndex];
+        if (option && !option.disabled) {
+          e.preventDefault();
+          selectOption(option.value);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  const activeOption = isOpen ? options[activeIndex] : undefined;
+  const activeOptionId = activeOption ? `${baseId}-opt-${activeOption.key}` : undefined;
+
   return (
     <div className={styles["autocomplete-container"]} data-open={isOpen}>
       <TextInput
@@ -71,24 +127,21 @@ export default function Autocomplete<T>({
         onFocus={() => {
           setIsFocused(true);
           setDismissed(false);
+          setActiveIndex(0);
         }}
         onBlur={() => setIsFocused(false)}
         onChange={(e) => {
           setQueryValue(e.target.value);
           setDismissed(false);
+          setActiveIndex(0);
         }}
+        onKeyDown={handleKeyDown}
+        aria-expanded={isOpen}
+        aria-activedescendant={activeOptionId}
         value={queryValue}
       />
       <div id={`${baseId}-menu`} className={styles["menu-popover"]} role="presentation">
-        <Menu
-          options={options}
-          baseId={baseId}
-          onChange={(v) => {
-            setDismissed(true);
-            onSelect(v);
-            setQueryValue("");
-          }}
-        />
+        <Menu options={options} baseId={baseId} activeId={activeOptionId} onChange={(v) => selectOption(v)} />
       </div>
     </div>
   );

--- a/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.tsx
@@ -51,7 +51,13 @@ export default function Autocomplete<T>({ textInput, options, onSelect, onFieldV
         {...textInput}
         onFocus={() => setIsOpen(true)}
         onBlur={() => setIsOpen(false)}
-        onChange={(e) => setQueryValue(e.target.value)}
+        onChange={(e) => {
+          setQueryValue(e.target.value);
+          // Selecting an option closes the menu without blurring the input
+          // (the listbox's onMouseDown prevents that) — typing again while
+          // still focused must reopen it, or the field looks unresponsive.
+          setIsOpen(true);
+        }}
         value={queryValue}
       />
       <div id={`${baseId}-menu`} className={styles["menu-popover"]} role="presentation">

--- a/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Autocomplete/Autocomplete.tsx
@@ -23,18 +23,37 @@ interface AutocompleteProps<T> {
   options: OptionModel<T>[];
   onSelect: (value: T) => void;
   onFieldValueChange?: (value: string) => void;
+  /** Characters (after trim) needed before the menu opens. Default 0 opens
+   *  on focus, showing whatever `options` already holds — for fields meant
+   *  to browse a full list. Set higher (e.g. 2) for fields backed by a
+   *  server search that itself only queries past a minimum length, so the
+   *  menu doesn't flash an empty "no options" state below that. */
+  minQueryLength?: number;
 }
 
-export default function Autocomplete<T>({ textInput, options, onSelect, onFieldValueChange }: AutocompleteProps<T>) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Autocomplete<T>({
+  textInput,
+  options,
+  onSelect,
+  onFieldValueChange,
+  minQueryLength = 0,
+}: AutocompleteProps<T>) {
+  const [isFocused, setIsFocused] = useState(false);
+  // True right after Escape or a selection — suppresses the menu until the
+  // next focus or keystroke, even though the field stays focused (the
+  // listbox's onMouseDown deliberately keeps focus on select, so "isFocused"
+  // alone can't tell a fresh open from one that was just dismissed).
+  const [dismissed, setDismissed] = useState(false);
   const [queryValue, setQueryValue] = useState("");
   const baseId = useId();
+
+  const isOpen = isFocused && !dismissed && queryValue.trim().length >= minQueryLength;
 
   // Close on Escape.
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsOpen(false);
+      if (e.key === "Escape") setDismissed(true);
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
@@ -49,14 +68,14 @@ export default function Autocomplete<T>({ textInput, options, onSelect, onFieldV
       <TextInput
         compact={true}
         {...textInput}
-        onFocus={() => setIsOpen(true)}
-        onBlur={() => setIsOpen(false)}
+        onFocus={() => {
+          setIsFocused(true);
+          setDismissed(false);
+        }}
+        onBlur={() => setIsFocused(false)}
         onChange={(e) => {
           setQueryValue(e.target.value);
-          // Selecting an option closes the menu without blurring the input
-          // (the listbox's onMouseDown prevents that) — typing again while
-          // still focused must reopen it, or the field looks unresponsive.
-          setIsOpen(true);
+          setDismissed(false);
         }}
         value={queryValue}
       />
@@ -65,7 +84,7 @@ export default function Autocomplete<T>({ textInput, options, onSelect, onFieldV
           options={options}
           baseId={baseId}
           onChange={(v) => {
-            setIsOpen(false);
+            setDismissed(true);
             onSelect(v);
             setQueryValue("");
           }}

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -93,9 +93,12 @@
 }
 
 /* Fixed width (not just min-width) so the neighbouring nav buttons don't
- * shift horizontally as the page number's digit count changes. */
+ * shift horizontally as either page number's digit count changes. Wide
+ * enough for "Page 100 sur 100" (the longest of the two locales) plus
+ * tabular-nums so digit glyphs themselves don't vary in width. */
 .footer-page-label {
-  width: 3.5rem;
+  width: 7rem;
+  font-variant-numeric: tabular-nums;
   text-align: center;
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -141,7 +141,7 @@ export default function DataTable<T>({
               onClick={() => setPage(currentPage - 1)}
             />
             <span className={`${styles["footer-label"]} ${styles["footer-page-label"]}`}>
-              {t("dataTable.pagination.pageNumber", { page: currentPage + 1 })}
+              {t("dataTable.pagination.pageNumber", { page: currentPage + 1, pageCount })}
             </span>
             <IconButton
               color="on-surface"

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -32,6 +32,13 @@ interface DataTableProps<T> {
    *  `ROWS_PER_PAGE_OPTIONS`). Omit to render every row with no pagination
    *  bar (default) — existing call sites are unaffected. */
   pageSize?: number;
+  /** Stable per-row identity, e.g. `(member) => member.user.id`. Omit only
+   *  for data that never reorders between renders — without it, React falls
+   *  back to array index as key, which misattributes any row-scoped
+   *  component state (open menus, in-flight click handlers) to the wrong
+   *  item as soon as `data` re-sorts (e.g. after an edit changes sort
+   *  order). */
+  rowKey?: (element: T) => string | number;
 }
 
 export interface DataTableColumn<T> {
@@ -52,6 +59,7 @@ export default function DataTable<T>({
   backgroundColor = "var(--surface-container)",
   firstColumnInset = false,
   pageSize,
+  rowKey,
 }: DataTableProps<T>) {
   const { t } = useTranslation();
   const paginationEnabled = pageSize !== undefined;
@@ -90,7 +98,7 @@ export default function DataTable<T>({
           </div>
         ))}
         {pageData.map((line, lineIndex) => (
-          <div className={styles["datatable-row"]} key={`row-${lineIndex}`}>
+          <div className={styles["datatable-row"]} key={rowKey ? rowKey(line) : `row-${lineIndex}`}>
             {columns.map((column) => {
               return (
                 <div className={styles["datatable-cell"]} key={column.label}>

--- a/apps/frontend/src/rework/components/shared/molecules/Menu/Menu.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Menu/Menu.tsx
@@ -67,7 +67,14 @@ const MenuInternal = <T,>({
       onMouseDown={(e) => e.preventDefault()}
     >
       {options.map((option) => {
-        const itemId = `${baseId}-opt-${option.value}`;
+        // `option.key` (already required, already unique — it's React's own
+        // list key) rather than `option.value`: `value` can be any type,
+        // including a non-primitive object (e.g. a candidate user record in
+        // `Autocomplete`), which stringifies to the same "[object Object]"
+        // for every option and both breaks the id's uniqueness and isn't
+        // valid unescaped in the `#${activeId}` selector `Menu` itself uses
+        // below to scroll the active option into view.
+        const itemId = `${baseId}-opt-${option.key}`;
         const isFocused = activeId === itemId;
 
         const isSelected = Array.isArray(selectedId)

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
@@ -210,7 +210,9 @@ export default function Select<T>({
   };
 
   const activeOption = isOpen && activeIndex >= 0 ? options[activeIndex] : undefined;
-  const activeOptionId = activeOption ? `${baseId}-opt-${activeOption.value}` : undefined;
+  // Must match Menu's own itemId, which is keyed by `option.key` (unique by
+  // contract) rather than `option.value` (can be a non-primitive).
+  const activeOptionId = activeOption ? `${baseId}-opt-${activeOption.key}` : undefined;
 
   return (
     <div

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -1,8 +1,6 @@
-// AUTHZ-06 (RFC Part 7 §37): one independently togglable chip per elevated
-// team role (admin/editor/analyst) — a member may hold several at once, so
-// this is a multi-select toggle group, not the single-select `FilterChips`
-// pattern. Visual language kept consistent with it (outlined pill, fills
-// with `--primary` when active).
+// Visual language kept consistent with `FilterChips`: outlined pill, fills
+// with `--primary` when active. Unlike `FilterChips`, this is a multi-select
+// toggle group (see `ELEVATED_TEAM_ROLES` for why).
 .roleChips {
   display: flex;
   flex-wrap: wrap;

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -8,17 +8,21 @@
 }
 
 .roleChip {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   transition:
     background 100ms ease,
     border-color 100ms ease,
     color 100ms ease;
   cursor: pointer;
-  border: 0.5px solid var(--outline-variant);
+  border: 1px solid var(--outline);
   border-radius: 999px;
   background: transparent;
-  padding: var(--spacing-3xs) var(--spacing-xs);
+  padding: 0 var(--spacing-xs);
+  height: 2rem;
   color: var(--on-surface-retreat);
-  font: var(--font-label-small);
+  font: var(--font-label-medium);
   white-space: nowrap;
 
   &:hover:not([data-active="true"]):not(:disabled) {

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -4,7 +4,7 @@
 .roleChips {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--spacing-2xs);
+  gap: var(--spacing-xs);
 }
 
 .roleChip {
@@ -19,7 +19,7 @@
   border: 1px solid var(--outline);
   border-radius: 999px;
   background: transparent;
-  padding: 0 var(--spacing-xs);
+  padding: 0 var(--spacing-s);
   height: 2rem;
   color: var(--on-surface-retreat);
   font: var(--font-label-medium);

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
@@ -1,0 +1,57 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useTranslation } from "react-i18next";
+import { UserTeamRelation } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import styles from "./TeamRoleChips.module.scss";
+
+// AUTHZ-06 (RFC Part 7 §37): one independently togglable chip per elevated
+// team role — a member may hold several at once, so this is a multi-select
+// toggle group, not a single-select pattern. `team_member` is deliberately
+// excluded: it's the implicit baseline when none of the three apply, not a
+// toggle of its own.
+export const ELEVATED_TEAM_ROLES: UserTeamRelation[] = ["team_admin", "team_editor", "team_analyst"];
+
+interface TeamRoleChipsProps {
+  heldRoles: UserTeamRelation[];
+  onToggle: (role: UserTeamRelation, held: boolean) => void;
+  /** Per-role gate for the current actor. Omit to leave every chip enabled. */
+  canAdminister?: (role: UserTeamRelation) => boolean;
+}
+
+export default function TeamRoleChips({ heldRoles, onToggle, canAdminister }: TeamRoleChipsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.roleChips} role="group">
+      {ELEVATED_TEAM_ROLES.map((role) => {
+        const held = heldRoles.includes(role);
+        const disabled = canAdminister ? !canAdminister(role) : false;
+        return (
+          <button
+            key={role}
+            type="button"
+            className={styles.roleChip}
+            data-active={held}
+            aria-pressed={held}
+            disabled={disabled}
+            onClick={() => onToggle(role, held)}
+          >
+            {t(`rework.teamRoles.${role}`)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
@@ -1,0 +1,92 @@
+.overlay {
+  display: flex;
+  position: fixed;
+  justify-content: center;
+  align-items: center;
+  z-index: 1300;
+  inset: 0;
+  background-color: var(--scrim);
+}
+
+// No `overflow: hidden` here — every child is inset by the dialog's own
+// padding (nothing touches the rounded edge directly), and clipping would
+// also cut off the Autocomplete's menu popover in `.searchRow` below.
+.dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  box-shadow: var(--shadow-s);
+  border-radius: var(--radius-m);
+  background-color: var(--surface-container-high);
+  padding: var(--spacing-l);
+  width: min(640px, 92vw);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3xs);
+}
+
+.title {
+  margin: 0;
+  color: var(--on-surface);
+  font: var(--font-title-large);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--on-surface-retreat);
+  font: var(--font-body-medium);
+}
+
+.searchRow {
+  position: relative;
+}
+
+// 8.5 rows tall — the half-row is a deliberate "there's more below" affordance.
+.pendingList {
+  --row-height: 4rem;
+
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0 var(--spacing-2xs) 0 0;
+  max-height: calc(8.5 * var(--row-height));
+  overflow-y: auto;
+  list-style: none;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+}
+
+.pendingRow {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-m);
+  border-radius: var(--radius-s);
+  padding: 0 var(--spacing-xs);
+  height: var(--row-height);
+}
+
+.pendingName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--on-surface);
+  font: var(--font-body-large);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pendingRoleChips {
+  flex-shrink: 0;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
@@ -51,7 +51,9 @@
   display: flex;
   flex-direction: column;
   margin: 0;
-  padding: 0 var(--spacing-2xs) 0 0;
+  border: 1px solid var(--outline-retreat);
+  border-radius: var(--radius-s);
+  padding: var(--spacing-s);
   max-height: calc(8.5 * var(--row-height));
   overflow-y: auto;
   list-style: none;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
@@ -83,7 +83,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: calc(3 * var(--row-height));
+  height: var(--row-height);
   color: var(--on-surface-muted);
   font: var(--font-body-medium);
   text-align: center;
@@ -94,9 +94,9 @@
   flex-shrink: 0;
   align-items: center;
   gap: var(--spacing-m);
-  border-radius: var(--radius-xs);
-  background-color: var(--surface-container);
-  padding: 0 var(--spacing-xs);
+  border-radius: var(--radius-s);
+  background-color: var(--surface-container-highest);
+  padding: 0 var(--spacing-xs) 0 var(--spacing-m);
   height: var(--row-height);
 }
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
@@ -67,6 +67,7 @@
 .pendingList {
   display: flex;
   flex-direction: column;
+  gap: var(--spacing-3xs);
   margin: 0;
   padding: 0;
   max-height: calc(8.5 * var(--row-height));
@@ -93,7 +94,8 @@
   flex-shrink: 0;
   align-items: center;
   gap: var(--spacing-m);
-  border-radius: var(--radius-s);
+  border-radius: var(--radius-xs);
+  background-color: var(--surface-container);
   padding: 0 var(--spacing-xs);
   height: var(--row-height);
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.module.scss
@@ -44,16 +44,31 @@
   position: relative;
 }
 
-// 8.5 rows tall — the half-row is a deliberate "there's more below" affordance.
-.pendingList {
-  --row-height: 4rem;
+// Always rendered (even with zero pending members) so the header stays put
+// as a landmark for the list below it.
+.pendingListContainer {
+  --row-height: 3rem;
 
   display: flex;
   flex-direction: column;
-  margin: 0;
+  gap: var(--spacing-xs);
   border: 1px solid var(--outline-retreat);
   border-radius: var(--radius-s);
   padding: var(--spacing-s);
+}
+
+.pendingListHeader {
+  flex-shrink: 0;
+  color: var(--on-surface-retreat);
+  font: var(--font-label-large);
+}
+
+// 8.5 rows tall — the half-row is a deliberate "there's more below" affordance.
+.pendingList {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
   max-height: calc(8.5 * var(--row-height));
   overflow-y: auto;
   list-style: none;
@@ -61,6 +76,16 @@
   &::-webkit-scrollbar {
     width: 4px;
   }
+}
+
+.pendingListEmpty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(3 * var(--row-height));
+  color: var(--on-surface-muted);
+  font: var(--font-body-medium);
+  text-align: center;
 }
 
 .pendingRow {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -209,6 +209,39 @@ describe("AddTeamMembersDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("still grants every selected role when addTeamMember resolves to null (204 No Content)", async () => {
+    // The real backend's add-member endpoint returns 204 No Content, which
+    // RTK Query's fetchBaseQuery resolves as `null` on success — not an
+    // error. A add-result check of `=== null` would misread this as a
+    // failure and skip every grant below it; `.ok` must not.
+    h.addTeamMember.mockReturnValue({ unwrap: () => Promise.resolve(null) });
+    h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve(null) });
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    selectCandidate(alice);
+
+    click(roleChip("team_editor"));
+    click(roleChip("team_analyst"));
+
+    await act(async () => {
+      click(confirmButton());
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(h.grantTeamMemberRole).toHaveBeenCalledWith({
+      teamId: "team-1",
+      userId: "u1",
+      grantTeamMemberRoleRequest: { relation: "team_editor" },
+    });
+    expect(h.grantTeamMemberRole).toHaveBeenCalledWith({
+      teamId: "team-1",
+      userId: "u1",
+      grantTeamMemberRoleRequest: { relation: "team_analyst" },
+    });
+    expect(h.showError).not.toHaveBeenCalled();
+  });
+
   it("confirming with two selected roles always adds on the team_member baseline, then grants both roles", async () => {
     h.addTeamMember.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -108,6 +108,7 @@ function selectCandidate(user: UserSummary) {
   h.candidates = [user];
   const input = portal().querySelector("input") as HTMLInputElement;
   act(() => {
+    input.focus();
     nativeInputValueSetter.call(input, user.username);
     input.dispatchEvent(new Event("input", { bubbles: true }));
   });
@@ -133,6 +134,24 @@ describe("AddTeamMembersDialog", () => {
     expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.title");
     expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.subtitle");
     expect(confirmButton().disabled).toBe(true);
+  });
+
+  it("does not focus the search input on open", () => {
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    const input = portal().querySelector("input");
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("does not open the suggestions menu below 2 characters", () => {
+    h.candidates = [alice];
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    const input = portal().querySelector("input") as HTMLInputElement;
+    act(() => {
+      input.focus();
+      nativeInputValueSetter.call(input, "a");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(portal().querySelector('[class*="autocomplete-container"]')?.getAttribute("data-open")).toBe("false");
   });
 
   it("selecting a candidate adds a pending row and enables confirm", () => {
@@ -206,7 +225,7 @@ describe("AddTeamMembersDialog", () => {
     });
   });
 
-  it("keeps a failed user in the pending list and does not close the dialog", async () => {
+  it("closes the dialog even when a member's add call fails", async () => {
     h.addTeamMember.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
     const onClose = vi.fn();
     render(<AddTeamMembersDialog open={true} team={team} onClose={onClose} />);
@@ -218,7 +237,6 @@ describe("AddTeamMembersDialog", () => {
       await Promise.resolve();
     });
 
-    expect(portal().textContent).toContain("Alice Doe (alice)");
-    expect(onClose).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -209,7 +209,7 @@ describe("AddTeamMembersDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("confirming with two selected roles adds with the highest-priority role and grants the other", async () => {
+  it("confirming with two selected roles always adds on the team_member baseline, then grants both roles", async () => {
     h.addTeamMember.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
@@ -225,9 +225,18 @@ describe("AddTeamMembersDialog", () => {
       await Promise.resolve();
     });
 
+    // Never add directly onto an elevated relation — a member with no
+    // separate team_member tuple has no floor to fall back to, and revoking
+    // their only elevated role later would 409 ("would silently remove them
+    // from the team").
     expect(h.addTeamMember).toHaveBeenCalledWith({
       teamId: "team-1",
-      addTeamMemberRequest: { user_id: "u1", relation: "team_editor" },
+      addTeamMemberRequest: { user_id: "u1", relation: "team_member" },
+    });
+    expect(h.grantTeamMemberRole).toHaveBeenCalledWith({
+      teamId: "team-1",
+      userId: "u1",
+      grantTeamMemberRoleRequest: { relation: "team_editor" },
     });
     expect(h.grantTeamMemberRole).toHaveBeenCalledWith({
       teamId: "team-1",
@@ -252,9 +261,9 @@ describe("AddTeamMembersDialog", () => {
       await Promise.resolve();
     });
 
-    // addTeamMember still succeeds (Alice is added as team_editor) — only
-    // the second grant fails, and it must say so by name and role rather
-    // than a generic "failed to update role" toast.
+    // addTeamMember still succeeds (Alice is added on the team_member
+    // baseline) — the grants fail, and it must say so by name and role
+    // rather than a generic "failed to update role" toast.
     expect(h.showError).toHaveBeenCalledWith(
       expect.objectContaining({
         detail: expect.stringContaining('"name":"Alice Doe (alice)"'),

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -145,10 +145,10 @@ describe("AddTeamMembersDialog", () => {
     expect(portal().querySelector('ul[class*="pendingList"]')).toBeNull();
   });
 
-  it("does not focus the search input on open", () => {
+  it("focuses the search input on open", () => {
     render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
     const input = portal().querySelector("input");
-    expect(document.activeElement).not.toBe(input);
+    expect(document.activeElement).toBe(input);
   });
 
   it("does not open the suggestions menu below 2 characters", () => {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -28,6 +28,7 @@ const h = vi.hoisted(() => ({
   addTeamMember: vi.fn(),
   grantTeamMemberRole: vi.fn(),
   candidates: [] as UserSummary[],
+  showError: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -37,7 +38,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
-  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn(), showWarn: vi.fn(), showInfo: vi.fn() }),
+  useToast: () => ({ showSuccess: vi.fn(), showError: h.showError, showWarn: vi.fn(), showInfo: vi.fn() }),
 }));
 
 vi.mock("../../../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
@@ -68,6 +69,7 @@ afterEach(() => {
   document.getElementById("modal-portal")?.remove();
   h.addTeamMember.mockReset();
   h.grantTeamMemberRole.mockReset();
+  h.showError.mockReset();
   h.candidates = [];
 });
 
@@ -232,6 +234,37 @@ describe("AddTeamMembersDialog", () => {
       userId: "u1",
       grantTeamMemberRoleRequest: { relation: "team_analyst" },
     });
+  });
+
+  it("names the user and the missing role when a grant call fails, so a dropped role is never silent", async () => {
+    h.addTeamMember.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    selectCandidate(alice);
+
+    click(roleChip("team_editor"));
+    click(roleChip("team_analyst"));
+
+    await act(async () => {
+      click(confirmButton());
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // addTeamMember still succeeds (Alice is added as team_editor) — only
+    // the second grant fails, and it must say so by name and role rather
+    // than a generic "failed to update role" toast.
+    expect(h.showError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining('"name":"Alice Doe (alice)"'),
+      }),
+    );
+    expect(h.showError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining('"role":"rework.teamRoles.team_analyst"'),
+      }),
+    );
   });
 
   it("closes the dialog even when a member's add call fails", async () => {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TeamWithPermissions, UserSummary } from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const h = vi.hoisted(() => ({
+  addTeamMember: vi.fn(),
+  grantTeamMemberRole: vi.fn(),
+  candidates: [] as UserSummary[],
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key} ${JSON.stringify(opts)}` : key),
+  }),
+}));
+
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn(), showWarn: vi.fn(), showInfo: vi.fn() }),
+}));
+
+vi.mock("../../../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
+  useAddTeamMemberMutation: () => [h.addTeamMember],
+  useGrantTeamMemberRoleMutation: () => [h.grantTeamMemberRole],
+  useSearchCandidateTeamMembersQuery: () => ({ data: h.candidates }),
+}));
+
+import AddTeamMembersDialog from "./AddTeamMembersDialog.tsx";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  document.getElementById("modal-portal")?.remove();
+  h.addTeamMember.mockReset();
+  h.grantTeamMemberRole.mockReset();
+  h.candidates = [];
+});
+
+function click(el: Element | null) {
+  if (!el) throw new Error("element not found");
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+const team: TeamWithPermissions = {
+  id: "team-1",
+  name: "Team One",
+  is_member: true,
+  admins: [],
+  permissions: ["can_administer_members", "can_administer_editors", "can_administer_analysts", "can_administer_admins"],
+} as TeamWithPermissions;
+
+const alice: UserSummary = { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" };
+
+function portal(): HTMLElement {
+  const el = document.getElementById("modal-portal");
+  if (!el) throw new Error("dialog portal not rendered");
+  return el;
+}
+
+function confirmButton(): HTMLButtonElement {
+  return Array.from(portal().querySelectorAll("button")).find(
+    (b) => b.textContent === "rework.teamSettings.members.addMembersDialog.confirm",
+  ) as HTMLButtonElement;
+}
+
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+
+/** Types into the search field so the component re-renders and picks up the
+ *  (mutated) mocked candidate list, then clicks the matching menu option. */
+function selectCandidate(user: UserSummary) {
+  h.candidates = [user];
+  const input = portal().querySelector("input") as HTMLInputElement;
+  act(() => {
+    nativeInputValueSetter.call(input, user.username);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  const option = Array.from(portal().querySelectorAll('[role="option"]')).find((o) =>
+    o.textContent?.includes(user.username!),
+  );
+  click(option ?? null);
+}
+
+function roleChip(role: string): HTMLButtonElement {
+  const label = `rework.teamRoles.${role}`;
+  return Array.from(portal().querySelectorAll("button")).find((b) => b.textContent === label) as HTMLButtonElement;
+}
+
+describe("AddTeamMembersDialog", () => {
+  it("renders nothing when closed", () => {
+    render(<AddTeamMembersDialog open={false} team={team} onClose={vi.fn()} />);
+    expect(document.getElementById("modal-portal")).toBeNull();
+  });
+
+  it("shows the header and a disabled confirm button with an empty pending list", () => {
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.title");
+    expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.subtitle");
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it("selecting a candidate adds a pending row and enables confirm", () => {
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    selectCandidate(alice);
+
+    expect(portal().textContent).toContain("Alice Doe (alice)");
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it("removing a pending row via its delete button clears it and disables confirm again", () => {
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    selectCandidate(alice);
+
+    const removeButton = Array.from(portal().querySelectorAll("button")).find((b) =>
+      b.getAttribute("aria-label")?.startsWith("rework.teamSettings.members.addMembersDialog.removeAria"),
+    );
+    click(removeButton ?? null);
+
+    // The removed candidate becomes searchable again, so it can still appear
+    // in the (closed) suggestions dropdown — assert on the pending list
+    // specifically, not the whole dialog's text.
+    expect(portal().querySelector('[class*="pendingList"]')).toBeNull();
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it("confirming with no role selected adds the user with the team_member baseline", async () => {
+    h.addTeamMember.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    const onClose = vi.fn();
+    render(<AddTeamMembersDialog open={true} team={team} onClose={onClose} />);
+    selectCandidate(alice);
+
+    await act(async () => {
+      click(confirmButton());
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(h.addTeamMember).toHaveBeenCalledWith({
+      teamId: "team-1",
+      addTeamMemberRequest: { user_id: "u1", relation: "team_member" },
+    });
+    expect(h.grantTeamMemberRole).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("confirming with two selected roles adds with the highest-priority role and grants the other", async () => {
+    h.addTeamMember.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    selectCandidate(alice);
+
+    click(roleChip("team_editor"));
+    click(roleChip("team_analyst"));
+
+    await act(async () => {
+      click(confirmButton());
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(h.addTeamMember).toHaveBeenCalledWith({
+      teamId: "team-1",
+      addTeamMemberRequest: { user_id: "u1", relation: "team_editor" },
+    });
+    expect(h.grantTeamMemberRole).toHaveBeenCalledWith({
+      teamId: "team-1",
+      userId: "u1",
+      grantTeamMemberRoleRequest: { relation: "team_analyst" },
+    });
+  });
+
+  it("keeps a failed user in the pending list and does not close the dialog", async () => {
+    h.addTeamMember.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
+    const onClose = vi.fn();
+    render(<AddTeamMembersDialog open={true} team={team} onClose={onClose} />);
+    selectCandidate(alice);
+
+    await act(async () => {
+      click(confirmButton());
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(portal().textContent).toContain("Alice Doe (alice)");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.test.tsx
@@ -136,6 +136,13 @@ describe("AddTeamMembersDialog", () => {
     expect(confirmButton().disabled).toBe(true);
   });
 
+  it("shows the pending-list container with its header and an empty placeholder even with no candidates selected", () => {
+    render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
+    expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.pendingListHeader");
+    expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.pendingListEmpty");
+    expect(portal().querySelector('ul[class*="pendingList"]')).toBeNull();
+  });
+
   it("does not focus the search input on open", () => {
     render(<AddTeamMembersDialog open={true} team={team} onClose={vi.fn()} />);
     const input = portal().querySelector("input");
@@ -172,9 +179,11 @@ describe("AddTeamMembersDialog", () => {
     click(removeButton ?? null);
 
     // The removed candidate becomes searchable again, so it can still appear
-    // in the (closed) suggestions dropdown — assert on the pending list
-    // specifically, not the whole dialog's text.
-    expect(portal().querySelector('[class*="pendingList"]')).toBeNull();
+    // in the (closed) suggestions dropdown — assert on the rows list
+    // specifically (tag-scoped, so it doesn't match the always-present
+    // pendingListContainer/pendingListEmpty), not the whole dialog's text.
+    expect(portal().querySelector('ul[class*="pendingList"]')).toBeNull();
+    expect(portal().textContent).toContain("rework.teamSettings.members.addMembersDialog.pendingListEmpty");
     expect(confirmButton().disabled).toBe(true);
   });
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from "react-i18next";
 import Button from "@shared/atoms/Button/Button.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import Autocomplete from "@shared/molecules/Autocomplete/Autocomplete.tsx";
-import TeamRoleChips, { ELEVATED_TEAM_ROLES } from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
+import TeamRoleChips from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
 import { Portal } from "@shared/utils/Portal.tsx";
 import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
@@ -112,21 +112,22 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
     setIsSubmitting(true);
 
     for (const member of pendingMembers) {
-      // AddTeamMemberRequest only carries one relation — add with the
-      // highest-priority selected role (falling back to the implicit
-      // `team_member` baseline), then grant any other selected elevated
-      // role one at a time, exactly like the members table already does
-      // for role changes on existing members. Errors surface via toast
-      // (below) but don't block the rest of the batch or keep the dialog
-      // open — the table reflects whatever actually succeeded.
-      const initialRole = ELEVATED_TEAM_ROLES.find((role) => member.roles.includes(role)) ?? "team_member";
-      const additionalRoles = member.roles.filter((role) => role !== initialRole);
-
+      // Always add on the team_member baseline, then grant every selected
+      // elevated role as its own tuple on top — never add directly on an
+      // elevated relation. A member added straight onto e.g. team_editor
+      // with no separate team_member tuple has no floor to fall back to:
+      // revoking their only elevated role would leave them with zero
+      // relations at all, which the backend correctly refuses ("would
+      // silently remove them from the team"). Every held role must stay
+      // revocable down to plain membership, never to nothing. Errors
+      // surface via toast (below) but don't block the rest of the batch or
+      // keep the dialog open — the table reflects whatever actually
+      // succeeded.
       const added = await runMutationAction({
         action: () =>
           addTeamMember({
             teamId: team.id,
-            addTeamMemberRequest: { user_id: member.user.id, relation: initialRole },
+            addTeamMemberRequest: { user_id: member.user.id, relation: "team_member" },
           }).unwrap(),
         onError: (error) =>
           notifyApiError(error, {
@@ -137,7 +138,7 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
       });
       if (added === null) continue;
 
-      for (const role of additionalRoles) {
+      for (const role of member.roles) {
         await runMutationAction({
           action: () =>
             grantTeamMemberRole({

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -189,31 +189,40 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
             />
           </div>
 
-          {pendingMembers.length > 0 && (
-            <ul className={styles.pendingList}>
-              {pendingMembers.map((member) => (
-                <li key={member.user.id} className={styles.pendingRow}>
-                  <span className={styles.pendingName}>{candidateLabel(member.user)}</span>
-                  <div className={styles.pendingRoleChips}>
-                    <TeamRoleChips
-                      heldRoles={member.roles}
-                      canAdminister={(role) => canAdministerTeamRole(capabilities, role)}
-                      onToggle={(role, held) => handleToggleRole(member.user.id, role, held)}
+          <div className={styles.pendingListContainer}>
+            <div className={styles.pendingListHeader}>
+              {t("rework.teamSettings.members.addMembersDialog.pendingListHeader")}
+            </div>
+            {pendingMembers.length > 0 ? (
+              <ul className={styles.pendingList}>
+                {pendingMembers.map((member) => (
+                  <li key={member.user.id} className={styles.pendingRow}>
+                    <span className={styles.pendingName}>{candidateLabel(member.user)}</span>
+                    <div className={styles.pendingRoleChips}>
+                      <TeamRoleChips
+                        heldRoles={member.roles}
+                        canAdminister={(role) => canAdministerTeamRole(capabilities, role)}
+                        onToggle={(role, held) => handleToggleRole(member.user.id, role, held)}
+                      />
+                    </div>
+                    <IconButton
+                      variant="icon"
+                      size="medium"
+                      icon={{ category: "outlined", type: "close" }}
+                      aria-label={t("rework.teamSettings.members.addMembersDialog.removeAria", {
+                        name: candidateLabel(member.user),
+                      })}
+                      onClick={() => handleRemovePending(member.user.id)}
                     />
-                  </div>
-                  <IconButton
-                    variant="icon"
-                    size="medium"
-                    icon={{ category: "outlined", type: "close" }}
-                    aria-label={t("rework.teamSettings.members.addMembersDialog.removeAria", {
-                      name: candidateLabel(member.user),
-                    })}
-                    onClick={() => handleRemovePending(member.user.id)}
-                  />
-                </li>
-              ))}
-            </ul>
-          )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className={styles.pendingListEmpty}>
+                {t("rework.teamSettings.members.addMembersDialog.pendingListEmpty")}
+              </div>
+            )}
+          </div>
 
           <div className={styles.actions}>
             <Button color="on-surface" variant="outlined" size="medium" onClick={onClose}>

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -111,13 +111,14 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
     if (pendingMembers.length === 0 || isSubmitting) return;
     setIsSubmitting(true);
 
-    const failed: PendingMember[] = [];
     for (const member of pendingMembers) {
       // AddTeamMemberRequest only carries one relation — add with the
       // highest-priority selected role (falling back to the implicit
       // `team_member` baseline), then grant any other selected elevated
       // role one at a time, exactly like the members table already does
-      // for role changes on existing members.
+      // for role changes on existing members. Errors surface via toast
+      // (below) but don't block the rest of the batch or keep the dialog
+      // open — the table reflects whatever actually succeeded.
       const initialRole = ELEVATED_TEAM_ROLES.find((role) => member.roles.includes(role)) ?? "team_member";
       const additionalRoles = member.roles.filter((role) => role !== initialRole);
 
@@ -134,14 +135,10 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
             forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
           }),
       });
-      if (added === null) {
-        failed.push(member);
-        continue;
-      }
+      if (added === null) continue;
 
-      let grantsOk = true;
       for (const role of additionalRoles) {
-        const granted = await runMutationAction({
+        await runMutationAction({
           action: () =>
             grantTeamMemberRole({
               teamId: team.id,
@@ -155,14 +152,11 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
               forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
             }),
         });
-        if (granted === null) grantsOk = false;
       }
-      if (!grantsOk) failed.push(member);
     }
 
     setIsSubmitting(false);
-    setPendingMembers(failed);
-    if (failed.length === 0) onClose();
+    onClose();
   };
 
   return (
@@ -187,8 +181,8 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
               textInput={{
                 placeholder: t("rework.teamSettings.members.addMembersDialog.searchPlaceholder"),
                 icon: { category: "outlined", type: "search" },
-                autoFocus: true,
               }}
+              minQueryLength={2}
               onFieldValueChange={setSearchQuery}
               options={suggestions.map((user) => ({ label: candidateLabel(user), value: user, key: user.id }))}
               onSelect={handleSelectCandidate}
@@ -208,7 +202,6 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
                     />
                   </div>
                   <IconButton
-                    color="on-surface"
                     variant="icon"
                     size="medium"
                     icon={{ category: "outlined", type: "close" }}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -123,7 +123,7 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
       // surface via toast (below) but don't block the rest of the batch or
       // keep the dialog open — the table reflects whatever actually
       // succeeded.
-      const added = await runMutationAction({
+      const addResult = await runMutationAction({
         action: () =>
           addTeamMember({
             teamId: team.id,
@@ -136,7 +136,13 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
             forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
           }),
       });
-      if (added === null) continue;
+      // addTeamMember resolves 204 No Content -> `data` is `null` on
+      // success. Branch on `.ok`, never on the resolved value itself —
+      // `T | null` can't tell "failed" apart from "succeeded with a
+      // falsy/empty result", which every add/grant call here actually
+      // returns. Checking `=== null` silently skipped every grant below
+      // for every member, on every add, always.
+      if (!addResult.ok) continue;
 
       for (const role of member.roles) {
         await runMutationAction({

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -1,0 +1,243 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import Button from "@shared/atoms/Button/Button.tsx";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import Autocomplete from "@shared/molecules/Autocomplete/Autocomplete.tsx";
+import TeamRoleChips, { ELEVATED_TEAM_ROLES } from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
+import { Portal } from "@shared/utils/Portal.tsx";
+import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
+import { useMutationAction } from "@core/hooks/useMutationAction.ts";
+import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
+import { canAdministerTeamRole } from "@hooks/teamCapabilities.ts";
+import {
+  TeamWithPermissions,
+  UserSummary,
+  UserTeamRelation,
+} from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
+import {
+  useAddTeamMemberMutation,
+  useGrantTeamMemberRoleMutation,
+  useSearchCandidateTeamMembersQuery,
+} from "../../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
+import styles from "./AddTeamMembersDialog.module.scss";
+
+interface PendingMember {
+  user: UserSummary;
+  roles: UserTeamRelation[];
+}
+
+interface AddTeamMembersDialogProps {
+  open: boolean;
+  team: TeamWithPermissions;
+  onClose: () => void;
+}
+
+function candidateLabel(user: UserSummary): string {
+  return `${user.first_name ?? ""} ${user.last_name ?? ""} (${user.username ?? user.id})`;
+}
+
+export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMembersDialogProps) {
+  const { t } = useTranslation();
+  const { notifyApiError } = useApiErrorToast();
+  const { runMutationAction } = useMutationAction();
+  const capabilities = useTeamCapabilities(team);
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [pendingMembers, setPendingMembers] = useState<PendingMember[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const trimmedQuery = searchQuery.trim();
+  const { data: candidates = [] } = useSearchCandidateTeamMembersQuery(
+    { teamId: team.id, query: trimmedQuery },
+    { skip: !open || trimmedQuery.length < 2 },
+  );
+  const pendingIds = new Set(pendingMembers.map((m) => m.user.id));
+  const suggestions = candidates.filter((user) => !pendingIds.has(user.id));
+
+  const [addTeamMember] = useAddTeamMemberMutation();
+  const [grantTeamMemberRole] = useGrantTeamMemberRoleMutation();
+
+  // Fresh slate on every open — a cancelled or completed run shouldn't leak
+  // into the next one.
+  useEffect(() => {
+    if (open) {
+      setPendingMembers([]);
+      setSearchQuery("");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleSelectCandidate = (user: UserSummary) => {
+    setPendingMembers((prev) => (prev.some((m) => m.user.id === user.id) ? prev : [...prev, { user, roles: [] }]));
+  };
+
+  const handleToggleRole = (userId: string, role: UserTeamRelation, held: boolean) => {
+    setPendingMembers((prev) =>
+      prev.map((m) =>
+        m.user.id === userId ? { ...m, roles: held ? m.roles.filter((r) => r !== role) : [...m.roles, role] } : m,
+      ),
+    );
+  };
+
+  const handleRemovePending = (userId: string) => {
+    setPendingMembers((prev) => prev.filter((m) => m.user.id !== userId));
+  };
+
+  const handleConfirm = async () => {
+    if (pendingMembers.length === 0 || isSubmitting) return;
+    setIsSubmitting(true);
+
+    const failed: PendingMember[] = [];
+    for (const member of pendingMembers) {
+      // AddTeamMemberRequest only carries one relation — add with the
+      // highest-priority selected role (falling back to the implicit
+      // `team_member` baseline), then grant any other selected elevated
+      // role one at a time, exactly like the members table already does
+      // for role changes on existing members.
+      const initialRole = ELEVATED_TEAM_ROLES.find((role) => member.roles.includes(role)) ?? "team_member";
+      const additionalRoles = member.roles.filter((role) => role !== initialRole);
+
+      const added = await runMutationAction({
+        action: () =>
+          addTeamMember({
+            teamId: team.id,
+            addTeamMemberRequest: { user_id: member.user.id, relation: initialRole },
+          }).unwrap(),
+        onError: (error) =>
+          notifyApiError(error, {
+            summary: t("rework.teamSettings.members.addMembersDialog.errors.addSummary"),
+            fallbackDetail: t("rework.teamSettings.members.addMembersDialog.errors.addDetail"),
+            forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
+          }),
+      });
+      if (added === null) {
+        failed.push(member);
+        continue;
+      }
+
+      let grantsOk = true;
+      for (const role of additionalRoles) {
+        const granted = await runMutationAction({
+          action: () =>
+            grantTeamMemberRole({
+              teamId: team.id,
+              userId: member.user.id,
+              grantTeamMemberRoleRequest: { relation: role },
+            }).unwrap(),
+          onError: (error) =>
+            notifyApiError(error, {
+              summary: t("rework.teamSettings.members.errors.updateRoleSummary"),
+              fallbackDetail: t("rework.teamSettings.members.errors.updateRoleDetail"),
+              forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
+            }),
+        });
+        if (granted === null) grantsOk = false;
+      }
+      if (!grantsOk) failed.push(member);
+    }
+
+    setIsSubmitting(false);
+    setPendingMembers(failed);
+    if (failed.length === 0) onClose();
+  };
+
+  return (
+    <Portal id="modal-portal">
+      <div className={styles.overlay} onClick={onClose}>
+        <div
+          className={styles.dialog}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="add-team-members-dialog-title"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className={styles.header}>
+            <p id="add-team-members-dialog-title" className={styles.title}>
+              {t("rework.teamSettings.members.addMembersDialog.title")}
+            </p>
+            <p className={styles.subtitle}>{t("rework.teamSettings.members.addMembersDialog.subtitle")}</p>
+          </div>
+
+          <div className={styles.searchRow}>
+            <Autocomplete<UserSummary>
+              textInput={{
+                placeholder: t("rework.teamSettings.members.addMembersDialog.searchPlaceholder"),
+                icon: { category: "outlined", type: "search" },
+                autoFocus: true,
+              }}
+              onFieldValueChange={setSearchQuery}
+              options={suggestions.map((user) => ({ label: candidateLabel(user), value: user, key: user.id }))}
+              onSelect={handleSelectCandidate}
+            />
+          </div>
+
+          {pendingMembers.length > 0 && (
+            <ul className={styles.pendingList}>
+              {pendingMembers.map((member) => (
+                <li key={member.user.id} className={styles.pendingRow}>
+                  <span className={styles.pendingName}>{candidateLabel(member.user)}</span>
+                  <div className={styles.pendingRoleChips}>
+                    <TeamRoleChips
+                      heldRoles={member.roles}
+                      canAdminister={(role) => canAdministerTeamRole(capabilities, role)}
+                      onToggle={(role, held) => handleToggleRole(member.user.id, role, held)}
+                    />
+                  </div>
+                  <IconButton
+                    color="on-surface"
+                    variant="icon"
+                    size="medium"
+                    icon={{ category: "outlined", type: "close" }}
+                    aria-label={t("rework.teamSettings.members.addMembersDialog.removeAria", {
+                      name: candidateLabel(member.user),
+                    })}
+                    onClick={() => handleRemovePending(member.user.id)}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className={styles.actions}>
+            <Button color="on-surface" variant="outlined" size="medium" onClick={onClose}>
+              {t("rework.teamSettings.members.addMembersDialog.cancel")}
+            </Button>
+            <Button
+              color="primary"
+              variant="filled"
+              size="medium"
+              disabled={pendingMembers.length === 0 || isSubmitting}
+              onClick={handleConfirm}
+            >
+              {t("rework.teamSettings.members.addMembersDialog.confirm")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -188,6 +188,7 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
               textInput={{
                 placeholder: t("rework.teamSettings.members.addMembersDialog.searchPlaceholder"),
                 icon: { category: "outlined", type: "search" },
+                autoFocus: true,
               }}
               minQueryLength={2}
               onFieldValueChange={setSearchQuery}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx
@@ -145,10 +145,17 @@ export default function AddTeamMembersDialog({ open, team, onClose }: AddTeamMem
               userId: member.user.id,
               grantTeamMemberRoleRequest: { relation: role },
             }).unwrap(),
+          // Names the user and role explicitly (rather than the table's
+          // generic "failed to update role" toast) — a dropped grant here
+          // is otherwise silent: the member still gets added, just missing
+          // one of the roles picked for them.
           onError: (error) =>
             notifyApiError(error, {
-              summary: t("rework.teamSettings.members.errors.updateRoleSummary"),
-              fallbackDetail: t("rework.teamSettings.members.errors.updateRoleDetail"),
+              summary: t("rework.teamSettings.members.errors.grantSummary"),
+              fallbackDetail: t("rework.teamSettings.members.errors.grantDetail", {
+                name: candidateLabel(member.user),
+                role: t(`rework.teamRoles.${role}`),
+              }),
               forbiddenDetail: t("rework.teamSettings.members.errors.forbiddenDetail"),
             }),
         });

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.module.scss
@@ -4,7 +4,6 @@
   gap: var(--spacing-m);
   height: 100%;
   min-height: 0;
-  overflow: hidden;
 }
 
 .team-settings-members-header {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx
@@ -14,14 +14,11 @@
 
 import TeamSettingsMembersTable from "./TeamSettingsMembersTable/TeamSettingsMembersTable.tsx";
 import LeaveTeamButton from "./LeaveTeamButton/LeaveTeamButton.tsx";
-import Autocomplete from "@shared/molecules/Autocomplete/Autocomplete.tsx";
+import AddTeamMembersDialog from "./AddTeamMembersDialog/AddTeamMembersDialog.tsx";
+import Button from "@shared/atoms/Button/Button.tsx";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { TeamWithPermissions, UserSummary } from "../../../../../../slices/controlPlane/controlPlaneOpenApi";
-import {
-  useAddTeamMemberMutation,
-  useSearchCandidateTeamMembersQuery,
-} from "../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
+import { TeamWithPermissions } from "../../../../../../slices/controlPlane/controlPlaneOpenApi";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
 import styles from "./TeamSettingsMembers.module.scss";
 
@@ -34,24 +31,8 @@ export default function TeamSettingsMembers({ team }: TeamSettingsMembersProps) 
 
   const { canAdministerMembers: can_administer_members } = useTeamCapabilities(team);
 
-  const [addTeamMember, { isLoading: isAddingMember }] = useAddTeamMemberMutation();
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
-  const [addUserQuery, setAddUserQuery] = useState<string>("");
-  const trimmedQuery = addUserQuery.trim();
-
-  const { data: suggestions = [] } = useSearchCandidateTeamMembersQuery(
-    { teamId: team.id, query: trimmedQuery },
-    { skip: !can_administer_members || trimmedQuery.length < 2 },
-  );
-
-  const handleAddMember = async (user: UserSummary) => {
-    if (isAddingMember) return;
-    await addTeamMember({
-      teamId: team.id,
-      addTeamMemberRequest: { user_id: user.id, relation: "team_member" },
-    });
-    setAddUserQuery("");
-  };
   return (
     <div className={styles["team-settings-members-container"]}>
       <div className={styles["team-settings-members-header"]}>
@@ -60,24 +41,17 @@ export default function TeamSettingsMembers({ team }: TeamSettingsMembersProps) 
           <LeaveTeamButton team={team} />
         </div>
         {can_administer_members && (
-          <Autocomplete<UserSummary>
-            textInput={{
-              placeholder: t("rework.teamSettings.members.addMember.placeholder"),
-              icon: { category: "outlined", type: "search" },
-            }}
-            onFieldValueChange={setAddUserQuery}
-            options={suggestions.map((user) => ({
-              label: `${user.first_name} ${user.last_name} (${user.username})`,
-              value: user,
-              key: user.id,
-            }))}
-            onSelect={handleAddMember}
-          ></Autocomplete>
+          <Button color="primary" variant="filled" size="medium" onClick={() => setIsAddDialogOpen(true)}>
+            {t("rework.teamSettings.members.addMembersDialog.buttonLabel")}
+          </Button>
         )}
       </div>
       <div className={styles["team-settings-members-table-wrapper"]}>
         <TeamSettingsMembersTable team={team} />
       </div>
+      {can_administer_members && (
+        <AddTeamMembersDialog open={isAddDialogOpen} team={team} onClose={() => setIsAddDialogOpen(false)} />
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TeamMember, TeamWithPermissions } from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const h = vi.hoisted(() => ({
+  teamMembers: [] as TeamMember[],
+  grantTeamMemberRole: vi.fn(),
+  revokeTeamMemberRole: vi.fn(),
+  removeTeamMember: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key} ${JSON.stringify(opts)}` : key),
+  }),
+}));
+
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn(), showWarn: vi.fn(), showInfo: vi.fn() }),
+}));
+
+vi.mock("../../../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
+  useListTeamMembersQuery: () => ({ data: h.teamMembers }),
+  useGrantTeamMemberRoleMutation: () => [h.grantTeamMemberRole],
+  useRevokeTeamMemberRoleMutation: () => [h.revokeTeamMemberRole],
+  useRemoveTeamMemberMutation: () => [h.removeTeamMember],
+}));
+
+import TeamSettingsMembersTable from "./TeamSettingsMembersTable.tsx";
+import { ConfirmationDialogProvider } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  h.grantTeamMemberRole.mockReset();
+  h.revokeTeamMemberRole.mockReset();
+  h.removeTeamMember.mockReset();
+  h.teamMembers = [];
+});
+
+function click(el: Element | null) {
+  if (!el) throw new Error("element not found");
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+const team: TeamWithPermissions = {
+  id: "team-1",
+  name: "Team One",
+  is_member: true,
+  admins: [],
+  permissions: ["can_administer_members", "can_administer_editors", "can_administer_analysts", "can_administer_admins"],
+} as TeamWithPermissions;
+
+function roleChip(role: string): HTMLButtonElement {
+  const label = `rework.teamRoles.${role}`;
+  return Array.from(container.querySelectorAll("button")).find((b) => b.textContent === label) as HTMLButtonElement;
+}
+
+describe("TeamSettingsMembersTable — revoke confirmation", () => {
+  it("clicking an already-active role chip does not revoke immediately — it opens a confirmation first", () => {
+    h.teamMembers = [
+      {
+        user: { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" },
+        relations: ["team_editor"],
+      } as TeamMember,
+    ];
+    render(
+      <ConfirmationDialogProvider>
+        <TeamSettingsMembersTable team={team} />
+      </ConfirmationDialogProvider>,
+    );
+
+    click(roleChip("team_editor"));
+
+    expect(h.revokeTeamMemberRole).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
+  });
+
+  it("confirming the dialog then calls revokeTeamMemberRole for that user and role", () => {
+    h.revokeTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    h.teamMembers = [
+      {
+        user: { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" },
+        relations: ["team_editor"],
+      } as TeamMember,
+    ];
+    render(
+      <ConfirmationDialogProvider>
+        <TeamSettingsMembersTable team={team} />
+      </ConfirmationDialogProvider>,
+    );
+
+    click(roleChip("team_editor"));
+    const confirmButton = Array.from(document.querySelectorAll('[role="alertdialog"] button')).find(
+      (b) => b.textContent === "rework.teamSettings.members.revokeRoleDialog.confirmLabel",
+    );
+    click(confirmButton ?? null);
+
+    expect(h.revokeTeamMemberRole).toHaveBeenCalledWith({
+      teamId: "team-1",
+      userId: "u1",
+      relation: "team_editor",
+    });
+  });
+
+  it("clicking cancel leaves the role untouched", () => {
+    h.teamMembers = [
+      {
+        user: { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" },
+        relations: ["team_admin"],
+      } as TeamMember,
+    ];
+    render(
+      <ConfirmationDialogProvider>
+        <TeamSettingsMembersTable team={team} />
+      </ConfirmationDialogProvider>,
+    );
+
+    click(roleChip("team_admin"));
+    const cancelButton = Array.from(document.querySelectorAll('[role="alertdialog"] button')).find(
+      (b) => b.textContent === "confirmationDialog.defaultCancelButtonLabel",
+    );
+    click(cancelButton ?? null);
+
+    expect(h.revokeTeamMemberRole).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+  });
+
+  it("clicking an inactive role chip still grants immediately with no confirmation", () => {
+    h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    h.teamMembers = [
+      {
+        user: { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" },
+        relations: ["team_member"],
+      } as TeamMember,
+    ];
+    render(
+      <ConfirmationDialogProvider>
+        <TeamSettingsMembersTable team={team} />
+      </ConfirmationDialogProvider>,
+    );
+
+    click(roleChip("team_editor"));
+
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+    expect(h.grantTeamMemberRole).toHaveBeenCalledWith({
+      teamId: "team-1",
+      userId: "u1",
+      grantTeamMemberRoleRequest: { relation: "team_editor" },
+    });
+  });
+});

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.test.tsx
@@ -49,7 +49,6 @@ vi.mock("../../../../../../../slices/controlPlane/controlPlaneApiEnhancements", 
 }));
 
 import TeamSettingsMembersTable from "./TeamSettingsMembersTable.tsx";
-import { ConfirmationDialogProvider } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -94,27 +93,8 @@ function roleChip(role: string): HTMLButtonElement {
   return Array.from(container.querySelectorAll("button")).find((b) => b.textContent === label) as HTMLButtonElement;
 }
 
-describe("TeamSettingsMembersTable — revoke confirmation", () => {
-  it("clicking an already-active role chip does not revoke immediately — it opens a confirmation first", () => {
-    h.teamMembers = [
-      {
-        user: { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" },
-        relations: ["team_editor"],
-      } as TeamMember,
-    ];
-    render(
-      <ConfirmationDialogProvider>
-        <TeamSettingsMembersTable team={team} />
-      </ConfirmationDialogProvider>,
-    );
-
-    click(roleChip("team_editor"));
-
-    expect(h.revokeTeamMemberRole).not.toHaveBeenCalled();
-    expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
-  });
-
-  it("confirming the dialog then calls revokeTeamMemberRole for that user and role", () => {
+describe("TeamSettingsMembersTable — role chip toggling", () => {
+  it("clicking an already-active role chip revokes it immediately, with no confirmation", () => {
     h.revokeTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     h.teamMembers = [
       {
@@ -122,18 +102,11 @@ describe("TeamSettingsMembersTable — revoke confirmation", () => {
         relations: ["team_editor"],
       } as TeamMember,
     ];
-    render(
-      <ConfirmationDialogProvider>
-        <TeamSettingsMembersTable team={team} />
-      </ConfirmationDialogProvider>,
-    );
+    render(<TeamSettingsMembersTable team={team} />);
 
     click(roleChip("team_editor"));
-    const confirmButton = Array.from(document.querySelectorAll('[role="alertdialog"] button')).find(
-      (b) => b.textContent === "rework.teamSettings.members.revokeRoleDialog.confirmLabel",
-    );
-    click(confirmButton ?? null);
 
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
     expect(h.revokeTeamMemberRole).toHaveBeenCalledWith({
       teamId: "team-1",
       userId: "u1",
@@ -141,30 +114,7 @@ describe("TeamSettingsMembersTable — revoke confirmation", () => {
     });
   });
 
-  it("clicking cancel leaves the role untouched", () => {
-    h.teamMembers = [
-      {
-        user: { id: "u1", first_name: "Alice", last_name: "Doe", username: "alice" },
-        relations: ["team_admin"],
-      } as TeamMember,
-    ];
-    render(
-      <ConfirmationDialogProvider>
-        <TeamSettingsMembersTable team={team} />
-      </ConfirmationDialogProvider>,
-    );
-
-    click(roleChip("team_admin"));
-    const cancelButton = Array.from(document.querySelectorAll('[role="alertdialog"] button')).find(
-      (b) => b.textContent === "confirmationDialog.defaultCancelButtonLabel",
-    );
-    click(cancelButton ?? null);
-
-    expect(h.revokeTeamMemberRole).not.toHaveBeenCalled();
-    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
-  });
-
-  it("clicking an inactive role chip still grants immediately with no confirmation", () => {
+  it("clicking an inactive role chip grants it immediately, with no confirmation", () => {
     h.grantTeamMemberRole.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     h.teamMembers = [
       {
@@ -172,11 +122,7 @@ describe("TeamSettingsMembersTable — revoke confirmation", () => {
         relations: ["team_member"],
       } as TeamMember,
     ];
-    render(
-      <ConfirmationDialogProvider>
-        <TeamSettingsMembersTable team={team} />
-      </ConfirmationDialogProvider>,
-    );
+    render(<TeamSettingsMembersTable team={team} />);
 
     click(roleChip("team_editor"));
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -191,6 +191,7 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
                 label: t("rework.teamSettings.members.table.deleteAction"),
                 value: "DELETE",
                 key: "DELETE",
+                destructive: true,
               },
             ]}
             onSelect={(_) => {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -14,7 +14,6 @@
 
 import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
-import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
 import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu.tsx";
 import DataTable, { DataTableColumn } from "@shared/molecules/DataTable/DataTable.tsx";
 import TeamRoleChips from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
@@ -56,7 +55,6 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
   const { t } = useTranslation();
   const { notifyApiError } = useApiErrorToast();
   const { runMutationAction } = useMutationAction();
-  const { showConfirmationDialog } = useConfirmationDialog();
 
   const { data: teamMembers } = useListTeamMembersQuery({ teamId: team.id });
   const [grantTeamMemberRole] = useGrantTeamMemberRoleMutation();
@@ -109,27 +107,6 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
       });
     },
     [runMutationAction, revokeTeamMemberRole, team.id, notifyApiError, t],
-  );
-
-  // A revoke is a single click away from an active chip that looks
-  // identical to the add-members dialog's (inert, staged-selection) chips —
-  // an accidental click here has an immediate, silent effect on a live
-  // member, unlike there. Confirming closes that gap the same way
-  // remove-member/leave-team already do for their own destructive actions.
-  const confirmRevokeRole = useCallback(
-    (teamMember: TeamMember, role: UserTeamRelation) => {
-      showConfirmationDialog({
-        title: t("rework.teamSettings.members.revokeRoleDialog.title"),
-        message: t("rework.teamSettings.members.revokeRoleDialog.message", {
-          role: t(`rework.teamRoles.${role}`),
-          name: `${teamMember.user.first_name} ${teamMember.user.last_name}`,
-        }),
-        confirmButtonLabel: t("rework.teamSettings.members.revokeRoleDialog.confirmLabel"),
-        criticalAction: true,
-        onConfirm: () => handleRevokeRole(teamMember.user.id, role),
-      });
-    },
-    [showConfirmationDialog, t, handleRevokeRole],
   );
 
   const handleRemoveMember = useCallback(
@@ -190,7 +167,7 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
             heldRoles={teamMember.relations}
             canAdminister={(role) => canAdministerTeamRole(capabilities, role)}
             onToggle={(role, held) =>
-              held ? confirmRevokeRole(teamMember, role) : handleGrantRole(teamMember.user.id, role)
+              held ? handleRevokeRole(teamMember.user.id, role) : handleGrantRole(teamMember.user.id, role)
             }
           />
         ),
@@ -233,7 +210,7 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
     can_administer_admins,
     can_administer_members,
     handleGrantRole,
-    confirmRevokeRole,
+    handleRevokeRole,
     handleRemoveMember,
   ]);
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -14,6 +14,7 @@
 
 import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
+import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
 import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu.tsx";
 import DataTable, { DataTableColumn } from "@shared/molecules/DataTable/DataTable.tsx";
 import TeamRoleChips from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
@@ -55,6 +56,7 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
   const { t } = useTranslation();
   const { notifyApiError } = useApiErrorToast();
   const { runMutationAction } = useMutationAction();
+  const { showConfirmationDialog } = useConfirmationDialog();
 
   const { data: teamMembers } = useListTeamMembersQuery({ teamId: team.id });
   const [grantTeamMemberRole] = useGrantTeamMemberRoleMutation();
@@ -107,6 +109,27 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
       });
     },
     [runMutationAction, revokeTeamMemberRole, team.id, notifyApiError, t],
+  );
+
+  // A revoke is a single click away from an active chip that looks
+  // identical to the add-members dialog's (inert, staged-selection) chips —
+  // an accidental click here has an immediate, silent effect on a live
+  // member, unlike there. Confirming closes that gap the same way
+  // remove-member/leave-team already do for their own destructive actions.
+  const confirmRevokeRole = useCallback(
+    (teamMember: TeamMember, role: UserTeamRelation) => {
+      showConfirmationDialog({
+        title: t("rework.teamSettings.members.revokeRoleDialog.title"),
+        message: t("rework.teamSettings.members.revokeRoleDialog.message", {
+          role: t(`rework.teamRoles.${role}`),
+          name: `${teamMember.user.first_name} ${teamMember.user.last_name}`,
+        }),
+        confirmButtonLabel: t("rework.teamSettings.members.revokeRoleDialog.confirmLabel"),
+        criticalAction: true,
+        onConfirm: () => handleRevokeRole(teamMember.user.id, role),
+      });
+    },
+    [showConfirmationDialog, t, handleRevokeRole],
   );
 
   const handleRemoveMember = useCallback(
@@ -167,7 +190,7 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
             heldRoles={teamMember.relations}
             canAdminister={(role) => canAdministerTeamRole(capabilities, role)}
             onToggle={(role, held) =>
-              held ? handleRevokeRole(teamMember.user.id, role) : handleGrantRole(teamMember.user.id, role)
+              held ? confirmRevokeRole(teamMember, role) : handleGrantRole(teamMember.user.id, role)
             }
           />
         ),
@@ -210,9 +233,17 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
     can_administer_admins,
     can_administer_members,
     handleGrantRole,
-    handleRevokeRole,
+    confirmRevokeRole,
     handleRemoveMember,
   ]);
 
-  return <DataTable columns={columns} data={sortedMembers} firstColumnInset pageSize={20} />;
+  return (
+    <DataTable
+      columns={columns}
+      data={sortedMembers}
+      rowKey={(member) => member.user.id}
+      firstColumnInset
+      pageSize={20}
+    />
+  );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -16,6 +16,7 @@ import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
 import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu.tsx";
 import DataTable, { DataTableColumn } from "@shared/molecules/DataTable/DataTable.tsx";
+import TeamRoleChips from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -30,14 +31,8 @@ import {
   useRevokeTeamMemberRoleMutation,
 } from "../../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { useTeamCapabilities } from "@hooks/useTeamCapabilities.ts";
-import styles from "./TeamSettingsMembersTable.module.scss";
+import { canAdministerTeamRole } from "@hooks/teamCapabilities.ts";
 
-// AUTHZ-06 (RFC Part 7 §34): a member may hold several of these at once (e.g.
-// a small team's sole admin who is also its editor and analyst) — each is
-// granted/revoked as its own independent, permission-checked action, never a
-// bulk role-set replace. `team_member` is deliberately excluded: it is the
-// implicit baseline when none of the three apply, not a toggle of its own.
-const ELEVATED_ROLES: UserTeamRelation[] = ["team_admin", "team_editor", "team_analyst"];
 const ROLE_PRIORITY: Record<UserTeamRelation, number> = {
   team_admin: 0,
   team_editor: 1,
@@ -66,22 +61,16 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
   const [revokeTeamMemberRole] = useRevokeTeamMemberRoleMutation();
   const [removeTeamMember] = useRemoveTeamMemberMutation();
 
+  const capabilities = useTeamCapabilities(team);
   const {
     canAdministerMembers: can_administer_members,
     canAdministerEditors: can_administer_editors,
     canAdministerAnalysts: can_administer_analysts,
     canAdministerAdmins: can_administer_admins,
-  } = useTeamCapabilities(team);
+  } = capabilities;
 
   const can_administer_anyone =
     can_administer_members || can_administer_editors || can_administer_analysts || can_administer_admins;
-
-  function getAdministerPermissionForTeamRole(target: UserTeamRelation): boolean | undefined {
-    if (target === "team_editor") return can_administer_editors;
-    if (target === "team_analyst") return can_administer_analysts;
-    if (target === "team_admin") return can_administer_admins;
-    return can_administer_members;
-  }
 
   const handleGrantRole = useCallback(
     async (userId: string, relation: UserTeamRelation) => {
@@ -174,27 +163,13 @@ export default function TeamSettingsMembersTable({ team }: TeamSettingsMembersTa
         label: t("rework.teamSettings.members.table.role"),
         size: "1.5fr",
         cellRenderer: (teamMember) => (
-          <div className={styles.roleChips} role="group">
-            {ELEVATED_ROLES.map((role) => {
-              const held = teamMember.relations.includes(role);
-              const canAdminister = Boolean(getAdministerPermissionForTeamRole(role));
-              return (
-                <button
-                  key={role}
-                  type="button"
-                  className={styles.roleChip}
-                  data-active={held}
-                  aria-pressed={held}
-                  disabled={!canAdminister}
-                  onClick={() =>
-                    held ? handleRevokeRole(teamMember.user.id, role) : handleGrantRole(teamMember.user.id, role)
-                  }
-                >
-                  {t(`rework.teamRoles.${role}`)}
-                </button>
-              );
-            })}
-          </div>
+          <TeamRoleChips
+            heldRoles={teamMember.relations}
+            canAdminister={(role) => canAdministerTeamRole(capabilities, role)}
+            onToggle={(role, held) =>
+              held ? handleRevokeRole(teamMember.user.id, role) : handleGrantRole(teamMember.user.id, role)
+            }
+          />
         ),
       },
     ];

--- a/apps/frontend/src/rework/core/hooks/teamCapabilities.ts
+++ b/apps/frontend/src/rework/core/hooks/teamCapabilities.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { TeamPermission } from "../../../slices/controlPlane/controlPlaneOpenApi";
+import type { TeamPermission, UserTeamRelation } from "../../../slices/controlPlane/controlPlaneOpenApi";
 
 /**
  * One boolean per `TeamPermission` the backend can grant on a team
@@ -101,4 +101,16 @@ export function hasElevatedTeamRole(capabilities: TeamCapabilities): boolean {
     capabilities.canRunEvaluations ||
     capabilities.canManageEvaluationCorpus
   );
+}
+
+/**
+ * Which granular "administer" permission gates granting/revoking a given
+ * `UserTeamRelation` — shared by the members table's role chips and the
+ * add-members dialog's role chips so both gate identically.
+ */
+export function canAdministerTeamRole(capabilities: TeamCapabilities, role: UserTeamRelation): boolean {
+  if (role === "team_editor") return capabilities.canAdministerEditors;
+  if (role === "team_analyst") return capabilities.canAdministerAnalysts;
+  if (role === "team_admin") return capabilities.canAdministerAdmins;
+  return capabilities.canAdministerMembers;
 }

--- a/apps/frontend/src/rework/core/hooks/useMutationAction.ts
+++ b/apps/frontend/src/rework/core/hooks/useMutationAction.ts
@@ -18,15 +18,26 @@ interface MutationActionOptions<T> {
   onSuccess?: (result: T) => void;
 }
 
+export type MutationActionResult<T> = { ok: true; data: T } | { ok: false };
+
 export function useMutationAction() {
-  const runMutationAction = async <T>({ action, onError, onSuccess }: MutationActionOptions<T>): Promise<T | null> => {
+  // Discriminated result, not `T | null` — most 204 No Content mutations
+  // (add/grant/revoke a team role, etc.) resolve their RTK Query result to
+  // `null` on success (empty body), which is indistinguishable from "failed"
+  // if a caller ever needs to branch on success/failure rather than just
+  // firing the action and letting the toast in `onError` handle feedback.
+  const runMutationAction = async <T>({
+    action,
+    onError,
+    onSuccess,
+  }: MutationActionOptions<T>): Promise<MutationActionResult<T>> => {
     try {
       const result = await action();
       onSuccess?.(result);
-      return result;
+      return { ok: true, data: result };
     } catch (error) {
       onError(error);
-      return null;
+      return { ok: false };
     }
   };
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -834,14 +834,18 @@ containers:
   `on-surface-retreat`).
 - **Right**, left to right: a rows-per-page `Select` (20/50/100, our own
   molecule, not MUI), then `IconButton` (`medium`, `icon` variant,
-  `on-surface`) first-page / previous-page, the current page number
-  (`body-medium`, `on-surface-retreat`), then next-page / last-page. All four
-  nav buttons disable at their respective bound (first/prev at page 1,
-  next/last at the last page) — the footer itself never hides, even when
-  every row fits on one page, so the count and page-size control stay
-  reachable. New icons `first_page`/`last_page` added to the app's Material
-  Symbols allow-list (`shared/utils/Type.ts`). New i18n keys: top-level
-  `dataTable.pagination.{first,prev,next,last,totalItems}`.
+  `on-surface`) first-page / previous-page, the current page label
+  ("Page X sur Y" / "Page X of Y", `body-medium`, `on-surface-retreat`,
+  `tabular-nums`), then next-page / last-page. All four nav buttons disable
+  at their respective bound (first/prev at page 1, next/last at the last
+  page) — the footer itself never hides, even when every row fits on one
+  page, so the count and page-size control stay reachable. New icons
+  `first_page`/`last_page` added to the app's Material Symbols allow-list
+  (`shared/utils/Type.ts`). New i18n keys: top-level
+  `dataTable.pagination.{first,prev,next,last,totalItems}`. The page label
+  (`dataTable.pagination.pageNumber`) is fixed-width (`7rem`, centered) so
+  the neighbouring nav buttons don't shift as either the current page or the
+  total page count gains a digit.
 
 `TeamSettingsMembersTable` is the first consumer, at an initial `pageSize={20}`
 (the rows-per-page `Select` lets the user switch to 50/100 from there).

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -896,9 +896,9 @@ generic `Dialog` primitive exists yet):
 - **Header:** title + subtitle (`body-medium`, `on-surface-retreat`).
 - **Search:** the same `Autocomplete` the old inline field used, reused
   as-is (candidates come from the existing `candidate-members` endpoint,
-  already scoped to non-members) — not auto-focused on open, and its menu
-  only opens once the query is 2+ characters (`minQueryLength={2}`, see
-  below), matching the backend search's own minimum.
+  already scoped to non-members) — auto-focused on open, and its menu only
+  opens once the query is 2+ characters (`minQueryLength={2}`, see below),
+  matching the backend search's own minimum.
 - **Pending-list container** — always rendered, even with zero pending
   candidates (`1px solid outline-retreat` border, `radius-s` (`8px`)
   corners, `spacing-s` (`12px`) padding so content isn't flush against the

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -933,13 +933,21 @@ generic `Dialog` primitive exists yet):
   surface as an error toast (`notifyApiError`), they just don't block the
   rest of the batch or keep the dialog open for a retry.
 
-**No new backend endpoint** — `AddTeamMemberRequest` only carries one
-`relation`, so confirming calls `addTeamMember` per pending user with their
-highest-priority selected role (`ELEVATED_TEAM_ROLES` order: admin > editor
-> analyst; falls back to the implicit `team_member` baseline when no chip is
-selected), then `grantTeamMemberRole` for each other selected elevated role
-— the same add-then-grant sequencing the members table already uses for
-role changes on existing members (§ AUTHZ-06 above).
+**No new backend endpoint** — confirming always calls `addTeamMember` on
+the `team_member` baseline first, then `grantTeamMemberRole` for every
+selected elevated role, one call per role (same pattern the members table
+already uses for role changes on existing members, § AUTHZ-06 above).
+**Never add directly onto an elevated relation** — a member added straight
+onto e.g. `team_editor` with no separate `team_member` tuple has no floor
+to fall back to: revoking their only elevated role later leaves them with
+zero relations at all, and the backend correctly 409s ("would silently
+remove them from the team, use remove_team_member instead") rather than
+allow that. Fixed 2026-07-26 — the first version picked the
+highest-priority selected role as the `addTeamMember` relation directly
+(skipping the grant call for that one role, saving an API round trip), which
+silently produced exactly this trap for every member added through the
+dialog with at least one elevated role: they'd display correctly, but their
+only/highest role could never be revoked back down to plain membership.
 
 **`TeamRoleChips`** — the members table's inline role-chip toggle group
 (admin/editor/analyst, multi-select, `data-active` fills `--primary`
@@ -957,24 +965,23 @@ control in the app. Chip padding-left/right `spacing-s` (`12px`, was
 **Members table: confirm before revoking a role (fixed 2026-07-26).**
 `TeamRoleChips` renders identically in both places, but only the table's
 instance is *live* — a click there immediately grants/revokes via the API,
-while the dialog's is a staged selection with no effect until "Ajouter".
-Reported symptom: a member added through the dialog with 2-3 roles ended up
-holding only the highest-priority one (admin > editor > analyst) once shown
-in the table. Investigation (control-plane audit log + a direct OpenFGA
-tuple read) showed every grant *did* persist — followed, within about a
-second, by an explicit revoke of the same role. The table's already-active
-chip requires only one click to undo, and a stray/second click landing on
-it right as the dialog closes is silent and instant, unlike every other
-destructive action on this page (remove member, leave team), which already
-confirm first. `TeamSettingsMembersTable`'s revoke path now does too
-(`ConfirmationDialog`, `criticalAction`, role + member name interpolated
-into the message) — granting is unaffected (still one click, additive and
-low-risk). Also fixed in the same pass: `DataTable` accepted an optional
-`rowKey` (default: array index, unchanged for other consumers);
-`TeamSettingsMembersTable` now passes `(member) => member.user.id` — with
-the previous index-based key, any row-scoped state or in-flight handler
-could misattribute to the wrong member as soon as the list re-sorted (which
-`sortedMembers` does on every role change).
+while the dialog's is a staged selection with no effect until "Ajouter". A
+stray/second click on an already-active chip is silent and instant, unlike
+every other destructive action on this page (remove member, leave team),
+which already confirm first. `TeamSettingsMembersTable`'s revoke path now
+does too (`ConfirmationDialog`, `criticalAction`, role + member name
+interpolated into the message) — granting is unaffected (still one click,
+additive and low-risk). This was investigated as a candidate root cause for
+a report of "a member added with 2-3 roles ends up holding only the
+highest-priority one" — it wasn't (see the `addTeamMember`-on-baseline fix
+above for the actual cause), but the missing confirmation was still a real,
+independent gap worth closing on its own. Also fixed in the same pass:
+`DataTable` accepted an optional `rowKey` (default: array index, unchanged
+for other consumers); `TeamSettingsMembersTable` now passes
+`(member) => member.user.id` — with the previous index-based key, any
+row-scoped state or in-flight handler could misattribute to the wrong
+member as soon as the list re-sorted (which `sortedMembers` does on every
+role change).
 
 **`Autocomplete` open-state rework (`isOpen` now derived, plus
 `minQueryLength`).** Previously `isOpen` was an imperatively toggled

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -962,22 +962,19 @@ outline-variant`, a size/color pair that didn't match any other chip-style
 control in the app. Chip padding-left/right `spacing-s` (`12px`, was
 `spacing-xs`/`8px`).
 
-**Members table: confirm before revoking a role (fixed 2026-07-26).**
-`TeamRoleChips` renders identically in both places, but only the table's
-instance is *live* — a click there immediately grants/revokes via the API,
-while the dialog's is a staged selection with no effect until "Ajouter". A
-stray/second click on an already-active chip is silent and instant, unlike
-every other destructive action on this page (remove member, leave team),
-which already confirm first. `TeamSettingsMembersTable`'s revoke path now
-does too (`ConfirmationDialog`, `criticalAction`, role + member name
-interpolated into the message) — granting is unaffected (still one click,
-additive and low-risk). This was investigated as a candidate root cause for
-a report of "a member added with 2-3 roles ends up holding only the
-highest-priority one" — it wasn't (see the `addTeamMember`-on-baseline fix
-above for the actual cause), but the missing confirmation was still a real,
-independent gap worth closing on its own. Also fixed in the same pass:
-`DataTable` accepted an optional `rowKey` (default: array index, unchanged
-for other consumers); `TeamSettingsMembersTable` now passes
+**Members table: role chips are a live, single-click toggle in both
+directions.** `TeamRoleChips` renders identically here and in the
+add-members dialog, but only the table's instance is *live* — a click
+there immediately grants/revokes via the API, while the dialog's is a
+staged selection with no effect until "Ajouter". A confirmation step was
+added on the revoke path (2026-07-26) while investigating a report of "a
+member added with 2-3 roles ends up holding only the highest-priority
+one" — it turned out not to be the cause (see the `addTeamMember`-on-
+baseline fix above for the actual root cause) and was removed again at the
+developer's explicit request the same day: revoking a role is back to a
+single click, symmetric with granting. Also fixed in the same investigation
+(kept): `DataTable` accepted an optional `rowKey` (default: array index,
+unchanged for other consumers); `TeamSettingsMembersTable` now passes
 `(member) => member.user.id` — with the previous index-based key, any
 row-scoped state or in-flight handler could misattribute to the wrong
 member as soon as the list re-sorted (which `sortedMembers` does on every

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1017,6 +1017,29 @@ only queries past a minimum length (this dialog, `minQueryLength={2}`)
 avoid flashing an empty "no options" state below that threshold. Affects
 every `Autocomplete` consumer, not just this dialog.
 
+**`Autocomplete` keyboard navigation (2026-07-26).** The first option is
+now virtually focused (`aria-activedescendant` pattern, DOM focus stays on
+the input) as soon as the menu opens with results; `ArrowDown`/`ArrowUp`
+move it, wrapping at each end; `Enter` selects whichever option is
+currently focused (closing the menu and clearing the field, same as a
+click). The focused index resets to `0` on every fresh keystroke or
+re-focus rather than reactively whenever the `options` prop changes —
+`options` is a new array reference (`.filter()`/`.map()` result) on nearly
+every parent render, not only when the candidate list itself changes, so
+tying the reset to it would keep stomping on the user's own up/down
+navigation mid-browse. Implementation mirrors `Select`'s existing
+`activeIndex`/`moveActive` pattern verbatim (same wrap-around, same
+disabled-skip behavior). Surfaced (and fixed in the same pass) a latent bug
+in the shared `Menu`: its per-option DOM id was built from `option.value`,
+which for `Select`'s own primitive-typed options happened to stringify
+uniquely, but for `Autocomplete`'s object-typed candidates (`UserSummary`
+records) stringifies to the same `"[object Object]"` for every option —
+breaking both `activeId` matching and the `#${activeId}` scroll-into-view
+selector (unescaped `[`/`]` aren't valid there). Menu's item id (and
+`Select`'s matching `activeOptionId`) now use `option.key` instead — already
+required, already unique by contract (it's the React list key), and a
+plain string regardless of `T`.
+
 **`IconButton` default color.** `color` is now optional, defaulting to
 `on-surface-retreat` — the baseline color intended for icon buttons that
 don't need a stronger color to draw attention (e.g. this dialog's row

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -899,16 +899,23 @@ generic `Dialog` primitive exists yet):
   already scoped to non-members) — not auto-focused on open, and its menu
   only opens once the query is 2+ characters (`minQueryLength={2}`, see
   below), matching the backend search's own minimum.
-- **Pending list** (`<ul>`, no column headers): one row per selected-but-
-  not-yet-added candidate — name/username, a `TeamRoleChips` role selector
-  (see below), and a `close`-icon `IconButton` to drop the row. `1px solid
-  outline-retreat` border, `radius-s` (`8px`) corners, `spacing-s` (`12px`)
-  padding so rows aren't flush against the border. Capped at
-  `8.5 * var(--row-height)` (`--row-height: 4rem`) — the half-row is a
-  deliberate "more below" affordance — with a `4px`-wide
-  `::-webkit-scrollbar` (thumb color inherited from the app's existing
-  global `outline-retreat` scrollbar rule in `styles/index.css`, already
-  thin by default; this only narrows it further for the denser list).
+- **Pending-list container** — always rendered, even with zero pending
+  candidates (`1px solid outline-retreat` border, `radius-s` (`8px`)
+  corners, `spacing-s` (`12px`) padding so content isn't flush against the
+  border): a fixed `pendingListHeader` label ("Membres à ajouter à
+  l'équipe", `label-large`, `on-surface-retreat`) above either —
+  - the rows `<ul>` (no column headers) once ≥1 candidate is pending: name/
+    username, a `TeamRoleChips` role selector (see below), and a
+    `close`-icon `IconButton` to drop the row. Row height `3rem` (`48px`).
+    Capped at `8.5 * var(--row-height)` — the half-row is a deliberate
+    "more below" affordance — with a `4px`-wide `::-webkit-scrollbar`
+    (thumb color inherited from the app's existing global `outline-retreat`
+    scrollbar rule in `styles/index.css`, already thin by default; this
+    only narrows it further for the denser list); or
+  - a centered (`body-medium`, `on-surface-muted`) "Aucun utilisateur
+    sélectionné pour l'instant" placeholder, `min-height: 3 * var(--row-height)`
+    so it isn't a sliver.
+
   **No `overflow: hidden` at the dialog level** — everything is inset by
   the dialog's own padding, and clipping would also cut off the
   `Autocomplete` menu popover in the search row above the list (same class
@@ -956,6 +963,18 @@ don't need a stronger color to draw attention (e.g. this dialog's row
 `close` button). Every existing call site already passed `color` explicitly
 so this is additive only; new call sites can omit it instead of repeating
 the same value.
+
+**`Button`/`IconButton` outlined-variant border fix.** Both previously set
+`--btn-border` to the passed `color`'s own "main" token (e.g. `on-surface`'s
+`main` is `on-surface`, which in dark theme is a near-white tone) —
+per M3, the outlined variant's border is always the neutral `outline`
+token regardless of `color`; only the label/icon take the scheme's color.
+This was invisible in light theme (where `on-surface` happens to read dark
+too) but washed the border out to near-invisible in dark theme, which is
+what surfaced it here (this dialog's `Annuler` button, `color="on-surface"`).
+Fixed at the shared-component level (`--btn-border: var(--outline)` in both
+`Button.module.scss` and `IconButton.module.scss`), so every existing
+`variant="outlined"` call site is corrected without touching call sites.
 
 #### Open UX issues
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -904,10 +904,13 @@ generic `Dialog` primitive exists yet):
   corners, `spacing-s` (`12px`) padding so content isn't flush against the
   border): a fixed `pendingListHeader` label ("Membres à ajouter à
   l'équipe", `label-large`, `on-surface-retreat`) above either —
-  - the rows `<ul>` (no column headers) once ≥1 candidate is pending: name/
-    username, a `TeamRoleChips` role selector (see below), and a
-    `close`-icon `IconButton` to drop the row. Row height `3rem` (`48px`).
-    Capped at `8.5 * var(--row-height)` — the half-row is a deliberate
+  - the rows `<ul>` (no column headers) once ≥1 candidate is pending, `2px`
+    (`spacing-3xs`) gap between rows: name/username, a `TeamRoleChips` role
+    selector (see below), and a `close`-icon `IconButton` to drop the row.
+    Each row is `surface-container` background, `radius-xs` (`4px`)
+    corners, height `3rem` (`48px`) — a visually distinct "chip" resting
+    inside the outer bordered container, not flush rules between rows.
+    List capped at `8.5 * var(--row-height)` — the half-row is a deliberate
     "more below" affordance — with a `4px`-wide `::-webkit-scrollbar`
     (thumb color inherited from the app's existing global `outline-retreat`
     scrollbar rule in `styles/index.css`, already thin by default; this
@@ -936,12 +939,16 @@ selected), then `grantTeamMemberRole` for each other selected elevated role
 role changes on existing members (§ AUTHZ-06 above).
 
 **`TeamRoleChips`** — the members table's inline role-chip toggle group
-(admin/editor/analyst, multi-select, `data-active` fills `--primary`) is
-extracted from `TeamSettingsMembersTable` into this shared molecule so the
-dialog's pending rows and the table use the identical implementation/CSS.
-Both gate each chip via the new `canAdministerTeamRole(capabilities, role)`
-helper (`core/hooks/teamCapabilities.ts`), replacing the table's former
-private closure of the same logic.
+(admin/editor/analyst, multi-select, `data-active` fills `--primary`
+background with `on-primary` text) is extracted from
+`TeamSettingsMembersTable` into this shared molecule so the dialog's
+pending rows and the table use the identical implementation/CSS. Both gate
+each chip via the new `canAdministerTeamRole(capabilities, role)` helper
+(`core/hooks/teamCapabilities.ts`), replacing the table's former private
+closure of the same logic. Sizing: height `2rem` (`32px`), `label-medium`
+text, default (inactive) border `1px solid outline` — was `0.5px
+outline-variant`, a size/color pair that didn't match any other chip-style
+control in the app.
 
 **`Autocomplete` open-state rework (`isOpen` now derived, plus
 `minQueryLength`).** Previously `isOpen` was an imperatively toggled

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -862,16 +862,84 @@ does that; `DataTable` clips its own rounded corners) and it was cropping
 the "add member" `Autocomplete` input's focus ring at the top of the flex
 column.
 
-**"Add member" `Autocomplete` (fixed 2026-07-26).** Uses `TextInput`'s
-`compact` variant, which now sets `display: none` on the hint/error/counter
-container (`.information`) instead of just skipping its flex/padding rules —
-previously the empty container still reserved a row's worth of height,
-which (a) misaligned the input's visual center against the title/
-`LeaveTeamButton` row and (b) pushed `Autocomplete`'s `menu-popover` (`top:
-100%` of the input's own wrapper) below the input with a large gap. Both
-now resolve automatically since the wrapper's rendered height matches the
-input exactly; the popover's only remaining offset is the deliberate
+**`Autocomplete` compact-field alignment (fixed 2026-07-26).** Uses
+`TextInput`'s `compact` variant, which now sets `display: none` on the
+hint/error/counter container (`.information`) instead of just skipping its
+flex/padding rules — previously the empty container still reserved a row's
+worth of height, which (a) misaligned the input's visual center against the
+title/`LeaveTeamButton` row and (b) pushed `Autocomplete`'s `menu-popover`
+(`top: 100%` of the input's own wrapper) below the input with a large gap.
+Both now resolve automatically since the wrapper's rendered height matches
+the input exactly; the popover's only remaining offset is the deliberate
 `margin-top: var(--spacing-3xs)` in `Autocomplete.module.scss`.
+
+#### Open UX issues
+
+- Not yet design-reviewed. First functional pass only.
+
+---
+
+### `AddTeamMembersDialog` — bulk add with per-user role selection (2026-07-26)
+
+**Location:**
+`src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/AddTeamMembersDialog/AddTeamMembersDialog.tsx`,
+`src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx`
+**Status:** `Functional`, first pass from a supplied mockup — not yet
+design-reviewed.
+
+The Members header's inline Autocomplete text input is replaced by a
+`filled`/`primary` `Button` ("Ajouter des membres", same header slot). It
+opens `AddTeamMembersDialog` — a `Portal`-based modal following the
+`ConfirmationDialog`/`DuplicateAgentDialog` shell (overlay + card, no
+generic `Dialog` primitive exists yet):
+
+- **Header:** title + subtitle (`body-medium`, `on-surface-retreat`).
+- **Search:** the same `Autocomplete` the old inline field used, reused
+  as-is (candidates come from the existing `candidate-members` endpoint,
+  already scoped to non-members).
+- **Pending list** (`<ul>`, no column headers): one row per selected-but-
+  not-yet-added candidate — name/username, a `TeamRoleChips` role selector
+  (see below), and a `close`-icon `IconButton` to drop the row. Capped at
+  `8.5 * var(--row-height)` (`--row-height: 4rem`) — the half-row is a
+  deliberate "more below" affordance — with a `4px`-wide
+  `::-webkit-scrollbar` (thumb color inherited from the app's existing
+  global `outline-retreat` scrollbar rule in `styles/index.css`, already
+  thin by default; this only narrows it further for the denser list).
+  **No `overflow: hidden` at the dialog level** — everything is inset by
+  the dialog's own padding, and clipping would also cut off the
+  `Autocomplete` menu popover in the search row above the list (same class
+  of bug just fixed on the old inline field, see above).
+- **Actions:** `Annuler` (`outlined`/`on-surface`) / `Ajouter`
+  (`filled`/`primary`, disabled while the list is empty or a submit is in
+  flight).
+
+**No new backend endpoint** — `AddTeamMemberRequest` only carries one
+`relation`, so confirming calls `addTeamMember` per pending user with their
+highest-priority selected role (`ELEVATED_TEAM_ROLES` order: admin > editor
+> analyst; falls back to the implicit `team_member` baseline when no chip is
+selected), then `grantTeamMemberRole` for each other selected elevated role
+— the same add-then-grant sequencing the members table already uses for
+role changes on existing members (§ AUTHZ-06 above). On partial failure,
+succeeded users drop out of the pending list and failed ones stay for a
+retry; the dialog only auto-closes once every pending user succeeds.
+
+**`TeamRoleChips`** — the members table's inline role-chip toggle group
+(admin/editor/analyst, multi-select, `data-active` fills `--primary`) is
+extracted from `TeamSettingsMembersTable` into this shared molecule so the
+dialog's pending rows and the table use the identical implementation/CSS.
+Both gate each chip via the new `canAdministerTeamRole(capabilities, role)`
+helper (`core/hooks/teamCapabilities.ts`), replacing the table's former
+private closure of the same logic.
+
+**`Autocomplete` reopen-on-type fix.** Selecting an option closes the menu
+(`setIsOpen(false)`) without blurring the input — the listbox's
+`onMouseDown` preventDefault deliberately keeps focus in the field for a
+"search again immediately" flow. Previously, typing a second query while
+still focused left the menu closed (`isOpen` was only ever set on
+focus/blur), which read as broken as soon as a flow expected back-to-back
+searches. `onChange` now also sets `isOpen(true)`, so typing while focused
+always reopens the menu — affects every `Autocomplete` consumer, not just
+this dialog (currently also `AdminTeamsPage`).
 
 #### Open UX issues
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -949,6 +949,29 @@ silently produced exactly this trap for every member added through the
 dialog with at least one elevated role: they'd display correctly, but their
 only/highest role could never be revoked back down to plain membership.
 
+**`useMutationAction`: `T | null` can't tell "failed" from "succeeded with
+a falsy result" (fixed 2026-07-26).** After the fix above shipped, every
+grant call in the batch was still silently skipped — `handleConfirm`
+checked `addResult === null` to detect a failed `addTeamMember` call before
+proceeding to the grant loop. `add_team_member`/`grant_team_member_role`
+both respond `204 No Content`; `fetchBaseQuery` resolves an empty body to
+`null` **on success**. Every add in this dialog therefore always looked
+like a failure to that check, and the grant loop below it never ran — with
+no thrown error, no console error, and no toast, since nothing had actually
+failed. This reproduced 100% of the time against the real backend but
+**never** against any mocked backend used to investigate the two prior
+reports in this session, because every mock's fetch stub serialized a
+JSON body (`"{}"`, 2 characters) for every response regardless of status
+code — never a truly empty one — so `added` was never `null` in any of
+that testing. `useMutationAction.ts` (`core/hooks/useMutationAction.ts`)
+now returns a discriminated `{ ok: true; data: T } | { ok: false }`
+instead of `T | null`; `handleConfirm` branches on `.ok`. No other call
+site branched on the return value (every other consumer just awaits the
+call and relies on the `onError` toast), so this is a non-breaking
+contract change. Caught by reproducing with a mock that returns a
+genuinely empty `204` body (`new Response(null, { status: 204 })`)
+instead of a serialized empty object.
+
 **`TeamRoleChips`** — the members table's inline role-chip toggle group
 (admin/editor/analyst, multi-select, `data-active` fills `--primary`
 background with `on-primary` text) is extracted from

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -954,6 +954,28 @@ outline-variant`, a size/color pair that didn't match any other chip-style
 control in the app. Chip padding-left/right `spacing-s` (`12px`, was
 `spacing-xs`/`8px`).
 
+**Members table: confirm before revoking a role (fixed 2026-07-26).**
+`TeamRoleChips` renders identically in both places, but only the table's
+instance is *live* — a click there immediately grants/revokes via the API,
+while the dialog's is a staged selection with no effect until "Ajouter".
+Reported symptom: a member added through the dialog with 2-3 roles ended up
+holding only the highest-priority one (admin > editor > analyst) once shown
+in the table. Investigation (control-plane audit log + a direct OpenFGA
+tuple read) showed every grant *did* persist — followed, within about a
+second, by an explicit revoke of the same role. The table's already-active
+chip requires only one click to undo, and a stray/second click landing on
+it right as the dialog closes is silent and instant, unlike every other
+destructive action on this page (remove member, leave team), which already
+confirm first. `TeamSettingsMembersTable`'s revoke path now does too
+(`ConfirmationDialog`, `criticalAction`, role + member name interpolated
+into the message) — granting is unaffected (still one click, additive and
+low-risk). Also fixed in the same pass: `DataTable` accepted an optional
+`rowKey` (default: array index, unchanged for other consumers);
+`TeamSettingsMembersTable` now passes `(member) => member.user.id` — with
+the previous index-based key, any row-scoped state or in-flight handler
+could misattribute to the wrong member as soon as the list re-sorted (which
+`sortedMembers` does on every role change).
+
 **`Autocomplete` open-state rework (`isOpen` now derived, plus
 `minQueryLength`).** Previously `isOpen` was an imperatively toggled
 boolean (set on focus/blur/select), which needed a one-off patch when a

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -855,7 +855,23 @@ flex column (`height: 100%` from the already-24px-padded `.teamSettingsPage`
 shell): the header row is fixed height, and the table wrapper takes
 `flex: 1; min-height: 0` so the table's bottom edge sits exactly `24px`
 above the viewport bottom, scrolling internally past `pageSize` rows on very
-short viewports rather than growing the page.
+short viewports rather than growing the page. The container's own
+`overflow: hidden` was removed — it isn't needed for the shrink-to-fit
+chain (`min-height: 0` on both the container and the table wrapper already
+does that; `DataTable` clips its own rounded corners) and it was cropping
+the "add member" `Autocomplete` input's focus ring at the top of the flex
+column.
+
+**"Add member" `Autocomplete` (fixed 2026-07-26).** Uses `TextInput`'s
+`compact` variant, which now sets `display: none` on the hint/error/counter
+container (`.information`) instead of just skipping its flex/padding rules —
+previously the empty container still reserved a row's worth of height,
+which (a) misaligned the input's visual center against the title/
+`LeaveTeamButton` row and (b) pushed `Autocomplete`'s `menu-popover` (`top:
+100%` of the input's own wrapper) below the input with a large gap. Both
+now resolve automatically since the wrapper's rendered height matches the
+input exactly; the popover's only remaining offset is the deliberate
+`margin-top: var(--spacing-3xs)` in `Autocomplete.module.scss`.
 
 #### Open UX issues
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -906,9 +906,11 @@ generic `Dialog` primitive exists yet):
   l'équipe", `label-large`, `on-surface-retreat`) above either —
   - the rows `<ul>` (no column headers) once ≥1 candidate is pending, `2px`
     (`spacing-3xs`) gap between rows: name/username, a `TeamRoleChips` role
-    selector (see below), and a `close`-icon `IconButton` to drop the row.
-    Each row is `surface-container` background, `radius-xs` (`4px`)
-    corners, height `3rem` (`48px`) — a visually distinct "chip" resting
+    selector (see below, `8px` gap between its own chips), and a
+    `close`-icon `IconButton` to drop the row. Each row is
+    `surface-container-highest` background, `radius-s` (`8px`) corners,
+    `padding-left: spacing-m` (`16px`, `padding-right` stays `spacing-xs`/
+    `8px`), height `3rem` (`48px`) — a visually distinct "chip" resting
     inside the outer bordered container, not flush rules between rows.
     List capped at `8.5 * var(--row-height)` — the half-row is a deliberate
     "more below" affordance — with a `4px`-wide `::-webkit-scrollbar`
@@ -916,8 +918,9 @@ generic `Dialog` primitive exists yet):
     scrollbar rule in `styles/index.css`, already thin by default; this
     only narrows it further for the denser list); or
   - a centered (`body-medium`, `on-surface-muted`) "Aucun utilisateur
-    sélectionné pour l'instant" placeholder, `min-height: 3 * var(--row-height)`
-    so it isn't a sliver.
+    sélectionné pour l'instant" placeholder, `height: var(--row-height)`
+    (`48px`) — same height as a single pending row, so the container's
+    overall height doesn't jump between the empty and one-candidate states.
 
   **No `overflow: hidden` at the dialog level** — everything is inset by
   the dialog's own padding, and clipping would also cut off the
@@ -948,7 +951,8 @@ each chip via the new `canAdministerTeamRole(capabilities, role)` helper
 closure of the same logic. Sizing: height `2rem` (`32px`), `label-medium`
 text, default (inactive) border `1px solid outline` — was `0.5px
 outline-variant`, a size/color pair that didn't match any other chip-style
-control in the app.
+control in the app. Chip padding-left/right `spacing-s` (`12px`, was
+`spacing-xs`/`8px`).
 
 **`Autocomplete` open-state rework (`isOpen` now derived, plus
 `minQueryLength`).** Previously `isOpen` was an imperatively toggled

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -896,10 +896,14 @@ generic `Dialog` primitive exists yet):
 - **Header:** title + subtitle (`body-medium`, `on-surface-retreat`).
 - **Search:** the same `Autocomplete` the old inline field used, reused
   as-is (candidates come from the existing `candidate-members` endpoint,
-  already scoped to non-members).
+  already scoped to non-members) — not auto-focused on open, and its menu
+  only opens once the query is 2+ characters (`minQueryLength={2}`, see
+  below), matching the backend search's own minimum.
 - **Pending list** (`<ul>`, no column headers): one row per selected-but-
   not-yet-added candidate — name/username, a `TeamRoleChips` role selector
-  (see below), and a `close`-icon `IconButton` to drop the row. Capped at
+  (see below), and a `close`-icon `IconButton` to drop the row. `1px solid
+  outline-retreat` border, `radius-s` (`8px`) corners, `spacing-s` (`12px`)
+  padding so rows aren't flush against the border. Capped at
   `8.5 * var(--row-height)` (`--row-height: 4rem`) — the half-row is a
   deliberate "more below" affordance — with a `4px`-wide
   `::-webkit-scrollbar` (thumb color inherited from the app's existing
@@ -911,7 +915,10 @@ generic `Dialog` primitive exists yet):
   of bug just fixed on the old inline field, see above).
 - **Actions:** `Annuler` (`outlined`/`on-surface`) / `Ajouter`
   (`filled`/`primary`, disabled while the list is empty or a submit is in
-  flight).
+  flight). Clicking `Ajouter` always closes the dialog once the batch
+  finishes, whether every add succeeded or not — per-user failures still
+  surface as an error toast (`notifyApiError`), they just don't block the
+  rest of the batch or keep the dialog open for a retry.
 
 **No new backend endpoint** — `AddTeamMemberRequest` only carries one
 `relation`, so confirming calls `addTeamMember` per pending user with their
@@ -919,9 +926,7 @@ highest-priority selected role (`ELEVATED_TEAM_ROLES` order: admin > editor
 > analyst; falls back to the implicit `team_member` baseline when no chip is
 selected), then `grantTeamMemberRole` for each other selected elevated role
 — the same add-then-grant sequencing the members table already uses for
-role changes on existing members (§ AUTHZ-06 above). On partial failure,
-succeeded users drop out of the pending list and failed ones stay for a
-retry; the dialog only auto-closes once every pending user succeeds.
+role changes on existing members (§ AUTHZ-06 above).
 
 **`TeamRoleChips`** — the members table's inline role-chip toggle group
 (admin/editor/analyst, multi-select, `data-active` fills `--primary`) is
@@ -931,15 +936,26 @@ Both gate each chip via the new `canAdministerTeamRole(capabilities, role)`
 helper (`core/hooks/teamCapabilities.ts`), replacing the table's former
 private closure of the same logic.
 
-**`Autocomplete` reopen-on-type fix.** Selecting an option closes the menu
-(`setIsOpen(false)`) without blurring the input — the listbox's
-`onMouseDown` preventDefault deliberately keeps focus in the field for a
-"search again immediately" flow. Previously, typing a second query while
-still focused left the menu closed (`isOpen` was only ever set on
-focus/blur), which read as broken as soon as a flow expected back-to-back
-searches. `onChange` now also sets `isOpen(true)`, so typing while focused
-always reopens the menu — affects every `Autocomplete` consumer, not just
-this dialog (currently also `AdminTeamsPage`).
+**`Autocomplete` open-state rework (`isOpen` now derived, plus
+`minQueryLength`).** Previously `isOpen` was an imperatively toggled
+boolean (set on focus/blur/select), which needed a one-off patch when a
+second query typed while still focused (post-selection) didn't reopen the
+menu. Replaced with a derived value: `isOpen = isFocused && !dismissed &&
+queryValue.trim().length >= minQueryLength`, where `dismissed` is a
+one-shot flag set by Escape or a selection and cleared on the next
+focus/keystroke. New optional prop `minQueryLength` (default `0`, opens
+immediately on focus — e.g. `AdminTeamsPage`'s browsable full-user-list
+field) lets a consumer whose menu is backed by a server search that itself
+only queries past a minimum length (this dialog, `minQueryLength={2}`)
+avoid flashing an empty "no options" state below that threshold. Affects
+every `Autocomplete` consumer, not just this dialog.
+
+**`IconButton` default color.** `color` is now optional, defaulting to
+`on-surface-retreat` — the baseline color intended for icon buttons that
+don't need a stronger color to draw attention (e.g. this dialog's row
+`close` button). Every existing call site already passed `color` explicitly
+so this is additive only; new call sites can omit it instead of repeating
+the same value.
 
 #### Open UX issues
 


### PR DESCRIPTION
## Summary

Replaces the Members section's inline "add member" text input with a
`filled`/`primary` **"Ajouter des membres"** button that opens a dialog:
search for one or more candidates, pick a role (Admin/Éditeur/Analyste) per
person via the same chip selector as the members table, then add them all
in one confirm. No new backend endpoint — confirming always adds on the
`team_member` baseline first, then grants each selected elevated role as
its own call.

Also includes a chain of bug fixes found while validating this feature
(several via live reproduction against the real backend, not just mocks —
see commit messages for the investigation detail on each), plus a couple of
small, related component fixes surfaced along the way:

- **`useMutationAction`** returned `T | null`, which can't distinguish a
  failed action from one that succeeded with a falsy result — every
  `add_team_member`/`grant_team_member_role` call responds `204 No
  Content`, which RTK Query resolves to `null` **on success**. This
  silently skipped every role grant after a member's initial add. Now
  returns a discriminated `{ok: true, data} | {ok: false}`.
- The dialog's confirm handler originally added a member directly onto
  their highest-priority selected role (skipping a separate `team_member`
  tuple to save an API call) — a member added that way has no floor to
  revoke down to, so removing their only/highest role later 409s ("would
  silently remove them from the team"). Now always adds on `team_member`
  first, then grants every selected role on top.
- `DataTable` used the array index as its row key; `TeamSettingsMembersTable`
  re-sorts on every role change, so this could misattribute row-scoped
  state after a reorder. Added an optional `rowKey` prop (default
  unchanged for other consumers).
- `Menu`'s per-option DOM id was built from `option.value`, which
  stringifies uniquely for `Select`'s primitive-typed options but collapses
  to the same `"[object Object]"` for `Autocomplete`'s object-typed
  candidates — breaking keyboard-nav id matching. Now built from
  `option.key` (already required, already unique); `Select` updated to
  match.
- `Button`/`IconButton`'s outlined variant colored its border from the
  passed `color` prop instead of the neutral M3 `outline` token — mostly
  invisible in light theme, but washed the border to near-invisible in dark
  theme.
- `IconButton`'s `color` prop is now optional, defaulting to
  `on-surface-retreat`.
- `Autocomplete` gained keyboard navigation (first result focused by
  default, arrow keys move it, Enter selects) and a `minQueryLength` prop
  so a server-backed search doesn't flash an empty "no options" state below
  its own minimum query length.
- Pagination footer ("Page X sur Y" instead of "Page X"), a few input
  alignment/focus-ring/scrollbar polish items on the Members page from
  earlier in this same work.

Extracted `TeamRoleChips` out of `TeamSettingsMembersTable` into a shared
molecule so the table and the new dialog use the identical role-chip
implementation.

First functional pass — not yet design-reviewed (mockup supplied by the
reporter, referenced in the doc updates below).

## Test plan

- [x] `make code-quality` (tsc + prettier + eslint) — clean
- [x] `npm test` — 60/60 files, 627/627 tests (multiple new/updated test
      files: `AddTeamMembersDialog.test.tsx`, `TeamSettingsMembersTable.test.tsx`,
      `Autocomplete.test.tsx`)
- [x] Live-verified end-to-end against a mock backend that faithfully
      reproduces the real `204 No Content` (empty body) response — the
      exact condition that caused the silent-grant-skip bug — confirming
      add + multi-role grant, revoke, and keyboard navigation all work
      against the real component tree
- [x] `docs/swift/ux/COMPONENT-UX.md` updated for every behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)