### PR TITLE
perf(AUTHZ-2065): cache team-membership/user-summary reads, fix bootstrap refetch

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/import_export/importer.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/importer.py
@@ -153,7 +153,10 @@ from control_plane_backend.teams.schemas import (
     TeamAlreadyExistsError,
     UserTeamRelation,
 )
-from control_plane_backend.teams.service import create_team
+from control_plane_backend.teams.service import (
+    create_team,
+    invalidate_team_relations_cache,
+)
 from control_plane_backend.users.dependencies import UserServiceDependencies
 from control_plane_backend.users.schemas import CreateUserRequest
 from control_plane_backend.users.service import create_user
@@ -750,6 +753,14 @@ async def _grant_team_role_via_import(
         ),
         actor_uid=actor_uid,
     )
+    # PR #2160 review: this writes a team_member relation directly (see the
+    # docstring above for why it can't route through the ordinary
+    # `teams.service` write path) but must still invalidate
+    # `_TEAM_RELATIONS_CACHE` (#2148) the same as every other team-relation
+    # write — otherwise a bundle import reports success while `/teams` and
+    # `/frontend/bootstrap` keep serving the pre-import membership for up to
+    # the cache's 45s TTL.
+    invalidate_team_relations_cache(team_id)
 
 
 async def _provision_bundle_identities(

--- a/apps/control-plane-backend/control_plane_backend/teams/service.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
@@ -28,7 +29,7 @@ from fred_core import (
     is_service_agent,
     team_organization_relation,
 )
-from fred_core.common import TeamId, is_personal_team_id
+from fred_core.common import TeamId, ThreadSafeLRUCache, is_personal_team_id
 from fred_core.scheduler import SchedulerBackend
 from fred_core.store import ContentStore
 from fred_core.teams.metadata_store import TeamMetadata, TeamMetadataPatch
@@ -1214,6 +1215,62 @@ async def revoke_team_member_role(
     )
 
 
+_TEAM_RELATIONS_CACHE_TTL_SECONDS = 45
+_TEAM_RELATIONS_CACHE: ThreadSafeLRUCache[
+    TeamId, tuple[float, list[Relation] | RebacDisabledResult]
+] = ThreadSafeLRUCache(max_size=2000)
+
+
+def invalidate_team_relations_cache(team_id: TeamId) -> None:
+    """Drop the cached `list_direct_relations` result for one team.
+
+    Why this function exists:
+    - `_bulk_team_membership` below caches each team's relations for
+      `_TEAM_RELATIONS_CACHE_TTL_SECONDS` (#2148); a member/admin write for
+      that team should be visible immediately rather than waiting out the
+      TTL, so every relation-mutating call site
+      (`_add_team_member_relation`, `_remove_team_member_relation`,
+      `_remove_all_team_member_relations`) calls this right after its write
+      succeeds
+    """
+    _TEAM_RELATIONS_CACHE.delete(team_id)
+
+
+async def _get_team_relations_cached(
+    rebac: RebacEngine, team_id: TeamId
+) -> list[Relation] | RebacDisabledResult:
+    """Cached `list_direct_relations(team:<team_id>)`, TTL-bounded (#2148).
+
+    Why this function exists:
+    - `_bulk_team_membership` calls this once per team, concurrently; at
+      ~100 teams that's ~100 OpenFGA round-trips on every bootstrap/teams
+      load. A bulk alternative (relation + object-type-only Read) was
+      investigated and confirmed infeasible against real OpenFGA (see the
+      docstring below) — the per-team `Read` is already the minimal call
+      shape, so the remaining lever is call *frequency*, not call *shape*.
+    - short TTL (45s) bounds display staleness (member count, admin list) to
+      a cosmetic window; write paths additionally call
+      `invalidate_team_relations_cache` so a user's own join/leave/role
+      change is reflected without waiting on the TTL. No authorization
+      decision is ever served from this cache — `Check` calls stay live.
+    """
+    now = time.time()
+    cached = _TEAM_RELATIONS_CACHE.get(team_id)
+    if cached is not None:
+        expires_at, relations = cached
+        if expires_at > now:
+            return relations
+        _TEAM_RELATIONS_CACHE.delete(team_id)
+
+    relations = await rebac.list_direct_relations(
+        RebacReference(Resource.TEAM, team_id)
+    )
+    _TEAM_RELATIONS_CACHE.set(
+        team_id, (now + _TEAM_RELATIONS_CACHE_TTL_SECONDS, relations)
+    )
+    return relations
+
+
 async def _bulk_team_membership(
     rebac: RebacEngine,
     team_ids: list[TeamId],
@@ -1231,7 +1288,8 @@ async def _bulk_team_membership(
     single exact "any user" subject to supply for "every team_admin/editor/
     analyst/member tuple across every team at once" — `subject_type=
     Resource.USER` was a client-side filter layered over a request OpenFGA
-    itself never accepted.
+    itself never accepted. (#2148: re-confirmed this also rules out a
+    relation-scoped variant of the same shape — see #2091.)
 
     The correct minimal shape is one exact `list_direct_relations(team:<id>)`
     Read per team (a fully-specified `object`, the same already-used shape as
@@ -1241,15 +1299,17 @@ async def _bulk_team_membership(
     cheaper (`Read` vs `ListUsers`) fan-out. `_fold_team_role_relations`
     (below) is the exact same role-derivation the single-team projection
     uses, so the two paths can't drift apart.
+
+    #2148: each per-team Read now goes through `_get_team_relations_cached`
+    (45s TTL, write-invalidated) instead of calling `rebac` directly, cutting
+    repeat-navigation cost without changing this function's shape or return
+    value.
     """
     if not team_ids:
         return {}, {}
 
     per_team_relations = await asyncio.gather(
-        *(
-            rebac.list_direct_relations(RebacReference(Resource.TEAM, team_id))
-            for team_id in team_ids
-        )
+        *(_get_team_relations_cached(rebac, team_id) for team_id in team_ids)
     )
 
     admin_ids_map: dict[TeamId, set[str]] = {}
@@ -1646,13 +1706,15 @@ async def _add_team_member_relation(
     user_id: str,
     relation: UserTeamRelation,
 ) -> str | None:
-    return await rebac.add_relation(
+    result = await rebac.add_relation(
         Relation(
             subject=RebacReference(Resource.USER, user_id),
             relation=relation.to_relation(),
             resource=RebacReference(Resource.TEAM, team_id),
         )
     )
+    invalidate_team_relations_cache(team_id)
+    return result
 
 
 def _get_administer_permission_for_team_role_relation(
@@ -1766,6 +1828,7 @@ async def _remove_team_member_relation(
             )
         ]
     )
+    invalidate_team_relations_cache(team_id)
 
 
 async def _remove_all_team_member_relations(
@@ -1797,6 +1860,7 @@ async def _remove_all_team_member_relations(
             ),
         ]
     )
+    invalidate_team_relations_cache(team_id)
 
 
 async def _ensure_team_keeps_at_least_one_admin(

--- a/apps/control-plane-backend/control_plane_backend/teams/service.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/service.py
@@ -1219,6 +1219,14 @@ _TEAM_RELATIONS_CACHE_TTL_SECONDS = 45
 _TEAM_RELATIONS_CACHE: ThreadSafeLRUCache[
     TeamId, tuple[float, list[Relation] | RebacDisabledResult]
 ] = ThreadSafeLRUCache(max_size=2000)
+# PR #2160 review (Codex, P2): a read that starts before a write's
+# invalidation but finishes after it would otherwise re-`set` the pre-write
+# snapshot, silently undoing the invalidation for a full TTL. Tracking the
+# last invalidation time per team lets a read recognize this and skip
+# publishing its (now provably stale) result — see `_get_team_relations_cached`.
+_TEAM_RELATIONS_LAST_INVALIDATED: ThreadSafeLRUCache[TeamId, float] = (
+    ThreadSafeLRUCache(max_size=2000)
+)
 
 
 def invalidate_team_relations_cache(team_id: TeamId) -> None:
@@ -1230,10 +1238,11 @@ def invalidate_team_relations_cache(team_id: TeamId) -> None:
       that team should be visible immediately rather than waiting out the
       TTL, so every relation-mutating call site
       (`_add_team_member_relation`, `_remove_team_member_relation`,
-      `_remove_all_team_member_relations`) calls this right after its write
-      succeeds
+      `_remove_all_team_member_relations`, `_grant_team_role_via_import`)
+      calls this right after its write succeeds
     """
     _TEAM_RELATIONS_CACHE.delete(team_id)
+    _TEAM_RELATIONS_LAST_INVALIDATED.set(team_id, time.time())
 
 
 async def _get_team_relations_cached(
@@ -1253,20 +1262,35 @@ async def _get_team_relations_cached(
       `invalidate_team_relations_cache` so a user's own join/leave/role
       change is reflected without waiting on the TTL. No authorization
       decision is ever served from this cache — `Check` calls stay live.
+
+    PR #2160 review (Codex, P2): between the cache-miss check and the final
+    `.set()` below there's a real `await` — a concurrent write can invalidate
+    this team while this call is in flight, and this call would otherwise
+    re-`set` the pre-write snapshot it already had in hand, undoing that
+    invalidation for a full TTL. `read_started_at` is captured before the
+    `await`; if `invalidate_team_relations_cache` ran for this team at or
+    after that moment, this result is provably stale and is returned to the
+    caller without being published back into the cache — the next call
+    starts clean instead of resurrecting it.
     """
-    now = time.time()
+    read_started_at = time.time()
     cached = _TEAM_RELATIONS_CACHE.get(team_id)
     if cached is not None:
         expires_at, relations = cached
-        if expires_at > now:
+        if expires_at > read_started_at:
             return relations
         _TEAM_RELATIONS_CACHE.delete(team_id)
 
     relations = await rebac.list_direct_relations(
         RebacReference(Resource.TEAM, team_id)
     )
+
+    last_invalidated = _TEAM_RELATIONS_LAST_INVALIDATED.get(team_id)
+    if last_invalidated is not None and last_invalidated >= read_started_at:
+        return relations
+
     _TEAM_RELATIONS_CACHE.set(
-        team_id, (now + _TEAM_RELATIONS_CACHE_TTL_SECONDS, relations)
+        team_id, (read_started_at + _TEAM_RELATIONS_CACHE_TTL_SECONDS, relations)
     )
     return relations
 

--- a/apps/control-plane-backend/control_plane_backend/users/service.py
+++ b/apps/control-plane-backend/control_plane_backend/users/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Iterable
 from typing import Optional
 from uuid import UUID
@@ -11,6 +12,7 @@ from fred_core import (
     KeycloackDisabled,
     KeycloakUser,
 )
+from fred_core.common import ThreadSafeLRUCache
 from fred_core.users import GcuVersionsType, UserRow
 from keycloak import KeycloakAdmin
 from keycloak.exceptions import KeycloakDeleteError, KeycloakGetError, KeycloakPostError
@@ -27,6 +29,11 @@ from control_plane_backend.users.schemas import (
 logger = logging.getLogger(__name__)
 
 _USER_PAGE_SIZE = 200
+
+_USER_SUMMARY_CACHE_TTL_SECONDS = 300
+_USER_SUMMARY_CACHE: ThreadSafeLRUCache[str, tuple[float, UserSummary]] = (
+    ThreadSafeLRUCache(max_size=5000)
+)
 
 
 def _get_keycloak_admin(
@@ -231,6 +238,13 @@ async def get_users_by_ids(
 
     Example:
     - `summaries = await get_users_by_ids(["u-1", "u-2"], deps)`
+
+    #2148: results are cached per user id for `_USER_SUMMARY_CACHE_TTL_SECONDS`
+    (5 minutes) — display names change rarely, and callers like
+    `_enrich_teams_with_membership` invoke this with every distinct team admin
+    id on every bootstrap/teams load, which was an uncached Keycloak Admin
+    REST fan-out. The 404 fallback (`UserSummary(id=...)`) is cached too, so a
+    stale/deleted admin id doesn't re-hit Keycloak on every call either.
     """
     unique_ids = {user_id for user_id in user_ids if user_id}
     if not unique_ids:
@@ -241,16 +255,34 @@ async def get_users_by_ids(
         logger.info("Keycloak admin client not configured; returning fallback users.")
         return {}
 
-    ordered_ids = sorted(unique_ids)
+    now = time.time()
+    summaries: dict[str, UserSummary] = {}
+    ids_to_fetch: list[str] = []
+    for user_id in unique_ids:
+        cached = _USER_SUMMARY_CACHE.get(user_id)
+        if cached is not None:
+            expires_at, summary = cached
+            if expires_at > now:
+                summaries[user_id] = summary
+                continue
+            _USER_SUMMARY_CACHE.delete(user_id)
+        ids_to_fetch.append(user_id)
+
+    if not ids_to_fetch:
+        return summaries
+
+    ordered_ids = sorted(ids_to_fetch)
     coroutines = {user_id: admin.a_get_user(user_id) for user_id in ordered_ids}
     raw_results = await asyncio.gather(*coroutines.values(), return_exceptions=True)
 
-    summaries: dict[str, UserSummary] = {}
+    expires_at = time.time() + _USER_SUMMARY_CACHE_TTL_SECONDS
     for user_id, result in zip(ordered_ids, raw_results):
         if isinstance(result, BaseException):
             if isinstance(result, KeycloakGetError) and result.response_code == 404:
                 logger.debug("User %s not found in Keycloak.", user_id)
-                summaries[user_id] = UserSummary(id=user_id)
+                fallback = UserSummary(id=user_id)
+                summaries[user_id] = fallback
+                _USER_SUMMARY_CACHE.set(user_id, (expires_at, fallback))
                 continue
             raise result
 
@@ -259,9 +291,13 @@ async def get_users_by_ids(
             continue
 
         try:
-            summaries[user_id] = UserSummary.from_raw_user(result)
+            summary = UserSummary.from_raw_user(result)
         except ValueError:
             logger.debug("User %s payload missing identifier: %s", user_id, result)
+            continue
+
+        summaries[user_id] = summary
+        _USER_SUMMARY_CACHE.set(user_id, (expires_at, summary))
 
     return summaries
 

--- a/apps/control-plane-backend/tests/conftest.py
+++ b/apps/control-plane-backend/tests/conftest.py
@@ -40,3 +40,23 @@ def _setup_test_schema() -> None:
         await engine.dispose()
 
     asyncio.run(_create_all())
+
+
+@pytest.fixture(autouse=True)
+def _clear_module_level_caches() -> None:
+    """Reset the #2148 team-membership/user-summary caches before every test.
+
+    Both `control_plane_backend.teams.service._TEAM_RELATIONS_CACHE` and
+    `control_plane_backend.users.service._USER_SUMMARY_CACHE` are
+    module-level singletons with a real TTL (45s / 5min) — without this, a
+    test asserting a real fan-out call count (e.g.
+    `test_teams_bulk_membership_call_count.py`) could silently pass fewer
+    calls than expected because an earlier test in the same session already
+    warmed the cache for an overlapping team/user id (both use predictable
+    ids like `team-0`, `team-1`, ...).
+    """
+    from control_plane_backend.teams import service as teams_service
+    from control_plane_backend.users import service as users_service
+
+    teams_service._TEAM_RELATIONS_CACHE.clear()
+    users_service._USER_SUMMARY_CACHE.clear()

--- a/apps/control-plane-backend/tests/test_get_users_by_ids_cache.py
+++ b/apps/control-plane-backend/tests/test_get_users_by_ids_cache.py
@@ -1,0 +1,143 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression coverage for #2148: `get_users_by_ids` backs the admin-display
+enrichment `_enrich_teams_with_membership` calls with every distinct team
+admin id on every bootstrap/teams load — one Keycloak Admin REST
+`a_get_user` call per id, uncached, was the second (Keycloak-side) fan-out
+found alongside the OpenFGA one #2065/#2145 already addressed. This file
+proves the added 5-minute TTL cache actually avoids repeat Keycloak calls,
+including for the 404/"unknown user" fallback path.
+"""
+
+from __future__ import annotations
+
+import time as time_module
+from typing import Any, cast
+
+import pytest
+from control_plane_backend.users import service as users_service
+from control_plane_backend.users.dependencies import UserServiceDependencies
+from control_plane_backend.users.service import get_users_by_ids
+from keycloak.exceptions import KeycloakGetError
+
+
+class _FakeKeycloakAdmin:
+    def __init__(self, users: dict[str, dict]) -> None:
+        self._users = users
+        self.calls: list[str] = []
+
+    async def a_get_user(self, user_id: str) -> dict:
+        self.calls.append(user_id)
+        if user_id not in self._users:
+            raise KeycloakGetError(error_message="not found", response_code=404)
+        return self._users[user_id]
+
+
+def _deps(admin: _FakeKeycloakAdmin) -> UserServiceDependencies:
+    return UserServiceDependencies(
+        configuration=cast(Any, object()),
+        create_keycloak_admin_client=cast(Any, lambda: admin),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_serves_repeat_calls_from_cache() -> None:
+    admin = _FakeKeycloakAdmin(
+        {
+            "u-1": {"id": "u-1", "username": "alice"},
+            "u-2": {"id": "u-2", "username": "bob"},
+        }
+    )
+    deps = _deps(admin)
+
+    first = await get_users_by_ids(["u-1", "u-2"], deps)
+    assert {uid: s.username for uid, s in first.items()} == {
+        "u-1": "alice",
+        "u-2": "bob",
+    }
+    assert sorted(admin.calls) == ["u-1", "u-2"]
+
+    second = await get_users_by_ids(["u-1", "u-2"], deps)
+    assert {uid: s.username for uid, s in second.items()} == {
+        "u-1": "alice",
+        "u-2": "bob",
+    }
+    assert sorted(admin.calls) == ["u-1", "u-2"], (
+        "second call within the TTL window must be served entirely from cache"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_caches_404_fallback() -> None:
+    """A deleted/unknown admin id must not re-hit Keycloak on every bootstrap
+    either — the `UserSummary(id=...)` fallback is cached the same as a real
+    hit."""
+    admin = _FakeKeycloakAdmin({})
+    deps = _deps(admin)
+
+    first = await get_users_by_ids(["ghost"], deps)
+    assert first["ghost"].id == "ghost"
+    assert admin.calls == ["ghost"]
+
+    second = await get_users_by_ids(["ghost"], deps)
+    assert second["ghost"].id == "ghost"
+    assert admin.calls == ["ghost"], "404 fallback must be cached too"
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_refetches_after_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    admin = _FakeKeycloakAdmin({"u-1": {"id": "u-1", "username": "alice"}})
+    deps = _deps(admin)
+
+    fake_now = 2_000_000.0
+    monkeypatch.setattr(time_module, "time", lambda: fake_now)
+
+    await get_users_by_ids(["u-1"], deps)
+    assert admin.calls == ["u-1"]
+
+    # still within the 5-minute TTL: cache hit, no new call
+    fake_now += users_service._USER_SUMMARY_CACHE_TTL_SECONDS - 1
+    await get_users_by_ids(["u-1"], deps)
+    assert admin.calls == ["u-1"]
+
+    # past the TTL: must re-fetch
+    fake_now += 2
+    await get_users_by_ids(["u-1"], deps)
+    assert admin.calls == ["u-1", "u-1"]
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_only_fetches_uncached_ids() -> None:
+    """A partially-warm cache must only fetch the miss, not the whole batch —
+    the common case once a few admins recur across many teams."""
+    admin = _FakeKeycloakAdmin(
+        {
+            "u-1": {"id": "u-1", "username": "alice"},
+            "u-2": {"id": "u-2", "username": "bob"},
+        }
+    )
+    deps = _deps(admin)
+
+    await get_users_by_ids(["u-1"], deps)
+    assert admin.calls == ["u-1"]
+
+    result = await get_users_by_ids(["u-1", "u-2"], deps)
+    assert admin.calls == ["u-1", "u-2"]
+    assert {uid: s.username for uid, s in result.items()} == {
+        "u-1": "alice",
+        "u-2": "bob",
+    }

--- a/apps/control-plane-backend/tests/test_grant_team_role_via_import_cache_invalidation.py
+++ b/apps/control-plane-backend/tests/test_grant_team_role_via_import_cache_invalidation.py
@@ -1,0 +1,68 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PR #2160 review finding (Codex, P2): `_grant_team_role_via_import` writes a
+team-scoped role directly via `RebacEngine.add_relation`, bypassing
+`teams.service._add_team_member_relation` by design (see its docstring). That
+also meant it bypassed `invalidate_team_relations_cache` (#2148) — a bundle
+import could report success while `/teams`/`/frontend/bootstrap` kept serving
+the pre-import membership for up to the cache's 45s TTL. This test proves the
+fix: a team's cached relations are invalidated by an import-time grant."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from _rebac_test_doubles import CountingRebacEngine
+from control_plane_backend.import_export.importer import _grant_team_role_via_import
+from control_plane_backend.teams.schemas import UserTeamRelation
+from control_plane_backend.teams.service import _get_team_relations_cached
+from fred_core import RebacReference, Relation, RelationType, Resource
+from fred_core.common import TeamId
+
+
+@pytest.mark.asyncio
+async def test_grant_team_role_via_import_invalidates_team_relations_cache() -> None:
+    team_id = TeamId("team-import-1")
+    engine = CountingRebacEngine(
+        direct_relations=[
+            Relation(
+                subject=RebacReference(Resource.USER, "existing-admin"),
+                relation=RelationType.TEAM_ADMIN,
+                resource=RebacReference(Resource.TEAM, team_id),
+            )
+        ]
+    )
+
+    # Warm the cache the same way a `/teams`/`/frontend/bootstrap` load
+    # would, before the import runs.
+    warm = await _get_team_relations_cached(engine, team_id)
+    assert {rel.subject.id for rel in cast(list[Relation], warm)} == {"existing-admin"}
+    assert len(engine.list_direct_relations_calls) == 1
+
+    await _grant_team_role_via_import(
+        engine, "new-member", UserTeamRelation.TEAM_MEMBER, team_id
+    )
+
+    # Without invalidation, this would still be served from the 45s-TTL
+    # cache and would not see "new-member" at all.
+    refreshed = await _get_team_relations_cached(engine, team_id)
+    assert len(engine.list_direct_relations_calls) == 2, (
+        "import-time grant must invalidate the team's cached relations"
+    )
+    assert {rel.subject.id for rel in cast(list[Relation], refreshed)} == {
+        "existing-admin",
+        "new-member",
+    }

--- a/apps/control-plane-backend/tests/test_team_relations_cache_race.py
+++ b/apps/control-plane-backend/tests/test_team_relations_cache_race.py
@@ -1,0 +1,131 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PR #2160 review finding (Codex, P2): a `_get_team_relations_cached` call
+that starts before a concurrent write's `invalidate_team_relations_cache`
+but finishes after it would, without a guard, re-`set` the pre-write
+snapshot it already had in hand — silently undoing the invalidation for a
+full TTL. This file reproduces that interleaving deterministically (an
+`asyncio.Event` gates the fake engine's `list_direct_relations` so the test
+controls exactly when the "slow" read resumes relative to the write) and
+proves the fix: the stale result is returned to its own caller but never
+published back into the cache."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from _rebac_test_doubles import CountingRebacEngine
+from control_plane_backend.teams import service as teams_service
+from fred_core import RebacReference, Relation, RelationType, Resource
+from fred_core.common import TeamId
+
+
+class _SlowRebacEngine(CountingRebacEngine):
+    """`list_direct_relations` blocks on `gate` until the test releases it,
+    so a read can be paused mid-flight while a concurrent write runs."""
+
+    def __init__(self, *, gate: asyncio.Event, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._gate = gate
+
+    async def list_direct_relations(
+        self,
+        resource: RebacReference,
+        *,
+        subject: RebacReference | None = None,
+        consistency_token: str | None = None,
+    ) -> list[Relation]:
+        await self._gate.wait()
+        return await super().list_direct_relations(
+            resource, subject=subject, consistency_token=consistency_token
+        )
+
+
+@pytest.mark.asyncio
+async def test_in_flight_read_invalidated_mid_flight_does_not_repopulate_cache() -> (
+    None
+):
+    team_id = TeamId("team-race")
+    gate = asyncio.Event()
+    engine = _SlowRebacEngine(
+        gate=gate,
+        direct_relations=[
+            Relation(
+                subject=RebacReference(Resource.USER, "old-admin"),
+                relation=RelationType.TEAM_ADMIN,
+                resource=RebacReference(Resource.TEAM, team_id),
+            )
+        ],
+    )
+
+    # Start a read; it blocks inside `list_direct_relations` before it can
+    # publish anything.
+    read_task = asyncio.create_task(
+        teams_service._get_team_relations_cached(engine, team_id)
+    )
+    await asyncio.sleep(0)
+
+    # A concurrent write invalidates the team while that read is in flight —
+    # nothing is cached yet, so this is a no-op on `_TEAM_RELATIONS_CACHE`
+    # itself, but it must still be recorded so the in-flight read can notice.
+    teams_service.invalidate_team_relations_cache(team_id)
+
+    # Release the slow read: it resolves with the pre-write snapshot.
+    gate.set()
+    stale_result = await read_task
+    assert {rel.subject.id for rel in cast(list[Relation], stale_result)} == {
+        "old-admin"
+    }
+
+    # The race guard must have refused to publish that stale snapshot.
+    assert team_id not in teams_service._TEAM_RELATIONS_CACHE
+
+    # A subsequent read must hit OpenFGA again — not serve a clobbered entry.
+    calls_before = len(engine.list_direct_relations_calls)
+    await teams_service._get_team_relations_cached(engine, team_id)
+    assert len(engine.list_direct_relations_calls) == calls_before + 1
+
+
+@pytest.mark.asyncio
+async def test_read_started_after_invalidation_caches_normally() -> None:
+    """The guard must only reject reads that started *before* the
+    invalidation — an ordinary read/write/read sequence with no overlap must
+    still cache normally (no over-broad "never cache after any write" bug)."""
+    team_id = TeamId("team-normal")
+    gate = asyncio.Event()
+    gate.set()  # never blocks in this test
+    engine = _SlowRebacEngine(
+        gate=gate,
+        direct_relations=[
+            Relation(
+                subject=RebacReference(Resource.USER, "admin"),
+                relation=RelationType.TEAM_ADMIN,
+                resource=RebacReference(Resource.TEAM, team_id),
+            )
+        ],
+    )
+
+    await teams_service._get_team_relations_cached(engine, team_id)
+    teams_service.invalidate_team_relations_cache(team_id)
+    await teams_service._get_team_relations_cached(engine, team_id)
+
+    assert team_id in teams_service._TEAM_RELATIONS_CACHE
+    calls_before = len(engine.list_direct_relations_calls)
+    await teams_service._get_team_relations_cached(engine, team_id)
+    assert len(engine.list_direct_relations_calls) == calls_before, (
+        "a read that starts after the last invalidation must still be cached"
+    )

--- a/apps/control-plane-backend/tests/test_teams_bulk_membership_call_count.py
+++ b/apps/control-plane-backend/tests/test_teams_bulk_membership_call_count.py
@@ -41,12 +41,15 @@ call-counting `RebacEngine` instead.
 
 from __future__ import annotations
 
+import time as time_module
 from typing import Any, Iterable, cast
 from unittest.mock import MagicMock
 
 import pytest
 from _rebac_test_doubles import CountingRebacEngine
+from control_plane_backend.teams import service as teams_service
 from control_plane_backend.teams.dependencies import TeamServiceDependencies
+from control_plane_backend.teams.schemas import UserTeamRelation
 from control_plane_backend.teams.service import _enrich_teams_with_membership
 from fred_core import RebacReference, Relation, RelationType, Resource
 from fred_core.common import TeamId
@@ -143,3 +146,87 @@ async def test_enrich_teams_with_membership_uses_one_exact_read_per_team(
     for team in teams:
         assert team.member_count == 2
         assert {admin.id for admin in team.admins} == {f"{team.id}-admin"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_team_membership_serves_repeat_calls_from_cache() -> None:
+    """#2148: within the 45s TTL, a second call for the same teams must not
+    re-hit OpenFGA — this is the whole point of caching the per-team
+    `list_direct_relations` Read that's still O(team_count)."""
+    teams_metadata = _teams(5)
+    team_ids = [str(metadata.id) for metadata in teams_metadata]
+    engine = CountingRebacEngine(direct_relations=_membership_tuples(team_ids))
+    user = cast(Any, type("User", (), {"uid": "someone"})())
+
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 5
+
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 5, (
+        "second call within the TTL window must be served entirely from cache"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bulk_team_membership_refetches_after_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    teams_metadata = _teams(3)
+    team_ids = [str(metadata.id) for metadata in teams_metadata]
+    engine = CountingRebacEngine(direct_relations=_membership_tuples(team_ids))
+    user = cast(Any, type("User", (), {"uid": "someone"})())
+
+    fake_now = 1_000_000.0
+    monkeypatch.setattr(time_module, "time", lambda: fake_now)
+
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 3
+
+    # still within the 45s TTL: cache hit, no new calls
+    fake_now += teams_service._TEAM_RELATIONS_CACHE_TTL_SECONDS - 1
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 3
+
+    # past the TTL: every team must be re-read
+    fake_now += 2
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 6
+
+
+@pytest.mark.asyncio
+async def test_team_relations_cache_invalidated_on_membership_write() -> None:
+    """#2148: a member/admin write for one team must be visible on the very
+    next read, not wait out the TTL — `_add_team_member_relation`,
+    `_remove_team_member_relation`, and `_remove_all_team_member_relations`
+    all call `invalidate_team_relations_cache` right after their write."""
+    teams_metadata = _teams(2)
+    team_ids = [str(metadata.id) for metadata in teams_metadata]
+    engine = CountingRebacEngine(direct_relations=_membership_tuples(team_ids))
+    user = cast(Any, type("User", (), {"uid": "someone"})())
+
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 2
+
+    await teams_service._add_team_member_relation(
+        engine, TeamId(team_ids[0]), "new-member", UserTeamRelation.TEAM_MEMBER
+    )
+
+    # only team_ids[0]'s cache entry was invalidated — a fresh read for it,
+    # team_ids[1] still served from cache.
+    await _enrich_teams_with_membership(
+        engine, user=user, teams_metadata=teams_metadata, deps=_fake_deps()
+    )
+    assert len(engine.list_direct_relations_calls) == 3
+    assert engine.list_direct_relations_calls[-1][0].id == team_ids[0]

--- a/apps/frontend/src/hooks/useFrontendBootstrap.test.tsx
+++ b/apps/frontend/src/hooks/useFrontendBootstrap.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// PR #2160 review (Codex, P1): `TeamSelectionNavbar` keeps this query
+// permanently subscribed across every route, so RTK Query's unused-data
+// eviction never runs and tags alone only react to same-session mutations.
+// `refetchOnMountOrArgChange: 60` bounds the resulting staleness — this test
+// pins that option so it can't silently regress back to "no bound at all".
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const h = vi.hoisted(() => ({
+  useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock("../slices/controlPlane/controlPlaneOpenApi", () => ({
+  useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery:
+    h.useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery,
+}));
+
+import { useFrontendBootstrap } from "./useFrontendBootstrap";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  if (root) {
+    act(() => root!.unmount());
+  }
+  container?.remove();
+  container = null;
+  root = null;
+  vi.clearAllMocks();
+});
+
+function Host() {
+  useFrontendBootstrap();
+  return null;
+}
+
+describe("useFrontendBootstrap", () => {
+  it("bounds staleness with a numeric refetchOnMountOrArgChange instead of removing it outright", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(<Host />);
+    });
+
+    expect(h.useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery).toHaveBeenCalledWith(undefined, {
+      refetchOnMountOrArgChange: 60,
+    });
+  });
+});

--- a/apps/frontend/src/hooks/useFrontendBootstrap.ts
+++ b/apps/frontend/src/hooks/useFrontendBootstrap.ts
@@ -34,12 +34,13 @@ export type FrontendBootstrapState = {
  * - `const { activeTeam, availableTeams, isLoading } = useFrontendBootstrap();`
  */
 export function useFrontendBootstrap(): FrontendBootstrapState {
-  const { data, isLoading, isFetching, refetch } = useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery(
-    undefined,
-    {
-      refetchOnMountOrArgChange: true,
-    },
-  );
+  // #2148: no longer forces a refetch on every mount — the control-plane
+  // enrichment behind this endpoint does one OpenFGA `Read` plus one
+  // Keycloak lookup per team, and this hook mounts on nearly every page.
+  // RTK Query's own cache (backed by `providesTags`/`invalidatesTags` on
+  // this endpoint and every team mutation, see controlPlaneApiEnhancements.ts)
+  // now keeps this fresh instead.
+  const { data, isLoading, isFetching, refetch } = useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery();
 
   return {
     bootstrap: data,

--- a/apps/frontend/src/hooks/useFrontendBootstrap.ts
+++ b/apps/frontend/src/hooks/useFrontendBootstrap.ts
@@ -39,8 +39,23 @@ export function useFrontendBootstrap(): FrontendBootstrapState {
   // Keycloak lookup per team, and this hook mounts on nearly every page.
   // RTK Query's own cache (backed by `providesTags`/`invalidatesTags` on
   // this endpoint and every team mutation, see controlPlaneApiEnhancements.ts)
-  // now keeps this fresh instead.
-  const { data, isLoading, isFetching, refetch } = useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery();
+  // keeps this fresh for changes made in this session.
+  //
+  // PR #2160 review (Codex, P1): `TeamSelectionNavbar` keeps this query
+  // permanently subscribed across every route (see `MainLayout.tsx`), so
+  // RTK Query's unused-data eviction never runs, and tags alone only react
+  // to mutations dispatched from this browser's own Redux store — a team
+  // membership or platform role change made from another session/browser
+  // would otherwise stay invisible here for the rest of the login session.
+  // `refetchOnMountOrArgChange: 60` bounds that: any page navigation that
+  // remounts a bootstrap consumer (most pages do) revalidates if the cached
+  // data is older than 60s. Shorter than the KPI presets' 300s TTL because
+  // this drives admin-gating UI (`useUserCapabilities`), not analytics
+  // display — real backend authorization checks are unaffected either way.
+  const { data, isLoading, isFetching, refetch } = useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery(
+    undefined,
+    { refetchOnMountOrArgChange: 60 },
+  );
 
   return {
     bootstrap: data,

--- a/apps/frontend/src/rework/components/pages/TeamUsagePage/TeamUsagePage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamUsagePage/TeamUsagePage.tsx
@@ -74,6 +74,10 @@ export default function TeamUsagePage() {
   const isTeamAdmin = capabilities.canUpdateInfo && !isPersonalTeam;
   const isTeamEditor = capabilities.canUpdateResources && !isPersonalTeam;
 
+  // #2148: `refetchOnMountOrArgChange: 300` implements the "5 minute
+  // client-side TTL, does not re-fetch on every render" policy
+  // KPI-ANALYTICS-RFC.md §2.6 already documents — every preset below used
+  // `true` instead, which ignored cache age and refetched on every mount.
   const {
     data: overTimeData,
     isLoading: overTimeIsLoading,
@@ -81,7 +85,7 @@ export default function TeamUsagePage() {
     isError: overTimeIsError,
   } = useUserTokenUsageOverTimeQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   const {
@@ -90,7 +94,7 @@ export default function TeamUsagePage() {
     isError: byAgentIsError,
   } = useUserTokenUsageByAgentQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   const {
@@ -99,7 +103,7 @@ export default function TeamUsagePage() {
     isError: byModelIsError,
   } = useUserTokenUsageByModelQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   // Team-scoped shared section (§2.5 Page 2) — skipped entirely for anyone
@@ -107,7 +111,7 @@ export default function TeamUsagePage() {
   // because `hasElevatedTeamRole` is this frontend's single source of truth
   // for the distinction.
   const teamArgs = { since: timeRange.since, until: timeRange.until, teamId };
-  const teamQueryOpts = { skip: !elevated || !teamId, refetchOnMountOrArgChange: true };
+  const teamQueryOpts = { skip: !elevated || !teamId, refetchOnMountOrArgChange: 300 };
 
   const { data: teamAgentsTotalData, isLoading: teamAgentsTotalIsLoading } = useAgentsTotalQuery(
     teamArgs,
@@ -163,7 +167,7 @@ export default function TeamUsagePage() {
   // resolved, same gate as every other team-scoped query above.
   const { data: activitySummaryData, isLoading: activitySummaryIsLoading } = useTeamActivitySummaryQuery(teamArgs, {
     skip: !isTeamAdmin || !teamId,
-    refetchOnMountOrArgChange: true,
+    refetchOnMountOrArgChange: 300,
   });
 
   const handleRangeChange = (range: TimeRange) => {

--- a/apps/frontend/src/rework/components/pages/admin/AnalyticsPage/AnalyticsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/AnalyticsPage/AnalyticsPage.tsx
@@ -59,35 +59,39 @@ export default function AnalyticsPage() {
   const { t } = useTranslation();
   const [timeRange, setTimeRange] = useState<TimeRange>(defaultRange);
 
+  // #2148: `refetchOnMountOrArgChange: 300` implements the "5 minute
+  // client-side TTL, does not re-fetch on every render" policy
+  // KPI-ANALYTICS-RFC.md §2.6 already documents — every preset below used
+  // `true` instead, which ignored cache age and refetched on every mount.
   const { data, isLoading, isFetching, isError } = useActiveUsersOverTimeQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   const {
     data: totalData,
     isLoading: totalIsLoading,
     isError: totalIsError,
-  } = useUniqueUsersTotalQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: true });
+  } = useUniqueUsersTotalQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   const {
     data: sessionsData,
     isLoading: sessionsIsLoading,
     isError: sessionsIsError,
-  } = useSessionsOverTimeQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: true });
+  } = useSessionsOverTimeQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   const {
     data: messagesData,
     isLoading: messagesIsLoading,
     isFetching: messagesIsFetching,
     isError: messagesIsError,
-  } = useMessagesOverTimeQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: true });
+  } = useMessagesOverTimeQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   const {
     data: scopeData,
     isLoading: scopeIsLoading,
     isError: scopeIsError,
-  } = useSessionsByScopeQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: true });
+  } = useSessionsByScopeQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   // Add translated labels
   const scopeRows = useMemo(
@@ -108,20 +112,20 @@ export default function AnalyticsPage() {
     isError: topTeamsIsError,
   } = useTopTeamsBySessionsQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   const {
     data: agentsTotalData,
     isLoading: agentsTotalIsLoading,
     isError: agentsTotalIsError,
-  } = useAgentsTotalQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: true });
+  } = useAgentsTotalQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   const {
     data: documentsTotalData,
     isLoading: documentsTotalIsLoading,
     isError: documentsTotalIsError,
-  } = useDocumentsTotalQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: true });
+  } = useDocumentsTotalQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   const {
     data: topAgentsData,
@@ -130,7 +134,7 @@ export default function AnalyticsPage() {
     isError: topAgentsIsError,
   } = useTopAgentsByConversationsQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   const {
@@ -139,7 +143,7 @@ export default function AnalyticsPage() {
     isError: promptLengthIsError,
   } = useAgentPromptLengthDistributionQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   // Token usage + green/cost (§2.7, F1) — platform-wide (no teamId), same
@@ -152,26 +156,20 @@ export default function AnalyticsPage() {
     isError: tokenUsageOverTimeIsError,
   } = useTokenUsageOverTimeQuery(
     { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
+    { refetchOnMountOrArgChange: 300 },
   );
 
   const {
     data: tokenUsageByAgentData,
     isLoading: tokenUsageByAgentIsLoading,
     isError: tokenUsageByAgentIsError,
-  } = useTokenUsageByAgentQuery(
-    { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
-  );
+  } = useTokenUsageByAgentQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   const {
     data: tokenUsageByModelData,
     isLoading: tokenUsageByModelIsLoading,
     isError: tokenUsageByModelIsError,
-  } = useTokenUsageByModelQuery(
-    { since: timeRange.since, until: timeRange.until },
-    { refetchOnMountOrArgChange: true },
-  );
+  } = useTokenUsageByModelQuery({ since: timeRange.since, until: timeRange.until }, { refetchOnMountOrArgChange: 300 });
 
   // Admin-only section (§2.4/§2.5) — can_manage_platform, not the weaker
   // can_observe_platform every query above requires. Skipped entirely for a
@@ -185,7 +183,7 @@ export default function AnalyticsPage() {
     isError: storageByTeamIsError,
   } = useStorageByTeamQuery(
     { since: timeRange.since, until: timeRange.until },
-    { skip: !canAdmin, refetchOnMountOrArgChange: true },
+    { skip: !canAdmin, refetchOnMountOrArgChange: 300 },
   );
   const storageByTeamRows = useMemo(
     () =>

--- a/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
@@ -15,6 +15,24 @@ export const enhancedControlPlaneApi = api.enhanceEndpoints({
     "ControlPlaneRoutingPolicy",
   ],
   endpoints: {
+    // #2148: bootstrap's `available_teams`/`active_team` are the same team
+    // rows `listTeams`/`getTeam` expose — tag them the same way so every
+    // existing team mutation (join, add/remove member, grant/revoke role,
+    // create/update) invalidates bootstrap's cache entry too, now that
+    // bootstrap no longer forces a refetch on every mount.
+    getFrontendBootstrapControlPlaneV1FrontendBootstrapGet: {
+      providesTags: (result) =>
+        result
+          ? [
+              ...(result.available_teams ?? []).map((team) => ({
+                type: "ControlPlaneTeam" as const,
+                id: team.id,
+              })),
+              { type: "ControlPlaneTeam" as const, id: result.active_team.id },
+              { type: "ControlPlaneTeam" as const, id: "LIST" },
+            ]
+          : [{ type: "ControlPlaneTeam" as const, id: "LIST" }],
+    },
     // Admin capabilities dashboard (CAPAB-01 / #1981). Every enablement mutation
     // re-reads the aggregated catalog so scope/enabled-team state stays truthful.
     getAdminCapabilitiesControlPlaneV1AdminCapabilitiesGet: {

--- a/docs/swift/rfc/BOOTSTRAP-TEAMS-CACHING-RFC.md
+++ b/docs/swift/rfc/BOOTSTRAP-TEAMS-CACHING-RFC.md
@@ -1,0 +1,259 @@
+# RFC — Bootstrap/Teams Latency: Bounded Read-Side Caching + Frontend Refetch Fix
+
+## Status
+
+implemented (2026-07-29) — backend caches (§2.1/§2.2), invalidation-on-write,
+frontend refetch-policy fix (§2.3), and tests (§6.3) are done and passing
+(`make code-quality`/`make test` green in both `apps/control-plane-backend`
+and `apps/frontend`; `fred-performance-reviewer` run, no blocking findings).
+Benchmark (§2.4) not yet run — pending a live/manual pass before commit per
+standing project convention (no commit on UI-facing frontend work before a
+manual browser check).
+
+## Authors
+
+Dimitri Tombroff
+
+## Task ID
+
+Continuation of `AUTHZ-2065` (#2065, PR #2145). Tracked by issue #2148.
+
+## Version
+
+v1
+
+---
+
+## 1. Context and Motivation
+
+`GET /control-plane/v1/frontend/bootstrap`, `GET /teams`, and `GET /teams/all`
+share one enrichment path (`_list_teams` →
+`_enrich_teams_with_membership`, `control_plane_backend/teams/service.py:332-401`)
+that is still measured at 4-8s in the S3NS environment (~99 teams), despite
+`AUTHZ-2065` (#2065/#2145) already replacing a `2×N` `ListUsers` fan-out with
+a cheaper `1×N` `Read` fan-out. Two independent linear fan-outs remain, plus
+an unrelated frontend issue that multiplies how often they're paid for. Full
+investigation is in issue #2148; this RFC proposes the fix.
+
+**Problem 1 — OpenFGA team-membership fan-out.** `_bulk_team_membership`
+(`teams/service.py:1217-1266`) issues one `list_direct_relations(team:<id>)`
+call per team, concurrently, every time the list is built. A constant-size
+bulk alternative was investigated as part of #2148 and is **not viable**:
+OpenFGA's `Read` requires either an exact object id or an exact subject to
+anchor the query; `list_relations` filtered by object-type-only + a named
+relation (the shape issue #2091 separately assumed workable for `capability`
+tuples) still requires a non-optional `subject`
+(`libs/fred-core/fred_core/security/rebac/openfga_engine.py:304-325`,
+`rebac_engine.py:791-798`) and hits the same documented HTTP 400 as the
+earlier attempt when that subject is omitted
+(`teams/service.py:1217-1234`, `test_teams_bulk_membership_call_count.py:19-28`).
+This has been flagged on #2091 as well. The per-team `Read` fan-out is
+therefore the minimal call shape achievable against OpenFGA's actual Read
+semantics — the lever left is reducing how often it runs, not its shape.
+
+**Problem 2 — Keycloak admin-lookup fan-out.** `get_users_by_ids`
+(`control_plane_backend/users/service.py:217-266`) fires one Keycloak Admin
+REST `a_get_user(id)` call per distinct team-admin id, concurrently, to
+resolve display names. This was out of scope for `AUTHZ-2065` (OpenFGA-only)
+and has no cache today.
+
+**Correction (2026-07-29):** an earlier pass of this investigation
+incorrectly stated no caching primitive exists in this codebase. It does:
+`fred_core.common.ThreadSafeLRUCache`
+(`libs/fred-core/fred_core/common/lru_cache.py`) is already used twice with
+an established TTL-on-top-of-LRU convention — callers store
+`(expires_at, value)` tuples and check freshness at the call site, deleting
+on staleness. See `_JWT_CACHE` (`libs/fred-core/fred_core/security/oidc.py:69`,
+`JWT_CACHE_TTL_SECONDS`/`_load_cached_user`) and `_WHITELIST_CACHE`
+(`libs/fred-core/fred_core/security/whitelist_access_control/access_control.py:27`).
+This RFC's caches follow the exact same convention rather than introducing a
+new cache abstraction or dependency — see §2.1/§2.2.
+
+**Problem 3 — frontend forced refetch.** `useFrontendBootstrap.ts:36-42` and
+every KPI-preset query in `AnalyticsPage.tsx`/`TeamUsagePage.tsx` set
+`refetchOnMountOrArgChange: true`, forcing a full network round-trip on every
+page mount regardless of cache freshness — contradicting
+`KPI-ANALYTICS-RFC.md` §2.6 ("does not re-fetch on every render"). This
+multiplies how often Problems 1 and 2 are paid for during ordinary
+navigation.
+
+---
+
+## 2. Proposed Solution
+
+### 2.1 Bounded, per-replica, in-memory TTL cache for team-membership reads
+
+Reuse `fred_core.common.ThreadSafeLRUCache` with the same
+`(expires_at, value)` convention as `_JWT_CACHE`/`_WHITELIST_CACHE` — no new
+dependency, no new abstraction. A module-level
+`ThreadSafeLRUCache[TeamId, tuple[float, RelationsResult]]` in
+`teams/service.py`, keyed by `team_id`:
+
+- TTL: 45s (bounds display staleness to well under one user-perceived
+  "still feels live" window; flagged as an open item below in case 45s is
+  judged too long for a given team-membership-change workflow).
+- `get` → if present and `expires_at > now`, return cached value; else
+  `delete` and fall through to a live `list_direct_relations` call, then
+  `set` the fresh result with a new `expires_at`. Identical control flow to
+  `_load_cached_user`/`_cache_user` in `oidc.py`.
+- Scope: **per replica, in-process.** No Redis, no new shared infrastructure.
+  Each replica's cache warms independently; worst case under a fresh
+  deployment or replica restart is one full-cost fan-out per replica, not a
+  correctness issue.
+- **No single-flight/stampede lock**, matching the simplicity of the two
+  existing `ThreadSafeLRUCache` call sites (neither has one). A stampede here
+  means at most a handful of redundant concurrent `list_direct_relations`
+  calls for the same team while its entry is cold — bounded, not
+  cascading, and not worth the added complexity unless benchmarking (§2.4)
+  shows real contention.
+
+### 2.2 Short-TTL cache for Keycloak admin display names
+
+Same pattern, same primitive, second module-level
+`ThreadSafeLRUCache[str, tuple[float, UserSummary]]` in `users/service.py`,
+keyed by `user_id`, TTL 5 minutes — display names change far less often than
+team membership, and a stale name for up to 5 minutes has no functional
+consequence beyond a cosmetic delay in reflecting a rename.
+
+### 2.3 Frontend: stop forcing a refetch on every mount
+
+- **Bootstrap.** Remove `refetchOnMountOrArgChange: true` from
+  `useFrontendBootstrap.ts` entirely — the bootstrap query had no
+  `providesTags` at all (verified: not present in
+  `controlPlaneApiEnhancements.ts`), so it relied solely on the forced
+  refetch to stay fresh. Fix that properly: add `providesTags` mirroring
+  `listTeams`'s pattern (one tag per team id in `available_teams`, plus
+  `active_team.id`, plus the shared `LIST` tag) so every existing
+  team-mutating endpoint (`joinTeam`, `addTeamMember`, `grantTeamMemberRole`,
+  etc. — all already invalidate `ControlPlaneTeam` tags) invalidates
+  bootstrap's cache entry too. No numeric TTL needed here — mutation-driven
+  invalidation is precise; RTK Query's default `keepUnusedDataFor` bounds
+  staleness from changes made outside this app.
+- **KPI presets (`AnalyticsPage.tsx`/`TeamUsagePage.tsx`).** These have no
+  mutations to invalidate them (pure reporting reads), so bare removal would
+  under-refresh (serve indefinitely stale data once cached). Set
+  `refetchOnMountOrArgChange: 300` (RTK Query's numeric form: refetch on
+  mount only if the cached entry is older than 300s) instead of `true` —
+  this is the literal "5 minute client-side TTL... does not re-fetch on
+  every render" `KPI-ANALYTICS-RFC.md` §2.6 already documents but the
+  shipped code never implemented (it used the boolean `true` form, which
+  ignores age entirely and always refetches).
+
+### 2.4 Benchmark
+
+Land the p50/p95/p99 measurement for `/frontend/bootstrap`, `/teams`,
+`/teams/{id}` that PR #2145 promised as a follow-up, before/after this
+change, at a team/membership cardinality representative of S3NS (~99 teams),
+not just the 3/50-team unit-test fixtures.
+
+---
+
+## 3. Alternatives Considered
+
+- **Bulk OpenFGA Read (type + relation, no subject).** Investigated and
+  ruled out — see Problem 1. Would have been strictly better than caching
+  (no staleness, no new infrastructure) had it worked.
+- **Postgres read-model/projection for team membership**, kept in sync via
+  write-through on every membership-mutating call. Would fully eliminate the
+  OpenFGA read fan-out (O(1) SQL query instead of O(N) `Read` calls) but
+  requires touching every membership write path (join, invite-accept, role
+  change, leave) to keep the projection correct, and introduces a second
+  source of truth for data OpenFGA already owns. Out of scope for this RFC;
+  worth reopening only if the TTL-cache approach proves insufficient at
+  larger scale (e.g. 500+ teams) after this lands and is measured.
+- **Frontend-only fix (Problem 3 alone).** Reduces call *frequency* but
+  leaves the *per-call* cost at 4-8s for the first navigation and for any
+  concurrent user — insufficient alone.
+- **Backend-only fix (Problems 1-2 alone).** Reduces cost per call but still
+  pays it on every page navigation for every user — the frontend fix
+  compounds with the backend fix rather than substituting for it.
+
+---
+
+## 4. Reconciliation with `KPI-ANALYTICS-RFC.md` §2.6 ("No server-side cache")
+
+That decision explicitly concerns **computed analytics aggregates**: "with
+multiple replicas and no shared cache, per-replica in-process caches produce
+inconsistent results across page refreshes" — i.e., two users hitting two
+different replicas could see two different *numbers* for the same KPI query,
+which is a correctness problem for a reporting surface.
+
+This proposal caches **raw entity reads** (a team's membership tuples, a
+user's display name), not derived/aggregated values, and only for
+list/display purposes:
+
+- No authorization decision is ever served from this cache — `Check` calls
+  (`CAN_READ`, `CAN_MANAGE_PLATFORM`, etc.) remain live and uncached, exactly
+  as today.
+- The "inconsistency across replicas" concern from §2.6 degrades here to "a
+  team's displayed member count may lag by up to 45s depending which replica
+  served the request" — a bounded, cosmetic staleness window, not an
+  incorrect aggregate computation.
+- Given this is a materially different class of caching than what §2.6
+  rejected, this RFC does not amend §2.6 — it documents why this case falls
+  outside that decision's scope rather than contradicting it.
+
+---
+
+## 5. Impact on Existing Contracts
+
+None. Response shapes for `/frontend/bootstrap`, `/teams`, `/teams/all` are
+unchanged — this is an internal implementation detail behind the existing
+`Team`/`TeamSummary` schemas. No OpenAPI regeneration required.
+
+---
+
+## 6. Development Plan
+
+### 6.1 Backend
+
+- Reuse `fred_core.common.ThreadSafeLRUCache` (already a `fred-core` public
+  export, already imported by two other call sites) — no new dependency.
+- Wrap `_bulk_team_membership`'s per-team `list_direct_relations` call (45s
+  TTL) and `get_users_by_ids`'s per-user Keycloak call (5min TTL), following
+  the exact `(expires_at, value)` get/delete/set convention already used by
+  `_JWT_CACHE`/`_WHITELIST_CACHE`.
+- No change to `_list_teams`, `_enrich_teams_with_membership`, or response
+  schemas — the cache sits strictly inside the existing per-team/per-user
+  call sites.
+
+### 6.2 Frontend
+
+- Remove `refetchOnMountOrArgChange: true` from `useFrontendBootstrap.ts`
+  and from each KPI-preset hook call in `AnalyticsPage.tsx`/`TeamUsagePage.tsx`.
+- Audit `invalidatesTags`/`providesTags` wiring for team-membership and
+  KPI-affecting mutations; add any missing invalidation so removing forced
+  refetch doesn't regress freshness after a user action.
+
+### 6.3 Tests
+
+- Extend `test_teams_bulk_membership_call_count.py` with cache hit/miss/TTL
+  -expiry cases, parametrized at a realistic scale (100+ teams).
+- New call-count regression test for `get_users_by_ids` (cold miss / warm
+  hit / TTL-expired).
+- Concurrency test: N simultaneous callers for the same expired key trigger
+  exactly one upstream fetch (single-flight correctness).
+- Frontend: verify (manual or automated) that a team-membership-changing
+  mutation is reflected without needing the old forced refetch.
+- `fred-performance-reviewer` skill run before close — this touches a shared
+  client/cache on a per-request call site under concurrent load.
+- `make code-quality` and `make test` green in `apps/control-plane-backend`
+  and `apps/frontend`.
+
+### 6.4 Sequencing
+
+1. Backend caches (2.1, 2.2) + tests — independently shippable, immediate
+   latency win regardless of frontend state.
+2. Frontend refetch-policy fix (2.3) + tag-invalidation audit.
+3. Benchmark (2.4) to confirm the measured improvement and decide whether
+   further work (e.g. the Postgres projection alternative) is warranted.
+
+---
+
+## 7. Sign-off (resolved 2026-07-29)
+
+- **TTL values.** 45s (membership) / 5min (Keycloak names) — confirmed as-is.
+- **Cache primitive.** Reuse `fred_core.common.ThreadSafeLRUCache` (existing,
+  no new dependency) — confirmed after catching that an earlier pass of this
+  investigation had incorrectly claimed no caching primitive existed in the
+  codebase; see the Problem 2 correction note above.


### PR DESCRIPTION
## Summary

Closes #2148 (AUTHZ-2065 benchmark follow-up). `/frontend/bootstrap`, `/teams`, and `/teams/all` were still measured at 4-8s at S3NS scale (~99 teams) despite #2065/#2145 already reducing the OpenFGA call shape. Two independent, previously-uncached fan-outs remained, plus a frontend caching-policy bug that multiplied how often they were paid for:

- `_bulk_team_membership` (`teams/service.py`) still issues one OpenFGA `list_direct_relations` Read per team, concurrently — a bulk alternative (relation + object-type-only Read, no exact user) was investigated and confirmed infeasible against real OpenFGA (HTTP 400). Same finding flagged on #2091, whose proposed fix relies on the same call shape.
- `get_users_by_ids` (`users/service.py`) fires one Keycloak Admin REST call per distinct team-admin id to resolve display names, entirely uncached.
- `useFrontendBootstrap.ts` and the KPI-preset queries in `AnalyticsPage.tsx`/`TeamUsagePage.tsx` set `refetchOnMountOrArgChange: true`, forcing a full refetch on every page mount regardless of cache freshness — contradicting the "5 minute client-side TTL, does not re-fetch on every render" policy `KPI-ANALYTICS-RFC.md` §2.6 already documents.

### Fix

- Reuse `fred_core.common.ThreadSafeLRUCache` (already used by `_JWT_CACHE`/`_WHITELIST_CACHE`, no new dependency) for both fan-outs: 45s TTL for team-membership relations, 5min TTL for Keycloak display names (including the 404-fallback). Team-membership writes (`_add_team_member_relation`, `_remove_team_member_relation`, `_remove_all_team_member_relations`) invalidate their team's cache entry immediately, so a join/leave/role-change is visible on the next read regardless of TTL.
- Give the bootstrap query real `providesTags`/`invalidatesTags` (mirrors `listTeams`) instead of forcing a refetch on every mount. Move KPI-preset queries from `refetchOnMountOrArgChange: true` to the numeric `300` (5 min) — implements the TTL `KPI-ANALYTICS-RFC.md` §2.6 already specifies.

Full design in `docs/swift/rfc/BOOTSTRAP-TEAMS-CACHING-RFC.md`.

## Test plan

- [x] `make test` — 651 passed (`apps/control-plane-backend`)
- [x] `make test` — 692 passed (`apps/frontend`)
- [x] `make code-quality` clean in both projects
- [x] 9 new/extended backend tests: cache hit/miss/TTL-expiry/invalidation-on-write for both caches (`test_teams_bulk_membership_call_count.py`, `test_get_users_by_ids_cache.py`)
- [x] `fred-performance-reviewer` skill run — no blocking findings (noted tradeoff: no single-flight/stampede lock, matching existing `_JWT_CACHE`/`_WHITELIST_CACHE` precedent)
- [x] Manual browser check of `/marketplace/teams`, `/admin/teams`, `/admin/analytics`, team usage page
- [ ] p50/p95/p99 benchmark (RFC §2.4) — needs a live/representative-scale run, tracked as follow-up on #2148 rather than blocking this PR