### PR TITLE
Fix/memory leak 1

### DIFF
--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pdf_markdown_processor/pdf_markdown_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pdf_markdown_processor/pdf_markdown_processor.py
@@ -76,6 +76,11 @@ class PdfMarkdownProcessor(BaseMarkdownProcessor):
         # extractor config is built once and reused rather than rebuilt per document.
         self._extractor_cache: dict[tuple[str, int], BasePdfExtractor] = {}
         self._extractor_cache_lock = threading.Lock()
+        # Same reasoning as _extractor_cache, for the OCR model used on extracted
+        # images (see _get_ocr_model): PaddleOCRmodel.__init__ loads two ONNX Runtime
+        # sessions from disk, so it must not be rebuilt per document either.
+        self._ocr_model: PaddleOCRmodel | None = None
+        self._ocr_model_lock = threading.Lock()
 
     def _remove_all_files(self, folder):
         shutil.rmtree(folder, ignore_errors=True)
@@ -171,6 +176,23 @@ class PdfMarkdownProcessor(BaseMarkdownProcessor):
                     self._extractor_cache[cache_key] = extractor
         return extractor
 
+    def _get_ocr_model(self) -> PaddleOCRmodel:
+        """Build the OCR model once and reuse it across documents.
+
+        Mirrors `_get_extractor` above: `PaddleOCRmodel.__init__` loads two ONNX
+        Runtime inference sessions (detection + recognition) from disk and builds
+        their thread pools, so rebuilding it per document — as the inline
+        `PaddleOCRmodel()` call in `_extract_md` used to — reloads that pipeline on
+        every file, on every one of the worker's concurrent activity threads. Same
+        cost `_get_extractor` already guards against for the docling extractor;
+        this closes the same gap for the image OCR/VLM loop's model.
+        """
+        if self._ocr_model is None:
+            with self._ocr_model_lock:
+                if self._ocr_model is None:
+                    self._ocr_model = PaddleOCRmodel()
+        return self._ocr_model
+
     def _pdf_kpi_timer(self, name: str, dims: Dims) -> AbstractContextManager:
         """Guarded KPI timer for the per-image OCR/VLM path.
 
@@ -248,7 +270,7 @@ class PdfMarkdownProcessor(BaseMarkdownProcessor):
                 "knowledge_flow.pdf.image_loop_latency_ms",
                 {"pdf_stage": "image_loop", "file_type": "pdf"},
             ):
-                ocr_model = PaddleOCRmodel()
+                ocr_model = self._get_ocr_model()
                 ocr_results = self._use_ocr(ocr_model, images_transcription)
                 for image_transcription, ocr_result in zip(images_transcription, ocr_results):
                     if use_image_describer:

--- a/apps/knowledge-flow-backend/tests/processors/input/pdf_markdown_processor/test_pdf_markdown_processor.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/pdf_markdown_processor/test_pdf_markdown_processor.py
@@ -253,6 +253,57 @@ def test_pdf_processor_builds_extractor_only_once_per_config(monkeypatch: pytest
     assert build_calls == [("docling", 2)]
 
 
+def test_pdf_processor_builds_ocr_model_only_once_across_documents(monkeypatch: pytest.MonkeyPatch, processor: PdfMarkdownProcessor, sample_pdf_file: Path, tmp_path: Path):
+    """`_get_ocr_model` must reuse the same PaddleOCRmodel instance across documents
+    instead of rebuilding it (and reloading its two ONNX Runtime sessions) on every
+    single file — the OCR-loop equivalent of `_get_extractor`'s caching above."""
+    img_path = tmp_path / "img0.png"
+
+    class FakeExtractor:
+        def extract(self, file_path: Path, work_dir: str):
+            return (f"Before\n\n![]({img_path})\n\nAfter", [ImageTranscription(image_path=img_path)])
+
+    build_calls: list[None] = []
+
+    class FakeOcrModel:
+        def __init__(self):
+            build_calls.append(None)
+
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.pdf_markdown_processor.pdf_markdown_processor.get_configuration",
+        lambda: SimpleNamespace(
+            vision_model=None,
+            processing=SimpleNamespace(
+                normalize_profile=lambda p: p,
+                get_profile_config=lambda p: SimpleNamespace(
+                    process_images=False,
+                    pdf=ProcessingConfig.PdfPipelineConfig(extractor="docling", do_ocr=True),
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.pdf_markdown_processor.pdf_markdown_processor.get_current_processing_profile",
+        lambda: "rich",
+    )
+    monkeypatch.setattr(processor, "_build_extractor", lambda *_: FakeExtractor())
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.pdf_markdown_processor.pdf_markdown_processor.PaddleOCRmodel",
+        FakeOcrModel,
+    )
+    monkeypatch.setattr(
+        processor,
+        "_use_ocr",
+        lambda model, images: [{"rec_texts": ["OCR extracted text"]}],
+    )
+
+    for i in range(3):
+        result = processor.convert_file_to_markdown(sample_pdf_file, tmp_path / f"out{i}", f"doc-{i}")
+        assert Path(result["md_file"]).exists()
+
+    assert len(build_calls) == 1
+
+
 def test_activity_in_activity_survives_to_thread_with_heartbeat():
     """`_extract_md` runs inside a Temporal activity but off the activity's own
     coroutine, via `to_thread_with_heartbeat` (asyncio.to_thread). `_pdf_kpi_timer`

--- a/docs/swift/issues/ISSUE-006-pdf-ocr-model-rebuilt-per-document.md
+++ b/docs/swift/issues/ISSUE-006-pdf-ocr-model-rebuilt-per-document.md
@@ -1,0 +1,75 @@
+# ISSUE-006 - knowledge-flow-worker OOM: PaddleOCRmodel rebuilt per document instead of cached
+
+Status: done (fix on branch `fix/memory-leak-1`, not yet merged to `swift`)
+Owner: Dimitri Tombroff
+Target window: fixed 2026-07-31, same day as reported
+
+## Problem
+`PdfMarkdownProcessor._extract_md()` built a fresh `PaddleOCRmodel()` — which loads two ONNX
+Runtime inference sessions (detection + recognition) from disk — on every single document with
+OCR-eligible images, instead of reusing one instance across documents. `DoclingPdfExtractor`,
+built in the same class, was already correctly cached for the same reason. This is a separate bug
+from the `fitz.Document` handle leak fixed in `569d08e6` (2026-07-30): that fix covers the
+`pymupdf` extractor path; this one is in the OCR/VLM image loop shared by every extractor whenever
+`use_ocr=True`.
+
+## Why it matters
+- Reproduced live on fredlab (`medium` profile, docling extractor, OCR on): worker memory grew
+  with total documents processed, not with concurrency (`ingestion_max_concurrent_activities: 3`
+  caps real parallelism, but memory kept climbing past 30+ documents regardless).
+- OOMKilled the worker pod even after raising its memory limit 3Gi → 5Gi — the extra headroom only
+  delayed the crash, `exitCode 137`/`OOMKilled` at 06:49:20Z 2026-07-31.
+- Independent of the leak, rebuilding two ONNX sessions from disk per document is wasted latency on
+  top of legitimate inference cost — a likely contributor to slow ingestion throughput.
+
+## Current evidence
+- `apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pdf_markdown_processor/pdf_markdown_processor.py`
+  (pre-fix, line ~251): `ocr_model = PaddleOCRmodel()` inside `_extract_md`'s OCR/VLM loop, called
+  once per document.
+- Same file, `_get_extractor`/`_extractor_cache` (line ~154): the docling extractor equivalent,
+  already lock-guarded and cached, with a comment explaining exactly why per-document rebuilds are
+  costly — no equivalent existed for the OCR model.
+- Live fredlab logs: two `Creating model: (...)` lines (`PP-OCRv6_tiny_det`,
+  `latin_PP-OCRv5_mobile_rec`) per document during `image OCR/VLM loop starting`, for every
+  document processed.
+- `kubectl get pod -o json` on the OOMKilled pod: `lastState.terminated.reason: OOMKilled`,
+  `exitCode: 137`, container ran 06:22:15Z→06:49:20Z.
+- Live memory samples (`kubectl top pod`, 15s interval) across two batches show growth tracking
+  total documents processed rather than concurrent workflow count (`running_wf` swung 6→38 without
+  proportional memory swing).
+
+## Scope
+- Active paths:
+  - `PdfMarkdownProcessor._extract_md()` OCR/VLM image loop — every PDF extractor
+    (`docling`, `pymupdf`) whenever the processing profile has `pdf.do_ocr: true`.
+- Not in scope:
+  - `PyMuPdfExtractor`'s `fitz.Document` handle leak — separately fixed in `569d08e6`.
+  - `DoclingPdfExtractor`'s own internal OCR pass (RapidOCR) — already cached via
+    `_get_document_converter`, unaffected.
+
+## Proposed fix
+- Applied: added `_get_ocr_model()` to `PdfMarkdownProcessor`, mirroring `_get_extractor`'s
+  lock-guarded single-instance cache. `_extract_md` now calls `self._get_ocr_model()` instead of
+  instantiating `PaddleOCRmodel()` inline. Regression test added
+  (`test_pdf_processor_builds_ocr_model_only_once_across_documents`) asserting the model is built
+  once across multiple documents.
+
+## Acceptance checks
+- [x] Unit tests pass, including the new caching regression test (9/9,
+      `tests/processors/input/pdf_markdown_processor/test_pdf_markdown_processor.py`).
+- [x] Live validation on fredlab: hotfix image (built from this branch) deployed to
+      `knowledge-flow-backend`/`knowledge-flow-worker`, same document batch re-ingested. Peak
+      memory 4142Mi (80% of the 5Gi limit) with repeated real decreases during processing (e.g.
+      -999Mi, -125Mi) — behavior never observed pre-fix, where memory only ever climbed. Batch
+      completed at 3781Mi, zero restarts, no OOM.
+- [ ] Longer-running / larger-batch validation (a third consecutive batch, or a genuinely large
+      single batch) to confirm the plateau holds over more documents than tested so far.
+
+## Promotion
+Promoted to: none — fix already implemented and live-validated on fredlab; awaiting PR review/merge
+of `fix/memory-leak-1` into `swift`, then a real release to replace the temporary Artifact-Registry
+hotfix image (`gcp-c1/argocd/fred-apps/values-fredlab.yaml`, `knowledgeFlow`/`knowledgeFlowWorker`
+currently point at a `europe-west1-docker.pkg.dev/.../knowledge-flow-backend:20260731-swift-fce260d6`
+build off this branch — temporary, must revert to `ghcr.io` once officially released).
+Notes: Full investigation timeline, raw monitoring samples, and root-cause analysis in the session
+report (not committed — ask Dimitri if you need the original).


### PR DESCRIPTION
Summary
PdfMarkdownProcessor._extract_md() built a fresh PaddleOCRmodel() — two ONNX Runtime sessions (detection + recognition) loaded from disk — on every single document with OCR-eligible images, instead of reusing one instance. The docling extractor right next to it in the same class was already cached (_extractor_cache) for exactly this reason; the OCR model had no equivalent.

Live on fredlab (medium profile, docling + OCR): worker memory grew with total documents processed, not with concurrency, and OOM-killed the pod even after raising its memory limit 3Gi → 5Gi — the extra headroom only delayed the crash. This is a separate bug from the fitz.Document leak fixed in #2176 / 569d08e6 (that one's in the pymupdf extractor path; this one is in the OCR/VLM image loop shared by every extractor).

Fix: added _get_ocr_model(), mirroring _get_extractor()'s lock-guarded single-instance cache. _extract_md now reuses the same PaddleOCRmodel across documents instead of rebuilding it. Also closes part of the "ingestion is slow" complaint — reloading two ONNX models per file was pure waste on top of legitimate inference cost.

Full root-cause writeup: docs/swift/issues/ISSUE-006-pdf-ocr-model-rebuilt-per-document.md.

Test plan
 Unit tests pass (9/9), including a new regression test asserting the OCR model is built once across multiple documents (test_pdf_processor_builds_ocr_model_only_once_across_documents).
 Live-validated on fredlab: built this branch as a temporary hotfix image, deployed to knowledge-flow-backend/knowledge-flow-worker, re-ran the same ingestion batch that previously OOM-killed the worker.
Before: memory only ever climbed — batch 1 ended at 4413Mi and never came back down over 4.5 min idle; batch 2 climbed straight through to OOM (exitCode 137) at 5046Mi.
After: repeated real decreases during processing (e.g. -999Mi, -125Mi in a single sample), peak 4142Mi (80% of the 5Gi limit), batch completed at 3781Mi, zero restarts, no OOM.
 Longer-running / larger-batch validation still worth doing before fully closing the loop — noted as an open acceptance check in ISSUE-006.
