### PR TITLE
Rename admin "Capabilities" to "Features", agent-form "Tools" tab to "Capabilities"

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -850,22 +850,22 @@
   "rework": {
     "admin": {
       "capabilities": {
-        "title": "Capabilities",
-        "subtitle": "Platform capability catalog: per-team enablement, platform defaults, and health.",
-        "loading": "Loading capabilities…",
-        "loadError": "Could not load the capability catalog.",
-        "empty": "No capabilities are advertised by any runtime pod yet.",
+        "title": "Features",
+        "subtitle": "Platform feature catalog: per-team enablement, platform defaults, and health.",
+        "loading": "Loading features…",
+        "loadError": "Could not load the feature catalog.",
+        "empty": "No features are advertised by any runtime pod yet.",
         "manageTeams": "Manage teams",
         "kindFilter": {
-          "tool": "Tools",
+          "tool": "Capabilities",
           "agent": "Agents",
           "model": "Models",
-          "aria": "Filter by capability kind"
+          "aria": "Filter by feature kind"
         },
         "emptyAgents": "No agent templates are registered by any runtime pod yet.",
         "emptyModels": "No models are advertised by any runtime pod yet.",
         "col": {
-          "capability": "Capability",
+          "capability": "Feature",
           "enabledTeams": "Enabled teams",
           "defaultOn": "Enabled for all",
           "health": "Health",
@@ -886,12 +886,12 @@
           "suspended": "{{count}} suspended",
           "suspendedAction": "Show the {{count}} suspended agent(s), grouped by team",
           "unknown": "{{count}} unknown",
-          "unknownHint": "The runtime pod was unreachable, so this capability's health can't be determined right now.",
+          "unknownHint": "The runtime pod was unreachable, so this feature's health can't be determined right now.",
           "healthy": "OK"
         },
         "suspendedDrawer": {
           "title": "{{name}} — suspended agents",
-          "subtitle": "Agents this capability breaks right now, grouped by team. Restore each team's access from Manage teams to revive them.",
+          "subtitle": "Agents this feature breaks right now, grouped by team. Restore each team's access from Manage teams to revive them.",
           "teamCount": "{{count}} agent(s)"
         },
         "defaultOnToast": "Default-on enabled platform-wide.",
@@ -900,7 +900,7 @@
         "defaultToggleError": "Could not change the default-on setting.",
         "defaultOffConfirm": {
           "title": "Disable default-on?",
-          "message": "Turning off default-on revokes inherited access for every team and may suspend agent instances that depend on this capability.",
+          "message": "Turning off default-on revokes inherited access for every team and may suspend agent instances that depend on this feature.",
           "confirm": "Disable",
           "cancel": "Cancel",
           "impact": "This will suspend {{count}} agent(s) that currently work.",
@@ -912,7 +912,7 @@
         },
         "matrix": {
           "title": "{{name}} — team access",
-          "subtitle": "Set each team's access: enable with settings, disable explicitly, or leave it on the platform default. Dimmed teams cannot use this capability right now.",
+          "subtitle": "Set each team's access: enable with settings, disable explicitly, or leave it on the platform default. Dimmed teams cannot use this feature right now.",
           "searchPlaceholder": "Search teams...",
           "clearSearch": "Clear search",
           "teamsLoading": "Loading teams…",
@@ -923,24 +923,24 @@
           "disable": "Disable",
           "cancel": "Cancel",
           "saveEnable": "Save & enable",
-          "enabledToast": "Capability enabled for {{team}}.",
-          "enableError": "Could not enable the capability.",
-          "disabledToast": "Capability disabled for {{team}}.",
+          "enabledToast": "Feature enabled for {{team}}.",
+          "enableError": "Could not enable the feature.",
+          "disabledToast": "Feature disabled for {{team}}.",
           "disabledSuspendedToast": "Disabled for {{team}} — {{count}} instance(s) suspended.",
-          "disableError": "Could not disable the capability.",
+          "disableError": "Could not disable the feature.",
           "default": "Default",
           "defaultToast": "{{team}} now follows the platform default.",
           "defaultSuspendedToast": "{{team}} now follows the platform default — {{count}} instance(s) suspended.",
-          "defaultError": "Could not reset the capability to the platform default.",
+          "defaultError": "Could not reset the feature to the platform default.",
           "rowControlAria": "Access for {{team}}",
           "personal": {
             "label": "All personal spaces",
             "hint": "Applies to every user's personal space at once — past, future, and users who never log in.",
             "enabledToast": "Enabled for all personal spaces.",
-            "enableError": "Could not enable the capability for personal spaces.",
+            "enableError": "Could not enable the feature for personal spaces.",
             "disabledToast": "Disabled for all personal spaces.",
             "disabledSuspendedToast": "Disabled for all personal spaces — {{count}} instance(s) suspended.",
-            "disableError": "Could not disable the capability for personal spaces.",
+            "disableError": "Could not disable the feature for personal spaces.",
             "defaultToast": "Personal spaces now follow the platform default.",
             "defaultSuspendedToast": "Personal spaces now follow the platform default — {{count}} instance(s) suspended.",
             "defaultError": "Could not reset the personal-space default."
@@ -1495,7 +1495,7 @@
         },
         "menu": {
           "analytics": "Analytics",
-          "capabilities": "Capabilities",
+          "capabilities": "Features",
           "corpusAudit": "Corpus audit",
           "migration": "Platform data",
           "selftest": "Self-test",
@@ -1888,6 +1888,7 @@
           "aria": "Form sections",
           "general": "General",
           "prompts": "Prompts",
+          "tools": "Capabilities",
           "commitments": "Commitments"
         },
         "selectPlaceholder": "Select an option",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -850,22 +850,22 @@
   "rework": {
     "admin": {
       "capabilities": {
-        "title": "Capacités",
-        "subtitle": "Catalogue des capacités de la plateforme : activation par équipe, valeurs par défaut et état.",
-        "loading": "Chargement des capacités…",
-        "loadError": "Impossible de charger le catalogue des capacités.",
-        "empty": "Aucune capacité n'est encore publiée par un pod runtime.",
+        "title": "Fonctionnalités",
+        "subtitle": "Catalogue des fonctionnalités de la plateforme : activation par équipe, valeurs par défaut et état.",
+        "loading": "Chargement des fonctionnalités…",
+        "loadError": "Impossible de charger le catalogue des fonctionnalités.",
+        "empty": "Aucune fonctionnalité n'est encore publiée par un pod runtime.",
         "manageTeams": "Gérer les équipes",
         "kindFilter": {
-          "tool": "Outils",
+          "tool": "Capacités",
           "agent": "Agents",
           "model": "Modèles",
-          "aria": "Filtrer par type de capacité"
+          "aria": "Filtrer par type de fonctionnalité"
         },
         "emptyAgents": "Aucun template d'agent n'est encore enregistré par un pod runtime.",
         "emptyModels": "Aucun modèle n'est encore publié par un pod runtime.",
         "col": {
-          "capability": "Capacité",
+          "capability": "Fonctionnalité",
           "enabledTeams": "Équipes activées",
           "defaultOn": "Activé pour tous",
           "health": "État",
@@ -886,12 +886,12 @@
           "suspended": "{{count}} suspendue(s)",
           "suspendedAction": "Afficher les {{count}} agent(s) suspendu(s), groupés par équipe",
           "unknown": "{{count}} inconnu(s)",
-          "unknownHint": "Le pod d'exécution était injoignable ; l'état de cette capacité ne peut pas être déterminé pour le moment.",
+          "unknownHint": "Le pod d'exécution était injoignable ; l'état de cette fonctionnalité ne peut pas être déterminé pour le moment.",
           "healthy": "OK"
         },
         "suspendedDrawer": {
           "title": "{{name}} — agents suspendus",
-          "subtitle": "Agents que cette capacité bloque actuellement, groupés par équipe. Rétablissez l'accès de chaque équipe depuis Gérer les équipes pour les réactiver.",
+          "subtitle": "Agents que cette fonctionnalité bloque actuellement, groupés par équipe. Rétablissez l'accès de chaque équipe depuis Gérer les équipes pour les réactiver.",
           "teamCount": "{{count}} agent(s)"
         },
         "defaultOnToast": "Activation par défaut appliquée à toute la plateforme.",
@@ -900,7 +900,7 @@
         "defaultToggleError": "Impossible de modifier le réglage d'activation par défaut.",
         "defaultOffConfirm": {
           "title": "Désactiver l'activation par défaut ?",
-          "message": "Désactiver l'activation par défaut révoque l'accès hérité pour toutes les équipes et peut suspendre les instances d'agents qui dépendent de cette capacité.",
+          "message": "Désactiver l'activation par défaut révoque l'accès hérité pour toutes les équipes et peut suspendre les instances d'agents qui dépendent de cette fonctionnalité.",
           "confirm": "Désactiver",
           "cancel": "Annuler",
           "impact": "Cela suspendra {{count}} agent(s) actuellement fonctionnel(s).",
@@ -912,7 +912,7 @@
         },
         "matrix": {
           "title": "{{name}} — accès des équipes",
-          "subtitle": "Définissez l'accès de chaque équipe : activer avec réglages, désactiver explicitement, ou laisser le défaut de la plateforme. Les équipes estompées ne peuvent pas utiliser cette capacité actuellement.",
+          "subtitle": "Définissez l'accès de chaque équipe : activer avec réglages, désactiver explicitement, ou laisser le défaut de la plateforme. Les équipes estompées ne peuvent pas utiliser cette fonctionnalité actuellement.",
           "searchPlaceholder": "Rechercher une équipe...",
           "clearSearch": "Effacer la recherche",
           "teamsLoading": "Chargement des équipes…",
@@ -923,24 +923,24 @@
           "disable": "Désactiver",
           "cancel": "Annuler",
           "saveEnable": "Enregistrer et activer",
-          "enabledToast": "Capacité activée pour {{team}}.",
-          "enableError": "Impossible d'activer la capacité.",
-          "disabledToast": "Capacité désactivée pour {{team}}.",
+          "enabledToast": "Fonctionnalité activée pour {{team}}.",
+          "enableError": "Impossible d'activer la fonctionnalité.",
+          "disabledToast": "Fonctionnalité désactivée pour {{team}}.",
           "disabledSuspendedToast": "Désactivée pour {{team}} — {{count}} instance(s) suspendue(s).",
-          "disableError": "Impossible de désactiver la capacité.",
+          "disableError": "Impossible de désactiver la fonctionnalité.",
           "default": "Défaut",
           "defaultToast": "{{team}} suit désormais le défaut de la plateforme.",
           "defaultSuspendedToast": "{{team}} suit désormais le défaut de la plateforme — {{count}} instance(s) suspendue(s).",
-          "defaultError": "Impossible de remettre la capacité au défaut de la plateforme.",
+          "defaultError": "Impossible de remettre la fonctionnalité au défaut de la plateforme.",
           "rowControlAria": "Accès pour {{team}}",
           "personal": {
             "label": "Tous les espaces personnels",
             "hint": "S'applique d'un coup à l'espace personnel de chaque utilisateur — passés, futurs, et ceux qui ne se connectent jamais.",
             "enabledToast": "Activée pour tous les espaces personnels.",
-            "enableError": "Impossible d'activer la capacité pour les espaces personnels.",
+            "enableError": "Impossible d'activer la fonctionnalité pour les espaces personnels.",
             "disabledToast": "Désactivée pour tous les espaces personnels.",
             "disabledSuspendedToast": "Désactivée pour tous les espaces personnels — {{count}} instance(s) suspendue(s).",
-            "disableError": "Impossible de désactiver la capacité pour les espaces personnels.",
+            "disableError": "Impossible de désactiver la fonctionnalité pour les espaces personnels.",
             "defaultToast": "Les espaces personnels suivent désormais le défaut de la plateforme.",
             "defaultSuspendedToast": "Les espaces personnels suivent désormais le défaut de la plateforme — {{count}} instance(s) suspendue(s).",
             "defaultError": "Impossible de remettre le défaut des espaces personnels."
@@ -1495,7 +1495,7 @@
         },
         "menu": {
           "analytics": "Analytiques",
-          "capabilities": "Capacités",
+          "capabilities": "Fonctionnalités",
           "corpusAudit": "Audit du corpus",
           "migration": "Données plateforme",
           "selftest": "Auto-test",
@@ -1888,6 +1888,7 @@
           "aria": "Sections du formulaire",
           "general": "Général",
           "prompts": "Prompts",
+          "tools": "Capacités",
           "commitments": "Engagement"
         },
         "selectPlaceholder": "Sélectionner une option",

--- a/apps/frontend/src/rework/features/helpCenter/content/en/features/admin.md
+++ b/apps/frontend/src/rework/features/helpCenter/content/en/features/admin.md
@@ -22,7 +22,7 @@ see.
 
 - **Teams**: the overview of the platform's teams.
 - **Analytics**: usage indicators at the platform scale.
-- **Capabilities**: the capability catalog, their default and per-team
+- **Features**: the feature catalog, their default and per-team
   activation.
 - **Activity**: running tasks and processing history.
 - **Self-test**: checks that the platform is working correctly.

--- a/apps/frontend/src/rework/features/helpCenter/content/en/features/capabilities.md
+++ b/apps/frontend/src/rework/features/helpCenter/content/en/features/capabilities.md
@@ -8,15 +8,17 @@ icon: extension
 # Agent capabilities
 
 A **capability** extends what an agent can do beyond conversation: draft a
-document, fill a template, query data… A capability is enabled **per team**,
-then attached to the agents that need it.
+document, fill a template, query data… Capabilities come from the platform's
+**feature catalog**: an administrator enables a feature for your team (see
+[Admin console](/help/en/features/admin)), then your team's editors can turn
+it on for the agents that need it, as one of that agent's capabilities.
 
 ## Enabling a capability
 
-Enabling capabilities is a team and platform matter. A capability not enabled
-for the team isn't available to its agents; if an active capability is later
-disabled, the agents that depend on it are **suspended** until it's restored
-(see [Agents](/help/en/features/agents)).
+Enabling a feature for your team is an administrator's job. A feature not
+enabled for the team isn't available to its agents as a capability; if an
+enabled feature is later disabled, the agents that depend on it are
+**suspended** until it's restored (see [Agents](/help/en/features/agents)).
 
 ## A few built-in capabilities
 

--- a/apps/frontend/src/rework/features/helpCenter/content/en/getting-started/concepts.md
+++ b/apps/frontend/src/rework/features/helpCenter/content/en/getting-started/concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Key concepts
 order: 20
-description: Team, agent, prompt, resource, session, capability — the platform's vocabulary.
+description: Team, agent, prompt, resource, session, feature, capability — the platform's vocabulary.
 icon: school
 ---
 
@@ -49,11 +49,18 @@ A **session** (or conversation) is an exchange with an agent. It keeps the
 message history, attachments, and produced documents. You can resume a session
 later or start a new one at any time.
 
+## Feature
+
+A **feature** is an extra function agents can use beyond conversation — for
+example drafting a document, filling a PowerPoint template, or querying
+tabular data. Features are enabled **per team** by an administrator (see
+[Admin console](/help/en/features/admin)).
+
 ## Capability
 
-A **capability** is an extra function an agent can call on — for example
-drafting a document, filling a PowerPoint template, or querying tabular data.
-Capabilities are enabled per team.
+Once a feature is enabled for your team, your editors can turn it on for a
+specific agent — it then becomes one of that agent's **capabilities** (see
+[Agents](/help/en/features/agents)).
 
 ## How it all fits together
 

--- a/apps/frontend/src/rework/features/helpCenter/content/fr/features/admin.md
+++ b/apps/frontend/src/rework/features/helpCenter/content/fr/features/admin.md
@@ -22,7 +22,7 @@ Ouvrez le **menu profil** (en bas du panneau de navigation) puis
 
 - **Équipes** : la vue d'ensemble des équipes de la plateforme.
 - **Analytiques** : les indicateurs d'usage à l'échelle de la plateforme.
-- **Capacités** : le catalogue des capacités, leur activation par défaut et par
+- **Fonctionnalités** : le catalogue des fonctionnalités, leur activation par défaut et par
   équipe.
 - **Activité** : les tâches en cours et l'historique de traitement.
 - **Auto-test** : les vérifications de bon fonctionnement de la plateforme.

--- a/apps/frontend/src/rework/features/helpCenter/content/fr/features/capabilities.md
+++ b/apps/frontend/src/rework/features/helpCenter/content/fr/features/capabilities.md
@@ -8,15 +8,20 @@ icon: extension
 # Les capacités des agents
 
 Une **capacité** étend ce qu'un agent sait faire au-delà de la conversation :
-rédiger un document, remplir un modèle, interroger des données… Une capacité
-s'active **par équipe**, puis se rattache aux agents qui en ont besoin.
+rédiger un document, remplir un modèle, interroger des données… Les capacités
+proviennent du **catalogue de fonctionnalités** de la plateforme : un
+administrateur active une fonctionnalité pour votre équipe (voir
+[Console d'administration](/help/fr/features/admin)), puis les éditeurs de
+votre équipe peuvent l'activer pour les agents qui en ont besoin, comme l'une
+des capacités de cet agent.
 
 ## Activer une capacité
 
-L'activation des capacités relève de l'équipe et de la plateforme. Une capacité
-non activée pour l'équipe n'est pas disponible pour ses agents ; si une capacité
-active est ensuite désactivée, les agents qui en dépendent sont **suspendus**
-jusqu'à son rétablissement (voir [Les agents](/help/fr/features/agents)).
+Activer une fonctionnalité pour votre équipe relève de l'administrateur. Une
+fonctionnalité non activée pour l'équipe n'est pas disponible pour ses agents
+en tant que capacité ; si une fonctionnalité active est ensuite désactivée,
+les agents qui en dépendent sont **suspendus** jusqu'à son rétablissement
+(voir [Les agents](/help/fr/features/agents)).
 
 ## Quelques capacités embarquées
 

--- a/apps/frontend/src/rework/features/helpCenter/content/fr/getting-started/concepts.md
+++ b/apps/frontend/src/rework/features/helpCenter/content/fr/getting-started/concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Les concepts clés
 order: 20
-description: Équipe, agent, prompt, ressource, session, capacité — le vocabulaire de la plateforme.
+description: Équipe, agent, prompt, ressource, session, fonctionnalité, capacité — le vocabulaire de la plateforme.
 icon: school
 ---
 
@@ -52,11 +52,19 @@ l'historique des messages, les pièces jointes et les documents produits. Vous
 pouvez reprendre une session plus tard ou en démarrer une nouvelle à tout
 moment.
 
+## Fonctionnalité
+
+Une **fonctionnalité** est une fonction supplémentaire que les agents peuvent
+utiliser au-delà de la conversation — par exemple rédiger un document, remplir
+un modèle PowerPoint ou interroger des données tabulaires. Les fonctionnalités
+s'activent **par équipe** par un administrateur (voir
+[Console d'administration](/help/fr/features/admin)).
+
 ## Capacité
 
-Une **capacité** est une fonction supplémentaire qu'un agent peut mobiliser —
-par exemple rédiger un document, remplir un modèle PowerPoint ou interroger des
-données tabulaires. Les capacités s'activent par équipe.
+Une fois qu'une fonctionnalité est activée pour votre équipe, vos éditeurs
+peuvent l'activer pour un agent en particulier — elle devient alors l'une des
+**capacités** de cet agent (voir [Les agents](/help/fr/features/agents)).
 
 ## Comment tout s'articule
 


### PR DESCRIPTION
## Summary
- The admin catalog page (title, subtitle, toasts, errors, sidebar nav) moves from "Capabilities"/"Capacités" to "Features"/"Fonctionnalités".
- Its internal kind-filter chip (`Tools`/`Agents`/`Models`) and the agent-creation form's tab (which already shows capability cards) move from "Tools"/"Outils" to "Capabilities"/"Capacités" — disambiguating the two concepts.
- Only display strings change: routes (`/admin/capabilities`), component names, and code identifiers are untouched.
- Help Center updated accordingly: the admin page bullet, the dedicated "Agent capabilities" article, and the platform glossary (`concepts.md`) now distinguish the two tiers — a **Feature** is enabled for a team by an administrator; once enabled, editors can turn it on per agent as one of that agent's **Capabilities**.

⚠️ **Heads up for merge order**: this PR and #2200/agent-form-ui-polish both independently touch the `rework.teams.formAgent.sections.tools` i18n key (both landing on the same final value, `"Capabilities"`/`"Capacités"`) — expect a possible trivial conflict depending on merge order.

## Test plan
- [x] `make code-quality`
- [x] `make test`
- [ ] Manual check: Admin → Features page (title, kind-filter labels), agent-creation form tab label, Help Center pages (admin, agent capabilities, key concepts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)