### PR TITLE
fix(RUNTIME): pin mcp<2.0.0 in fred-runtime, raise dependent floors

### DIFF
--- a/apps/fred-agents/pyproject.toml
+++ b/apps/fred-agents/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Fredlab", email = "contact@fredlab.com" }]
 dependencies = [
   "fred-core>=3.4.0",
   "fred-sdk>=3.3.0",
-  "fred-runtime[app]>=3.3.0",
+  "fred-runtime[app]>=3.4.2",
   # First-party capabilities installed on this pod: installing the package IS
   # the registration (AGENT-CAPABILITY-RFC §4/§7, fred.capabilities entry point).
   "fred-capability-writable-document>=0.1.0",

--- a/apps/fred-agents/uv.lock
+++ b/apps/fred-agents/uv.lock
@@ -668,7 +668,7 @@ dev = [
 
 [[package]]
 name = "fred-capability-writable-document"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../../libs/fred-capability-writable-document" }
 dependencies = [
     { name = "fastapi" },
@@ -811,7 +811,7 @@ dev = [
 
 [[package]]
 name = "fred-runtime"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "../../libs/fred-runtime" }
 dependencies = [
     { name = "alembic" },
@@ -824,6 +824,7 @@ dependencies = [
     { name = "langchain-mcp-adapters" },
     { name = "langfuse" },
     { name = "langgraph" },
+    { name = "mcp" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -850,6 +851,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.2.1" },
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = ">=1.2.9" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },

--- a/docs/swift/platform/DEVELOPER_CONTRACT.md
+++ b/docs/swift/platform/DEVELOPER_CONTRACT.md
@@ -104,7 +104,35 @@ Each PR must explicitly confirm:
 - New external dependency tests marked as integration.
 - Documentation updated when behavior/rules changed.
 
-## 6) AI Assistant Instructions
+## 6) Python Dependency Version Pins
+
+Third-party packages sometimes ship a major version with no upper bound in
+their own dependency declaration — a fresh `uv lock`/`uv sync` can then pull
+a breaking release without any change on our side. This has bitten this repo
+once already (`mcp` 2.0.0, 2026-08-01, #2194 — `langchain-mcp-adapters`
+declared `mcp>=1.24.0` unbounded, and `mcp` 2.0.0 broke import at boot
+before any upstream release supported it).
+
+- If a module's `pyproject.toml` needs to cap a **transitive** dependency
+  (one it doesn't import directly), add it as an explicit direct dependency
+  with the bound, not a comment-only note — the resolver only respects
+  declared constraints. Example, `libs/fred-runtime/pyproject.toml`:
+  ```
+  "langchain-mcp-adapters>=0.2.1",
+  "mcp>=1.24.0,<2.0.0",  # caps the unbounded transitive constraint above
+  ```
+- State the reason and link the tracking issue/upstream issue in a comment
+  directly above the pin — the next reader (human or assistant) must be able
+  to tell whether the cap is still needed without archaeology.
+- Regenerating the module's `uv.lock` and running `make code-quality` /
+  `make test` after touching a pin is required before merge — pinning alone
+  does not prove the resolution still installs cleanly.
+- Before lifting a cap, confirm the upstream package that forced it has an
+  actual released (not draft/unmerged) version compatible with the newer
+  major — check the linked upstream issue/PR state, don't assume time alone
+  fixed it.
+
+## 7) AI Assistant Instructions
 
 When prompting an assistant, start with:
 

--- a/libs/fred-capability-writable-document/pyproject.toml
+++ b/libs/fred-capability-writable-document/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-capability-writable-document"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fred agent capability: co-author a session-scoped Markdown document from chat (writable_document)."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -11,7 +11,7 @@ dependencies = [
   "fred-sdk>=3.3.0",
   # fred-runtime supplies the pod config loader the store + Alembic env read to
   # build their async engine (`load_agent_pod_config().storage.postgres`).
-  "fred-runtime>=3.3.0",
+  "fred-runtime>=3.4.2",
   "pydantic>=2.7.0,<3.0.0",
   "langchain-core>=0.3.0",
   "langchain>=0.3.0",

--- a/libs/fred-capability-writable-document/uv.lock
+++ b/libs/fred-capability-writable-document/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "fred-capability-writable-document"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -714,7 +714,7 @@ dev = [
 
 [[package]]
 name = "fred-runtime"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "../fred-runtime" }
 dependencies = [
     { name = "alembic" },
@@ -727,6 +727,7 @@ dependencies = [
     { name = "langchain-mcp-adapters" },
     { name = "langfuse" },
     { name = "langgraph" },
+    { name = "mcp" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -748,6 +749,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.2.1" },
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = ">=1.2.9" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },

--- a/libs/fred-runtime/pyproject.toml
+++ b/libs/fred-runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-runtime"
-version = "3.4.1"
+version = "3.4.2"
 description = "Runtime adapters and infrastructure wiring for Fred v2 agents."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -13,6 +13,12 @@ dependencies = [
   "deepagents>=0.6.12",
   "httpx>=0.28.1",
   "langchain-mcp-adapters>=0.2.1",
+  # langchain-mcp-adapters declares mcp>=1.24.0 with no upper bound (true for
+  # every release through 0.3.1). mcp 2.0.0 (2026-07-28) is a breaking
+  # rewrite langchain-mcp-adapters does not support yet — pin here to keep
+  # fresh installs on mcp v1 until upstream ships v2 support. See #2194 and
+  # https://github.com/langchain-ai/langchain-mcp-adapters/issues/578.
+  "mcp>=1.24.0,<2.0.0",
   "langchain>=1.3.14",
   "langchain-core>=0.3.0",
   "langgraph>=1.2.9",

--- a/libs/fred-runtime/uv.lock
+++ b/libs/fred-runtime/uv.lock
@@ -643,7 +643,7 @@ dev = [
 
 [[package]]
 name = "fred-runtime"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -656,6 +656,7 @@ dependencies = [
     { name = "langchain-mcp-adapters" },
     { name = "langfuse" },
     { name = "langgraph" },
+    { name = "mcp" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -704,6 +705,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters", specifier = ">=0.2.1" },
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = ">=1.2.9" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },


### PR DESCRIPTION
## Summary

- `langchain-mcp-adapters` declares `mcp>=1.24.0` with no upper bound (true for every release through 0.3.1 — [upstream issue](https://github.com/langchain-ai/langchain-mcp-adapters/issues/578)). `mcp` published a breaking `2.0.0` on 2026-07-28, and no released `langchain-mcp-adapters` supports it yet.
- A fresh `uv lock`/`uv sync` resolves `mcp==2.0.0`, and any consumer importing `fred_runtime.app.create_agent_app` crashes at boot (`ImportError: cannot import name 'RequestContext' from 'mcp.shared.context'`). Reproduced locally 2026-08-01; hit independently by the `bid-agents` sibling repo doing a cold resolve.
- `libs/fred-runtime`: pin `mcp>=1.24.0,<2.0.0`, patch bump `3.4.1 -> 3.4.2`.
- `apps/fred-agents`, `libs/fred-capability-writable-document`: raise the `fred-runtime` floor to `>=3.4.2`; bump `fred-capability-writable-document` `0.1.0 -> 0.1.1` (independently published to PyPI, equally exposed).
- `docs/swift/platform/DEVELOPER_CONTRACT.md`: new short section (no RFC — settled/mechanical) documenting the pinning pattern for unbounded transitive deps.
- `uv.lock` regenerated for all three touched modules — `mcp` still resolves to `1.28.1` everywhere, so no behavior change, just the new declared bound.

Closes #2194.

## Test plan

- [x] `make code-quality` — `libs/fred-runtime`, `apps/fred-agents`, `libs/fred-capability-writable-document`
- [x] `make test` — same three modules (714 / 42 / 50 passed)
- [x] `uv run python -c "from fred_runtime.app import create_agent_app"` boot-import smoke check
- [ ] PyPI republish of `fred-runtime` 3.4.2 and `fred-capability-writable-document` 0.1.1 (manual, requires `PYPI_TOKEN` — left for the developer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)