### PR TITLE
fix(fred-core): live_object_census() type-key collisions + honest cost caveat

### DIFF
--- a/apps/control-plane-backend/uv.lock
+++ b/apps/control-plane-backend/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/fred-agents/uv.lock
+++ b/apps/fred-agents/uv.lock
@@ -718,7 +718,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/knowledge-flow-backend/uv.lock
+++ b/apps/knowledge-flow-backend/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-capability-ppt-filler/uv.lock
+++ b/libs/fred-capability-ppt-filler/uv.lock
@@ -572,7 +572,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-capability-writable-document/uv.lock
+++ b/libs/fred-capability-writable-document/uv.lock
@@ -621,7 +621,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-core/fred_core/diagnostics/gc_diagnostics.py
+++ b/libs/fred-core/fred_core/diagnostics/gc_diagnostics.py
@@ -155,6 +155,21 @@ class GCTypeReport:
     top_types: tuple[tuple[str, int], ...]
 
 
+def _type_key(obj: object) -> str:
+    """Module-qualified type name for grouping in a report — plain
+    `type(obj).__name__` conflates unrelated classes that happen to share a
+    short name (e.g. two different `Config` classes in two different
+    modules), which is exactly the kind of ambiguity a diagnostic report must
+    not have. Builtins/stdlib types (`__module__ == "builtins"`) stay bare
+    (`dict`, not `builtins.dict`) — no realistic collision there, and the
+    prefix would just be noise on the types that dominate every count."""
+    cls = type(obj)
+    module = getattr(cls, "__module__", None)
+    if not module or module == "builtins":
+        return cls.__name__
+    return f"{module}.{cls.__qualname__}"
+
+
 def collect_and_report_types(top_n: int = 20, *, log: bool = True) -> GCTypeReport:
     """Heavier variant of collect_and_trim: reports WHICH object types make up
     the reference-cycle garbage, not just a count (this is how ISSUE-010 was
@@ -173,7 +188,7 @@ def collect_and_report_types(top_n: int = 20, *, log: bool = True) -> GCTypeRepo
         gc.set_debug(old_flags)
 
     new_garbage = gc.garbage[pre_existing_garbage_count:]
-    top_types = tuple(Counter(type(o).__name__ for o in new_garbage).most_common(top_n))
+    top_types = tuple(Counter(_type_key(o) for o in new_garbage).most_common(top_n))
     garbage_count = len(new_garbage)
     del gc.garbage[pre_existing_garbage_count:]
     # Drop our own reference too, or the collect() below can't free these.
@@ -231,14 +246,13 @@ def live_object_census(top_n: int = 20, *, log: bool = True) -> LiveObjectCensus
     garbage, never memory some live code is still genuinely holding a reference
     to — the two are different bug classes with different symptoms here.
 
-    Two things this census can silently miss, both surfaced explicitly rather
-    than left as a footnote:
+    Three things this census can silently miss or mislead on, all surfaced
+    explicitly rather than left as a footnote:
     - Sizes are sys.getsizeof() — SHALLOW, an object's own overhead, not what
       it points to (a dict of huge values looks small; the values themselves
       show up under their own type instead). top_by_count is often more
       telling than top_by_size for exactly that reason. No third-party
-      deep-sizer (e.g. pympler) is used, to keep this module dependency-free
-      and safe to run on a live pod without a second thought.
+      deep-sizer (e.g. pympler) is used, to keep this module dependency-free.
     - gc.get_objects() only tracks container-shaped objects that could join a
       cycle — plain bytes/str/most native buffers (including, often, tensor
       storage) are invisible here even at gigabyte scale. A real leak entirely
@@ -246,16 +260,26 @@ def live_object_census(top_n: int = 20, *, log: bool = True) -> LiveObjectCensus
       the logged/returned total is compared against current_rss_kb(): a small
       shallow-total-to-RSS ratio is the census itself telling you to look
       elsewhere, not a clean bill of health.
+    - This is O(objects currently tracked) — millions on a real pod (~1.3M
+      seen live on fredlab) — and runs synchronously wherever it's called
+      from (e.g. the SIGUSR2 handler, on the event loop thread), taking real
+      wall-clock time (multiple seconds observed live). An on-demand
+      diagnostic, not something to call from a request path or a tight
+      periodic loop.
 
     sizing_failures counts objects whose sys.getsizeof() raised (rare — a
     handful of types lack or break __sizeof__); when non-zero,
-    total_bytes_shallow/top_by_size undercount by that many objects' worth."""
+    total_bytes_shallow/top_by_size undercount by that many objects' worth.
+
+    Types are grouped by _type_key() (module-qualified, e.g.
+    "myapp.models.Config" — see its docstring for why bare __name__ isn't
+    enough)."""
     objects = gc.get_objects()
     counts: Counter[str] = Counter()
     sizes: Counter[str] = Counter()
     sizing_failures = 0
     for obj in objects:
-        name = type(obj).__name__
+        name = _type_key(obj)
         counts[name] += 1
         try:
             sizes[name] += sys.getsizeof(obj)

--- a/libs/fred-core/fred_core/diagnostics/gc_diagnostics.py
+++ b/libs/fred-core/fred_core/diagnostics/gc_diagnostics.py
@@ -155,19 +155,40 @@ class GCTypeReport:
     top_types: tuple[tuple[str, int], ...]
 
 
-def _type_key(obj: object) -> str:
+def _type_key_for_class(cls: type) -> str:
     """Module-qualified type name for grouping in a report — plain
-    `type(obj).__name__` conflates unrelated classes that happen to share a
-    short name (e.g. two different `Config` classes in two different
-    modules), which is exactly the kind of ambiguity a diagnostic report must
-    not have. Builtins/stdlib types (`__module__ == "builtins"`) stay bare
-    (`dict`, not `builtins.dict`) — no realistic collision there, and the
-    prefix would just be noise on the types that dominate every count."""
-    cls = type(obj)
-    module = getattr(cls, "__module__", None)
-    if not module or module == "builtins":
-        return cls.__name__
-    return f"{module}.{cls.__qualname__}"
+    `cls.__name__` conflates unrelated classes that happen to share a short
+    name (e.g. two different `Config` classes in two different modules),
+    which is exactly the kind of ambiguity a diagnostic report must not
+    have. Builtins (`__module__ == "builtins"`, e.g. `dict`, `list`) stay
+    bare — no realistic collision there, and the prefix would just be noise
+    on the types that dominate every count. Everything else, including other
+    stdlib types (e.g. `collections.Counter`), is qualified.
+
+    Never raises: a class whose metaclass overrides `__getattribute__` and
+    breaks on `__module__`/`__qualname__` access falls back to an
+    id-based placeholder rather than aborting the whole scan — one hostile
+    type in a heap of millions of ordinary ones must not take the census
+    down with it."""
+    try:
+        module = getattr(cls, "__module__", None)
+        name = getattr(cls, "__qualname__", None) or getattr(cls, "__name__", None)
+        if not name:
+            return f"<unknown-type id={id(cls)}>"
+        if not module or module == "builtins":
+            return name
+        return f"{module}.{name}"
+    except Exception:
+        return f"<unknown-type id={id(cls)}>"
+
+
+def _type_key(obj: object) -> str:
+    """Module-qualified type name for a single object — see
+    _type_key_for_class() for the actual logic. Callers walking many
+    instances that share a handful of types (e.g. live_object_census's heap
+    scan) should call _type_key_for_class() directly with their own
+    per-class cache instead, to avoid redoing this work per instance."""
+    return _type_key_for_class(type(obj))
 
 
 def collect_and_report_types(top_n: int = 20, *, log: bool = True) -> GCTypeReport:
@@ -271,15 +292,25 @@ def live_object_census(top_n: int = 20, *, log: bool = True) -> LiveObjectCensus
     handful of types lack or break __sizeof__); when non-zero,
     total_bytes_shallow/top_by_size undercount by that many objects' worth.
 
-    Types are grouped by _type_key() (module-qualified, e.g.
+    Types are grouped by _type_key_for_class() (module-qualified, e.g.
     "myapp.models.Config" — see its docstring for why bare __name__ isn't
-    enough)."""
+    enough), resolved once per distinct class and cached for the rest of the
+    walk rather than recomputed per instance."""
     objects = gc.get_objects()
     counts: Counter[str] = Counter()
     sizes: Counter[str] = Counter()
     sizing_failures = 0
+    # A real pod's ~1.3M tracked objects overwhelmingly share a handful of
+    # types (dict, str-holding wrappers, pydantic models, ...) — resolve each
+    # class's key once and reuse it, instead of redoing _type_key_for_class's
+    # getattr/format work per instance.
+    type_key_cache: dict[type, str] = {}
     for obj in objects:
-        name = _type_key(obj)
+        cls = type(obj)
+        name = type_key_cache.get(cls)
+        if name is None:
+            name = _type_key_for_class(cls)
+            type_key_cache[cls] = name
         counts[name] += 1
         try:
             sizes[name] += sys.getsizeof(obj)

--- a/libs/fred-core/fred_core/tests/diagnostics/test_gc_diagnostics.py
+++ b/libs/fred-core/fred_core/tests/diagnostics/test_gc_diagnostics.py
@@ -230,6 +230,57 @@ def test_type_key_disambiguates_same_named_classes_from_different_modules():
     assert key_b == "fake_module_b.Config"
 
 
+def test_type_key_qualifies_non_builtin_stdlib_types():
+    # Copilot review on #2199: the docstring previously said "builtins/stdlib
+    # types" stay bare, but the actual condition is __module__ == "builtins"
+    # only — a non-builtin stdlib type like collections.Counter must still be
+    # qualified, or a Counter and some hypothetical unrelated app-level
+    # "Counter" class would collide in a report exactly like the bug this
+    # module exists to prevent.
+    from collections import Counter as StdlibCounter
+
+    assert gcd._type_key(StdlibCounter()) == "collections.Counter"
+
+
+def test_type_key_for_class_survives_a_hostile_metaclass():
+    # chatgpt-codex-connector review on #2199: a class whose metaclass
+    # overrides __getattribute__ and raises on __module__/__qualname__
+    # access must not abort the whole census/report for every other
+    # ordinary object — it degrades to a placeholder instead.
+    class HostileMeta(type):
+        def __getattribute__(cls, name):
+            if name in ("__module__", "__qualname__", "__name__"):
+                raise RuntimeError("nope")
+            return type.__getattribute__(cls, name)
+
+    class Hostile(metaclass=HostileMeta):
+        pass
+
+    key = gcd._type_key_for_class(Hostile)
+    assert key.startswith("<unknown-type id=")
+
+
+def test_live_object_census_caches_type_key_per_class(monkeypatch):
+    # chatgpt-codex-connector review on #2199: with ~1.3M tracked objects
+    # sharing a handful of types, _type_key_for_class() must be called at
+    # most once per distinct class, not once per instance.
+    calls: list[type] = []
+    real = gcd._type_key_for_class
+
+    def counting(cls):
+        calls.append(cls)
+        return real(cls)
+
+    monkeypatch.setattr(gcd, "_type_key_for_class", counting)
+    instances = [object() for _ in range(50)]
+    try:
+        result = gcd.live_object_census(log=False)
+        assert result.total_objects >= 50
+        assert calls.count(object) <= 1
+    finally:
+        del instances
+
+
 def test_shallow_fraction_of_rss_handles_unknown_rss():
     assert gcd._shallow_fraction_of_rss(1000, None) == "RSS unknown"
     assert gcd._shallow_fraction_of_rss(1000, 0) == "RSS unknown"

--- a/libs/fred-core/fred_core/tests/diagnostics/test_gc_diagnostics.py
+++ b/libs/fred-core/fred_core/tests/diagnostics/test_gc_diagnostics.py
@@ -250,6 +250,13 @@ def test_type_key_for_class_survives_a_hostile_metaclass():
     class HostileMeta(type):
         def __getattribute__(cls, name):
             if name in ("__module__", "__qualname__", "__name__"):
+                # Deliberately non-standard (a real __getattribute__ should
+                # only ever raise AttributeError): getattr()'s own built-in
+                # fallback already covers a conforming implementation, so a
+                # plain AttributeError here wouldn't exercise the new
+                # try/except Exception in _type_key_for_class at all. This
+                # class exists specifically to prove that guard survives
+                # non-conforming real-world code too.
                 raise RuntimeError("nope")
             return type.__getattribute__(cls, name)
 

--- a/libs/fred-core/fred_core/tests/diagnostics/test_gc_diagnostics.py
+++ b/libs/fred-core/fred_core/tests/diagnostics/test_gc_diagnostics.py
@@ -118,6 +118,7 @@ def test_collect_and_report_types_leaves_nothing_pinned_in_gc_garbage():
         def __init__(self) -> None:
             self.other: "_Node | None" = None
 
+    expected_key = gcd._type_key(_Node())
     a, b = _Node(), _Node()
     a.other, b.other = b, a
     del a, b
@@ -126,7 +127,7 @@ def test_collect_and_report_types_leaves_nothing_pinned_in_gc_garbage():
     try:
         report = collect_and_report_types(log=False)
         assert report.held_for_inspection >= 1
-        assert any(name == "_Node" for name, _count in report.top_types)
+        assert any(name == expected_key for name, _count in report.top_types)
         # Regression check: the function must drop its own reference to the
         # collected garbage before its final gc.collect(), or that collect()
         # can't actually free anything and freed_after_clear is always 0.
@@ -148,7 +149,10 @@ def test_live_object_census_returns_a_populated_result(caplog):
         result = live_object_census(log=True)
     assert result.total_objects > 0
     assert result.total_bytes_shallow > 0
-    assert result.sizing_failures == 0
+    # Not hard-asserted at 0: some real-world type in the test process's own
+    # dependency graph could legitimately raise from __sizeof__. The
+    # non-zero case has its own dedicated, forced test below.
+    assert 0 <= result.sizing_failures <= result.total_objects
     assert result.rss_kb is None or result.rss_kb > 0
     assert result.top_by_count
     assert result.top_by_size
@@ -168,7 +172,11 @@ def test_live_object_census_counts_reflect_a_known_live_object():
     try:
         result = live_object_census(top_n=1000, log=False)
         counts = dict(result.top_by_count)
-        assert counts.get("_Marker", 0) >= 50
+        # Derived via _type_key(), not hardcoded as "_Marker": the key is
+        # module-qualified (see _type_key's own tests), so a plain bare-name
+        # assertion here would silently stop matching if that ever changes.
+        expected_key = gcd._type_key(markers[0])
+        assert counts.get(expected_key, 0) >= 50
     finally:
         del markers
 
@@ -191,6 +199,35 @@ def test_live_object_census_counts_sizing_failures_instead_of_swallowing_them(ca
         )
     finally:
         del broken
+
+
+def test_type_key_keeps_builtins_bare():
+    assert gcd._type_key({}) == "dict"
+    assert gcd._type_key(()) == "tuple"
+
+
+def test_type_key_disambiguates_same_named_classes_from_different_modules():
+    # The exact regression this exists for: two classes named identically,
+    # "defined in different modules" (simulated via __module__), must not
+    # collapse into one census key.
+    class Config:
+        pass
+
+    class _ConfigB:
+        pass
+
+    Config.__qualname__ = "Config"
+    _ConfigB.__name__ = "Config"
+    _ConfigB.__qualname__ = "Config"
+
+    Config.__module__ = "fake_module_a"
+    _ConfigB.__module__ = "fake_module_b"
+
+    key_a = gcd._type_key(Config())
+    key_b = gcd._type_key(_ConfigB())
+    assert key_a != key_b
+    assert key_a == "fake_module_a.Config"
+    assert key_b == "fake_module_b.Config"
 
 
 def test_shallow_fraction_of_rss_handles_unknown_rss():

--- a/libs/fred-core/pyproject.toml
+++ b/libs/fred-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 description = "Core shared utilities for Fred backends (config, storage, security, and runtime helpers)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/fred-core/uv.lock
+++ b/libs/fred-core/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-runtime/uv.lock
+++ b/libs/fred-runtime/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-sdk/uv.lock
+++ b/libs/fred-sdk/uv.lock
@@ -501,7 +501,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.7.1"
+version = "3.7.2"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Small follow-up to #2198 (`live_object_census()`), which merged before its last round of
Copilot review comments (4, all "suppressed"/non-blocking) got addressed. Fixes all four
here:

- **Module-qualified type keys** — `_type_key(obj)` replaces bare `type(obj).__name__` in
  both `collect_and_report_types()` and `live_object_census()`. Two unrelated classes
  sharing a short name (e.g. two different `myapp.Config` / `otherapp.Config`) no longer
  collapse into one misleading census entry. Builtins stay bare (`dict`, not
  `builtins.dict`) — no realistic collision there, and the prefix is just noise on the
  types that dominate every count.
- **Honest cost caveat** — the docstring no longer claims `live_object_census()` is "safe
  to run on a live pod without a second thought". It's O(tracked objects) — millions on a
  real pod (~1.3M seen live on fredlab) — and runs synchronously wherever it's called
  from, taking real wall-clock time (multi-second, observed live). Now documented as an
  on-demand diagnostic, not something for a request path or tight loop.
- **Test robustness** — the "no sizing failures" assertion is no longer a hard `== 0`
  (a real dependency in the test process could legitimately break `__sizeof__` and make
  the suite flaky); relaxed to the actual invariant, with the dedicated forced-failure
  test already covering the non-zero case explicitly. Tests asserting on a specific
  type's census key now derive it via `_type_key()` instead of hardcoding the bare class
  name.
- 2 new direct unit tests for `_type_key()` itself.

fred-core patch bump `3.7.1 -> 3.7.2` (real behavior change: census/type-report keys are
no longer just bare `__name__`). Relocked every path-dependent consumer.

## Test plan

- [x] 30/30 diagnostics tests (2 new for `_type_key()`, existing ones adjusted for
      qualified keys and relaxed `sizing_failures` assertion).
- [x] Full fred-core suite green (428/428, excluding integration tests needing a live
      OpenFGA server).
- [x] Every path-dependent consumer's full suite re-run and green after the version bump:
      fred-runtime (716/716), knowledge-flow-backend (761/761).
- [x] ruff / basedpyright / bandit all clean, no `# nosec` suppressions needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
