### PR TITLE
Team members page: compact search + "more" menu for leave-team

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1729,6 +1729,7 @@
           "updateRoleDetail": "Could not update member role.",
           "updateRoleSummary": "Failed to update role"
         },
+        "moreActions": "More actions",
         "search": {
           "ariaLabel": "Search for a member",
           "clearAriaLabel": "Clear search",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1889,6 +1889,7 @@
           "aria": "Form sections",
           "general": "General",
           "prompts": "Prompts",
+          "tools": "Tools",
           "commitments": "Commitments"
         },
         "selectPlaceholder": "Select an option",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1729,6 +1729,7 @@
           "updateRoleDetail": "Impossible de mettre à jour le rôle du membre.",
           "updateRoleSummary": "Échec de la mise à jour du rôle"
         },
+        "moreActions": "Plus d'actions",
         "search": {
           "ariaLabel": "Rechercher un membre",
           "clearAriaLabel": "Effacer la recherche",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1889,6 +1889,7 @@
           "aria": "Sections du formulaire",
           "general": "Général",
           "prompts": "Prompts",
+          "tools": "Outils",
           "commitments": "Engagement"
         },
         "selectPlaceholder": "Sélectionner une option",

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.test.tsx
@@ -125,6 +125,18 @@ describe("DataTable", () => {
     expect(container.style.getPropertyValue("--datatable-row-height")).toBe("2.5rem");
   });
 
+  it("maps the size preset to its row-height CSS variable", () => {
+    render(<DataTable columns={columns} data={makeRows(3)} size="medium" />);
+    const mediumContainer = document.querySelector('[class*="datatable-container"]') as HTMLElement;
+    expect(mediumContainer.style.getPropertyValue("--datatable-row-height")).toBe("3rem");
+  });
+
+  it("lets an explicit rowHeight override the size preset", () => {
+    render(<DataTable columns={columns} data={makeRows(3)} size="medium" rowHeight="4rem" />);
+    const container = document.querySelector('[class*="datatable-container"]') as HTMLElement;
+    expect(container.style.getPropertyValue("--datatable-row-height")).toBe("4rem");
+  });
+
   it("shows a persistent footer with the total item count even when every row fits on one page", () => {
     render(<DataTable columns={columns} data={makeRows(10)} pageSize={20} />);
     expect(rowValues()).toHaveLength(10);

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -22,6 +22,13 @@ import { OptionModel } from "@models/Option.model.ts";
 
 const ROWS_PER_PAGE_OPTIONS = [20, 50, 100];
 
+export type DataTableRowSize = "medium" | "small";
+
+const ROW_HEIGHT_BY_SIZE: Record<DataTableRowSize, string> = {
+  medium: "3rem" /* 48px */,
+  small: "2.5rem" /* 40px */,
+};
+
 export type SortDirection = "asc" | "desc";
 export interface SortState {
   columnLabel: string;
@@ -53,8 +60,14 @@ interface DataTableProps<T> {
   firstColumnInset?: boolean;
   /** Overrides the row height (header + body, both become equal) — e.g.
    *  "2.5rem" for a denser table. Omit to keep each row type's own default
-   *  height, unaffected — other DataTable call sites don't opt in. */
+   *  height, unaffected — other DataTable call sites don't opt in. Takes
+   *  precedence over `size` when both are given. */
   rowHeight?: string;
+  /** Named row-height presets ("medium" = 48px, "small" = 40px), applied the
+   *  same way as `rowHeight` (header + body become equal). Omit to keep each
+   *  row type's own default height, unaffected — other DataTable call sites
+   *  don't opt in. */
+  size?: DataTableRowSize;
   /** Enables pagination and sets the initial rows-per-page (should be one of
    *  `ROWS_PER_PAGE_OPTIONS`). Omit to render every row with no pagination
    *  bar (default) — existing call sites are unaffected. Ignored when
@@ -130,6 +143,7 @@ export default function DataTable<T>({
   backgroundColor = "var(--surface-container)",
   firstColumnInset = false,
   rowHeight,
+  size,
   pageSize,
   serverPagination,
   rowKey,
@@ -241,6 +255,7 @@ export default function DataTable<T>({
 
   const containerClasses = [styles["datatable-container"]];
   if (firstColumnInset) containerClasses.push(styles["first-column-inset"]);
+  const resolvedRowHeight = rowHeight ?? (size ? ROW_HEIGHT_BY_SIZE[size] : undefined);
 
   return (
     <div
@@ -249,7 +264,7 @@ export default function DataTable<T>({
         {
           "--grid-layout": tableGridLayout,
           "--datatable-background-color": backgroundColor,
-          ...(rowHeight ? { "--datatable-row-height": rowHeight } : {}),
+          ...(resolvedRowHeight ? { "--datatable-row-height": resolvedRowHeight } : {}),
         } as React.CSSProperties
       }
     >

--- a/apps/frontend/src/rework/components/shared/molecules/PageHeader/PageHeader.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/PageHeader/PageHeader.module.css
@@ -29,6 +29,13 @@
   min-width: 0;
 }
 
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+  min-width: 0;
+}
+
 .title {
   margin: 0;
   color: var(--on-surface);

--- a/apps/frontend/src/rework/components/shared/molecules/PageHeader/PageHeader.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PageHeader/PageHeader.test.tsx
@@ -39,4 +39,14 @@ describe("PageHeader", () => {
     const withoutActions = renderToStaticMarkup(<PageHeader title="X" />);
     expect(withoutActions).not.toContain("<button");
   });
+
+  it("renders titleAction next to the title when given, omits it when not", () => {
+    const withTitleAction = renderToStaticMarkup(
+      <PageHeader title="X" titleAction={<button aria-label="More actions">more</button>} />,
+    );
+    expect(withTitleAction).toContain("More actions");
+
+    const withoutTitleAction = renderToStaticMarkup(<PageHeader title="X" />);
+    expect(withoutTitleAction).not.toContain("<button");
+  });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/PageHeader/PageHeader.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PageHeader/PageHeader.tsx
@@ -18,6 +18,11 @@ import styles from "./PageHeader.module.css";
 interface PageHeaderProps {
   title: string;
   subtitle?: string;
+  /** Optional icon button (e.g. a page-level "more" menu) rendered immediately
+   *  to the right of the `<h1>`, inside the title row — distinct from `actions`,
+   *  which renders as a separate block right-aligned at the far end of the
+   *  header. Omit to render nothing. */
+  titleAction?: ReactNode;
   actions?: ReactNode;
   /** Optional "you are here" trail or one-off link rendered above the title row. */
   breadcrumb?: ReactNode;
@@ -35,13 +40,16 @@ interface PageHeaderProps {
  * aligns to the top when there is one, so `actions` sits at the title's
  * baseline instead of drifting down toward the two-line block's middle.
  */
-export default function PageHeader({ title, subtitle, actions, breadcrumb, tabs }: PageHeaderProps) {
+export default function PageHeader({ title, subtitle, titleAction, actions, breadcrumb, tabs }: PageHeaderProps) {
   return (
     <div className={styles.wrapper}>
       {breadcrumb && <div className={styles.breadcrumb}>{breadcrumb}</div>}
       <div className={subtitle ? `${styles.header} ${styles.headerWithSubtitle}` : styles.header}>
         <div className={styles.titleBlock}>
-          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.titleRow}>
+            <h1 className={styles.title}>{title}</h1>
+            {titleAction}
+          </div>
           {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
         </div>
         {actions && <div className={styles.actions}>{actions}</div>}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembers.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import TeamSettingsMembersTable from "./TeamSettingsMembersTable/TeamSettingsMembersTable.tsx";
-import LeaveTeamButton from "./LeaveTeamButton/LeaveTeamButton.tsx";
+import TeamSettingsMembersMenu from "./TeamSettingsMembersMenu/TeamSettingsMembersMenu.tsx";
 import AddTeamMembersDialog from "./AddTeamMembersDialog/AddTeamMembersDialog.tsx";
 import Button from "@shared/atoms/Button/Button.tsx";
 import PageHeader from "@shared/molecules/PageHeader/PageHeader.tsx";
@@ -40,6 +40,7 @@ export default function TeamSettingsMembers({ team }: TeamSettingsMembersProps) 
     <div className={styles["team-settings-members-container"]}>
       <PageHeader
         title={t("rework.teamSettings.members.title")}
+        titleAction={<TeamSettingsMembersMenu team={team} />}
         actions={
           <>
             <div className={styles["team-settings-members-search"]}>
@@ -49,9 +50,9 @@ export default function TeamSettingsMembers({ team }: TeamSettingsMembersProps) 
                 placeholder={t("rework.teamSettings.members.search.placeholder")}
                 ariaLabel={t("rework.teamSettings.members.search.ariaLabel")}
                 clearAriaLabel={t("rework.teamSettings.members.search.clearAriaLabel")}
+                size="small"
               />
             </div>
-            <LeaveTeamButton team={team} />
             {can_administer_members && (
               <Button color="primary" variant="filled" size="medium" onClick={() => setIsAddDialogOpen(true)}>
                 {t("rework.teamSettings.members.addMembersDialog.buttonLabel")}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersMenu/TeamSettingsMembersMenu.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersMenu/TeamSettingsMembersMenu.tsx
@@ -14,7 +14,7 @@
 
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import Button from "@shared/atoms/Button/Button.tsx";
+import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu.tsx";
 import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider.tsx";
 import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
@@ -26,15 +26,19 @@ import {
   useRemoveTeamMemberMutation,
 } from "../../../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 
-interface LeaveTeamButtonProps {
+interface TeamSettingsMembersMenuProps {
   team: TeamWithPermissions;
 }
 
+type MembersMenuAction = "leave";
+
 /**
- * AUTHZ-09 self-service "leave team" action. Disabled for the last remaining
+ * Page-level "more" menu for the team members page, rendered next to the
+ * title via `PageHeader`'s `titleAction` slot. Currently holds the AUTHZ-09
+ * self-service "leave team" action; disabled for the last remaining
  * team_admin (the "at least one admin" invariant, shared with #1985).
  */
-export default function LeaveTeamButton({ team }: LeaveTeamButtonProps) {
+export default function TeamSettingsMembersMenu({ team }: TeamSettingsMembersMenuProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { showConfirmationDialog } = useConfirmationDialog();
@@ -75,15 +79,27 @@ export default function LeaveTeamButton({ team }: LeaveTeamButtonProps) {
   };
 
   return (
-    <Button
-      color="error"
-      variant="filled"
-      size="medium"
-      disabled={isLastAdmin}
-      title={isLastAdmin ? t("rework.teamSettings.leaveTeam.lastAdminTooltip") : undefined}
-      onClick={handleLeaveTeam}
-    >
-      {t("rework.teamSettings.navigation.leaveTeam")}
-    </Button>
+    <IconButtonMenu<MembersMenuAction>
+      iconButton={{
+        color: "on-surface-retreat",
+        variant: "icon",
+        size: "medium",
+        icon: { category: "outlined", type: "more_vert" },
+        "aria-label": t("rework.teamSettings.members.moreActions"),
+        title: t("rework.teamSettings.members.moreActions"),
+      }}
+      options={[
+        {
+          key: "leave",
+          value: "leave",
+          label: t("rework.teamSettings.navigation.leaveTeam"),
+          icon: { category: "outlined", type: "logout" },
+          destructive: true,
+          disabled: isLastAdmin,
+          description: isLastAdmin ? t("rework.teamSettings.leaveTeam.lastAdminTooltip") : undefined,
+        },
+      ]}
+      onSelect={() => handleLeaveTeam()}
+    />
   );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -15,7 +15,7 @@
 import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
 import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu.tsx";
-import DataTable, { DataTableColumn } from "@shared/molecules/DataTable/DataTable.tsx";
+import DataTable, { DataTableColumn, DataTableRowSize } from "@shared/molecules/DataTable/DataTable.tsx";
 import TeamRoleChips from "@shared/molecules/TeamRoleChips/TeamRoleChips.tsx";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -56,6 +56,8 @@ interface TeamSettingsMembersTableProps {
    * already fetches every member in one call, no backend pagination/search
    * to coordinate with. Ignored below 2 characters. */
   search: string;
+  /** Row height preset, forwarded to `DataTable`. Defaults to "medium" (48px). */
+  size?: DataTableRowSize;
 }
 
 const MIN_SEARCH_LENGTH = 2;
@@ -67,7 +69,7 @@ function matchesSearch(member: TeamMember, tokens: string[]): boolean {
   return tokens.every((token) => haystacks.some((haystack) => haystack.includes(token)));
 }
 
-export default function TeamSettingsMembersTable({ team, search }: TeamSettingsMembersTableProps) {
+export default function TeamSettingsMembersTable({ team, search, size = "medium" }: TeamSettingsMembersTableProps) {
   const { t } = useTranslation();
   const { notifyApiError } = useApiErrorToast();
   const { runMutationAction } = useMutationAction();
@@ -244,6 +246,7 @@ export default function TeamSettingsMembersTable({ team, search }: TeamSettingsM
       rowKey={(member) => member.user.id}
       firstColumnInset
       pageSize={20}
+      size={size}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Members page search field switched to `size:small`.
- `PageHeader` gains a `titleAction` slot (rendered next to the `<h1>`, distinct from the right-aligned `actions` block) so a page-level "more" menu can sit beside the title — reusable by other pages.
- "Leave team" moves from a standalone button into that "more" menu (`TeamSettingsMembersMenu`, renamed from `LeaveTeamButton`), still disabled with an explanatory description for the last remaining `team_admin`.
- `DataTable` gains a `size` preset (`"medium"` = 48px / `"small"` = 40px row height); the members table now defaults to `"medium"` and exposes the prop for future use.
- Fixes a missing i18n key (`rework.teams.formAgent.sections.tools`) that made the agent-creation form's "Tools" tab render its raw i18n key instead of a label.

## Test plan
- [x] `make code-quality` (tsc/prettier/eslint)
- [x] `make test` (full frontend suite)
- [ ] Manual check: Team Settings → Members — search field size, "more" menu placement/behavior, last-admin disabled state

🤖 Generated with [Claude Code](https://claude.com/claude-code)