### PR TITLE
eval ui polish 6 fixes

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1952,7 +1952,8 @@
         "campaignInfo": "Run information",
         "meta": {
           "dataset": "Evaluation",
-          "profile": "Scoring profile",
+          "author": "Author",
+          "profile": "Structural-check profile",
           "judge": "Judge",
           "team": "Evaluation ID",
           "created": "Created",
@@ -1971,6 +1972,10 @@
         "caseTitle": "Case detail",
         "copyJson": "Copy JSON",
         "copied": "Copied",
+        "downloadJson": "Download JSON",
+        "downloadRun": "Download JSON",
+        "downloading": "Preparing…",
+        "downloadError": "Download failed",
         "latency": "Latency",
         "input": "Input",
         "expected": "Expected output",
@@ -1982,6 +1987,18 @@
         "skipped": "skipped",
         "passed": "passed",
         "failed": "failed"
+      },
+      "controls": {
+        "searchEvaluations": "Search by name…",
+        "sortLabel": "Sort",
+        "sort": {
+          "newest": "Newest first",
+          "oldest": "Oldest first",
+          "name": "Name (A–Z)"
+        },
+        "page": "Page {{current}} of {{total}}",
+        "prev": "Previous",
+        "next": "Next"
       },
       "evaluations": {
         "title": "Evaluations",
@@ -2037,6 +2054,7 @@
         "viewFullDetail": "View full detail →",
         "metricsCount": "{{count}} metrics",
         "targetInstance": "Instance · {{id}}",
+        "targetManaged": "Managed instance",
         "detail": "Detail",
         "deleteTitle": "Delete run",
         "deleteSuccess": "Run deleted",
@@ -2058,12 +2076,12 @@
           "criticalFailures": "Critical failures"
         },
         "col": {
-          "run": "Run / ID",
-          "target": "Target",
-          "state": "State",
+          "run": "Run",
+          "target": "Agent",
+          "state": "Status",
           "verdict": "Verdict",
-          "progress": "Progress",
-          "scores": "Profile / judge"
+          "progress": "Done",
+          "judge": "Judge"
         }
       },
       "runCreate": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1952,7 +1952,8 @@
         "campaignInfo": "Informations de l'exécution",
         "meta": {
           "dataset": "Évaluation",
-          "profile": "Profil de scoring",
+          "author": "Auteur",
+          "profile": "Profil de vérifications structurelles",
           "judge": "Juge",
           "team": "Identifiant d'évaluation",
           "created": "Créée le",
@@ -1971,6 +1972,10 @@
         "caseTitle": "Détail du cas",
         "copyJson": "Copier en JSON",
         "copied": "Copié",
+        "downloadJson": "Télécharger le JSON",
+        "downloadRun": "Télécharger le JSON",
+        "downloading": "Préparation…",
+        "downloadError": "Échec du téléchargement",
         "latency": "Latence",
         "input": "Entrée",
         "expected": "Sortie attendue",
@@ -1982,6 +1987,18 @@
         "skipped": "ignoré",
         "passed": "réussi",
         "failed": "échoué"
+      },
+      "controls": {
+        "searchEvaluations": "Rechercher par nom…",
+        "sortLabel": "Trier",
+        "sort": {
+          "newest": "Plus récentes d'abord",
+          "oldest": "Plus anciennes d'abord",
+          "name": "Nom (A–Z)"
+        },
+        "page": "Page {{current}} sur {{total}}",
+        "prev": "Précédent",
+        "next": "Suivant"
       },
       "evaluations": {
         "title": "Évaluations",
@@ -2037,6 +2054,7 @@
         "viewFullDetail": "Voir le détail complet →",
         "metricsCount": "{{count}} métriques",
         "targetInstance": "Instance · {{id}}",
+        "targetManaged": "Instance gérée",
         "detail": "Détail",
         "deleteTitle": "Supprimer l'exécution",
         "deleteSuccess": "Exécution supprimée",
@@ -2058,12 +2076,12 @@
           "criticalFailures": "Échecs critiques"
         },
         "col": {
-          "run": "Exécution / ID",
-          "target": "Cible",
-          "state": "État",
+          "run": "Run",
+          "target": "Agent",
+          "state": "Statut",
           "verdict": "Verdict",
-          "progress": "Progression",
-          "scores": "Profil / juge"
+          "progress": "Fait",
+          "judge": "Juge"
         }
       },
       "runCreate": {

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -43,8 +43,21 @@ import Icon from "@shared/atoms/Icon/Icon.tsx";
 export default function TeamContentNavbar() {
   const { agentIconName, agentsNicknamePlural } = useFrontendProperties();
   const { t } = useTranslation();
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const { pathname } = location;
   const navigate = useNavigate();
+
+  // "Back" from a focused view (settings / usage) should return to wherever the
+  // user came from, not always dump them on the agents page. React Router marks
+  // the first history entry of a session with key "default"; navigating back from
+  // there would leave the app, so fall back to the team's agents view then.
+  const handleBack = () => {
+    if (location.key === "default") {
+      navigate(`/team/${teamId}/agents`);
+    } else {
+      navigate(-1);
+    }
+  };
   const { teamId, isPersonalTeam, selectedTeam, canOpenTeamSettings, bannerColor, bannerStyle } = useSelectedTeam();
   const capabilities = useTeamCapabilities(selectedTeam);
   const { canUpdateAgents, canUpdateInfo } = capabilities;
@@ -234,7 +247,7 @@ export default function TeamContentNavbar() {
                 color={"primary"}
                 variant={"text"}
                 size={"medium"}
-                onClick={() => navigate(`/team/${teamId}/agents`)}
+                onClick={handleBack}
                 icon={{ category: "outlined", type: "arrow_back", filled: true }}
               >
                 {t("rework.back")}
@@ -253,7 +266,7 @@ export default function TeamContentNavbar() {
               color={"primary"}
               variant={"text"}
               size={"medium"}
-              onClick={() => navigate(`/team/${teamId}/agents`)}
+              onClick={handleBack}
               icon={{ category: "outlined", type: "arrow_back", filled: true }}
             >
               {t("rework.back")}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -37,6 +37,7 @@ import {
   useCancelRunEvaluationV1RunsRunIdCancelPostMutation,
   useAnalyzeRunEvaluationV1RunsRunIdAnalyzePostMutation,
   useGetRunEvaluationV1RunsRunIdGetQuery,
+  useLazyGetRunReportEvaluationV1RunsRunIdReportGetQuery,
   useGetTelemetryEvaluationV1TelemetryGetQuery,
   useGetTelemetrySessionEvaluationV1TelemetrySessionRunIdGetQuery,
   useListRunCasesEvaluationV1RunsRunIdCasesGetQuery,
@@ -45,6 +46,9 @@ import {
   type EvaluationRun,
   type RunAnalysisResult,
 } from "../../../../../../../slices/evaluation/evaluationOpenApi";
+import { useUsersByIdsQuery } from "../../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
+import { userDisplayName } from "../../../../../../core/utils/userDisplayName";
+import { downloadCaseJson, downloadRunReportJson } from "./evaluationExport";
 import styles from "./EvaluationRunDetail.module.css";
 
 // ── Helpers (pure logic — no UI framework) ──────────────────────────────────
@@ -162,6 +166,7 @@ export default function EvaluationRunDetail({
   const [cancelError, setCancelError] = useState<string | null>(null);
   const [analysis, setAnalysis] = useState<RunAnalysisResult | null>(null);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   // Whether the run is still active. Starts false — we don't know the state
   // until the first fetch resolves — then tracks run.operational_state. Used
@@ -185,6 +190,10 @@ export default function EvaluationRunDetail({
 
   const [cancelRun, { isLoading: isCancelling }] = useCancelRunEvaluationV1RunsRunIdCancelPostMutation();
   const [analyzeRun, { isLoading: isAnalyzing }] = useAnalyzeRunEvaluationV1RunsRunIdAnalyzePostMutation();
+  const [fetchRunReport, { isFetching: isDownloadingRun }] = useLazyGetRunReportEvaluationV1RunsRunIdReportGetQuery();
+
+  const authorUids = run?.created_by ? [run.created_by] : [];
+  const { data: authorUsers = [] } = useUsersByIdsQuery({ ids: authorUids }, { skip: authorUids.length === 0 });
 
   const { data: telemetry } = useGetTelemetryEvaluationV1TelemetryGetQuery();
   // Unlike `run`/`cases` above, this poll had no isLive gate — it kept hitting
@@ -245,6 +254,20 @@ export default function EvaluationRunDetail({
     }
   };
 
+  // Run-level export: the backend report is already a self-contained, versioned
+  // record (evaluation + all cases + metric_averages + cached analysis), so it is
+  // fetched on demand and saved as-is rather than reassembled from the loaded page.
+  const handleDownloadRun = async () => {
+    setDownloadError(null);
+    try {
+      const report = await fetchRunReport({ runId }).unwrap();
+      downloadRunReportJson(report);
+    } catch (e) {
+      const detail = (e as { data?: { detail?: unknown } })?.data?.detail;
+      setDownloadError(typeof detail === "string" ? detail : t("rework.evaluation.detail.downloadError"));
+    }
+  };
+
   if (runLoading) {
     return <div className={styles.centered}>{t("rework.evaluation.detail.loading")}</div>;
   }
@@ -265,13 +288,17 @@ export default function EvaluationRunDetail({
   const globalScore = metricEntries.length
     ? Math.round((metricEntries.reduce((sum, [, avg]) => sum + avg, 0) / metricEntries.length) * 100)
     : null;
+  const authorSummary = run.created_by ? authorUsers.find((user) => user.id === run.created_by) : undefined;
+  const authorLabel = run.created_by ? userDisplayName(run.created_by, authorSummary) : "—";
 
   const metadata: { label: string; value: string }[] = [
     {
       label: t("rework.evaluation.detail.meta.dataset"),
       value: `${run.snapshot.evaluation_name} v${run.snapshot.evaluation_version}`,
     },
-    { label: t("rework.evaluation.detail.meta.profile"), value: run.profile },
+    // Show a human display name when the control-plane user lookup can resolve
+    // it; otherwise fall back to the raw uid so the audit information is never lost.
+    { label: t("rework.evaluation.detail.meta.author"), value: authorLabel },
     { label: t("rework.evaluation.detail.meta.judge"), value: run.judge_profile_id },
     { label: t("rework.evaluation.detail.meta.team"), value: run.evaluation_id },
     { label: t("rework.evaluation.detail.meta.created"), value: formatDate(run.created_at) },
@@ -309,6 +336,16 @@ export default function EvaluationRunDetail({
               {isAnalyzing ? t("rework.evaluation.detail.analyzing") : t("rework.evaluation.detail.analyze")}
             </Button>
           )}
+          <Button
+            color="on-surface"
+            variant="outlined"
+            size="medium"
+            disabled={isDownloadingRun}
+            icon={{ category: "outlined", type: "download" }}
+            onClick={handleDownloadRun}
+          >
+            {isDownloadingRun ? t("rework.evaluation.detail.downloading") : t("rework.evaluation.detail.downloadRun")}
+          </Button>
           {/* `telemetry.enabled` is a static config flag (tracer == "langfuse"),
               not a live reachability check — a deployment can have it set
               without ever actually running Langfuse. Only show this action
@@ -333,6 +370,7 @@ export default function EvaluationRunDetail({
       </div>
 
       {cancelError && <div className={styles.errorBanner}>{cancelError}</div>}
+      {downloadError && <div className={styles.errorBanner}>{downloadError}</div>}
 
       {/* Hero state row — canonical task state + domain verdict (two distinct planes). */}
       <div className={styles.heroRow}>
@@ -563,6 +601,14 @@ function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: Retu
           icon={{ category: "outlined", type: copied ? "check_circle" : "content_copy" }}
           aria-label={copied ? t("rework.evaluation.detail.copied") : t("rework.evaluation.detail.copyJson")}
           onClick={handleCopy}
+        />
+        <IconButton
+          color="on-surface"
+          variant="icon"
+          size="small"
+          icon={{ category: "outlined", type: "download" }}
+          aria-label={t("rework.evaluation.detail.downloadJson")}
+          onClick={() => downloadCaseJson(caseData)}
         />
       </div>
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.module.css
@@ -121,30 +121,6 @@
   text-align: left;
 }
 
-.nameHeaderCell {
-  transform: translateX(-4px);
-}
-
-.targetHeaderCell {
-  transform: translateX(-38px);
-}
-
-.stateHeaderCell {
-  transform: translateX(-68px);
-}
-
-.verdictHeaderCell {
-  transform: translateX(-104px);
-}
-
-.progressHeaderCell {
-  transform: translateX(-140px);
-}
-
-.scoresHeaderCell {
-  transform: translateX(-176px);
-}
-
 .bodyRow {
   position: relative;
   cursor: pointer;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.module.css
@@ -60,6 +60,17 @@
   flex: 1 1 180px;
 }
 
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-m);
+}
+
+.toolbarSpacer {
+  flex: 1 1 auto;
+}
+
 /* ── Grid table ──────────────────────────────────────────────────────────── */
 
 .table {
@@ -73,10 +84,21 @@
 
 .row {
   display: grid;
-  grid-template-columns: 1.6fr 1fr auto auto 160px 180px auto;
+  grid-template-columns:
+    minmax(0, 0.78fr)
+    minmax(0, 0.9fr)
+    minmax(0, 0.62fr)
+    minmax(0, 0.72fr)
+    minmax(0, 0.9fr)
+    minmax(0, 0.95fr)
+    max-content;
   align-items: center;
-  gap: var(--spacing-m);
-  padding: var(--spacing-s) var(--spacing-m);
+  column-gap: var(--spacing-s);
+  padding: var(--spacing-s) var(--spacing-xs);
+}
+
+.row > * {
+  min-width: 0;
 }
 
 .headerRow {
@@ -85,14 +107,53 @@
   font: var(--font-label-small-emphasized);
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  padding-left: var(--spacing-xs);
+  padding-right: var(--spacing-xs);
+}
+
+.nameHeaderCell,
+.targetHeaderCell,
+.stateHeaderCell,
+.verdictHeaderCell,
+.progressHeaderCell,
+.scoresHeaderCell,
+.actionsHeaderCell {
+  text-align: left;
+}
+
+.nameHeaderCell {
+  transform: translateX(-4px);
+}
+
+.targetHeaderCell {
+  transform: translateX(-38px);
+}
+
+.stateHeaderCell {
+  transform: translateX(-68px);
+}
+
+.verdictHeaderCell {
+  transform: translateX(-104px);
+}
+
+.progressHeaderCell {
+  transform: translateX(-140px);
+}
+
+.scoresHeaderCell {
+  transform: translateX(-176px);
 }
 
 .bodyRow {
   position: relative;
   cursor: pointer;
-  border-top: 1px solid var(--outline-variant);
   color: var(--on-surface);
   font: var(--font-body-medium);
+}
+
+.bodyRow + .bodyRow {
+  border-top: 1px solid var(--outline-variant);
 }
 
 .bodyRow:hover {
@@ -130,6 +191,18 @@
   gap: var(--spacing-xs);
 }
 
+.targetCell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  min-width: 0;
+}
+
+.targetName {
+  color: var(--on-surface);
+  font: var(--font-body-medium-emphasized);
+}
+
 .name {
   color: var(--on-surface);
   font: var(--font-body-medium-emphasized);
@@ -146,11 +219,17 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2xs);
-  /* Grid items default to min-width: auto, letting long content (e.g. a
-     long judge_profile_id like "MISTRAL-SMALL") blow past this column's
-     180px track and spill into the actions column next to it. Allow the
-     item to shrink to its track so the pill below can ellipsis instead. */
   min-width: 0;
+}
+
+.stateCell,
+.verdictCell {
+  display: flex;
+  align-items: center;
+}
+
+.stateCell {
+  padding-left: var(--spacing-m);
 }
 
 .scoreLine {
@@ -172,13 +251,49 @@
 
 .actionsCell {
   display: flex;
-  flex-shrink: 0;
   justify-content: flex-end;
-  gap: var(--spacing-xs);
-  /* Grid equivalent of flex-shrink: 0 — never let this column collapse
-     below the Detail/Delete buttons' natural width, whatever the sibling
-     scoresCell column does. */
+  gap: var(--spacing-s);
   min-width: max-content;
+}
+
+.actionsHeaderCell {
+  left: 0;
+  justify-self: end;
+}
+
+.nameHeaderCell,
+.nameCell {
+  grid-column: 1;
+}
+
+.targetHeaderCell,
+.targetCell {
+  grid-column: 2;
+}
+
+.stateHeaderCell,
+.stateCell {
+  grid-column: 3;
+}
+
+.verdictHeaderCell,
+.verdictCell {
+  grid-column: 4;
+}
+
+.progressHeaderCell,
+.progressCell {
+  grid-column: 5;
+}
+
+.scoresHeaderCell,
+.scoresCell {
+  grid-column: 6;
+}
+
+.actionsHeaderCell,
+.actionsCell {
+  grid-column: 7;
 }
 
 .muted {
@@ -277,5 +392,14 @@
 .caseLink {
   align-self: flex-end;
   color: var(--primary);
+  font: var(--font-label-medium);
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-s);
+  color: var(--on-surface-retreat);
   font: var(--font-label-medium);
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.module.css
@@ -92,8 +92,8 @@
     minmax(0, 0.9fr)
     minmax(0, 0.95fr)
     max-content;
-  align-items: center;
   column-gap: var(--spacing-s);
+  align-items: center;
   padding: var(--spacing-s) var(--spacing-xs);
 }
 
@@ -103,12 +103,12 @@
 
 .headerRow {
   border-bottom: 1px solid var(--outline-variant);
+  padding-right: var(--spacing-xs);
+  padding-left: var(--spacing-xs);
   color: var(--on-surface-retreat);
   font: var(--font-label-small-emphasized);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  padding-left: var(--spacing-xs);
-  padding-right: var(--spacing-xs);
 }
 
 .nameHeaderCell,

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
@@ -35,6 +35,7 @@ import { FieldBlock, StatusPill, operationalToTaskState, scoreTone, verdictTone 
 import { useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery } from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
 import {
   useDeleteRunEvaluationV1RunsRunIdDeleteMutation,
+  useGetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetQuery,
   useListRunCasesEvaluationV1RunsRunIdCasesGetQuery,
   useListRunsEvaluationV1EvaluationsEvaluationIdRunsGetQuery,
   useStartRunEvaluationV1EvaluationsEvaluationIdRunsPostMutation,
@@ -195,6 +196,17 @@ export default function EvaluationRuns({
     { evaluationId, sort, offset, limit: RUNS_PAGE_SIZE },
     { skip: !evaluationId, pollingInterval: 10_000 },
   );
+  // Dashboard KPIs must reflect every run of the evaluation, not just the current
+  // page — a dedicated aggregate query, independent of offset/limit.
+  const {
+    data: summary,
+    isLoading: isSummaryLoading,
+    isError: isSummaryError,
+    refetch: refetchSummary,
+  } = useGetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetQuery(
+    { evaluationId },
+    { skip: !evaluationId, pollingInterval: 10_000 },
+  );
 
   // Deleting the last row of a non-first page (or any other drop in `total`, e.g.
   // a concurrent delete from another tab) can leave `offset` pointing past the new
@@ -219,6 +231,7 @@ export default function EvaluationRuns({
       showSuccess({ summary: t("rework.evaluation.runs.deleteSuccess") });
       setDeleteTarget(null);
       refetch();
+      refetchSummary();
     } catch {
       showError({ summary: t("rework.evaluation.runs.deleteError") });
     }
@@ -230,14 +243,10 @@ export default function EvaluationRuns({
   const total = data?.total ?? 0;
   const pageCount = Math.max(1, Math.ceil(total / RUNS_PAGE_SIZE));
   const currentPage = Math.floor(offset / RUNS_PAGE_SIZE) + 1;
-  const running = runs.filter((run) => run.operational_state === "running").length;
-  // operationalToTaskState is the canonical mapper (it also treats "succeeded"
-  // as terminal-success, matching the backend's own documented either/or) —
-  // reuse it instead of comparing the raw string, so this count can't silently
-  // drop to 0 if the backend ever reports "succeeded" instead of "completed".
-  const completed = runs.filter((run) => operationalToTaskState(run.operational_state) === "succeeded").length;
-  const totalCases = runs.reduce((sum, run) => sum + run.completed_cases, 0);
-  const criticalErrors = runs.reduce((sum, run) => sum + run.execution_error_cases, 0);
+  const running = summary?.running_count ?? 0;
+  const completed = summary?.completed_count ?? 0;
+  const totalCases = summary?.total_cases_completed ?? 0;
+  const criticalErrors = summary?.critical_error_cases ?? 0;
   const agentNameByInstanceId = buildAgentLabels(managedInstances);
   const sortOptions: OptionModel<RunSortValue>[] = [
     { value: "created_at:desc", key: "newest", label: t("rework.evaluation.controls.sort.newest") },
@@ -313,26 +322,26 @@ export default function EvaluationRuns({
         <KpiStatCard
           label={t("rework.evaluation.runs.kpi.active")}
           value={running}
-          isLoading={isLoading}
-          isError={isError}
+          isLoading={isSummaryLoading}
+          isError={isSummaryError}
         />
         <KpiStatCard
           label={t("rework.evaluation.runs.kpi.completed")}
           value={completed}
-          isLoading={isLoading}
-          isError={isError}
+          isLoading={isSummaryLoading}
+          isError={isSummaryError}
         />
         <KpiStatCard
           label={t("rework.evaluation.runs.kpi.casesEvaluated")}
           value={totalCases}
-          isLoading={isLoading}
-          isError={isError}
+          isLoading={isSummaryLoading}
+          isError={isSummaryError}
         />
         <KpiStatCard
           label={t("rework.evaluation.runs.kpi.criticalFailures")}
           value={criticalErrors}
-          isLoading={isLoading}
-          isError={isError}
+          isLoading={isSummaryLoading}
+          isError={isSummaryError}
         />
       </div>
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
@@ -195,6 +195,16 @@ export default function EvaluationRuns({
     { evaluationId, sort, offset, limit: RUNS_PAGE_SIZE },
     { skip: !evaluationId, pollingInterval: 10_000 },
   );
+
+  // Deleting the last row of a non-first page (or any other drop in `total`, e.g.
+  // a concurrent delete from another tab) can leave `offset` pointing past the new
+  // last page — snap back so the table never renders an empty page while later
+  // pages still hold data.
+  useEffect(() => {
+    if (!data) return;
+    const maxOffset = Math.max(0, Math.ceil(data.total / RUNS_PAGE_SIZE) - 1) * RUNS_PAGE_SIZE;
+    if (offset > maxOffset) setOffset(maxOffset);
+  }, [data, offset]);
   const { data: managedInstances = [] } = useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery(
     { teamId },
     { skip: !teamId },

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
@@ -356,7 +356,7 @@ export default function EvaluationRuns({
             const isRunning = run.operational_state === "running";
             const targetDisplayName =
               run.target.kind === "managed_instance"
-                ? agentNameByInstanceId.get(run.target.agent_instance_id) ?? t("rework.evaluation.runs.targetManaged")
+                ? (agentNameByInstanceId.get(run.target.agent_instance_id) ?? t("rework.evaluation.runs.targetManaged"))
                 : run.target.agent_id;
             const targetId =
               run.target.kind === "managed_instance" ? run.target.agent_instance_id.slice(0, 8) : run.target.agent_id;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRuns.tsx
@@ -17,12 +17,14 @@
 // row here, which is exactly what makes two Runs comparable: they differ only by
 // the target/config each froze in its RunSnapshot.
 
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@shared/atoms/Button/Button";
 import { IndicatorDot } from "@shared/atoms/IndicatorDot/IndicatorDot";
 import { TaskStateBadge } from "@shared/atoms/TaskStateBadge/TaskStateBadge";
 import ProgressBar from "@shared/atoms/ProgressBar/ProgressBar";
+import Select from "@shared/molecules/Select/Select";
+import type { OptionModel } from "@models/Option.model.ts";
 import { Breadcrumb } from "@shared/molecules/Breadcrumb/Breadcrumb";
 import KpiStatCard from "@shared/molecules/KpiStatCard/KpiStatCard";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice";
@@ -30,6 +32,7 @@ import { InlineDrawer } from "@shared/molecules/InlineDrawer/InlineDrawer";
 import { ConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialog";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { FieldBlock, StatusPill, operationalToTaskState, scoreTone, verdictTone } from "./EvaluationShared";
+import { useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery } from "../../../../../../../slices/controlPlane/controlPlaneOpenApi";
 import {
   useDeleteRunEvaluationV1RunsRunIdDeleteMutation,
   useListRunCasesEvaluationV1RunsRunIdCasesGetQuery,
@@ -40,6 +43,12 @@ import {
 } from "../../../../../../../slices/evaluation/evaluationOpenApi";
 import styles from "./EvaluationRuns.module.css";
 
+// Server-side page size for the runs table. The backend caps limit at 200; this
+// stays well under it and keeps the table scannable at scale.
+const RUNS_PAGE_SIZE = 25;
+
+type RunSortValue = "created_at:desc" | "created_at:asc";
+
 interface EvaluationRunsProps {
   teamId: string;
   evaluationId: string;
@@ -49,13 +58,20 @@ interface EvaluationRunsProps {
   onOpenRun: (runId: string, selectedCaseId?: string) => void;
 }
 
-function targetLabel(target: EvaluationRun["target"], t: (k: string, o?: Record<string, unknown>) => string): string {
-  if (target.kind === "managed_instance") {
-    return t("rework.evaluation.runs.targetInstance", {
-      id: target.agent_instance_id.slice(0, 8),
-    });
+function buildAgentLabels(instances: Array<{ agent_instance_id: string; display_name: string }>): Map<string, string> {
+  const counts = new Map<string, number>();
+  for (const instance of instances) {
+    counts.set(instance.display_name, (counts.get(instance.display_name) ?? 0) + 1);
   }
-  return target.agent_id;
+  return new Map(
+    instances.map((instance) => {
+      const duplicated = (counts.get(instance.display_name) ?? 0) > 1;
+      const label = duplicated
+        ? `${instance.display_name} · ${instance.agent_instance_id.slice(0, 6)}`
+        : instance.display_name;
+      return [instance.agent_instance_id, label];
+    }),
+  );
 }
 
 // ── Case drawer ────────────────────────────────────────────────────────────
@@ -168,9 +184,20 @@ export default function EvaluationRuns({
   // flag, so relaunching one row doesn't disable every other row's Rerun button.
   const [reruningRunId, setReruningRunId] = useState<string | null>(null);
 
-  const { data, isLoading, isError, refetch } = useListRunsEvaluationV1EvaluationsEvaluationIdRunsGetQuery(
-    { evaluationId },
+  const [sort, setSort] = useState<RunSortValue>("created_at:desc");
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    setOffset(0);
+  }, [sort]);
+
+  const { data, isLoading, isError, isFetching, refetch } = useListRunsEvaluationV1EvaluationsEvaluationIdRunsGetQuery(
+    { evaluationId, sort, offset, limit: RUNS_PAGE_SIZE },
     { skip: !evaluationId, pollingInterval: 10_000 },
+  );
+  const { data: managedInstances = [] } = useGetTeamAgentInstancesControlPlaneV1TeamsTeamIdAgentInstancesGetQuery(
+    { teamId },
+    { skip: !teamId },
   );
   const [deleteRun, { isLoading: isDeleting }] = useDeleteRunEvaluationV1RunsRunIdDeleteMutation();
   const [startRun] = useStartRunEvaluationV1EvaluationsEvaluationIdRunsPostMutation();
@@ -187,7 +214,12 @@ export default function EvaluationRuns({
     }
   };
 
-  const runs = data ?? [];
+  // The list endpoint is now paginated: it returns { runs, total } rather than a
+  // bare array. `total` is the full server-side count (not this page's length).
+  const runs = data?.runs ?? [];
+  const total = data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / RUNS_PAGE_SIZE));
+  const currentPage = Math.floor(offset / RUNS_PAGE_SIZE) + 1;
   const running = runs.filter((run) => run.operational_state === "running").length;
   // operationalToTaskState is the canonical mapper (it also treats "succeeded"
   // as terminal-success, matching the backend's own documented either/or) —
@@ -196,16 +228,11 @@ export default function EvaluationRuns({
   const completed = runs.filter((run) => operationalToTaskState(run.operational_state) === "succeeded").length;
   const totalCases = runs.reduce((sum, run) => sum + run.completed_cases, 0);
   const criticalErrors = runs.reduce((sum, run) => sum + run.execution_error_cases, 0);
-
-  // Most recent run, sorted defensively — do not assume the API already
-  // orders by recency. Only a "managed_instance" target can be one-click
-  // rerun (see StartRunRequest); anything else falls back to "New run…".
-  const mostRecentRun = useMemo(
-    () => [...runs].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())[0] ?? null,
-    [runs],
-  );
-  const rerunManagedTarget = mostRecentRun?.target.kind === "managed_instance" ? mostRecentRun.target : null;
-  const rerunTargetLabel = mostRecentRun ? targetLabel(mostRecentRun.target, t) : "";
+  const agentNameByInstanceId = buildAgentLabels(managedInstances);
+  const sortOptions: OptionModel<RunSortValue>[] = [
+    { value: "created_at:desc", key: "newest", label: t("rework.evaluation.controls.sort.newest") },
+    { value: "created_at:asc", key: "oldest", label: t("rework.evaluation.controls.sort.oldest") },
+  ];
 
   // Reruns any given run of this evaluation — not just the most recent one. Reuses
   // that run's own target and exact metric selection ("New run…" but without having
@@ -263,31 +290,12 @@ export default function EvaluationRuns({
         </div>
         <div className={styles.headerActionsColumn}>
           <div className={styles.headerActions}>
+            {/* Rerun lives per-row in the runs table (each run can be relaunched
+                with its own target and metrics); the header only offers "New run". */}
             <Button color="on-surface" variant="outlined" size="medium" onClick={onNewRun}>
               {t("rework.evaluation.runs.newRun")}
             </Button>
-            {rerunManagedTarget && mostRecentRun && (
-              <Button
-                color="primary"
-                variant="filled"
-                size="medium"
-                disabled={reruningRunId === mostRecentRun.run_id}
-                onClick={() => handleRerunRun(mostRecentRun)}
-              >
-                {reruningRunId === mostRecentRun.run_id
-                  ? t("rework.evaluation.runCreate.starting")
-                  : t("rework.evaluation.runs.rerun", { target: rerunTargetLabel })}
-              </Button>
-            )}
           </div>
-          {rerunManagedTarget && (
-            <p className={styles.rerunHint}>
-              {t("rework.evaluation.runs.rerunHint", {
-                target: rerunTargetLabel,
-                model: rerunManagedTarget.agent_instance_id,
-              })}
-            </p>
-          )}
         </div>
       </div>
 
@@ -318,6 +326,17 @@ export default function EvaluationRuns({
         />
       </div>
 
+      <div className={styles.toolbar}>
+        <div className={styles.toolbarSpacer} />
+        <Select<RunSortValue>
+          size="medium"
+          options={sortOptions}
+          value={sort}
+          onChange={(value) => setSort(value)}
+          label={t("rework.evaluation.controls.sortLabel")}
+        />
+      </div>
+
       {!isLoading && runs.length === 0 && (
         <ServiceNotice icon="reviews" title={t("rework.evaluation.runs.empty")} centered />
       )}
@@ -325,17 +344,22 @@ export default function EvaluationRuns({
       {!isLoading && runs.length > 0 && (
         <div className={styles.table} role="table">
           <div className={`${styles.row} ${styles.headerRow}`} role="row">
-            <span>{t("rework.evaluation.runs.col.run")}</span>
-            <span>{t("rework.evaluation.runs.col.target")}</span>
-            <span>{t("rework.evaluation.runs.col.state")}</span>
-            <span>{t("rework.evaluation.runs.col.verdict")}</span>
-            <span>{t("rework.evaluation.runs.col.progress")}</span>
-            <span>{t("rework.evaluation.runs.col.scores")}</span>
-            <span />
+            <div className={styles.nameHeaderCell}>{t("rework.evaluation.runs.col.run")}</div>
+            <div className={styles.targetHeaderCell}>{t("rework.evaluation.runs.col.target")}</div>
+            <div className={styles.stateHeaderCell}>{t("rework.evaluation.runs.col.state")}</div>
+            <div className={styles.verdictHeaderCell}>{t("rework.evaluation.runs.col.verdict")}</div>
+            <div className={styles.progressHeaderCell}>{t("rework.evaluation.runs.col.progress")}</div>
+            <div className={styles.scoresHeaderCell}>{t("rework.evaluation.runs.col.judge")}</div>
+            <div className={styles.actionsHeaderCell} />
           </div>
-
           {runs.map((run) => {
             const isRunning = run.operational_state === "running";
+            const targetDisplayName =
+              run.target.kind === "managed_instance"
+                ? agentNameByInstanceId.get(run.target.agent_instance_id) ?? t("rework.evaluation.runs.targetManaged")
+                : run.target.agent_id;
+            const targetId =
+              run.target.kind === "managed_instance" ? run.target.agent_instance_id.slice(0, 8) : run.target.agent_id;
             return (
               <div
                 key={run.run_id}
@@ -356,13 +380,16 @@ export default function EvaluationRuns({
                     <div className={styles.mono}>{run.run_id.slice(0, 12)}</div>
                   </div>
                 </div>
-                <span className={styles.mono}>{targetLabel(run.target, t)}</span>
-                <span>
+                <div className={styles.targetCell}>
+                  <span className={styles.targetName}>{targetDisplayName}</span>
+                  <span className={styles.mono}>{targetId}</span>
+                </div>
+                <div className={styles.stateCell}>
                   <TaskStateBadge state={operationalToTaskState(run.operational_state)} />
-                </span>
-                <span>
+                </div>
+                <div className={styles.verdictCell}>
                   <StatusPill label={run.verdict} tone={verdictTone(run.verdict)} />
-                </span>
+                </div>
                 <div className={styles.progressCell}>
                   <span className={styles.muted}>
                     {run.completed_cases} / {run.total_cases}
@@ -370,10 +397,7 @@ export default function EvaluationRuns({
                   <ProgressBar theme="secondary" current={run.completed_cases} max={run.total_cases || 1} />
                 </div>
                 <div className={styles.scoresCell}>
-                  <div className={styles.scoreLine}>
-                    <span className={styles.muted}>{run.profile}</span>
-                    <StatusPill label={run.judge_profile_id} tone={scoreTone(run.verdict === "passed" ? 100 : 50)} />
-                  </div>
+                  <StatusPill label={run.judge_profile_id} tone={scoreTone(run.verdict === "passed" ? 100 : 50)} />
                 </div>
                 <div className={styles.actionsCell} onClick={(e) => e.stopPropagation()}>
                   <Button color="on-surface" variant="outlined" size="small" onClick={() => onOpenRun(run.run_id)}>
@@ -405,6 +429,30 @@ export default function EvaluationRuns({
               </div>
             );
           })}
+        </div>
+      )}
+
+      {!isLoading && total > RUNS_PAGE_SIZE && (
+        <div className={styles.pagination}>
+          <span>{t("rework.evaluation.controls.page", { current: currentPage, total: pageCount })}</span>
+          <Button
+            color="on-surface"
+            variant="outlined"
+            size="small"
+            disabled={offset === 0 || isFetching}
+            onClick={() => setOffset(Math.max(0, offset - RUNS_PAGE_SIZE))}
+          >
+            {t("rework.evaluation.controls.prev")}
+          </Button>
+          <Button
+            color="on-surface"
+            variant="outlined"
+            size="small"
+            disabled={currentPage >= pageCount || isFetching}
+            onClick={() => setOffset(offset + RUNS_PAGE_SIZE)}
+          >
+            {t("rework.evaluation.controls.next")}
+          </Button>
         </div>
       )}
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.module.css
@@ -55,6 +55,24 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+.toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-m);
+  flex-wrap: wrap;
+}
+.toolbarSearch {
+  flex: 1;
+  min-width: 220px;
+}
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-m);
+  color: var(--on-surface-retreat);
+  font: var(--font-label-medium);
+}
 
 .bodyRow {
   cursor: pointer;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.module.css
@@ -57,9 +57,9 @@
 }
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   gap: var(--spacing-m);
-  flex-wrap: wrap;
 }
 .toolbarSearch {
   flex: 1;
@@ -67,8 +67,8 @@
 }
 .pagination {
   display: flex;
-  align-items: center;
   justify-content: flex-end;
+  align-items: center;
   gap: var(--spacing-m);
   color: var(--on-surface-retreat);
   font: var(--font-label-medium);

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.tsx
@@ -16,9 +16,13 @@
 // AGENT-EVALUATION §8.5). An Evaluation is the versioned, reusable case set;
 // opening one shows its Runs. Creating one never starts a run.
 
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@shared/atoms/Button/Button";
+import TextInput from "@shared/atoms/TextInput/TextInput";
+import Select from "@shared/molecules/Select/Select";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice";
+import type { OptionModel } from "@models/Option.model.ts";
 import { StatusPill } from "./EvaluationShared";
 import { useListEvaluationsQuery } from "../../../../../../../slices/evaluation/evaluationApiEnhancements";
 import styles from "./Evaluations.module.css";
@@ -29,12 +33,47 @@ interface EvaluationsProps {
   onOpenEvaluation: (evaluationId: string, name: string) => void;
 }
 
+// One page holds enough to scan without scrolling forever; the server enforces its
+// own ceiling (limit ≤ 200), so this stays well within it.
+const PAGE_SIZE = 25;
+
+type SortValue = "created_at:desc" | "created_at:asc" | "name:asc";
+
 export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation }: EvaluationsProps) {
   const { t } = useTranslation();
 
-  const { data, isLoading, isError } = useListEvaluationsQuery({ teamId }, { skip: !teamId });
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [sort, setSort] = useState<SortValue>("created_at:desc");
+  const [offset, setOffset] = useState(0);
+
+  // Debounce the search box so each keystroke doesn't fire a request.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  // Any change to the filter or sort invalidates the current page offset —
+  // otherwise you could land on "page 5" of a result set that now has one page.
+  useEffect(() => {
+    setOffset(0);
+  }, [debouncedSearch, sort]);
+
+  const { data, isLoading, isError, isFetching } = useListEvaluationsQuery(
+    { teamId, q: debouncedSearch || undefined, sort, offset, limit: PAGE_SIZE },
+    { skip: !teamId },
+  );
 
   const evaluations = data?.evaluations ?? [];
+  const total = data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  const sortOptions: OptionModel<SortValue>[] = [
+    { value: "created_at:desc", key: "newest", label: t("rework.evaluation.controls.sort.newest") },
+    { value: "created_at:asc", key: "oldest", label: t("rework.evaluation.controls.sort.oldest") },
+    { value: "name:asc", key: "name", label: t("rework.evaluation.controls.sort.name") },
+  ];
 
   if (isError) {
     return (
@@ -59,6 +98,24 @@ export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation 
         <Button color="primary" variant="filled" size="medium" onClick={onNewEvaluation}>
           {t("rework.evaluation.evaluations.new")}
         </Button>
+      </div>
+
+      <div className={styles.toolbar}>
+        <div className={styles.toolbarSearch}>
+          <TextInput
+            icon={{ category: "outlined", type: "search" }}
+            placeholder={t("rework.evaluation.controls.searchEvaluations")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <Select<SortValue>
+          size="medium"
+          options={sortOptions}
+          value={sort}
+          onChange={(value) => setSort(value)}
+          label={t("rework.evaluation.controls.sortLabel")}
+        />
       </div>
 
       {isLoading && <p className={styles.muted}>{t("common.loading")}</p>}
@@ -111,6 +168,30 @@ export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation 
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {!isLoading && total > PAGE_SIZE && (
+        <div className={styles.pagination}>
+          <span>{t("rework.evaluation.controls.page", { current: currentPage, total: pageCount })}</span>
+          <Button
+            color="on-surface"
+            variant="outlined"
+            size="small"
+            disabled={offset === 0 || isFetching}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            {t("rework.evaluation.controls.prev")}
+          </Button>
+          <Button
+            color="on-surface"
+            variant="outlined"
+            size="small"
+            disabled={currentPage >= pageCount || isFetching}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            {t("rework.evaluation.controls.next")}
+          </Button>
         </div>
       )}
     </div>

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/evaluationExport.ts
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/evaluationExport.ts
@@ -1,0 +1,62 @@
+// Copyright Thales 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { downloadFile } from "../../../../../../../utils/downloadUtils";
+import type {
+  EvaluationCaseResponse,
+  RunReportResponse,
+} from "../../../../../../../slices/evaluation/evaluationOpenApi";
+
+// Bumped only when the exported envelope shape changes, so a consumer (a human or
+// an AI agent reading the dump) can tell which layout to expect. Independent of the
+// backend's own RunReportResponse.schema_version, which travels inside the payload.
+const CASE_EXPORT_SCHEMA_VERSION = "1";
+
+/** A single case exported as a self-describing, versioned envelope. */
+export interface EvaluationCaseExport {
+  schema_version: string;
+  kind: "evaluation_case";
+  exported_at: string;
+  case: EvaluationCaseResponse;
+}
+
+function saveJson(payload: unknown, filename: string): void {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  downloadFile(blob, filename);
+}
+
+/**
+ * Download one case as a typed, versioned JSON file — the shareable equivalent of
+ * the existing clipboard copy, but wrapped so the raw EvaluationCaseResponse isn't
+ * mistaken for a bare, unversioned blob.
+ */
+export function downloadCaseJson(caseData: EvaluationCaseResponse): void {
+  const envelope: EvaluationCaseExport = {
+    schema_version: CASE_EXPORT_SCHEMA_VERSION,
+    kind: "evaluation_case",
+    exported_at: new Date().toISOString(),
+    case: caseData,
+  };
+  saveJson(envelope, `evaluation-case-${caseData.case_id}.json`);
+}
+
+/**
+ * Download the whole run as a JSON file. The backend's run report is already a
+ * self-contained, versioned record (schema_version, evaluation, all cases,
+ * metric_averages, and the analysis when available), so it is exported as-is —
+ * no re-wrapping needed.
+ */
+export function downloadRunReportJson(report: RunReportResponse): void {
+  saveJson(report, `evaluation-run-${report.run.run_id}.json`);
+}

--- a/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
+++ b/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
@@ -24,7 +24,14 @@ const injectedRtkApi = api.injectEndpoints({
       ListRunsEvaluationV1EvaluationsEvaluationIdRunsGetApiResponse,
       ListRunsEvaluationV1EvaluationsEvaluationIdRunsGetApiArg
     >({
-      query: (queryArg) => ({ url: `/evaluation/v1/evaluations/${queryArg.evaluationId}/runs` }),
+      query: (queryArg) => ({
+        url: `/evaluation/v1/evaluations/${queryArg.evaluationId}/runs`,
+        params: {
+          offset: queryArg.offset,
+          limit: queryArg.limit,
+          sort: queryArg.sort,
+        },
+      }),
     }),
     getRunEvaluationV1RunsRunIdGet: build.query<
       GetRunEvaluationV1RunsRunIdGetApiResponse,
@@ -110,6 +117,10 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/evaluation/v1/evaluations`,
         params: {
           team_id: queryArg.teamId,
+          offset: queryArg.offset,
+          limit: queryArg.limit,
+          sort: queryArg.sort,
+          q: queryArg.q,
         },
       }),
     }),
@@ -171,9 +182,13 @@ export type StartRunEvaluationV1EvaluationsEvaluationIdRunsPostApiArg = {
   startRunRequest: StartRunRequest;
 };
 export type ListRunsEvaluationV1EvaluationsEvaluationIdRunsGetApiResponse =
-  /** status 200 Successful Response */ EvaluationRun[];
+  /** status 200 Successful Response */ EvaluationRunListResponse;
 export type ListRunsEvaluationV1EvaluationsEvaluationIdRunsGetApiArg = {
   evaluationId: string;
+  offset?: number;
+  limit?: number;
+  /** Sort as 'field:direction' (created_at, verdict, operational_state), e.g. 'created_at:desc'. */
+  sort?: string | null;
 };
 export type GetRunEvaluationV1RunsRunIdGetApiResponse = /** status 200 Successful Response */ EvaluationRun;
 export type GetRunEvaluationV1RunsRunIdGetApiArg = {
@@ -233,6 +248,12 @@ export type ListEvaluationsEvaluationV1EvaluationsGetApiResponse =
   /** status 200 Successful Response */ EvaluationListResponse;
 export type ListEvaluationsEvaluationV1EvaluationsGetApiArg = {
   teamId: string;
+  offset?: number;
+  limit?: number;
+  /** Sort as 'field:direction' (created_at, name, version), e.g. 'created_at:desc'. */
+  sort?: string | null;
+  /** Case-insensitive search on the evaluation name. */
+  q?: string | null;
 };
 export type DeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteApiResponse = unknown;
 export type DeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteApiArg = {
@@ -334,6 +355,7 @@ export type EvaluationRun = {
   run_id: string;
   evaluation_id: string;
   task_id: string | null;
+  created_by: string;
   target: ManagedInstanceTarget | RuntimeAgentTarget;
   profile: string;
   judge_profile_id: string;
@@ -352,6 +374,10 @@ export type EvaluationRun = {
   created_at: string;
   started_at: string | null;
   completed_at: string | null;
+};
+export type EvaluationRunListResponse = {
+  runs: EvaluationRun[];
+  total: number;
 };
 export type ValidationError = {
   loc: (string | number)[];

--- a/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
+++ b/apps/frontend/src/slices/evaluation/evaluationOpenApi.ts
@@ -33,6 +33,12 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
     }),
+    getRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGet: build.query<
+      GetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetApiResponse,
+      GetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetApiArg
+    >({
+      query: (queryArg) => ({ url: `/evaluation/v1/evaluations/${queryArg.evaluationId}/runs/summary` }),
+    }),
     getRunEvaluationV1RunsRunIdGet: build.query<
       GetRunEvaluationV1RunsRunIdGetApiResponse,
       GetRunEvaluationV1RunsRunIdGetApiArg
@@ -189,6 +195,11 @@ export type ListRunsEvaluationV1EvaluationsEvaluationIdRunsGetApiArg = {
   limit?: number;
   /** Sort as 'field:direction' (created_at, verdict, operational_state), e.g. 'created_at:desc'. */
   sort?: string | null;
+};
+export type GetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetApiResponse =
+  /** status 200 Successful Response */ EvaluationRunSummaryResponse;
+export type GetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetApiArg = {
+  evaluationId: string;
 };
 export type GetRunEvaluationV1RunsRunIdGetApiResponse = /** status 200 Successful Response */ EvaluationRun;
 export type GetRunEvaluationV1RunsRunIdGetApiArg = {
@@ -388,6 +399,13 @@ export type ValidationError = {
 };
 export type HttpValidationError = {
   detail?: ValidationError[];
+};
+export type EvaluationRunSummaryResponse = {
+  total_runs: number;
+  running_count: number;
+  completed_count: number;
+  total_cases_completed: number;
+  critical_error_cases: number;
 };
 export type EvaluationMetricResultResponse = {
   name: string;
@@ -616,6 +634,8 @@ export const {
   useStartRunEvaluationV1EvaluationsEvaluationIdRunsPostMutation,
   useListRunsEvaluationV1EvaluationsEvaluationIdRunsGetQuery,
   useLazyListRunsEvaluationV1EvaluationsEvaluationIdRunsGetQuery,
+  useGetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetQuery,
+  useLazyGetRunsSummaryEvaluationV1EvaluationsEvaluationIdRunsSummaryGetQuery,
   useGetRunEvaluationV1RunsRunIdGetQuery,
   useLazyGetRunEvaluationV1RunsRunIdGetQuery,
   useDeleteRunEvaluationV1RunsRunIdDeleteMutation,


### PR DESCRIPTION
# PR — Evaluation UI/backend polish: 6 fixes from a walkthrough

## 1. What problem does this solve — and where is it tracked?

**Issue:** #2141 — Evaluation UI/backend polish: 6 fixes from a walkthrough

**Problem in one sentence:** The evaluation settings UI had several product gaps and misleading behaviors — redundant rerun controls, no typed/versioned JSON export, no list scaling on evaluations/runs, missing run-author metadata, misleading scoring-profile wording, and a hardcoded "Back" that always dropped users on Agents.

**Backlog ref:** n/a — tracked directly in #2141. This is the frontend slice; the backend fixes (#3 list endpoints, #4 doc, #5 schema) live in the fred-agent-evaluator repo on branch `45-…` (separate PR).

## 2. Before you wrote a single line of code

- **RFC written?** Not required — frontend/product polish against an already-tracked issue. No new backend contract or design surface is introduced here; the UI consumes existing/generated API fields (`created_by`, paginated list params) that were added in the backend PR.
- **Plan presented?** Yes — the six fixes were scoped from the walkthrough issue and implemented incrementally with per-fix checkpoints.
- **Confirmation received?** Yes — implementation was explicitly requested and refined live during the session.

## 3. What you built

Frontend fixes for #2141 in `apps/frontend/src/rework/.../TeamSettingsEvaluations/` and `TeamContentNavbar.tsx`:

- **#1** — Removed the redundant header "Rerun" (most-recent) button; kept "+ New run". Per-row rerun stays. Dropped the now-dead `mostRecentRun`/`rerunManagedTarget` derivations.
- **#2** — Typed/versioned JSON export (`evaluationExport.ts`): case-level (`{schema_version, kind, exported_at, case}` download) next to the existing clipboard copy, and run-level (downloads the backend's already-versioned `RunReportResponse` — all cases + metric averages + analysis when present).
- **#3** — Search-by-name + sort + real pagination on the evaluations list; explicit sort + pagination on the runs list (both wired to the new offset/limit/sort/q + total backend contract).
- **#5 (frontend)** — Surfaced the run author (`created_by`) in the Run information panel; relabelled the misleading "Scoring profile" as the structural-check profile.
- **#6** — Settings/Usage "Back" is now history-based (`navigate(-1)`) with a fallback to the team's agents view when there's no history; both hardcoded branches fixed.
- Regenerated the evaluation OpenAPI client (`evaluationOpenApi.ts`) to pick up `created_by` and the paginated list contract.
- (The commit also carries agent-name labelling for run targets — `buildAgentLabels`/`managedInstances` — added on top of the above.)

## 4. Proof of quality

**Tests added or updated:**

| Test | File | What it covers |
|------|------|-----------------|
| none added | n/a | Frontend UI wiring + generated-client refresh. The existing suite (692 tests) still passes; see gap note below. |

**Honest gap:** the pagination offset/reset logic and `evaluationExport.ts` (envelope shape, filename) are unit-testable and currently have no dedicated test. Worth a follow-up.

**`make code-quality` (last lines):**

```
npx tsc --noEmit
npx prettier . --check
All matched files use Prettier code style!
npx eslint "src/**/*.{ts,tsx}"
All frontend code quality checks completed        (exit 0)
```

Note: 3 files in the original commit were unformatted — fixed with `prettier --write` (formatting-only, now uncommitted pending amend).

`basedpyright`: n/a — frontend-only PR, no Python package in this repo touched. (The backend baseline lives in the fred-agent-evaluator PR.)

**`make test` (summary):**

```
Test Files  66 passed (66)
     Tests  692 passed (692)
  Duration  20.52s
```

## 5. Docs updated

| What changed | File updated |
|---|---|
| Backlog `[ ]` item now done | n/a here — `EVAL-LLM-ANALYSIS-BACKLOG.md` (#4) is updated in the fred-agent-evaluator PR, not this repo |
| New behaviour, API field, or contract change | `evaluationOpenApi.ts` regenerated (generated client — the contract itself changed in the backend PR) |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — no backend contract file in this repo touched |
| UX component implemented or visual status changed | not updated — `docs/swift/ux/COMPONENT-UX.md` was not touched; these are polish edits to existing views, no new component. Flag if a status line is expected. |
| Phase progress row | n/a |
| WORKPLAN sprint item finished | n/a — frozen doc, tracking is GitHub #2141 |
| Code and a design doc now diverge | n/a |

## 6. Close-out statement

```
## Task close-out
- Code: frontend fixes for #2141 (#1 header rerun removed, #2 typed/versioned JSON export, #3 search/sort/pagination on both lists, #5 run author + relabelled profile, #6 history-based Back) + regenerated evaluation client; prettier applied to 3 unformatted files.
- Tests: none added (UI wiring + client refresh); existing suite green — 692 passed / 66 files. Gap: pagination + evaluationExport untested (follow-up).
- Docs updated: evaluationOpenApi.ts (generated). COMPONENT-UX.md not updated (no new component). Backend docs (#4) live in the fred-agent-evaluator PR.
- Backlog: none in this repo — tracked on GitHub #2141.
- Skipped steps: Step 1 RFC (not required — product polish, no new contract); Step 3.5 issue already exists (#2141).
```

## 7. Risk and rollback

**What breaks if this is wrong?** Purely the evaluation settings UI (list scaling, export buttons, run metadata, Back nav). No backend behavior, no shared component outside these views except `TeamContentNavbar` Back — worst case a wrong Back destination, non-destructive. Requires the backend PR (`45-…`) to be deployed for pagination/`created_by` to return data; against the old backend the lists still render (params ignored, author blank).

**How do we roll back?** Revert the frontend commit(s) on this branch — no migrations, no persisted state, no contract owned here.