### PR TITLE
feat(frontend): add migration warning banner on login

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1581,5 +1581,8 @@
       "title": "Privacy policy",
       "backToApp": "Back to app"
     }
+  },
+  "migrationBanner": {
+    "message": "From now on, the files and agents you create will not be kept when we switch to the new version."
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1581,5 +1581,8 @@
       "title": "Politique de confidentialité",
       "backToApp": "Retourner à l'application"
     }
+  },
+  "migrationBanner": {
+    "message": "À partir de maintenant, les fichiers et les agents que vous créez ne seront pas conservés lors de la bascule vers la nouvelle version."
   }
 }

--- a/frontend/src/migration/MigrationBanner.module.css
+++ b/frontend/src/migration/MigrationBanner.module.css
@@ -1,0 +1,52 @@
+/* KEA MIGRATION (throwaway) — overlay banner, see MigrationBanner.tsx */
+
+.banner {
+  display: flex;
+  position: absolute;
+  top: var(--spacing-m);
+  right: var(--spacing-xl);
+  left: var(--spacing-xl);
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-s);
+  z-index: 1100;
+  animation: slide-in 200ms ease-out;
+  margin: 0 auto;
+  box-shadow: var(--shadow-s);
+  border-radius: var(--radius-s);
+  background-color: var(--red-40);
+  padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) var(--spacing-m);
+  max-width: 1100px;
+}
+
+.message {
+  margin: 0;
+  color: var(--red-99);
+  font: var(--font-body-medium-emphasized);
+}
+
+/* IconButton sets --main-color on the button itself via [data-color], so the
+   override has to target the button too — inheriting from .banner would lose. */
+.banner button {
+  --main-color: var(--red-99);
+  --state-on-surface-hover: rgb(255 255 255 / 20%);
+  --state-on-surface-pressed: rgb(255 255 255 / 30%);
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateY(-8px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .banner {
+    animation: none;
+  }
+}

--- a/frontend/src/migration/MigrationBanner.tsx
+++ b/frontend/src/migration/MigrationBanner.tsx
@@ -1,0 +1,79 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ---------------------------------------------------------------------------
+// KEA MIGRATION (one-shot, throwaway-on-kea).
+// Warns every user, once per session (i.e. once per login), that the content
+// they create now will not survive the switch to the new version.
+// Rendered as an overlay over the page content only — never over the sidebar.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import styles from "./MigrationBanner.module.css";
+
+const DISMISSED_KEY = "kea-migration-banner-dismissed";
+const AUTO_HIDE_MS = 30_000;
+
+const wasDismissed = () => {
+  try {
+    return sessionStorage.getItem(DISMISSED_KEY) === "true";
+  } catch {
+    return false; // private mode / storage disabled: show the banner anyway
+  }
+};
+
+const markDismissed = () => {
+  try {
+    sessionStorage.setItem(DISMISSED_KEY, "true");
+  } catch {
+    /* storage unavailable — the banner simply reappears on reload */
+  }
+};
+
+export default function MigrationBanner() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(() => !wasDismissed());
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => {
+      markDismissed();
+      setOpen(false);
+    }, AUTO_HIDE_MS);
+    return () => window.clearTimeout(timer);
+  }, [open]);
+
+  if (!open) return null;
+
+  const close = () => {
+    markDismissed();
+    setOpen(false);
+  };
+
+  return (
+    <div className={styles.banner} role="status" aria-live="polite">
+      <p className={styles.message}>{t("migrationBanner.message")}</p>
+      <IconButton
+        color="on-surface"
+        variant="icon"
+        size="xs"
+        icon={{ category: "outlined", type: "close" }}
+        onClick={close}
+        aria-label={t("common.close")}
+      />
+    </div>
+  );
+}

--- a/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.module.css
+++ b/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.module.css
@@ -9,6 +9,16 @@
   overflow: visible;
 }
 
+/* Positioning context for overlays (e.g. the migration banner) so they cover
+   the page content only, never the sidebar. */
+.contentArea {
+  display: flex;
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+}
+
 .content {
   width: 100%;
   overflow: auto;

--- a/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.tsx
+++ b/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router-dom";
 import Sidebar from "@shared/organisms/Sidebar/Sidebar.tsx";
 import { CssBaseline } from "@mui/material";
+import MigrationBanner from "src/migration/MigrationBanner.tsx"; // KEA-MIGRATION (throwaway)
 import styles from "./MainLayout.module.css";
 
 export default function MainLayout() {
@@ -11,9 +12,12 @@ export default function MainLayout() {
         <nav className={styles.sidebar}>
           <Sidebar />
         </nav>
-        <main className={styles.content}>
-          <Outlet />
-        </main>
+        <div className={styles.contentArea}>
+          <MigrationBanner /> {/* KEA-MIGRATION (throwaway) */}
+          <main className={styles.content}>
+            <Outlet />
+          </main>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Contexte

Avant la bascule vers la nouvelle version, les utilisateurs doivent être prévenus que le contenu qu'ils créent maintenant ne sera pas conservé.

## Changement

Ajoute une bannière rouge en overlay, affichée en haut de la zone de contenu à chaque connexion.

- **Overlay** (`position: absolute`, z-index 1100) : recouvre le contenu sans le décaler, et reste fixe quand la page défile.
- **Ancrée dans la zone de contenu uniquement** : elle démarre à droite de la sidebar, jamais par-dessus l'historique des conversations ni les équipes. Le `<main>` est enveloppé dans une `.contentArea` en `position: relative` qui lui sert de repère.
- **Auto-masquage après 30 s**, ou fermeture manuelle via la croix blanche à droite.
- **Une fois par session** (= une fois par connexion) via un flag `sessionStorage`, donc pas de réaffichage à chaque changement de page ou rechargement.
- Fond `--red-40`, texte et croix en `--red-99`.

## Suppression après la bascule

Le composant vit dans `frontend/src/migration/`, le dossier déjà marqué `KEA-MIGRATION (throwaway)`. Pour le retirer : supprimer les deux fichiers, les 2 lignes marquées `KEA-MIGRATION` dans `MainLayout.tsx` et la clé `migrationBanner` des locales.

## Fichiers

| Fichier | Rôle |
|---|---|
| `frontend/src/migration/MigrationBanner.tsx` | Composant (nouveau) |
| `frontend/src/migration/MigrationBanner.module.css` | Styles (nouveau) |
| `frontend/src/rework/.../MainLayout.tsx` | Montage de la bannière |
| `frontend/src/rework/.../MainLayout.module.css` | `.contentArea` (contexte de positionnement) |
| `frontend/src/locales/{fr,en}/translation.json` | Clé `migrationBanner.message` |

## Vérifications

- `npx tsc --noEmit` : OK
- `npx prettier --check` sur les fichiers touchés : OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)