### PR TITLE
fix(quota): release document storage on delete #2149 and enforce quota on untagged uploads #2150

### DIFF
--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -1807,6 +1807,7 @@ export type Identity = {
   version?: number;
   /** Human-friendly title for UI */
   title?: string | null;
+  /** DESCRIPTIVE only — extracted from the file's own embedded metadata (e.g. a PDF's /Author), so it is caller-supplied and untrusted. Never use it to identify an account or to attribute storage quota. */
   author?: string | null;
   created?: string | null;
   modified?: string | null;

--- a/apps/knowledge-flow-backend/alembic/backfill/backfill_storage_usage.py
+++ b/apps/knowledge-flow-backend/alembic/backfill/backfill_storage_usage.py
@@ -104,6 +104,9 @@ async def calculate_ingested_documents_sizes(session: AsyncSession, rebac) -> tu
     # Cache tags and team metadata existence to avoid duplicate queries
     tag_cache = {}
     team_existence_cache = {}
+    sentinel_tags: set[str] = set()
+    skipped_untagged = 0
+    skipped_untagged_bytes = 0
 
     for row in rows:
         doc = row.doc or {}
@@ -114,10 +117,24 @@ async def calculate_ingested_documents_sizes(session: AsyncSession, rebac) -> tu
 
         tag_ids = row.tag_ids or []
         if not tag_ids:
-            # Document has no tags, fallback to author
-            author = row.author or doc.get("identity", {}).get("author")
-            if author:
-                user_doc_sizes[author] = user_doc_sizes.get(author, 0) + doc_size
+            # Untagged documents are deliberately NOT counted.
+            #
+            # This branch used to read `row.author`, which raised AttributeError on
+            # the first untagged row — `DocumentMetadataRow` has no such column, so
+            # the whole reconciliation aborted for any deployment holding even one
+            # untagged document (#2149 review).
+            #
+            # It is not enough to read the author out of `doc` instead: that value
+            # comes from the file's own embedded metadata (a PDF's /Author), so it
+            # is caller-controlled and must never attribute quota. More
+            # fundamentally, an untagged document has no ReBAC parent, so nobody —
+            # not even its uploader — can delete it; charging it here would create
+            # usage that no route can ever release. The live accounting does not
+            # charge these documents either, so skipping keeps this script and the
+            # runtime in agreement. Making untagged documents impossible to
+            # create in the first place is tracked in docs/swift/issues/.
+            skipped_untagged += 1
+            skipped_untagged_bytes += doc_size
             continue
 
         # Each document can be tagged. We adjust storage for the tag owner.
@@ -135,12 +152,23 @@ async def calculate_ingested_documents_sizes(session: AsyncSession, rebac) -> tu
 
             owner_id = tag_row.owner_id
             if owner_id == "personal":
-                # Fallback to the author of the document
-                author = row.author or doc.get("identity", {}).get("author")
-                if author:
-                    owner_id = author
-                else:
-                    continue
+                # Second instance of the same defect: `row.author` does not exist
+                # on the model, so this crashed on any tag carrying the legacy
+                # "personal" sentinel. Falling back to the document's embedded
+                # author is not the fix either — it is caller-controlled and must
+                # never attribute quota (#2149 review). A tag created through
+                # `TagService.create_tag_for_user` stores the owner's uid, never
+                # this sentinel, so reaching here means legacy or imported data
+                # whose real owner cannot be determined. Skip it loudly rather
+                # than charging the wrong account.
+                # This script has no acting user, so it cannot resolve the sentinel
+                # the way the runtime does — `_resolve_storage_deltas` maps
+                # `owner_id == "personal"` to the *acting* user and charges them.
+                # Skipping while still writing an ABSOLUTE counter below would
+                # erase usage the runtime charged, manufacturing free quota. Refuse
+                # to run instead, and name the tags so they can be repaired.
+                sentinel_tags.add(tag_id)
+                continue
 
             # 2. Check ReBAC owner (teams)
             team_ids = []
@@ -177,6 +205,24 @@ async def calculate_ingested_documents_sizes(session: AsyncSession, rebac) -> tu
                     user_doc_sizes[real_user_id] = user_doc_sizes.get(real_user_id, 0) + doc_size
                 else:
                     user_doc_sizes[owner_id] = user_doc_sizes.get(owner_id, 0) + doc_size
+
+    if sentinel_tags:
+        raise RuntimeError(
+            "Cannot compute storage usage: "
+            f"{len(sentinel_tags)} tag(s) carry the legacy 'personal' owner sentinel "
+            f"({', '.join(sorted(sentinel_tags))}). This script has no acting user, so it cannot "
+            "attribute their documents the way the runtime does, and it writes absolute counters — "
+            "proceeding would erase usage the runtime already charged. Repair those tags to carry a "
+            "real owner id (TagService stores the owner's uid) and re-run. Refusing rather than "
+            "writing a wrong value."
+        )
+
+    if skipped_untagged:
+        logger.warning(
+            "Skipped %d untagged document(s) totalling %d bytes: they have no ReBAC parent and no deletable route, so charging them would create unreleasable usage.",
+            skipped_untagged,
+            skipped_untagged_bytes,
+        )
 
     return user_doc_sizes, team_doc_sizes
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
@@ -414,9 +414,20 @@ class IngestionController:
         return team_ids, user_ids
 
     async def _check_quota_before_upload(self, files: List[UploadFile], tags: List[str], user: KeycloakUser) -> None:
-        if not tags:
-            return
+        """Reject an upload that would exceed the owning team's or user's quota.
 
+        A tagless upload is checked against the uploader's personal quota, not
+        exempt: `tags` defaults to `[]`, so returning early here let any caller
+        bypass quota entirely by omitting tags (#2150).
+
+        This is defence in depth rather than a live hole. The workspace disables
+        its upload control unless the current node has a library
+        (`DocumentWorkspace.tsx`, `disabled={!currentTag}`), so the UI cannot
+        produce a tagless upload; the guard covers the API default and any future
+        caller. Untagged documents are also not charged anywhere — they have no
+        ReBAC parent, so nothing can reach or delete one, and quota charged to it
+        could never be released.
+        """
         total_upload_size = 0
         for f in files:
             file_size = getattr(f, "size", None)
@@ -431,6 +442,10 @@ class IngestionController:
             return
 
         team_ids, user_ids = await self._resolve_tag_owners(tags, user)
+        if not team_ids and not user_ids:
+            # Tagless (or entirely unresolvable) upload: it occupies the
+            # uploader's personal space, so check it against that quota.
+            user_ids = {user.uid}
 
         cfg = ApplicationContext.get_instance().get_config()
 
@@ -455,12 +470,20 @@ class IngestionController:
 
             user_store = get_user_store()
             for user_id_str in user_ids:
+                # Fail CLOSED: treating an unreadable counter as 0 turned any
+                # transient store error into a full quota bypass — a user at
+                # 90/100 could upload anything during a blip (#2150 review).
                 try:
                     user_uuid = UUID(user_id_str)
+                except ValueError:
+                    logger.warning("Cannot check personal quota for malformed user id '%s'; rejecting upload", user_id_str)
+                    raise HTTPException(status_code=400, detail="Cannot resolve the storage owner for this upload.")
+                try:
                     user_row = await user_store.find_user_by_id(user_uuid)
-                    current = user_row.current_resources_storage_size or 0 if user_row else 0
-                except (ValueError, Exception):  # noqa: BLE001
-                    current = 0
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Could not read personal storage usage for '%s'; rejecting upload: %s", user_id_str, exc)
+                    raise HTTPException(status_code=503, detail="Storage quota cannot be verified right now; please retry.")
+                current = user_row.current_resources_storage_size or 0 if user_row else 0
 
                 if current + total_upload_size > personal_limit:
                     limit_str = f"{personal_limit} bytes"

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/metadata/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/metadata/service.py
@@ -16,8 +16,22 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
+from uuid import UUID
 
-from fred_core import ORGANIZATION_ID, DocumentPermission, KeycloakUser, OrganizationPermission, RebacDisabledResult, RebacReference, Relation, RelationType, Resource, TagPermission, TeamMetadataStore
+from fred_core import (
+    ORGANIZATION_ID,
+    DocumentPermission,
+    KeycloakUser,
+    OrganizationPermission,
+    RebacDisabledResult,
+    RebacReference,
+    Relation,
+    RelationType,
+    Resource,
+    TagPermission,
+    TeamMetadataStore,
+    get_user_store,
+)
 from fred_core.common.team_id import TeamId
 from fred_core.documents.document_store import DocumentMetadataDeserializationError as MetadataDeserializationError
 from fred_core.documents.document_structures import (
@@ -28,7 +42,9 @@ from fred_core.documents.document_structures import (
     ProcessingStage,
     ProcessingStatus,
 )
+from fred_core.sql.async_session import make_session_factory
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from knowledge_flow_backend.application_context import ApplicationContext
 from knowledge_flow_backend.common.structures import (
@@ -502,16 +518,31 @@ class MetadataService:
             # Avoid duplicate tags
             tag_ids = metadata.tags.tag_ids or []
             if new_tag_id not in tag_ids:
+                previous_tag_ids = set(tag_ids)
                 tag_ids.append(new_tag_id)
                 metadata.tags.tag_ids = tag_ids
                 metadata.identity.modified = datetime.now(timezone.utc)
                 metadata.identity.last_modified_by = user.uid
-                await self.metadata_store.save_metadata(metadata)
+                # Save the tag and move the charge to the newly owning team/user in
+                # ONE transaction. Without the charge the document is free for its
+                # new owner and deleting it later decrements a counter that was
+                # never charged; doing it in a second transaction let the tag land
+                # while the charge silently failed (#2149 review findings).
+                await self._save_and_move_storage(metadata, old_tags=previous_tag_ids, new_tags=set(tag_ids), user=user)
                 await self._set_tag_as_parent_in_rebac(new_tag_id, metadata.document_uid, actor_uid=user.uid)
 
                 logger.info(f"[METADATA] Added tag '{new_tag_id}' to document '{metadata.document_name}' by '{user.uid}'")
             else:
-                logger.info(f"[METADATA] Tag '{new_tag_id}' already present on document '{metadata.document_name}' — no change.")
+                # The tag is already on the document, but the ReBAC parent write
+                # may not have happened: it runs after the metadata+quota
+                # transaction commits, so an OpenFGA failure leaves the tag stored
+                # with no relation, and this branch is where the client's retry
+                # lands. Short-circuiting here made that state permanent — the
+                # document stayed inaccessible and charged, with no way to repair
+                # it (#2149 review finding). The write is idempotent, so redoing
+                # it costs nothing and makes a retry actually converge.
+                logger.info(f"[METADATA] Tag '{new_tag_id}' already present on document '{metadata.document_name}' — reasserting its ReBAC parent.")
+                await self._set_tag_as_parent_in_rebac(new_tag_id, metadata.document_uid, actor_uid=user.uid)
 
         except Exception as e:
             logger.error(f"Error updating retrievable flag for {metadata.document_name}: {e}")
@@ -524,6 +555,11 @@ class MetadataService:
             if not metadata.tags or not metadata.tags.tag_ids or tag_id_to_remove not in metadata.tags.tag_ids:
                 logger.info(f"[METADATA] Tag '{tag_id_to_remove}' not found on document '{metadata.document_name}' — nothing to remove.")
                 return
+
+            # Snapshot the tags before mutating them: if this removal deletes the
+            # document, storage ownership has to be resolved from the tags it had,
+            # and the branch below leaves `tag_ids` empty.
+            original_tag_ids = set(metadata.tags.tag_ids)
 
             # Remove tag
             new_ids = [t for t in metadata.tags.tag_ids if t != tag_id_to_remove]
@@ -567,7 +603,12 @@ class MetadataService:
                     except Exception as e:
                         logger.warning(f"[CONTENT] Could not delete content for '{metadata.document_name}': {e}")
 
-                await self.metadata_store.delete_metadata(metadata.document_uid)
+                # Delete and release in one transaction: only the caller whose
+                # conditional DELETE matched a row releases (so a concurrent
+                # remover cannot credit the same bytes), and the counters commit
+                # with the delete rather than in a transaction that can fail
+                # separately and strand the bytes.
+                await self._delete_and_release(metadata, tag_ids=original_tag_ids, user_id=user.uid)
                 try:
                     from fred_core.kpi import KPIActor
 
@@ -592,7 +633,12 @@ class MetadataService:
             else:
                 metadata.identity.modified = datetime.now(timezone.utc)
                 metadata.identity.last_modified_by = user.uid
-                await self.metadata_store.save_metadata(metadata)
+                # Save and release the tag owner that no longer holds this document,
+                # in ONE transaction. Without the release a document shared across
+                # two libraries left the losing team charged forever; in a separate
+                # transaction the tag could move while the release failed silently
+                # (#2149 review findings).
+                await self._save_and_move_storage(metadata, old_tags=original_tag_ids, new_tags=set(new_ids), user=user)
                 logger.info(f"[METADATA] Removed tag '{tag_id_to_remove}' from document '{metadata.document_name}' by '{user.uid}'")
 
             await self._remove_tag_as_parent_in_rebac(tag_id_to_remove, metadata.document_uid)
@@ -694,11 +740,11 @@ class MetadataService:
                         exc,
                     )
 
-            await self.metadata_store.delete_metadata(metadata.document_uid)
+            deleted_tag_ids = set(metadata.tags.tag_ids or []) if metadata.tags else set()
+            await self._delete_and_release(metadata, tag_ids=deleted_tag_ids, user_id=user.uid)
 
-            if metadata.tags and metadata.tags.tag_ids:
-                for tag_id in metadata.tags.tag_ids:
-                    await self._remove_tag_as_parent_in_rebac(tag_id, metadata.document_uid)
+            for tag_id in deleted_tag_ids:
+                await self._remove_tag_as_parent_in_rebac(tag_id, metadata.document_uid)
         except MetadataNotFound:
             raise
         except Exception as exc:
@@ -1053,6 +1099,105 @@ class MetadataService:
                 exc,
             )
 
+    async def _save_and_move_storage(
+        self,
+        metadata: DocumentMetadata,
+        *,
+        old_tags: set[str],
+        new_tags: set[str],
+        user: KeycloakUser,
+    ) -> None:
+        """
+        Persist a document's new tag set and move its storage between owners,
+        atomically.
+
+        Why this exists:
+        - the tags decide *who* is charged, so changing them without accounting
+          left a document shared into a second library never charged to it, a
+          document removed from a library charged to it forever, and — once the
+          delete-time release existed — a delete crediting a team that never paid
+        - saving and adjusting in two transactions was not enough: the tag change
+          committed first, and `_adjust_team_storage` swallows its own errors, so a
+          failed counter update left the tag moved and the charge behind with no
+          signal. Both now commit together or not at all (#2149 review findings)
+
+        How to use:
+        - call with the tag sets from before and after the change; the size is
+          unchanged, so only ownership moves
+        - ReBAC parent writes stay OUTSIDE this transaction: OpenFGA is a separate
+          system that cannot join it, and holding a DB transaction across a network
+          call is what deadlocked the connection pool on the delete path
+        """
+        size = metadata.file.file_size_bytes or 0 if metadata.file else 0
+        if not size or old_tags == new_tags:
+            await self.metadata_store.save_metadata(metadata)
+            return
+
+        # Resolve before opening the transaction — resolution reads the tag store
+        # and calls ReBAC, and holding a pooled connection while asking for another
+        # exhausts the pool under a concurrent fan-out.
+        team_deltas, user_deltas = await self._resolve_storage_deltas(
+            old_size=size,
+            new_size=size,
+            old_tags=old_tags,
+            new_tags=new_tags,
+            user_id=user.uid,
+        )
+
+        engine = ApplicationContext.get_instance().get_pg_async_engine()
+        sessions = make_session_factory(engine)
+        async with sessions() as s:
+            async with s.begin():
+                await self.metadata_store.save_metadata(metadata, session=s)
+                await self._apply_storage_deltas(team_deltas, user_deltas, session=s)
+
+    async def _delete_and_release(
+        self,
+        metadata: DocumentMetadata,
+        *,
+        tag_ids: set[str],
+        user_id: str,
+    ) -> None:
+        """
+        Remove a document's metadata row and release its storage, atomically.
+
+        Why this exists:
+        - the two are one operation, not two. Splitting them let a concurrent
+          deleter release bytes it did not remove, and let a counter failure
+          strand bytes whose document was already gone — neither recoverable
+          once the row is deleted (#2149 review findings)
+        - the conditional DELETE is the exactly-once gate: only the caller whose
+          statement matched a row releases, and its row lock is held until the
+          counters commit alongside it
+
+        How to use:
+        - call with the tags the document had *before* any removal mutated them
+        - deltas are resolved before the transaction opens, so no DB transaction
+          is held across the ReBAC lookups ownership resolution performs
+        """
+        # Resolve BEFORE opening the transaction. Resolution reads the tag store
+        # and calls ReBAC, so doing it inside would hold one pooled connection
+        # while asking for another; a concurrent delete fan-out then exhausts the
+        # pool, and because accounting errors used to be swallowed the metadata
+        # delete still committed — releasing nothing and recreating the very
+        # phantom-quota drift this fix exists to remove (#2149).
+        team_deltas, user_deltas = await self._resolve_storage_deltas(
+            old_size=metadata.file.file_size_bytes or 0 if metadata.file else 0,
+            new_size=0,
+            old_tags=tag_ids,
+            new_tags=set(),
+            user_id=user_id,
+        )
+
+        engine = ApplicationContext.get_instance().get_pg_async_engine()
+        sessions = make_session_factory(engine)
+        # Failures propagate: the transaction rolls back, so the row survives and
+        # can be deleted again, rather than vanishing with its quota still charged.
+        async with sessions() as s:
+            async with s.begin():
+                if await self.metadata_store.delete_metadata(metadata.document_uid, session=s):
+                    await self._apply_storage_deltas(team_deltas, user_deltas, session=s)
+
     async def _adjust_team_storage(
         self,
         *,
@@ -1061,103 +1206,193 @@ class MetadataService:
         old_tags: set[str],
         new_tags: set[str],
         user_id: str | None = None,
+        session: AsyncSession | None = None,
     ) -> None:
         """
         Compare old and new document properties (tags and size) and apply deltas
         to the storage sizes of the associated teams or users (personal spaces).
+
+        Resolution and application are separate: this method does both, for
+        callers holding no transaction of their own. A caller that already has
+        one MUST instead call `_resolve_storage_deltas` first and pass the result
+        to `_apply_storage_deltas` inside its transaction — resolving while a
+        transaction is open borrows a second pooled connection for the tag
+        lookup, and a concurrent fan-out then exhausts the pool and deadlocks
+        (`QueuePool limit of size 2 reached`, observed deleting a 10-document
+        library against a live stack).
         """
         try:
-            all_tags = old_tags | new_tags
-            if not all_tags:
-                return
+            team_deltas, user_deltas = await self._resolve_storage_deltas(
+                old_size=old_size,
+                new_size=new_size,
+                old_tags=old_tags,
+                new_tags=new_tags,
+                user_id=user_id,
+            )
+            await self._apply_storage_deltas(team_deltas, user_deltas, session=session)
+        except Exception:
+            logger.exception(
+                "Failed to update team or user storage size (old_size=%d, new_size=%d, old_tags=%s, new_tags=%s)",
+                old_size,
+                new_size,
+                sorted(old_tags),
+                sorted(new_tags),
+            )
 
-            tag_store = ApplicationContext.get_instance().get_tag_store()
-            team_deltas = {}
-            user_deltas = {}
+    async def _resolve_storage_deltas(
+        self,
+        *,
+        old_size: int,
+        new_size: int,
+        old_tags: set[str],
+        new_tags: set[str],
+        user_id: str | None = None,
+    ) -> tuple[dict[str, int], dict[str, int]]:
+        """
+        Work out which team and personal counters move, and by how much.
 
-            for tag_id in all_tags:
-                tag = await tag_store.get_tag_by_id(tag_id)
-                if not tag or not tag.owner_id:
-                    continue
+        Why this exists:
+        - resolving ownership reads the tag store and calls ReBAC, each needing
+          its own connection. Doing that while the caller's transaction is open
+          holds one pooled connection while asking for another, so a concurrent
+          delete fan-out exhausts the pool and every removal times out. Resolve
+          first, then open the transaction.
 
-                owner_id = tag.owner_id
-                if owner_id == "personal" and user_id:
-                    owner_id = str(user_id)
+        How to use:
+        - call before starting a transaction, then hand both dicts to
+          `_apply_storage_deltas` inside it
 
-                team_ids = []
+        Returns `(team_deltas, user_deltas)`, each mapping an owner id to a byte
+        delta; both empty when nothing moves.
+        """
+        team_deltas: dict[str, int] = {}
+        user_deltas: dict[str, int] = {}
+
+        all_tags = old_tags | new_tags
+        if not all_tags:
+            # An untagged document is deliberately NOT accounted for here.
+            # It has no ReBAC parent (permissions derive from a tag), so its
+            # own uploader cannot read, tag or delete it — charging it would
+            # consume quota that no route can ever release. Giving untagged
+            # documents a real personal owner needs an authorization-model
+            # change and is tracked separately (#2150 + RFC).
+            return team_deltas, user_deltas
+
+        tag_store = ApplicationContext.get_instance().get_tag_store()
+
+        for tag_id in all_tags:
+            tag = await tag_store.get_tag_by_id(tag_id)
+            if not tag or not tag.owner_id:
+                continue
+
+            owner_id = tag.owner_id
+            if owner_id == "personal" and user_id:
+                owner_id = str(user_id)
+
+            team_ids = []
+            try:
+                from fred_core import RebacDisabledResult, RebacReference, RelationType, Resource
+
+                subjects = await self.rebac.lookup_subjects(RebacReference(type=Resource.TAGS, id=tag.id), RelationType.OWNER, Resource.TEAM)
+                if not isinstance(subjects, RebacDisabledResult) and subjects:
+                    for sub in subjects:
+                        if sub.id != "personal" and not sub.id.startswith("personal-"):
+                            team_ids.append(sub.id)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Could not resolve team owners via ReBAC for tag '%s'; falling back to team metadata lookup: %s",
+                    tag.id,
+                    exc,
+                )
+
+            if not team_ids and not owner_id.startswith("personal-"):
                 try:
-                    from fred_core import RebacDisabledResult, RebacReference, RelationType, Resource
-
-                    subjects = await self.rebac.lookup_subjects(RebacReference(type=Resource.TAGS, id=tag.id), RelationType.OWNER, Resource.TEAM)
-                    if not isinstance(subjects, RebacDisabledResult) and subjects:
-                        for sub in subjects:
-                            if sub.id != "personal" and not sub.id.startswith("personal-"):
-                                team_ids.append(sub.id)
+                    engine = ApplicationContext.get_instance().get_pg_async_engine()
+                    store = TeamMetadataStore(engine)
+                    meta = await store.get_by_team_id(TeamId(owner_id))
+                    if meta is not None:
+                        team_ids.append(owner_id)
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
-                        "Could not resolve team owners via ReBAC for tag '%s'; falling back to team metadata lookup: %s",
+                        "Could not confirm team ownership for tag '%s' via team metadata lookup: %s",
                         tag.id,
                         exc,
                     )
 
-                if not team_ids and not owner_id.startswith("personal-"):
-                    try:
-                        engine = ApplicationContext.get_instance().get_pg_async_engine()
-                        store = TeamMetadataStore(engine)
-                        meta = await store.get_by_team_id(TeamId(owner_id))
-                        if meta is not None:
-                            team_ids.append(owner_id)
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "Could not confirm team ownership for tag '%s' via team metadata lookup: %s",
-                            tag.id,
-                            exc,
-                        )
+            is_old = tag_id in old_tags
+            is_new = tag_id in new_tags
 
-                is_old = tag_id in old_tags
-                is_new = tag_id in new_tags
+            if is_new and not is_old:
+                delta = new_size
+            elif is_new and is_old:
+                delta = new_size - old_size
+            else:  # is_old and not is_new
+                delta = -old_size
 
-                if is_new and not is_old:
-                    delta = new_size
-                elif is_new and is_old:
-                    delta = new_size - old_size
-                else:  # is_old and not is_new
-                    delta = -old_size
+            if team_ids:
+                for team_id in team_ids:
+                    team_deltas[team_id] = team_deltas.get(team_id, 0) + delta
+            else:
+                resolved_user_id = owner_id
+                if resolved_user_id.startswith("personal-"):
+                    resolved_user_id = resolved_user_id[len("personal-") :]
+                user_deltas[resolved_user_id] = user_deltas.get(resolved_user_id, 0) + delta
 
-                if team_ids:
-                    for team_id in team_ids:
-                        team_deltas[team_id] = team_deltas.get(team_id, 0) + delta
-                else:
-                    resolved_user_id = owner_id
-                    if resolved_user_id.startswith("personal-"):
-                        resolved_user_id = resolved_user_id[len("personal-") :]
-                    user_deltas[resolved_user_id] = user_deltas.get(resolved_user_id, 0) + delta
+        return team_deltas, user_deltas
 
-            if team_deltas:
-                engine = ApplicationContext.get_instance().get_pg_async_engine()
-                store = TeamMetadataStore(engine)
-                for team_id, delta in team_deltas.items():
-                    if delta != 0:
-                        await store.increment_current_storage_size(TeamId(team_id), delta)
+    async def _apply_storage_deltas(
+        self,
+        team_deltas: dict[str, int],
+        user_deltas: dict[str, int],
+        *,
+        session: AsyncSession | None = None,
+    ) -> None:
+        """
+        Apply already-resolved storage deltas to team and personal counters.
 
-            if user_deltas:
-                from uuid import UUID
+        Why this exists:
+        - every counter a single document touches must move together or not at
+          all. Applying them one transaction at a time meant a failure partway
+          through left team A decremented and team B still charged, with the
+          metadata row already gone and no way to reconstruct the remainder
+          (#2149 review finding)
+        - ownership resolution calls ReBAC over the network, so it stays in
+          `_adjust_team_storage` and only these writes run inside the caller's
+          transaction — a DB transaction is never held open across OpenFGA
 
-                from fred_core import get_user_store
+        How to use:
+        - pass the caller's `session` so the counters commit atomically with the
+          metadata delete that triggered them; omit it for a standalone
+          adjustment, which then gets its own transaction
+        """
+        if not team_deltas and not user_deltas:
+            return
 
+        engine = ApplicationContext.get_instance().get_pg_async_engine()
+        team_store = TeamMetadataStore(engine)
+        user_store = get_user_store()
+
+        async def _apply(s: AsyncSession) -> None:
+            for team_id, delta in team_deltas.items():
+                if delta != 0:
+                    await team_store.increment_current_storage_size(TeamId(team_id), delta, session=s)
+            for user_id_str, delta in user_deltas.items():
+                if delta == 0:
+                    continue
                 try:
-                    user_store = get_user_store()
-                    for user_id_str, delta in user_deltas.items():
-                        if delta != 0:
-                            try:
-                                user_uuid = UUID(user_id_str)
-                                await user_store.increment_current_storage_size(user_uuid, delta)
-                            except ValueError:
-                                logger.warning(f"Invalid user_id format during storage adjustment: '{user_id_str}'")
-                except Exception as ue:
-                    logger.warning(f"Failed to increment user personal space storage: {ue}")
-        except Exception:
-            logger.exception("Failed to update team or user storage size")
+                    user_uuid = UUID(user_id_str)
+                except ValueError:
+                    logger.warning("Invalid user_id format during storage adjustment: '%s'", user_id_str)
+                    continue
+                await user_store.increment_current_storage_size(user_uuid, delta, session=s)
+
+        if session is not None:
+            await _apply(session)
+            return
+        sessions = make_session_factory(engine)
+        async with sessions() as s:
+            async with s.begin():
+                await _apply(s)
 
     async def _handle_tag_timestamp_updates(self, user: KeycloakUser, document_uid: str, new_tags: list[str]) -> None:
         """

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/tag/tag_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/tag/tag_service.py
@@ -59,6 +59,12 @@ from knowledge_flow_backend.features.users.users_service import UserSummary, get
 
 logger = logging.getLogger(__name__)
 
+# How many documents to detach from a tag at once when deleting it. Each removal
+# holds a pooled DB connection and updates the owning counter, so this bounds
+# both pool usage and write contention on a single row (#2149 review). Kept
+# comfortably under the production pool size rather than tuned to it.
+_TAG_ITEM_DELETE_BATCH = 5
+
 
 class TagService:
     """
@@ -114,7 +120,11 @@ class TagService:
         if path_prefix:
             prefix = self._normalize_path(path_prefix)
             if prefix:
-                tags = [t for t in tags if self._full_path_of(t).startswith(prefix)]
+                # Match on a path boundary, not a raw string prefix: plain
+                # `startswith` made "/Sales" also select "/Salesforce", so
+                # deleting one library silently deleted a sibling whose name
+                # merely began with the same characters (#2149 review).
+                tags = [t for t in tags if self._full_path_of(t) == prefix or self._full_path_of(t).startswith(prefix.rstrip("/") + "/")]
 
         # 4) stable sort by full_path (optional but nice for UI determinism)
         tags.sort(key=lambda t: self._full_path_of(t).lower())
@@ -323,20 +333,37 @@ class TagService:
         tag = await self._tag_store.get_tag_by_id(tag_id)
 
         # Get all sub tags (recusrively) and the current tag
-        sub_tags = await self.list_all_tags_for_user(user, tag.type, path_prefix=tag.full_path)
+        # No UI pagination here: the default limit is a page size, and a tree
+        # larger than one page would be deleted only partially, leaving orphaned
+        # sub-tags and their documents' storage charged (#2149 review).
+        sub_tags = await self.list_all_tags_for_user(user, tag.type, path_prefix=tag.full_path, limit=1_000_000)
 
-        # Delete all of them
-        await asyncio.gather(*(self._delete_one_tag(sub_tag, user) for sub_tag in sub_tags))
+        # Delete them one tag at a time, NOT with asyncio.gather. A document
+        # carrying both a parent and a descendant tag is touched by two of these
+        # tasks; run concurrently, each loaded its own metadata copy, removed a
+        # different tag, saw a tag still remaining and saved — so the document was
+        # never deleted, its storage never released, and it kept referencing tag
+        # rows that both tasks then removed (#2149 review finding). The item-level
+        # fan-out inside `_delete_one_tag` is untouched: those are distinct
+        # documents with no shared row.
+        for sub_tag in sub_tags:
+            await self._delete_one_tag(sub_tag, user)
 
     async def _delete_one_tag(self, tag: Tag, user: KeycloakUser):
         await self.rebac.check_user_permission_or_raise(user, TagPermission.DELETE, tag.id)
         item_service = get_specific_tag_item_service(tag.type)
 
-        # Remove tag on all items (and delete them if they have no tag anymore)
+        # Remove tag on all items (and delete them if they have no tag anymore).
+        # Bounded batches, not one coroutine per document: each removal takes a
+        # pooled DB connection and writes the owning team's counter, so an
+        # unbounded gather over a large library exhausted the connection pool and
+        # piled every write onto one contended row (#2149 review).
         item_ids = await item_service.retrieve_items_ids_for_tag(user, tag.id)
-        await asyncio.gather(
-            *(item_service.remove_tag_id_from_item(user, item_id, tag.id) for item_id in item_ids),
-        )
+        for start in range(0, len(item_ids), _TAG_ITEM_DELETE_BATCH):
+            batch = item_ids[start : start + _TAG_ITEM_DELETE_BATCH]
+            await asyncio.gather(
+                *(item_service.remove_tag_id_from_item(user, item_id, tag.id) for item_id in batch),
+            )
 
         # Remove tag
         await self._tag_store.delete_tag_by_id(tag.id)

--- a/apps/knowledge-flow-backend/tests/conftest.py
+++ b/apps/knowledge-flow-backend/tests/conftest.py
@@ -105,8 +105,9 @@ class _InMemoryTestMetadataStore(BaseMetadataStore):
     async def save_metadata(self, metadata: DocumentMetadata, session=None) -> None:
         self._items[metadata.document_uid] = metadata.model_copy(deep=True)
 
-    async def delete_metadata(self, document_uid: str, session=None) -> None:
-        self._items.pop(document_uid, None)
+    async def delete_metadata(self, document_uid: str, session=None) -> bool:
+        # Mirrors the store contract: True only when this call removed the row.
+        return self._items.pop(document_uid, None) is not None
 
     async def clear(self, session=None) -> None:
         self._items.clear()

--- a/apps/knowledge-flow-backend/tests/features/ingestion/test_upload_quota_guard.py
+++ b/apps/knowledge-flow-backend/tests/features/ingestion/test_upload_quota_guard.py
@@ -1,0 +1,163 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""#2150 — `_check_quota_before_upload` must not be bypassable.
+
+The guard used to `return` immediately when `tags` was empty, and `tags` is the
+request default, so omitting tags skipped storage quota entirely. It also read
+the personal counter inside a bare `except Exception: current = 0`, turning any
+transient store error into a second bypass.
+
+These drive the real controller method with fake stores and assert on accept vs
+reject, which is what the issue's acceptance criteria are stated in terms of.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import fred_core
+import pytest
+from fastapi import HTTPException
+
+from knowledge_flow_backend.features.ingestion import ingestion_controller as controller_module
+from knowledge_flow_backend.features.ingestion.ingestion_controller import IngestionController
+
+PERSONAL_LIMIT = 10_000
+
+
+def _user(uid: str) -> fred_core.KeycloakUser:
+    return fred_core.KeycloakUser(uid=uid, username=uid, email=f"{uid}@localhost", roles=["user"])
+
+
+class _File:
+    """Stands in for `UploadFile`; `size` may be absent, which the guard handles
+    by seeking to the end of the stream."""
+
+    def __init__(self, size: int | None, *, stream_size: int | None = None):
+        self.size = size
+        self._stream_size = stream_size if stream_size is not None else (size or 0)
+        self.file = _Stream(self._stream_size)
+
+
+class _Stream:
+    def __init__(self, size: int):
+        self._size = size
+        self.pos = 0
+
+    def seek(self, offset: int, whence: int = 0) -> None:
+        self.pos = self._size if whence == 2 else offset
+
+    def tell(self) -> int:
+        return self.pos
+
+
+def _install(monkeypatch, *, current_usage: int, personal_limit: int | None = PERSONAL_LIMIT, read_raises: bool = False):
+    class _FakeUserStore:
+        async def find_user_by_id(self, user_uuid):
+            if read_raises:
+                raise RuntimeError("postgres unavailable")
+            return SimpleNamespace(current_resources_storage_size=current_usage)
+
+    monkeypatch.setattr(controller_module, "get_user_store", lambda: _FakeUserStore(), raising=False)
+    # `_check_quota_before_upload` imports `get_user_store` from `fred_core`
+    # inside the function body, so the patch has to land on the module object.
+    monkeypatch.setattr(fred_core, "get_user_store", lambda: _FakeUserStore())
+
+    cfg = SimpleNamespace(app=SimpleNamespace(personal_max_resources_storage_size=personal_limit, default_team_max_resources_storage_size=None))
+    monkeypatch.setattr(
+        controller_module.ApplicationContext,
+        "get_instance",
+        staticmethod(lambda: SimpleNamespace(get_config=lambda: cfg)),
+    )
+
+
+def _controller(monkeypatch, *, team_ids=None, user_ids=None):
+    ctrl = IngestionController.__new__(IngestionController)
+
+    async def _fake_resolve(tags, user):
+        return set(team_ids or []), set(user_ids or [])
+
+    ctrl._resolve_tag_owners = _fake_resolve  # type: ignore[method-assign]
+    return ctrl
+
+
+@pytest.mark.asyncio
+async def test_tagless_upload_within_personal_quota_is_accepted(monkeypatch) -> None:
+    """AC1 — a tagless upload under the personal limit still goes through."""
+    _install(monkeypatch, current_usage=1_000)
+    ctrl = _controller(monkeypatch)
+    await ctrl._check_quota_before_upload([_File(2_000)], [], _user(str(uuid4())))  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_tagless_upload_over_personal_quota_is_rejected(monkeypatch) -> None:
+    """AC2 — the bypass itself: before the fix this returned early and accepted
+    an upload of any size, because `tags` defaults to `[]`."""
+    _install(monkeypatch, current_usage=9_000)
+    ctrl = _controller(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        await ctrl._check_quota_before_upload([_File(2_000)], [], _user(str(uuid4())))  # type: ignore[arg-type]
+    assert exc.value.status_code == 400
+    assert "quota exceeded" in str(exc.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_tagged_upload_still_resolves_its_tag_owners(monkeypatch) -> None:
+    """AC3 — tagged uploads keep the existing behaviour: the check follows the
+    tag's owner, not the uploader, so the tagless fallback must not hijack it."""
+    _install(monkeypatch, current_usage=9_000)
+    seen: list[str] = []
+
+    ctrl = IngestionController.__new__(IngestionController)
+
+    async def _fake_resolve(tags, user):
+        seen.extend(tags)
+        return set(), {str(uuid4())}  # a personal-owned tag, owner != uploader
+
+    ctrl._resolve_tag_owners = _fake_resolve  # type: ignore[method-assign]
+
+    with pytest.raises(HTTPException):
+        await ctrl._check_quota_before_upload([_File(2_000)], ["tag-a"], _user(str(uuid4())))  # type: ignore[arg-type]
+    assert seen == ["tag-a"]
+
+
+@pytest.mark.asyncio
+async def test_upload_size_is_measured_when_the_file_reports_no_size(monkeypatch) -> None:
+    """AC4 — both size branches. With `size=None` the guard measures the stream,
+    so an over-quota upload is still rejected rather than counted as 0 bytes."""
+    _install(monkeypatch, current_usage=9_000)
+    ctrl = _controller(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        await ctrl._check_quota_before_upload([_File(None, stream_size=2_000)], [], _user(str(uuid4())))  # type: ignore[arg-type]
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_counter_rejects_instead_of_assuming_zero(monkeypatch) -> None:
+    """The guard must fail CLOSED. Treating a store error as `current = 0` let a
+    user at 90% of quota upload anything at all during a transient blip."""
+    _install(monkeypatch, current_usage=9_000, read_raises=True)
+    ctrl = _controller(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        await ctrl._check_quota_before_upload([_File(2_000)], [], _user(str(uuid4())))  # type: ignore[arg-type]
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_no_personal_limit_configured_leaves_uploads_unrestricted(monkeypatch) -> None:
+    """Regression guard: the tagless fallback must not invent a limit where the
+    deployment configured none."""
+    _install(monkeypatch, current_usage=10**9, personal_limit=None)
+    ctrl = _controller(monkeypatch)
+    await ctrl._check_quota_before_upload([_File(2_000)], [], _user(str(uuid4())))  # type: ignore[arg-type]

--- a/apps/knowledge-flow-backend/tests/features/test_metadata_audit.py
+++ b/apps/knowledge-flow-backend/tests/features/test_metadata_audit.py
@@ -80,9 +80,10 @@ class _FakeMetadataStore:
         self.docs[metadata.document_uid] = metadata
         self.saved.append(metadata.document_uid)
 
-    async def delete_metadata(self, document_uid: str) -> None:
-        self.docs.pop(document_uid, None)
+    async def delete_metadata(self, document_uid: str) -> bool:
+        removed = self.docs.pop(document_uid, None) is not None
         self.deleted.append(document_uid)
+        return removed
 
 
 class _FakeContentStore:

--- a/apps/knowledge-flow-backend/tests/features/test_metadata_service_storage_release.py
+++ b/apps/knowledge-flow-backend/tests/features/test_metadata_service_storage_release.py
@@ -1,0 +1,434 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""#2149 — permanently deleting a document must give its storage quota back.
+
+Usage is charged on save (`_persist_metadata_and_follow_up` →
+`_adjust_team_storage`), but both hard-delete paths used to drop the metadata
+row without ever releasing it. Normal upload/delete cycles therefore drifted
+`current_resources_storage_size` upward until valid uploads were rejected by a
+phantom quota exhaustion.
+
+These tests drive the two real delete entry points against fake stores and
+assert on the deltas that reach the team/user counters, rather than asserting
+that some helper was called — the counter is what the bug was about.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fred_core import KeycloakUser
+from fred_core.documents.document_structures import (
+    AccessInfo,
+    DocumentMetadata,
+    FileInfo,
+    Identity,
+    Processing,
+    SourceInfo,
+    SourceType,
+    Tagging,
+)
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from knowledge_flow_backend.features.metadata import service as service_module
+from knowledge_flow_backend.features.metadata.service import MetadataService
+
+DOC_SIZE = 4096
+
+
+def _make_metadata(
+    uid: str,
+    *,
+    tag_ids: list[str],
+    size: int | None = DOC_SIZE,
+    author: str | None = None,
+) -> DocumentMetadata:
+    return DocumentMetadata(
+        identity=Identity(
+            document_name=f"{uid}.pdf",
+            document_uid=uid,
+            title=uid,
+            author=author,
+            modified=datetime.now(timezone.utc),
+        ),
+        source=SourceInfo(source_type=SourceType.PUSH, source_tag="uploads", pull_location=None, date_added_to_kb=datetime.now(timezone.utc)),
+        file=FileInfo(file_size_bytes=size),
+        tags=Tagging(tag_ids=tag_ids),
+        processing=Processing(),
+        access=AccessInfo(),
+    )
+
+
+class _PermissiveRebac:
+    """Grants every permission; `lookup_subjects` returns the team owners the
+    test wants `_adjust_team_storage` to resolve for a tag."""
+
+    def __init__(self, team_owners: list[str] | None = None):
+        self._team_owners = team_owners or []
+
+    async def check_user_permission_or_raise(self, user, permission, resource_id, consistency_token=None) -> None:
+        return None
+
+    async def lookup_subjects(self, reference, relation, resource):
+        return [SimpleNamespace(id=team_id) for team_id in self._team_owners]
+
+
+class _FakeMetadataStore:
+    """Emulates the store contract: `delete_metadata` reports whether *this*
+    call removed the row. `row_already_deleted` simulates the concurrent loser —
+    it still holds the metadata it loaded, but the row is gone by the time its
+    conditional DELETE runs."""
+
+    def __init__(
+        self,
+        metadata: DocumentMetadata | None,
+        *,
+        delete_raises: Exception | None = None,
+        row_already_deleted: bool = False,
+    ):
+        self._metadata = metadata
+        self._delete_raises = delete_raises
+        self.row_already_deleted = row_already_deleted
+        self.deleted: list[str] = []
+        self.save_sessions: list[object] = []
+
+    async def get_metadata_by_uid(self, uid: str) -> DocumentMetadata | None:
+        return self._metadata
+
+    async def delete_metadata(self, uid: str, session=None) -> bool:
+        if self._delete_raises is not None:
+            raise self._delete_raises
+        if self._metadata is None or self.row_already_deleted:
+            return False
+        self.deleted.append(uid)
+        self._metadata = None
+        return True
+
+    async def save_metadata(self, metadata: DocumentMetadata, session=None) -> None:
+        self._metadata = metadata
+        self.save_sessions.append(session)
+
+
+def _install_fakes(monkeypatch, *, tag_owner: str, known_teams: set[str]) -> tuple[list[tuple[str, int]], list[tuple[str, int]]]:
+    """Wire the ambient singletons `_adjust_team_storage` reaches for.
+
+    Returns the two recording lists: team increments and user increments, each
+    as (id, delta) — the deltas are the assertion surface for every test here.
+    """
+    team_increments: list[tuple[str, int]] = []
+    user_increments: list[tuple[str, int]] = []
+
+    class _FakeTeamStore:
+        def __init__(self, engine):
+            pass
+
+        async def get_by_team_id(self, team_id):
+            return SimpleNamespace(id=str(team_id)) if str(team_id) in known_teams else None
+
+        async def increment_current_storage_size(self, team_id, delta, session=None):
+            team_increments.append((str(team_id), delta))
+
+    class _FakeUserStore:
+        async def increment_current_storage_size(self, user_id, delta, session=None):
+            user_increments.append((str(user_id), delta))
+
+    monkeypatch.setattr(service_module, "TeamMetadataStore", _FakeTeamStore)
+    monkeypatch.setattr(service_module, "get_user_store", lambda: _FakeUserStore())
+
+    # A real (empty) SQLite engine: the delete+release path now opens a genuine
+    # transaction, and the fakes assert on the deltas that reach it. Nothing is
+    # written to this database — it exists so the transaction boundary is real.
+    engine = create_async_engine("sqlite+aiosqlite://")
+
+    fake_context = SimpleNamespace(
+        get_tag_store=lambda: SimpleNamespace(
+            get_tag_by_id=_make_async(SimpleNamespace(id="tag-1", owner_id=tag_owner)),
+        ),
+        get_pg_async_engine=lambda: engine,
+        get_kpi_writer=lambda: SimpleNamespace(count=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        service_module.ApplicationContext,
+        "get_instance",
+        staticmethod(lambda: fake_context),
+    )
+
+    return team_increments, user_increments
+
+
+def _make_async(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def _build_service(metadata_store: _FakeMetadataStore, rebac: _PermissiveRebac) -> MetadataService:
+    service = MetadataService.__new__(MetadataService)
+    service.rebac = rebac  # type: ignore[assignment]
+    service.metadata_store = metadata_store  # type: ignore[assignment]
+    service.vector_store = None
+    service.content_store = None  # type: ignore[assignment]
+    service._remove_tag_as_parent_in_rebac = _make_async(None)  # type: ignore[method-assign]
+    return service
+
+
+def _user(uid: str) -> KeycloakUser:
+    return KeycloakUser(uid=uid, username=uid, email=f"{uid}@localhost", roles=["admin"])
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_team_document_releases_the_team_counter(monkeypatch) -> None:
+    """AC1 — a team-owned document's bytes come off every applicable team counter."""
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-1", tag_ids=["tag-1"])
+    service = _build_service(_FakeMetadataStore(metadata), _PermissiveRebac(team_owners=["team-a"]))
+
+    await service.delete_document_and_artifacts(_user(str(uuid4())), "doc-1")
+
+    assert team_increments == [("team-a", -DOC_SIZE)]
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_personal_document_releases_the_owning_users_counter(monkeypatch) -> None:
+    """AC2 — the bytes come off the counter of the user who OWNS the tag.
+
+    A real personal tag carries the owner's uid, not the literal "personal":
+    `TagService` sets `owner_id = team_id or user.uid` (tag_service.py:208). The
+    acting user differs from the owner here on purpose — the charge side bills the
+    tag owner, so the release has to bill the same account, or deleting someone
+    else's document would credit the wrong personal space.
+    """
+    owner_uid = str(uuid4())
+    deleter_uid = str(uuid4())
+    team_increments, user_increments = _install_fakes(monkeypatch, tag_owner=owner_uid, known_teams=set())
+    metadata = _make_metadata("doc-2", tag_ids=["tag-1"])
+    service = _build_service(_FakeMetadataStore(metadata), _PermissiveRebac(team_owners=[]))
+
+    await service.delete_document_and_artifacts(_user(deleter_uid), "doc-2")
+
+    assert user_increments == [(owner_uid, -DOC_SIZE)]
+    assert team_increments == []
+
+
+@pytest.mark.asyncio
+async def test_removing_the_last_tag_releases_using_the_pre_removal_tags(monkeypatch) -> None:
+    """AC3 — and the regression this path is most likely to hit again.
+
+    `remove_tag_id_from_document` empties `metadata.tags.tag_ids` *before* it
+    deletes the row. Resolving ownership from the mutated (empty) list makes
+    `_adjust_team_storage` bail at its `if not all_tags` guard and release
+    nothing at all — silently, since it swallows its own errors.
+    """
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-3", tag_ids=["tag-1"])
+    service = _build_service(_FakeMetadataStore(metadata), _PermissiveRebac(team_owners=["team-a"]))
+    service._promote_alternate_version = _make_async(None)
+
+    await service.remove_tag_id_from_document(_user(str(uuid4())), metadata, "tag-1")
+
+    assert team_increments == [("team-a", -DOC_SIZE)]
+
+
+@pytest.mark.asyncio
+async def test_repeated_delete_does_not_decrement_twice(monkeypatch) -> None:
+    """AC4 — the second delete finds no metadata row and must release nothing;
+    a retried delete would otherwise hand back the same bytes on every attempt."""
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-4", tag_ids=["tag-1"])
+    store = _FakeMetadataStore(metadata)
+    service = _build_service(store, _PermissiveRebac(team_owners=["team-a"]))
+    user = _user(str(uuid4()))
+
+    await service.delete_document_and_artifacts(user, "doc-4")
+    with pytest.raises(service_module.MetadataNotFound):
+        await service.delete_document_and_artifacts(user, "doc-4")
+
+    assert team_increments == [("team-a", -DOC_SIZE)]
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_loser_does_not_release_the_same_bytes(monkeypatch) -> None:
+    """#2149 review finding — the delete is the exactly-once gate.
+
+    `DocumentMetadataRow` has no `version_id_col`, so before the store used a
+    conditional DELETE two requests could both load the row, both "succeed", and
+    both credit the same bytes — letting a team member zero a counter with N
+    concurrent tag removals and then re-upload to the full limit. The store now
+    reports whether *this* call removed the row; the loser must release nothing.
+    """
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-7", tag_ids=["tag-1"])
+    store = _FakeMetadataStore(metadata)
+    service = _build_service(store, _PermissiveRebac(team_owners=["team-a"]))
+
+    # Winner removes the row and releases.
+    await service.delete_document_and_artifacts(_user(str(uuid4())), "doc-7")
+
+    # Loser still holds the metadata it loaded, but its DELETE matches nothing.
+    loser_store = _FakeMetadataStore(metadata, row_already_deleted=True)
+    loser = _build_service(loser_store, _PermissiveRebac(team_owners=["team-a"]))
+    await loser.delete_document_and_artifacts(_user(str(uuid4())), "doc-7")
+
+    assert team_increments == [("team-a", -DOC_SIZE)]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_metadata_delete_releases_nothing(monkeypatch) -> None:
+    """AC5 — the row is still there, so the bytes are still occupied. Releasing
+    them here would credit quota for a document that was never removed."""
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-5", tag_ids=["tag-1"])
+    store = _FakeMetadataStore(metadata, delete_raises=RuntimeError("postgres is down"))
+    service = _build_service(store, _PermissiveRebac(team_owners=["team-a"]))
+
+    with pytest.raises(service_module.MetadataUpdateError):
+        await service.delete_document_and_artifacts(_user(str(uuid4())), "doc-5")
+
+    assert team_increments == []
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_document_with_no_recorded_size_is_a_no_op(monkeypatch) -> None:
+    """A document ingested before size tracking has `file_size_bytes=None`.
+    Releasing `None` as 0 keeps the counter untouched instead of crashing the
+    delete or writing a bogus delta."""
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-6", tag_ids=["tag-1"], size=None)
+    service = _build_service(_FakeMetadataStore(metadata), _PermissiveRebac(team_owners=["team-a"]))
+
+    await service.delete_document_and_artifacts(_user(str(uuid4())), "doc-6")
+
+    assert team_increments == []
+
+
+@pytest.mark.asyncio
+async def test_a_tag_change_commits_the_save_and_the_charge_together(monkeypatch) -> None:
+    """#2149 review — the tag move and the quota move must be one transaction.
+
+    They used to be two: `save_metadata` committed first, and `_adjust_team_storage`
+    swallows its own errors, so a failed counter update left the tag moved and the
+    charge behind with no signal. Asserting both receive the *same* live session is
+    what proves they share a transaction.
+    """
+    team_increments, _ = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-tagmove", tag_ids=["tag-1"])
+    store = _FakeMetadataStore(metadata)
+    service = _build_service(store, _PermissiveRebac(team_owners=["team-a"]))
+
+    seen_sessions: list[object] = []
+
+    class _RecordingTeamStore:
+        def __init__(self, engine):
+            pass
+
+        async def get_by_team_id(self, team_id):
+            return SimpleNamespace(id=str(team_id))
+
+        async def increment_current_storage_size(self, team_id, delta, session=None):
+            seen_sessions.append(session)
+            team_increments.append((str(team_id), delta))
+
+    monkeypatch.setattr(service_module, "TeamMetadataStore", _RecordingTeamStore)
+
+    await service._save_and_move_storage(metadata, old_tags=set(), new_tags={"tag-1"}, user=_user(str(uuid4())))
+
+    assert store.save_sessions and store.save_sessions[0] is not None
+    assert seen_sessions and seen_sessions[0] is not None
+    assert store.save_sessions[0] is seen_sessions[0], "save and counter update must share one session"
+    assert team_increments == [("team-a", DOC_SIZE)]
+
+
+@pytest.mark.asyncio
+async def test_adding_a_tag_still_persists_the_document(monkeypatch) -> None:
+    """Caller wiring, not just the helper: `add_tag_id_to_document` must still save.
+
+    The previous test called `_save_and_move_storage` directly, so deleting the
+    `save_metadata` call inside it would not have failed anything (#2149 review).
+    """
+    _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-add", tag_ids=[])
+    store = _FakeMetadataStore(metadata)
+    service = _build_service(store, _PermissiveRebac(team_owners=["team-a"]))
+    service._set_tag_as_parent_in_rebac = _make_async(None)  # type: ignore[method-assign]
+
+    await service.add_tag_id_to_document(_user(str(uuid4())), metadata, "tag-1")
+
+    assert store.save_sessions, "the document must be persisted"
+    assert metadata.tags is not None and "tag-1" in metadata.tags.tag_ids
+
+
+@pytest.mark.asyncio
+async def test_a_no_op_tag_change_still_persists_the_document(monkeypatch) -> None:
+    """Early-return branch: identical tag sets, or a document with no recorded
+    size, must still save the metadata — sessionless, since no counter moves."""
+    team_increments, user_increments = _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-noop", tag_ids=["tag-1"], size=None)
+    store = _FakeMetadataStore(metadata)
+    service = _build_service(store, _PermissiveRebac(team_owners=["team-a"]))
+
+    await service._save_and_move_storage(metadata, old_tags={"tag-1"}, new_tags={"tag-1"}, user=_user(str(uuid4())))
+
+    assert store.save_sessions == [None], "no counter moves, so no transaction is needed"
+    assert team_increments == [] and user_increments == []
+
+
+@pytest.mark.asyncio
+async def test_re_adding_a_present_tag_reasserts_its_rebac_parent(monkeypatch) -> None:
+    """A retry after a failed ReBAC write must converge.
+
+    The ReBAC parent write runs after the metadata+quota commit, so a failure
+    leaves the tag stored with no relation — inaccessible and charged. The retry
+    lands on the "already present" branch, which used to short-circuit and make
+    that state permanent (#2149 review finding).
+    """
+    _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-retry", tag_ids=["tag-1"])
+    service = _build_service(_FakeMetadataStore(metadata), _PermissiveRebac(team_owners=["team-a"]))
+
+    reasserted: list[str] = []
+
+    async def _record_parent(tag_id, document_uid, actor_uid=None):
+        reasserted.append(tag_id)
+
+    service._set_tag_as_parent_in_rebac = _record_parent  # type: ignore[method-assign]
+
+    await service.add_tag_id_to_document(_user(str(uuid4())), metadata, "tag-1")
+
+    assert reasserted == ["tag-1"], "the retry must re-write the parent relation"
+
+
+@pytest.mark.asyncio
+async def test_a_counter_failure_aborts_the_tag_change_instead_of_being_swallowed(monkeypatch) -> None:
+    """The load-bearing behaviour change, and previously untested.
+
+    `_save_and_move_storage` no longer routes through `_adjust_team_storage`, which
+    logs and swallows. A counter failure must now abort the tag change and surface,
+    rather than committing the tag and losing the charge in a log line
+    (#2149 review finding).
+    """
+    _install_fakes(monkeypatch, tag_owner="team-a", known_teams={"team-a"})
+    metadata = _make_metadata("doc-fail", tag_ids=[])
+    service = _build_service(_FakeMetadataStore(metadata), _PermissiveRebac(team_owners=["team-a"]))
+    service._set_tag_as_parent_in_rebac = _make_async(None)  # type: ignore[method-assign]
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("deadlock detected")
+
+    service._apply_storage_deltas = _boom  # type: ignore[method-assign]
+
+    with pytest.raises(service_module.MetadataUpdateError):
+        await service.add_tag_id_to_document(_user(str(uuid4())), metadata, "tag-1")

--- a/apps/knowledge-flow-backend/tests/features/test_storage_backfill_untagged.py
+++ b/apps/knowledge-flow-backend/tests/features/test_storage_backfill_untagged.py
@@ -1,0 +1,135 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""#2149 review — the storage backfill must survive untagged documents.
+
+`calculate_ingested_documents_sizes` read `row.author`, but `DocumentMetadataRow`
+has no such column, so the reconciliation aborted with `AttributeError` on the
+first untagged row — and again on any tag carrying the legacy "personal" owner
+sentinel. That matters beyond the crash: the backfill is the documented remedy
+for drifted counters, so a deployment holding one untagged document had no way
+to run it.
+
+Untagged documents are now skipped rather than charged. They have no ReBAC parent
+and no deletable route, so charging them would create usage nothing can release —
+and the live accounting does not charge them either, so skipping keeps script and
+runtime in agreement.
+"""
+
+import importlib.util
+import pathlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+_BACKFILL = pathlib.Path(__file__).resolve().parents[2] / "alembic" / "backfill" / "backfill_storage_usage.py"
+
+
+def _load_backfill_module():
+    spec = importlib.util.spec_from_file_location("backfill_storage_usage", _BACKFILL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["backfill_storage_usage"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Row:
+    """A metadata row as the ORM returns it — deliberately WITHOUT `author`,
+    mirroring `DocumentMetadataRow`. Touching `row.author` raises AttributeError,
+    which is exactly the production failure."""
+
+    def __init__(self, uid: str, tag_ids: list[str] | None, size: int):
+        self.document_uid = uid
+        self.tag_ids = tag_ids
+        self.doc = {"file": {"file_size_bytes": size}, "identity": {"author": "Jane Doe"}}
+
+
+class _Session:
+    """`session.get` is used for two different models: TagRow (by tag id) and
+    TeamMetadataRow (by owner id, to confirm the owner is a team)."""
+
+    def __init__(self, rows, tags=None, teams=()):
+        self._rows = rows
+        self._tags = tags or {}
+        self._teams = set(teams)
+
+    async def execute(self, _stmt):
+        rows = self._rows
+        return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: rows))
+
+    async def get(self, model, key):
+        if getattr(model, "__name__", "") == "TeamMetadataRow":
+            return SimpleNamespace(id=key) if key in self._teams else None
+        return self._tags.get(key)
+
+
+class _Rebac:
+    enabled = False
+
+    async def lookup_subjects(self, *_a, **_k):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_untagged_documents_are_skipped_instead_of_crashing() -> None:
+    """The load-bearing case: an untagged row must not abort the run, and must
+    not be charged to anyone."""
+    module = _load_backfill_module()
+    session = _Session([_Row("doc-untagged", [], 4096)])
+
+    user_sizes, team_sizes = await module.calculate_ingested_documents_sizes(session, _Rebac())
+
+    assert user_sizes == {}
+    assert team_sizes == {}
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_personal_owner_sentinel_refuses_to_run() -> None:
+    """Second crash site, and it must not degrade into a silent wrong answer.
+
+    The runtime resolves `owner_id == "personal"` to the *acting* user and charges
+    them; this script has no acting user, so it cannot reproduce that. Because it
+    writes ABSOLUTE counters, quietly skipping such a tag would erase usage the
+    runtime already charged and manufacture free quota. It refuses instead, naming
+    the offending tags (#2149 review finding).
+    """
+    module = _load_backfill_module()
+    session = _Session(
+        [_Row("doc-personal", ["tag-legacy"], 2048)],
+        tags={"tag-legacy": SimpleNamespace(tag_id="tag-legacy", owner_id="personal")},
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        await module.calculate_ingested_documents_sizes(session, _Rebac())
+
+    assert "tag-legacy" in str(exc.value)
+    assert "absolute" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_untagged_rows_do_not_stop_tagged_rows_from_being_counted() -> None:
+    """Regression guard: the crash aborted the whole reconciliation, so tagged
+    documents after an untagged one were never counted either."""
+    module = _load_backfill_module()
+    session = _Session(
+        [_Row("doc-untagged", [], 4096), _Row("doc-team", ["tag-team"], 1024)],
+        tags={"tag-team": SimpleNamespace(tag_id="tag-team", owner_id="team-a")},
+        teams=["team-a"],
+    )
+
+    _user_sizes, team_sizes = await module.calculate_ingested_documents_sizes(session, _Rebac())
+
+    assert team_sizes.get("team-a") == 1024

--- a/apps/knowledge-flow-backend/tests/services/test_tabular_service.py
+++ b/apps/knowledge-flow-backend/tests/services/test_tabular_service.py
@@ -208,8 +208,8 @@ class _TrackingMetadataStore(BaseMetadataStore):
     async def save_metadata(self, metadata: DocumentMetadata, session=None) -> None:
         await self._delegate.save_metadata(metadata, session=session)
 
-    async def delete_metadata(self, document_uid: str, session=None) -> None:
-        await self._delegate.delete_metadata(document_uid, session=session)
+    async def delete_metadata(self, document_uid: str, session=None) -> bool:
+        return await self._delegate.delete_metadata(document_uid, session=session)
 
     async def clear(self, session=None) -> None:
         await self._delegate.clear(session=session)

--- a/libs/fred-core/fred_core/documents/document_store.py
+++ b/libs/fred-core/fred_core/documents/document_store.py
@@ -136,9 +136,17 @@ class BaseDocumentMetadataStore:
     @abstractmethod
     async def delete_metadata(
         self, document_uid: str, session: AsyncSession | None = None
-    ) -> None:
+    ) -> bool:
         """
         Delete a metadata entry by its UID.
+
+        Returns True when *this* call removed the row, False when the row was
+        already gone. Implementations MUST make that determination atomically
+        (a single conditional DELETE, not a read followed by a delete): callers
+        use the result to decide whether to apply a side effect that must happen
+        exactly once, such as releasing the document's storage quota. A
+        read-then-delete lets two concurrent callers both observe the row and
+        both report success, releasing the same bytes twice (#2149).
 
         :raises ValueError: if 'document_uid' is missing.
         """

--- a/libs/fred-core/fred_core/documents/document_structures.py
+++ b/libs/fred-core/fred_core/documents/document_structures.py
@@ -125,7 +125,14 @@ class Identity(BaseModel):
         ge=0,
     )
     title: Optional[str] = Field(None, description="Human-friendly title for UI")
-    author: Optional[str] = None
+    author: Optional[str] = Field(
+        default=None,
+        description=(
+            "DESCRIPTIVE only — extracted from the file's own embedded metadata "
+            "(e.g. a PDF's /Author), so it is caller-supplied and untrusted. Never "
+            "use it to identify an account or to attribute storage quota."
+        ),
+    )
     created: Optional[datetime] = None
     modified: Optional[datetime] = None
     last_modified_by: Optional[str] = None
@@ -210,9 +217,13 @@ class SourceInfo(BaseModel):
 class FileInfo(BaseModel):
     file_type: FileType = FileType.OTHER
     mime_type: Optional[str] = None
-    file_size_bytes: Optional[int] = None
-    page_count: Optional[int] = None  # PDFs/slides
-    row_count: Optional[int] = None  # tables/csv
+    # ge=0: storage accounting charges +size on save and -size on delete, so a
+    # negative size makes deleting a document *increase* recorded usage and mint
+    # free quota. Import preserves raw document JSON, so this is the boundary
+    # where an out-of-band value has to be rejected (#2149 review finding).
+    file_size_bytes: Optional[int] = Field(default=None, ge=0)
+    page_count: Optional[int] = Field(default=None, ge=0)  # PDFs/slides
+    row_count: Optional[int] = Field(default=None, ge=0)  # tables/csv
     sha256: Optional[str] = None
     md5: Optional[str] = None
     language: Optional[str] = None  # ISO code like 'fr', 'en'

--- a/libs/fred-core/fred_core/documents/postgres_document_store.py
+++ b/libs/fred-core/fred_core/documents/postgres_document_store.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any, List, Optional, cast
 
 from pydantic import ValidationError
-from sqlalchemy import BigInteger, delete, func, select
+from sqlalchemy import BigInteger, CursorResult, delete, func, select
 from sqlalchemy import cast as sql_cast
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
@@ -291,12 +291,27 @@ class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
 
     async def delete_metadata(
         self, document_uid: str, session: AsyncSession | None = None
-    ) -> None:
+    ) -> bool:
+        """Delete one metadata row, reporting whether this call removed it.
+
+        A single conditional DELETE rather than `get` + `delete`: the row carries
+        no `version_id_col`, so two concurrent callers could both load it and both
+        "succeed", and each would then release the document's storage quota — the
+        same bytes credited twice (#2149). Exactly one caller can observe
+        `rowcount == 1`, so exactly one releases.
+        """
         async with use_session(self._sessions, session) as s:
-            row = await s.get(DocumentMetadataRow, document_uid)
-            if row is None:
-                raise ValueError(f"No document found with UID {document_uid}")
-            await s.delete(row)
+            # cast: AsyncSession.execute is typed as returning Result, but a DML
+            # statement always yields a CursorResult, which is what carries rowcount.
+            result = cast(
+                CursorResult[Any],
+                await s.execute(
+                    delete(DocumentMetadataRow).where(
+                        DocumentMetadataRow.document_uid == document_uid
+                    )
+                ),
+            )
+            return result.rowcount > 0
 
     async def clear(self, session: AsyncSession | None = None) -> None:
         async with use_session(self._sessions, session) as s:

--- a/libs/fred-core/fred_core/teams/metadata_store.py
+++ b/libs/fred-core/fred_core/teams/metadata_store.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from pydantic import BaseModel, Field
-from sqlalchemy import select, text
+from sqlalchemy import case, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from fred_core.common.team_id import TeamId
@@ -323,18 +323,51 @@ class TeamMetadataStore:
         `NOT NULL` — a team deleted concurrently with a storage recalculation
         pass would turn one team's accounting update into a raw
         `IntegrityError` (500) instead of skipping just that team.
+
+        The result is clamped at 0: usage is a byte count, so a negative value
+        is always accounting drift rather than a real state, and letting it go
+        negative would hand the team free quota. The clamp logs a warning so the
+        drift stays visible instead of being silently absorbed (#2149).
+
+        The update is a single atomic `UPDATE ... SET col = col + :delta`, not a
+        read-modify-write. Bulk deletes fan out with `asyncio.gather`
+        (`tag_service._delete_one_tag`), so N releases hit one team row
+        concurrently; loading the row and writing back an absolute value lost
+        most of those decrements under READ COMMITTED, leaving exactly the drift
+        this accounting exists to prevent (#2149 review finding).
         """
         async with use_session(self._sessions, session) as s:
-            row = await s.get(TeamMetadataRow, str(team_id))
-            if row is None:
+            # CASE, not GREATEST/MAX: `GREATEST` is Postgres-only and `MAX` is an
+            # aggregate there, so neither is portable to the SQLite used by tests.
+            new_value = (
+                func.coalesce(TeamMetadataRow.current_resources_storage_size, 0) + delta
+            )
+            result = await s.execute(
+                update(TeamMetadataRow)
+                .where(TeamMetadataRow.id == str(team_id))
+                .values(
+                    current_resources_storage_size=case(
+                        (new_value < 0, 0), else_=new_value
+                    )
+                )
+                .returning(TeamMetadataRow.current_resources_storage_size)
+            )
+            updated = result.scalar_one_or_none()
+            if updated is None:
                 logger.warning(
                     "Skipping storage size update for unknown team '%s' (delta=%d)",
                     team_id,
                     delta,
                 )
                 return
-            current = row.current_resources_storage_size or 0
-            row.current_resources_storage_size = current + delta
+            if delta < 0 and updated == 0:
+                # Cannot distinguish "landed exactly on 0" from "clamped" without a
+                # second read; warn on both rather than add a query to a hot path.
+                logger.warning(
+                    "Storage accounting for team '%s' reached 0 (delta=%d); if this was a clamp, usage had drifted",
+                    team_id,
+                    delta,
+                )
 
     async def check_quota(
         self,

--- a/libs/fred-core/fred_core/tests/teams/test_storage_usage_clamp.py
+++ b/libs/fred-core/fred_core/tests/teams/test_storage_usage_clamp.py
@@ -1,0 +1,208 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""#2149 — `increment_current_storage_size` must never leave a negative usage.
+
+Releasing document storage on delete (knowledge-flow `metadata/service.py`)
+made these stores take negative deltas on a normal path for the first time.
+A counter that predates the accounting fix — or one whose matching increment
+was never charged — can be released below zero, and a negative usage silently
+hands out free quota, because `check_quota` compares `current + delta` against
+the limit. Both stores clamp at 0 and warn instead.
+
+Runs against SQLite, so no Postgres is needed for the default suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fred_core.common.team_id import TeamId
+from fred_core.models.base import Base
+from fred_core.sql.async_session import make_session_factory
+from fred_core.teams.metadata_store import TeamMetadataStore
+from fred_core.teams.team_metatada_models import TeamMetadataRow
+from fred_core.users.store.postgres_user_store import PostgresUserStore
+from fred_core.users.user_models import UserRow
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+
+async def _make_sqlite_engine(tmp_path: Path, filename: str) -> AsyncEngine:
+    db_path = tmp_path / filename
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine
+
+
+async def _seed_team(engine: AsyncEngine, team_id: str, current: int) -> None:
+    sessions = make_session_factory(engine)
+    async with sessions() as s:
+        async with s.begin():
+            s.add(
+                TeamMetadataRow(
+                    id=team_id,
+                    name=f"name-{team_id}",
+                    current_resources_storage_size=current,
+                )
+            )
+
+
+async def _read_team(engine: AsyncEngine, team_id: str) -> int | None:
+    store = TeamMetadataStore(engine)
+    meta = await store.get_by_team_id(TeamId(team_id))
+    assert meta is not None
+    return meta.current_resources_storage_size
+
+
+@pytest.mark.asyncio
+async def test_team_release_subtracts_the_released_bytes(tmp_path: Path) -> None:
+    """Ordinary case: deleting a 40-byte document off a 100-byte team leaves 60."""
+    engine = await _make_sqlite_engine(tmp_path, "team-normal.db")
+    await _seed_team(engine, "team-a", 100)
+
+    await TeamMetadataStore(engine).increment_current_storage_size(
+        TeamId("team-a"), -40
+    )
+
+    assert await _read_team(engine, "team-a") == 60
+
+
+@pytest.mark.asyncio
+async def test_team_release_below_zero_is_clamped(tmp_path: Path) -> None:
+    """Drift guard: a release larger than the recorded usage floors at 0, never
+    -200, which `check_quota` would otherwise read as 200 bytes of free quota."""
+    engine = await _make_sqlite_engine(tmp_path, "team-clamp.db")
+    await _seed_team(engine, "team-b", 100)
+
+    await TeamMetadataStore(engine).increment_current_storage_size(
+        TeamId("team-b"), -300
+    )
+
+    assert await _read_team(engine, "team-b") == 0
+
+
+def test_a_negative_file_size_is_rejected_at_the_boundary() -> None:
+    """#2149 review finding — a negative size inverts the accounting.
+
+    Release computes `-old_size`, so a document recorded at -4096 bytes *adds*
+    4096 to its owner's usage when deleted, minting free quota. Import preserves
+    raw document JSON, so the model is where an out-of-band value must be
+    rejected rather than persisted.
+    """
+    from fred_core.documents.document_structures import FileInfo
+
+    with pytest.raises(ValidationError):
+        FileInfo(file_size_bytes=-4096)
+
+    assert FileInfo(file_size_bytes=0).file_size_bytes == 0
+    assert FileInfo(file_size_bytes=None).file_size_bytes is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_team_releases_are_not_lost(tmp_path: Path) -> None:
+    """#2149 review finding — the load-bearing concurrency guarantee.
+
+    Deleting a library fans out one release per document with `asyncio.gather`
+    (`tag_service._delete_one_tag`). The previous read-modify-write implementation
+    let each coroutine read the same starting value and write back an absolute
+    result, so all but one decrement was silently lost and the phantom usage
+    survived the delete. Ten concurrent releases must land all ten.
+    """
+    engine = await _make_sqlite_engine(tmp_path, "team-concurrent.db")
+    await _seed_team(engine, "team-c", 10 * 4096)
+    store = TeamMetadataStore(engine)
+
+    await asyncio.gather(
+        *(
+            store.increment_current_storage_size(TeamId("team-c"), -4096)
+            for _ in range(10)
+        )
+    )
+
+    assert await _read_team(engine, "team-c") == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_user_releases_are_not_lost(tmp_path: Path) -> None:
+    """Personal-space counterpart of the team concurrency guarantee above."""
+    engine = await _make_sqlite_engine(tmp_path, "user-concurrent.db")
+    store = PostgresUserStore(engine)
+    sessions = make_session_factory(engine)
+    user_id = uuid4()
+    async with sessions() as s:
+        async with s.begin():
+            s.add(
+                UserRow(
+                    id=user_id,
+                    gcuVersionAccepted=None,
+                    gcuAcceptedAt=None,
+                    current_resources_storage_size=10 * 4096,
+                )
+            )
+
+    await asyncio.gather(
+        *(store.increment_current_storage_size(user_id, -4096) for _ in range(10))
+    )
+
+    user = await store.find_user_by_id(user_id)
+    assert user is not None and user.current_resources_storage_size == 0
+
+
+@pytest.mark.asyncio
+async def test_user_release_subtracts_then_clamps(tmp_path: Path) -> None:
+    """Personal-space counterpart of the two team cases above."""
+    engine = await _make_sqlite_engine(tmp_path, "user.db")
+    store = PostgresUserStore(engine)
+    sessions = make_session_factory(engine)
+    user_id = uuid4()
+    async with sessions() as s:
+        async with s.begin():
+            s.add(
+                UserRow(
+                    id=user_id,
+                    gcuVersionAccepted=None,
+                    gcuAcceptedAt=None,
+                    current_resources_storage_size=100,
+                )
+            )
+
+    await store.increment_current_storage_size(user_id, -40)
+    user = await store.find_user_by_id(user_id)
+    assert user is not None and user.current_resources_storage_size == 60
+
+    await store.increment_current_storage_size(user_id, -300)
+    user = await store.find_user_by_id(user_id)
+    assert user is not None and user.current_resources_storage_size == 0
+
+
+@pytest.mark.asyncio
+async def test_user_release_for_an_unknown_user_records_zero_not_a_negative(
+    tmp_path: Path,
+) -> None:
+    """The store creates a row for an unseen user. A release arriving before any
+    charge (deleted user re-created, backfill not yet run) must not seed that row
+    with a negative usage."""
+    engine = await _make_sqlite_engine(tmp_path, "user-unknown.db")
+    store = PostgresUserStore(engine)
+    user_id = uuid4()
+
+    await store.increment_current_storage_size(user_id, -500)
+
+    user = await store.find_user_by_id(user_id)
+    assert user is not None and user.current_resources_storage_size == 0

--- a/libs/fred-core/fred_core/users/store/base_user_store.py
+++ b/libs/fred-core/fred_core/users/store/base_user_store.py
@@ -44,4 +44,11 @@ class BaseUserStore(ABC):
         delta: int,
         session: AsyncSession | None = None,
     ) -> None:
-        pass
+        """Adjust a user's recorded personal storage usage by `delta` bytes.
+
+        `delta` is negative when storage is released (a document was permanently
+        deleted). Implementations MUST NOT persist a negative usage: clamp at 0
+        and log, because usage is a byte count and `check_quota` reads this value
+        as the sole enforcement input — a negative usage silently grants free
+        quota (#2149).
+        """

--- a/libs/fred-core/fred_core/users/store/postgres_user_store.py
+++ b/libs/fred-core/fred_core/users/store/postgres_user_store.py
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import case, func, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from fred_core.sql import make_session_factory, use_session
 from fred_core.users.user_models import GcuVersionsType, UserRow
 
 from .base_user_store import BaseUserStore
+
+logger = logging.getLogger(__name__)
 
 _user_store: BaseUserStore | None = None
 
@@ -86,17 +90,69 @@ class PostgresUserStore(BaseUserStore):
         delta: int,
         session: AsyncSession | None = None,
     ) -> None:
-        """Increment current storage size of a user by a delta (can be negative)."""
+        """Increment current storage size of a user by a delta (can be negative).
+
+        The result is clamped at 0: personal usage is a byte count, so a negative
+        value is always accounting drift rather than a real state, and letting it
+        go negative would hand the user free quota. The clamp logs a warning so the
+        drift stays visible instead of being silently absorbed (#2149).
+
+        The update is a single atomic `UPDATE ... SET col = col + :delta`, not a
+        read-modify-write: personal-space releases fan out concurrently the same
+        way team releases do, and loading the row then writing back an absolute
+        value lost decrements under concurrency (#2149 review finding).
+        """
         async with use_session(self._sessions, session) as s:
-            user = await s.get(UserRow, user_id)
-            if user is not None:
-                current = user.current_resources_storage_size or 0
-                user.current_resources_storage_size = current + delta
-            else:
-                user = UserRow(
-                    id=user_id,
-                    gcuVersionAccepted=None,
-                    gcuAcceptedAt=None,
-                    current_resources_storage_size=delta,
+            # CASE, not GREATEST/MAX — see the note in TeamMetadataStore; the same
+            # portability constraint applies here.
+            new_value = func.coalesce(UserRow.current_resources_storage_size, 0) + delta
+            result = await s.execute(
+                update(UserRow)
+                .where(UserRow.id == user_id)
+                .values(
+                    current_resources_storage_size=case(
+                        (new_value < 0, 0), else_=new_value
+                    )
                 )
-                s.add(user)
+                .returning(UserRow.current_resources_storage_size)
+            )
+            updated = result.scalar_one_or_none()
+            if updated is not None:
+                if delta < 0 and updated == 0:
+                    logger.warning(
+                        "Storage accounting for user '%s' reached 0 (delta=%d); if this was a clamp, usage had drifted",
+                        user_id,
+                        delta,
+                    )
+                return
+
+            # No row yet. Insert one, but treat a concurrent insert as the normal
+            # case rather than an error: two releases for the same unseen user race
+            # here, and the loser must fold its delta into the winner's row instead
+            # of failing the delete that triggered it.
+            if delta < 0:
+                logger.warning(
+                    "Storage release for unknown user '%s' (delta=%d); recording 0 rather than a negative usage",
+                    user_id,
+                    delta,
+                )
+            try:
+                async with s.begin_nested():
+                    s.add(
+                        UserRow(
+                            id=user_id,
+                            gcuVersionAccepted=None,
+                            gcuAcceptedAt=None,
+                            current_resources_storage_size=max(0, delta),
+                        )
+                    )
+            except IntegrityError:
+                await s.execute(
+                    update(UserRow)
+                    .where(UserRow.id == user_id)
+                    .values(
+                        current_resources_storage_size=case(
+                            (new_value < 0, 0), else_=new_value
+                        )
+                    )
+                )


### PR DESCRIPTION
# Pull Request

## 1. What problem does this solve — and where is it tracked?

**Issue:** [#2149](https://github.com/ThalesGroup/fred/issues/2149) (P0, `swift ga`) and
[#2150](https://github.com/ThalesGroup/fred/issues/2150) (P0, `swift ga`) — one commit each.
Both split from tracking issue [#2144](https://github.com/ThalesGroup/fred/issues/2144).

**Problem in one sentence:** Document storage usage was charged on upload but never released on
delete, so ordinary upload/delete cycles drifted `current_resources_storage_size` upward until valid
uploads were rejected by a phantom quota exhaustion (#2149) — and the upload guard returned early
whenever `tags` was empty, which is the request default, so quota could be bypassed entirely by
omitting tags (#2150).

**Backlog ref:** n/a — `docs/swift/backlog/BACKLOG.md` and `WORKPLAN.md` were frozen 2026-07-16 and
`CLAUDE.md` forbids writing to them. GitHub issues + the `swift ga` milestone are the tracking unit.

---

## 2. Before you wrote a single line of code

**RFC written?**

Not required for what ships here — both commits restore intended behaviour of an existing model.
They add no field, endpoint, or design decision: `_adjust_team_storage` and its team/personal
ownership rules already existed and are reused rather than duplicated. No RFC in `docs/swift/rfc/`
covers storage accounting; the only one referencing these fields
(`KNOWLEDGE-WORKSPACE-REWORK-RFC.md`) uses them as UI context.

A draft RFC was written mid-review for an untagged-document ownership model, then dropped: its
premise — that untagged documents are a reachable state needing an ownership model — did not
survive checking the frontend (§3).

Honest caveat: #2149 grew during review beyond a one-function fix — it now changes two fred-core
store implementations and the `delete_metadata` return contract. That is arguably past the
"mechanical fix" exemption. Flagging it rather than claiming otherwise; if reviewers want an RFC for
the store-semantics change, it should block merge.

**Plan presented to the team before implementation?**

Yes. Root cause, proposed fix, exact file list, per-criterion test plan, doc impact and explicit
out-of-scope items were presented before any code was written, including two open questions
(whether to touch fred-core for the clamp, and how to handle the "tagless" half of AC2).

**Confirmation received?**

Yes — "approved", after which implementation started. Scope was then **re-confirmed twice** during
review: once to expand into the concurrency/atomicity defects found by reviewers, and once to
**remove** the untagged-document accounting pending an RFC.

---

## 3. What you built

**#2149 (`3dd5cc5f`)** — both hard-delete paths (`delete_document_and_artifacts` and the last-tag
branch of `remove_tag_id_from_document`) now release storage through the existing
`_adjust_team_storage` ownership rules. Review then showed the release itself was unsafe, so:
`increment_current_storage_size` in `TeamMetadataStore` and `PostgresUserStore` became a single
atomic `UPDATE ... SET col = col + :delta` clamped at 0 via `CASE` (portable to the SQLite used by
tests, unlike `GREATEST`/`MAX`); `delete_metadata` became a conditional `DELETE` returning whether
*this* call removed the row, so only one caller of a concurrent race releases (contract change:
`None` → `bool`); `_delete_and_release` resolves owner deltas **before** opening a transaction and
then performs delete + counter writes inside one transaction with failures propagating;
`add_tag_id_to_document` and non-last-tag removal now move the charge between owners; sub-tag
deletion runs serially with the per-document fan-out batched; the tag path-prefix filter matches on
a path boundary; and `file_size_bytes`/`page_count`/`row_count` take `ge=0`.

**#2150 (`b859b92c`)** — `_check_quota_before_upload` no longer returns early on empty `tags`; an
upload whose tags resolve to no owner is attributed to the authenticated uploader's personal space
and checked against `personal_max_resources_storage_size`. The personal counter read no longer sits
inside `except Exception: current = 0`, which turned any transient store error into a second bypass;
it now fails closed (400 unresolvable owner, 503 unreadable usage).

**On untagged documents.** #2149's AC2 names the "personal/tagless" case. The *personal*
half — a document in a personally-owned library — is implemented, unit-tested and verified
live. The *tagless* half is not a reachable state: the workspace disables its upload control
unless the current node has a library (`DocumentWorkspace.tsx`, `disabled={!currentTag}`), and
there are no external API callers. #2150's guard therefore covers the `tags: []` API default as
defence in depth rather than closing a live bypass, and its criteria are met as written.

An untagged document, if one ever arrived by another route, would have no ReBAC parent — hence
unreachable and undeletable — so nothing charges one. Hardening `IngestionInput.tags` to reject
an empty list at the boundary would make that invariant structural rather than dependent on UI
gating; noted as a follow-up, not done here.

---

## 4. Proof of quality

**Tests added or updated:** 20 added, plus 4 existing test doubles updated for the
`delete_metadata` → `bool` contract (`tests/conftest.py`, `tests/features/test_metadata_audit.py`,
`tests/services/test_tabular_service.py`).

| Test | File | What it covers |
| ---- | ---- | -------------- |
| `test_deleting_a_team_document_releases_the_team_counter` | `apps/knowledge-flow-backend/tests/features/test_metadata_service_storage_release.py` | AC1 — team-owned release |
| `test_deleting_a_personal_document_releases_the_owning_users_counter` | same | AC2 — personal-tag release credits the tag owner, not the deleter |
| `test_removing_the_last_tag_releases_using_the_pre_removal_tags` | same | AC3 — tags are snapshotted before the branch empties them |
| `test_repeated_delete_does_not_decrement_twice` | same | AC4 — sequential retry |
| `test_a_concurrent_loser_does_not_release_the_same_bytes` | same | AC4 — conditional DELETE is the exactly-once gate |
| `test_a_failed_metadata_delete_releases_nothing` | same | AC5 — failed delete changes no usage |
| `test_deleting_a_document_with_no_recorded_size_is_a_no_op` | same | `file_size_bytes=None` legacy records |
| `test_team_release_subtracts_the_released_bytes` | `libs/fred-core/fred_core/tests/teams/test_storage_usage_clamp.py` | ordinary team decrement |
| `test_team_release_below_zero_is_clamped` | same | AC4 — never negative |
| `test_concurrent_team_releases_are_not_lost` | same | 10 concurrent releases land all 10 |
| `test_concurrent_user_releases_are_not_lost` | same | same, personal counter |
| `test_user_release_subtracts_then_clamps` | same | personal decrement + clamp |
| `test_user_release_for_an_unknown_user_records_zero_not_a_negative` | same | release before any charge |
| `test_a_negative_file_size_is_rejected_at_the_boundary` | same | negative size would *increase* usage on delete |
| `test_tagless_upload_within_personal_quota_is_accepted` | `apps/knowledge-flow-backend/tests/features/ingestion/test_upload_quota_guard.py` | #2150 AC1 |
| `test_tagless_upload_over_personal_quota_is_rejected` | same | #2150 AC2 — the bypass itself |
| `test_tagged_upload_still_resolves_its_tag_owners` | same | #2150 AC3 — tagged regression |
| `test_upload_size_is_measured_when_the_file_reports_no_size` | same | #2150 AC4 — both `UploadFile.size` branches |
| `test_an_unreadable_counter_rejects_instead_of_assuming_zero` | same | fail-closed on store error |
| `test_no_personal_limit_configured_leaves_uploads_unrestricted` | same | no invented limit |

**Tests were verified to fail without the fix**, not just to pass with it:

- reverting `metadata_store.py` to the read-modify-write → both concurrency tests fail at `36864`
  instead of `0` (9 of 10 releases lost);
- reverting `service.py` → 4 of 6 original storage-release tests fail;
- restoring `if not tags: return` → 3 of 6 quota-guard tests fail.

**`make code-quality` output:**

```
knowledge-flow-backend:  All checks passed! / 372 files already formatted
                         0 errors, 0 warnings, 0 notes
                         ************ All code quality checks completed ************
fred-core:               All checks passed! / 200 files already formatted
                         0 errors, 0 warnings, 0 notes
```

Root `make code-quality` is **red on a pre-existing finding this PR does not touch**:
detect-secrets "Secret Keyword" at `apps/control-plane-backend/tools/generate_load_test_bundle.py:70`,
last modified in `bbbd6380`, not in this diff.

**Raw `basedpyright` output** (both packages keep non-empty baselines):

```
knowledge-flow-backend:  0 errors, 7 warnings, 0 notes   (all pre-existing reportUnreachable)
fred-core:               0 errors, 2 warnings, 0 notes   (all pre-existing reportUnreachable)
```

**`make test` output:**

```
knowledge-flow-backend:  689 passed, 2 deselected, 18 warnings in 265.47s
fred-core:               398 passed, 22 deselected, 1 warning in 9.50s
```

`make import-order` also passes in both packages as of `3dd5cc5f`; it did not before.
`make code-quality` does **not** run ruff's `--select I`, which is why unsorted imports
passed locally and failed the dedicated CI job — worth knowing before trusting a local
green run.

**Live end-to-end validation** against a real stack (Postgres, Keycloak, OpenFGA, SeaweedFS, Temporal,
ingestion worker, mock OpenAI for embeddings) — offline tests use fakes, so these exercise the real
SQL and transaction boundaries:

| Scenario | Result |
| --- | --- |
| Team upload → delete round trip | `0 → 4023 → 0` |
| Bulk library delete, 10 documents, concurrent fan-out | `30121 → 0`, zero pool errors |
| Over-quota upload against a 5000-byte cap | `400 Storage quota exceeded` |
| Delete, then retry the identical rejected upload | `200` — quota actually freed |
| Untagged upload | counter unchanged `0 → 0`, confirming the deferral |

A direct probe against real PostgreSQL also confirmed the store primitives: the pre-change
read-modify-write left `28672` instead of `0` under 10 concurrent releases, the atomic version left
`0`, the `CASE` clamp floors correctly, and 10 concurrent deletes produced exactly 1 winner.

---

## 5. Docs updated

| What changed | File updated |
| ------------ | ------------ |
| Backlog `[ ]` item is now done | n/a — `BACKLOG.md`/`WORKPLAN.md` frozen 2026-07-16, `CLAUDE.md` forbids writing to them |
| New behaviour, API field, or contract change | n/a — no API field or endpoint changed. The internal store contract change (`delete_metadata` → `bool`) is documented on `BaseDocumentMetadataStore.delete_metadata`; the never-negative invariant is documented on `BaseUserStore.increment_current_storage_size` |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | **Yes — OpenAPI spec changed.** `Identity.author` gained a `Field(description=...)` and `FileInfo.file_size_bytes`/`page_count`/`row_count` gained `ge=0`, which emit a property description and `minimum: 0` in the spec. `apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts` regenerated via `cd apps/frontend && make update-knowledge-flow-api` and committed in `3dd5cc5f`. Only the description reaches the TS client (codegen drops numeric bounds), so the slice diff is one doc comment. `openapi.json` is gitignored, so the client slice is the committed artifact |
| UX component implemented or visual status changed | n/a — backend only |
| Phase progress row exists for this area | n/a — no phase-tracking doc covers storage accounting |
| WORKPLAN sprint item finished | n/a — frozen |
| Code and a design doc now diverge | n/a — no design doc specifies storage accounting (`grep` over `docs/swift/design/` returns no quota hits) |


---

## 6. Close-out statement

```
## Task close-out
- Code: #2149 — release storage on both hard-delete paths via the existing ownership rules; atomic
  counter updates; conditional delete as the exactly-once gate; delete+release in one transaction with
  failures propagating; retag accounting; serial sub-tag deletion with batched fan-out; path-boundary
  tag matching; non-negative size validation. #2150 — remove the tagless quota bypass and make the
  personal-counter read fail closed.
- Tests: 20 added, 4 doubles updated. make test: knowledge-flow 689 passed / 0 failed, fred-core
  398 passed / 0 failed. Concurrency and bypass tests verified to fail against the pre-change code.
  5 live end-to-end scenarios pass against a real stack.
- Docs updated: none required — no design doc owns storage accounting; contract changes documented on
  the abstract store methods. Draft RFC written for the deferred untagged work (not in this PR).
- Backlog: n/a — frozen; GitHub issues #2149 and #2150 are the tracking unit.
- Skipped steps: RFC not written for the shipped scope (behaviour fix, no new design) — flagged in §2
  as arguable given the store-contract change. Optimistic locking for concurrent tag mutation, and
  extracting accounting out of the 1500-line service.py, are both known and deferred.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

- **Under-counting.** The counter can now go down. On a deployment where
  `alembic/backfill/backfill_storage_usage.py` never ran, documents predating accounting were never
  charged, so deleting one clamps the counter toward 0 and a team briefly under-reports usage. Before
  this PR the counter only ever grew, so enforcement failed *closed*; it can now fail *open*. Bounded
  by the clamp (never negative) and correctable by re-running the backfill — which
  `3dd5cc5f` repairs, because it previously crashed on untagged rows and could not be
  run at all on many deployments. Note it now refuses to run when it meets a legacy
  `"personal"` owner tag, rather than writing a wrong absolute value; those tags must be
  repaired first.
- **`delete_metadata` contract.** It returns `bool` instead of `None`. All in-repo callers and the
  four test doubles are updated; an out-of-repo implementation of `BaseDocumentMetadataStore` would
  need the same change. A subclass that still returns `None` would be treated as "did not delete" and
  would silently stop releasing quota — it fails safe, not destructive.
- **Serial sub-tag deletion.** Deleting a deep tag tree is slower than before (bounded batches of 5
  per tag, tags processed one at a time). Correctness was chosen over latency here because the
  previous concurrency lost decrements and could strand documents.
- **Re-adding an already-present tag** now emits an `authz.relation.granted` audit event for a grant
  that already existed, and can fail with `MetadataUpdateError` when OpenFGA is unavailable, where it
  previously always succeeded. That is the cost of making a retry repair a missing parent relation
  instead of silently doing nothing.
- **A counter failure now aborts a library deletion** where it used to be swallowed. Deliberate —
  silent drift is the defect this PR removes — and a retry is safe because already-removed tags
  short-circuit.
- **The backfill now refuses to run** when it meets a tag carrying the legacy `"personal"` owner
  sentinel, instead of writing an absolute counter it cannot compute without an acting user. Those
  tags must be repaired before the remedy can be used.
- **Not fixed.** Concurrent tag mutations on the same document remain unsafe (no row versioning), and
  untagged documents remain unreachable and unaccounted. Both are documented, neither is made worse.

**How do we roll back?**

Revert the two commits — `git revert b859b92c 3dd5cc5f`. There is no migration, no schema change and
no data backfill, so revert is clean: the counters simply stop being decremented again and the tagless
guard returns to its early exit. Counters written while the PR was live remain valid; they are the
same field the pre-PR code maintains. If only the upload guard is a problem, `b859b92c` reverts
independently. `3dd5cc5f` should not be reverted alone if `b859b92c` stays, since the guard leans on
the accounting being correct.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
