### PR TITLE
fix(authz): stop gating team content/execution on public-discovery CAN_READ

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/product/api.py
+++ b/apps/control-plane-backend/control_plane_backend/product/api.py
@@ -577,7 +577,12 @@ async def get_team_prompts(
     - `GET /control-plane/v1/teams/personal/prompts?lang=fr`
     """
 
-    team_id = await require_team_access(user, team_id, deps.team_dependencies)
+    team_id = await require_team_access(
+        user,
+        team_id,
+        deps.team_dependencies,
+        required_permissions=[TeamPermission.CAN_USE_TEAM_AGENTS],
+    )
     return await list_prompts(team_id, deps, lang=lang)
 
 
@@ -644,7 +649,12 @@ async def get_context_prompts_early(
     - ``GET /control-plane/v1/teams/bid-and-capture/prompts/context?lang=fr``
     """
 
-    team_id = await require_team_access(user, team_id, deps.team_dependencies)
+    team_id = await require_team_access(
+        user,
+        team_id,
+        deps.team_dependencies,
+        required_permissions=[TeamPermission.CAN_USE_TEAM_AGENTS],
+    )
     return await list_context_prompts(user, team_id, deps, lang=lang)
 
 
@@ -674,7 +684,12 @@ async def get_team_prompt(
     - `GET /control-plane/v1/teams/personal/prompts/1234`
     """
 
-    team_id = await require_team_access(user, team_id, deps.team_dependencies)
+    team_id = await require_team_access(
+        user,
+        team_id,
+        deps.team_dependencies,
+        required_permissions=[TeamPermission.CAN_USE_TEAM_AGENTS],
+    )
     result = await get_prompt(team_id, prompt_id, deps)
     if result is None:
         raise HTTPException(

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -62,6 +62,23 @@ is the current authority for implemented runtime behavior.
 > instead of re-deriving a stricter one. Regular users are unaffected — the
 > least-privilege re-check still runs for every non-service-agent call.
 
+> ✅ **Public-team content/execution gap closed — 2026-07-29 (issue #2146, PR #2147).**
+> TEAM-09/TEAM-10 widened `TeamPermission.CAN_READ` to include any authenticated
+> user via the `public` marketplace-discovery relation on `PUBLIC`-visibility
+> teams (the default for every team). Every pod-side authorization check that
+> gates real content or execution — not just team-profile discovery — must
+> therefore use `TeamPermission.CAN_USE_TEAM_AGENTS` (`team_member`-only)
+> instead. This was true at turn start (`_authorize_execution_or_raise`,
+> §2.2/§2.4) but not at three sibling checks, all now fixed: the per-tool-call
+> reverify (`ToolObservabilityMiddleware._reverify_team_authorization`), the
+> OpenAI-compatible `/v1/chat/completions` surface
+> (`openai_compat_router.py`), and the control-plane's own prompt-library
+> reads (`product/api.py`, `control-plane-backend`). Every other reference to
+> `CAN_READ` below and in §8's dated history predates this fix and should be
+> read as `CAN_USE_TEAM_AGENTS` for anything that returns real content or
+> executes an agent; `CAN_READ` alone remains correct only for team-profile
+> discovery (e.g. `get_team_agent_instance_runtime`, config-only). See §8.28.
+
 This document is the authoritative design reference for the Phase 1 runtime
 execution contract. It describes what was frozen, where it lives, what the
 architectural boundaries are, and what is explicitly deferred.
@@ -128,8 +145,8 @@ Browser / CLI                control-plane              fred-runtime pod
 
 The managed path is the only one authorized for production frontend calls. The
 agent pod authenticates the Keycloak JWT and authorizes the request itself:
-OpenFGA `CAN_READ` for regular collaborative-team users, exact intrinsic
-ownership for a personal space, or the scoped service-agent rule.
+OpenFGA `CAN_USE_TEAM_AGENTS` for regular collaborative-team users, exact
+intrinsic ownership for a personal space, or the scoped service-agent rule.
 `control-plane` resolves which
 runtime pod serves which agent instance (via `prepare-execution`) but issues no
 capability and never proxies the SSE stream. The runtime currently performs an
@@ -247,7 +264,7 @@ credential the pod must trust.
 2. **Session ownership** — an existing `session_id` must belong to the caller
    (conversations are private per owner; blocks intra-team session hijacking).
 3. **Team authorization** — a regular collaborative-team caller must hold
-   OpenFGA `CAN_READ`; a personal-space caller must present the exact canonical
+   OpenFGA `CAN_USE_TEAM_AGENTS`; a personal-space caller must present the exact canonical
    `personal-<uid>` derived from the JWT; the scoped service-agent rule is the
    only other bypass. Denial fails closed (403). Under the `c3` profile a direct
    `agent_id` is forbidden entirely.
@@ -273,7 +290,7 @@ per-finding acceptance criteria live in
 |---:|---|---|
 | 1 | `POST /agents/execute/stream` | Validate request and Keycloak identity; normalize trusted runtime context |
 | 2 | Session/checkpoint access | Verify resumed checkpoint ownership when applicable; for an existing session, verify existence and owner in PostgreSQL |
-| 3 | Pod execution authorization | For a regular collaborative-team user, require OpenFGA `CAN_READ`; personal ownership and the scoped service-agent rule keep their documented behavior |
+| 3 | Pod execution authorization | For a regular collaborative-team user, require OpenFGA `CAN_USE_TEAM_AGENTS`; personal ownership and the scoped service-agent rule keep their documented behavior |
 | 4 | Managed runtime binding | Call the control-plane internal binding endpoint, authorize the team there, read the instance and team capability settings, then cross-check the resolved owner team |
 | 5 | Model authorization | Resolve usable model capabilities with a team-scoped OpenFGA lookup before model routing |
 | 6 | Runtime activation | Build request context/services/capabilities, activate MCP tools, construct the selected ReAct/Deep/Graph runtime and executor |
@@ -381,7 +398,9 @@ agent pod is the execution authority (RUNTIME-07 rev. 2):
   audience strictly (`verify_aud=True`), and each pod validates `aud == its own
   client_id` (per-agent audience — anti-confused-deputy, decision D5c).
 - **Authorization** — for a collaborative team, the pod runs a per-request
-  OpenFGA check that the caller holds `CAN_READ` on
+  OpenFGA check that the caller holds `CAN_USE_TEAM_AGENTS` (`team_member`-only —
+  unlike `CAN_READ`, which also admits the `public` marketplace-discovery
+  relation; see the 2026-07-29 callout above) on
   `runtime_context.team_id`. A canonical personal space
   (`personal-<authenticated uid>`) uses intrinsic ownership by exact identity
   comparison, and the evaluation worker's `service_agent` identity uses the
@@ -671,7 +690,7 @@ responsibilities:
 Fred code IS responsible for:
 
 - Endpoint protection (Keycloak RBAC, OpenFGA REBAC)
-- Team-scoped managed agent authorization (pod-side OpenFGA `CAN_READ` on `runtime_context.team_id`)
+- Team-scoped managed agent authorization (pod-side OpenFGA `CAN_USE_TEAM_AGENTS` on `runtime_context.team_id`)
 - Runtime execution contracts (this module)
 - History and checkpoint access validation
 - Managed execution semantics (`agent_instance_id` resolution via control-plane)
@@ -1705,6 +1724,50 @@ told the model how to behave after a tool failure. This is prompt-only:
 whether `summarize_document`/`list_document_tree` should raise instead of
 returning error text as a normal result is a separate, larger structural
 fix (tracked in a follow-up issue linked from #2073), not addressed here.
+
+---
+
+### 8.28 ✅ Pod-side execution/content checks moved off public-discovery `CAN_READ` (issue #2146, PR #2147, 2026-07-29)
+
+**Supersedes the `CAN_READ`/`can_read` wording in §8.9–§8.11 and the earlier
+top-of-document callouts** — accurate for their own dates, superseded now.
+
+**What changed.** TEAM-09/TEAM-10 (`FRED-TEAM-CONFIG-RFC.md` §5.1.1/§5.1.2)
+deliberately widened `TeamPermission.CAN_READ` to include any authenticated
+user via the `public` marketplace-discovery relation, granted unconditionally
+on every `PUBLIC`-visibility team (the default for every team). The OpenFGA
+model (`schema.fga`) already anticipated this and kept `can_use_team_agents`
+strictly `team_member`-only, but three pod-side/runtime call sites written
+before that split still checked the wide `CAN_READ`, so a non-member visiting
+a public team could execute its agents or read tool-call context, not just
+see that the team exists:
+
+1. `_authorize_execution_or_raise` (agent_app.py, §2.2/§2.4) — turn-start
+   managed-execution authorization.
+2. `ToolObservabilityMiddleware._reverify_team_authorization`
+   (`tool_observability.py`, §8.9-era per-tool-call reverify) — re-checked
+   the same wide permission on every tool call after turn start.
+3. The OpenAI-compatible `/v1/chat/completions` surface
+   (`openai_compat_router.py`) — a separate gate duplicating (1) rather than
+   funneling through it, so it carried the same gap independently.
+
+All three now require `TeamPermission.CAN_USE_TEAM_AGENTS`. The equivalent
+control-plane-side leak (prompt-library content reachable via the same
+over-wide default) was fixed in the same PR in
+`control_plane_backend/product/api.py` (`get_team_prompts`,
+`get_context_prompts_early`, `get_team_prompt`), mirroring the precedent
+`post_prepare_execution` in the same file had already set.
+
+**Not changed by this fix**: `get_team_agent_instance_runtime` stays on
+`CAN_READ` deliberately — it returns instance config only, never prompt
+content, so public-discovery visibility is the correct (and intended) gate
+for it. `product/teams/service.py`'s `_list_teams` (`GET /teams`) also stays
+on `CAN_READ` — whether every public team should appear in a non-member's
+team list is an open product question, not folded into this fix.
+
+**Verification.** `make validation-report` against a live local stack: 190
+passed/35 failed/0 error before, 205 passed/20 failed/0 error after — the
+remaining 20 are exclusively the `GET /teams` open question above.
 
 ---
 

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -1358,12 +1358,21 @@ async def _authorize_execution_or_raise(
       the owner's `team_editor` tuple self-heals on first touch inside
       `RebacEngine.check_user_team_permission_or_raise`, and `add_relation`'s
       write-guard refuses any tuple naming a personal team except that one, so
-      the plain `CAN_READ` check below already authorizes the owner and denies
-      everyone else (another user's space, or the bare `"personal"` alias, for
-      which no tuple is ever provisioned) — no special-casing needed here.
-    - otherwise require the caller to hold `CAN_READ` on the requested team — the
-      same relation the control-plane required before it would mint a grant. The
-      team is caller-supplied but safe: OpenFGA only authorizes teams the user
+      the `CAN_USE_TEAM_AGENTS` check below already authorizes the owner
+      (`team_editor` implies `team_member`) and denies everyone else (another
+      user's space, or the bare `"personal"` alias, for which no tuple is
+      ever provisioned) — no special-casing needed here.
+    - otherwise require the caller to hold `CAN_USE_TEAM_AGENTS` on the
+      requested team — `team_member`-only, unlike `CAN_READ` (which also
+      admits the `public` marketplace-discovery relation, TEAM-09/TEAM-10).
+      Execution is real content access, not discovery, so a public-team
+      visitor must not pass here even though they can see the team profile.
+      This used to check `CAN_READ` (the same relation the control-plane
+      required before it would mint a grant) — that predates TEAM-09's
+      `public` relation and was never revisited; `product/api.py`'s
+      `post_prepare_execution` made the identical correction for the same
+      reason (returns prompt content, not just config). The team is
+      caller-supplied but safe: OpenFGA only authorizes teams the user
       actually holds a relation to. Authorization and denial are both audited;
       any OpenFGA denial fails closed (403).
 
@@ -1446,7 +1455,7 @@ async def _authorize_execution_or_raise(
     # since no tuple is ever provisioned for that literal string).
     try:
         await rebac.check_user_team_permission_or_raise(
-            authenticated_user, TeamPermission.CAN_READ, team_id
+            authenticated_user, TeamPermission.CAN_USE_TEAM_AGENTS, team_id
         )
     except AuthorizationError as exc:
         _emit_audit_event(

--- a/libs/fred-runtime/fred_runtime/app/openai_compat_router.py
+++ b/libs/fred-runtime/fred_runtime/app/openai_compat_router.py
@@ -188,7 +188,10 @@ def create_openai_compat_router(
 
         # F-A: gate this surface with the same pod-side OpenFGA check as
         # /agents/execute. When ReBAC is active, the caller must present a team
-        # (X-Fred-Team-Id) and hold CAN_READ on it; identity is the validated JWT.
+        # (X-Fred-Team-Id) and hold CAN_USE_TEAM_AGENTS on it (team_member-only,
+        # unlike CAN_READ which also admits the public marketplace-discovery
+        # relation — this is real execution, not discovery); identity is the
+        # validated JWT.
         rebac = get_runtime_context().config.rebac_engine
         if authenticated_user is not None and rebac is not None and rebac.enabled:
             if not team_id:
@@ -198,7 +201,7 @@ def create_openai_compat_router(
                 )
             try:
                 await rebac.check_user_team_permission_or_raise(
-                    authenticated_user, TeamPermission.CAN_READ, team_id
+                    authenticated_user, TeamPermission.CAN_USE_TEAM_AGENTS, team_id
                 )
             except AuthorizationError as exc:
                 raise HTTPException(

--- a/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/tool_observability.py
@@ -161,9 +161,10 @@ class ToolObservabilityMiddleware(AgentMiddleware):
         """
         Per-tool-call ReBAC re-check (RUNTIME least-privilege gap, see
         docs/swift audit): `_authorize_execution_or_raise` (agent_app.py)
-        verifies CAN_READ on the turn's team exactly once, at turn start.
-        Every tool call after that — potentially many, in a long ReAct loop —
-        ran unchecked, trusting that one decision for the rest of the turn.
+        verifies CAN_USE_TEAM_AGENTS on the turn's team exactly once, at turn
+        start. Every tool call after that — potentially many, in a long ReAct
+        loop — ran unchecked, trusting that one decision for the rest of the
+        turn.
         This re-runs the same OpenFGA check at the one chokepoint every tool
         call already passes through, so a stale/dropped team membership (or a
         tool call scoped to a different team than the one authorized at turn
@@ -206,7 +207,7 @@ class ToolObservabilityMiddleware(AgentMiddleware):
             return
         await rebac.check_permission_or_raise(
             RebacReference(Resource.USER, user_id),
-            TeamPermission.CAN_READ,
+            TeamPermission.CAN_USE_TEAM_AGENTS,
             RebacReference(Resource.TEAM, team_id),
         )
 

--- a/libs/fred-runtime/tests/test_agent_app.py
+++ b/libs/fred-runtime/tests/test_agent_app.py
@@ -2631,7 +2631,7 @@ _ALICE = KeycloakUser(uid="alice", username="alice", roles=[], email=None)
 async def test_authorize_allows_when_user_holds_team_relation(
     monkeypatch, minimal_config
 ) -> None:
-    """An enabled engine that grants CAN_READ lets the request proceed."""
+    """An enabled engine that grants CAN_USE_TEAM_AGENTS lets the request proceed."""
     engine = _FakeRebacEngine(enabled=True, deny=False)
     _wire_engine(monkeypatch, engine)
     container = PodApplicationContext(minimal_config)
@@ -2640,7 +2640,7 @@ async def test_authorize_allows_when_user_holds_team_relation(
         _managed_request(), _ALICE, container
     )
 
-    assert engine.calls == [("alice", TeamPermission.CAN_READ, "fredlab")]
+    assert engine.calls == [("alice", TeamPermission.CAN_USE_TEAM_AGENTS, "fredlab")]
     with container._audit_events_lock:
         events = list(container.audit_events_buffer)
     assert events[-1]["audit_event"] == "rebac_authorized"
@@ -2807,10 +2807,11 @@ async def test_authorize_allows_personal_space_owner_via_rebac_check(
     monkeypatch, minimal_config
 ) -> None:
     """A human caller acting on their own canonical personal_team_id is authorized
-    through the plain `CAN_READ` team check — no special-casing here (AUTHZ-08,
-    supersedes AUTHZ-05 item 8b). In the real system this succeeds because
-    `RebacEngine.check_user_team_permission_or_raise` self-heals the owner's own
-    `team_editor` tuple on first touch; this test only proves agent_app.py no
+    through the plain `CAN_USE_TEAM_AGENTS` team check — no special-casing here
+    (AUTHZ-08, supersedes AUTHZ-05 item 8b). In the real system this succeeds
+    because `RebacEngine.check_user_team_permission_or_raise` self-heals the
+    owner's own `team_editor` tuple on first touch (which implies `team_member`,
+    which `CAN_USE_TEAM_AGENTS` requires); this test only proves agent_app.py no
     longer short-circuits before the check, i.e. the engine IS consulted."""
     engine = _FakeRebacEngine(enabled=True, deny=False)  # models the self-healed tuple
     _wire_engine(monkeypatch, engine)
@@ -2821,7 +2822,7 @@ async def test_authorize_allows_personal_space_owner_via_rebac_check(
     )
 
     assert engine.calls == [
-        ("alice", TeamPermission.CAN_READ, personal_team_id(_ALICE.uid))
+        ("alice", TeamPermission.CAN_USE_TEAM_AGENTS, personal_team_id(_ALICE.uid))
     ]
     with container._audit_events_lock:
         events = list(container.audit_events_buffer)
@@ -2833,10 +2834,11 @@ async def test_authorize_allows_personal_space_owner_via_rebac_check(
 async def test_authorize_denies_other_users_personal_space_via_rebac_check(
     monkeypatch, minimal_config
 ) -> None:
-    """Alice requesting Bob's personal space is denied — via the plain `CAN_READ`
-    team check, not a local identity guard. In the real system no tuple is ever
-    provisioned for Alice on Bob's space (self-heal only ever grants the space's
-    own owner), and `RebacEngine.add_relation`'s write-guard refuses any other
+    """Alice requesting Bob's personal space is denied — via the plain
+    `CAN_USE_TEAM_AGENTS` team check, not a local identity guard. In the real
+    system no tuple is ever provisioned for Alice on Bob's space (self-heal
+    only ever grants the space's own owner), and `RebacEngine.add_relation`'s
+    write-guard refuses any other
     shape naming a personal team (AUTHZ-08) — that invariant is proven in
     fred-core's own test suite, not here. This test only proves agent_app.py
     defers to the check rather than special-casing the outcome."""
@@ -2851,7 +2853,7 @@ async def test_authorize_denies_other_users_personal_space_via_rebac_check(
 
     assert exc.value.status_code == 403
     assert engine.calls == [
-        ("alice", TeamPermission.CAN_READ, personal_team_id(_BOB.uid))
+        ("alice", TeamPermission.CAN_USE_TEAM_AGENTS, personal_team_id(_BOB.uid))
     ]
     with container._audit_events_lock:
         events = list(container.audit_events_buffer)
@@ -2876,7 +2878,7 @@ async def test_authorize_denies_bare_personal_alias(
         )
 
     assert exc.value.status_code == 403
-    assert engine.calls == [("alice", TeamPermission.CAN_READ, "personal")]
+    assert engine.calls == [("alice", TeamPermission.CAN_USE_TEAM_AGENTS, "personal")]
 
 
 # ---------------------------------------------------------------------------

--- a/validation/scenarios/test_runtime_team_isolation.py
+++ b/validation/scenarios/test_runtime_team_isolation.py
@@ -50,6 +50,13 @@ def _identifiers(team_item: dict) -> set[str]:
     return {str(team_item.get(k)) for k in ("id", "name", "team_id") if team_item.get(k)}
 
 
+# Hard-required since #2107 (CreateAgentInstanceRequest.usage_statement) — every
+# enroll call in this file needs one or FastAPI 422s the request before any
+# authz check runs, masking every permission assertion below with a validation
+# error instead.
+USAGE_STATEMENT = "Validation-suite disposable instance, deleted at teardown."
+
+
 MEMBERS = sorted(u for u, fu in USERS.items() if TEST_TEAM in fu.teams)
 NON_MEMBERS = sorted(u for u, fu in USERS.items() if TEST_TEAM not in fu.teams)
 PLAIN_MEMBERS = sorted(u for u in MEMBERS if not USERS[u].can_enroll_in(TEST_TEAM))
@@ -203,7 +210,7 @@ def enrolled_agent(cp):
     name = f"val-{uuid.uuid4().hex[:8]}"
     created = admin.post(
         f"/teams/{team_id}/agent-instances",
-        json={"template_id": template_id, "display_name": name},
+        json={"template_id": template_id, "display_name": name, "usage_statement": USAGE_STATEMENT},
     )
     assert created.status_code in (200, 201), (
         f"Team operator ({TEAM_OPERATOR_USERNAME}) could not enroll {AGENT_TAG} into {TEST_TEAM!r}: "
@@ -360,7 +367,11 @@ def test_plain_member_cannot_enroll_agent_in_collaborative_team(username: str, c
     team_id, template = _resolve_test_template(operator)
     resp = cp(username).post(
         f"/teams/{team_id}/agent-instances",
-        json={"template_id": template["template_id"], "display_name": f"deny-{uuid.uuid4().hex[:6]}"},
+        json={
+            "template_id": template["template_id"],
+            "display_name": f"deny-{uuid.uuid4().hex[:6]}",
+            "usage_statement": USAGE_STATEMENT,
+        },
     )
     assert resp.status_code in (403, 404), (
         f"{username} unexpectedly enrolled {AGENT_TAG} into {TEST_TEAM}: "
@@ -381,6 +392,7 @@ def test_team_admin_cannot_enroll_agent_without_editor_role(username: str, cp) -
         json={
             "template_id": template["template_id"],
             "display_name": f"deny-admin-{uuid.uuid4().hex[:6]}",
+            "usage_statement": USAGE_STATEMENT,
         },
     )
     instance_id = None
@@ -442,7 +454,7 @@ def test_user_can_enroll_agent_in_their_personal_team(username: str, cp) -> None
     name = f"personal-val-{uuid.uuid4().hex[:6]}"
     created = client.post(
         f"/teams/{personal_id}/agent-instances",
-        json={"template_id": template["template_id"], "display_name": name},
+        json={"template_id": template["template_id"], "display_name": name, "usage_statement": USAGE_STATEMENT},
     )
     assert created.status_code in (200, 201), (
         f"{username} could not enroll {AGENT_TAG} in their personal team: "


### PR DESCRIPTION
## Summary

Fixes #2146 (partially — see "Deliberately not touched" below, left open).

TEAM-09/TEAM-10 (`FRED-TEAM-CONFIG-RFC.md` §5.1.1/§5.1.2) deliberately widened `TeamPermission.CAN_READ` to include any authenticated user via the `public` marketplace-discovery relation on `PUBLIC`-visibility teams (the default for every team, including `fredlab`/`northbridge`/`swiftpost`). The OpenFGA model already anticipated this and kept `can_use_team_agents`/`can_read_conversations` strictly `team_member`-only (`schema.fga`) — but two application call sites written before that split still defaulted to the wide `CAN_READ`, so a non-member visiting a public team could read its full prompt library and execute its agents, not just see that the team exists.

Confirmed live: a non-member of `fredlab` (e.g. `derek`, belonging only to `northbridge`) could `GET /teams/{fredlab}/prompts` and get a 200 with the full prompt text, and could `POST` directly to the fred-agents runtime pod's `/agents/execute/stream` for fredlab's agent and have it actually dispatch — both bypassing membership entirely.

- **`control-plane-backend/product/api.py`**: `get_team_prompts`, `get_context_prompts_early`, and `get_team_prompt` now require `TeamPermission.CAN_USE_TEAM_AGENTS` instead of falling back to `require_team_access`'s `CAN_READ` default — mirroring the precedent already set by `post_prepare_execution` and `get_team_agent_templates` in the same file.
- **`fred-runtime/agent_app.py`**: `_authorize_execution_or_raise`'s managed-execution branch now checks `CAN_USE_TEAM_AGENTS` instead of `CAN_READ`. Personal-space self-heal (AUTHZ-08) is unaffected — the owner's self-healed `team_editor` tuple implies `team_member`, which `CAN_USE_TEAM_AGENTS` already requires.
- **`validation/scenarios/test_runtime_team_isolation.py`**: unrelated pre-existing harness bug fixed along the way — `usage_statement` became hard-required on `CreateAgentInstanceRequest` in #2107, and this file's 4 enroll call sites never sent it, so every enroll request 422'd on body validation before authz ever ran, masking every runtime-scenario assertion in this file behind an unrelated validation error.

**Deliberately NOT touched**: `_list_teams` (`GET /teams`) still filters on the default `CAN_READ`, so every public team still appears in a non-member's team list. Unlike the two leaks above this may be intentional (TEAM-10 frames `public` as marketplace discoverability), but it conflicts with the isolation invariant `validation/README.md` documents for identity-only users. Left open as a product decision, not folded into this mechanical permission fix.

## Test plan

- [x] `pytest libs/fred-runtime/tests/test_agent_app.py` — 59 passed
- [x] `pytest apps/control-plane-backend/tests/test_main.py -k prompt` — 22 passed
- [x] `ruff check` / `ruff format --check` on all touched files
- [x] `make validation-report` against a live local stack (Keycloak/Postgres/OpenFGA/Temporal + control-plane-backend + fred-agents): **190 passed/35 failed/0 error → 205 passed/20 failed/0 error**. Every remaining failure is the `GET /teams` design question above; none are new regressions.