### PR TITLE
fix(OPS-04): give knowledge-flow its own task database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ setup-env: ## Create each backend's .env from its .env.template (idempotent), fi
 	@for dir in $(ENV_APPS); do \
 		f="$$dir/config/.env"; \
 		[ -f "$$f" ] || continue; \
-		for key in FRED_POSTGRES_PASSWORD OPENSEARCH_PASSWORD OPENFGA_API_TOKEN MINIO_SECRET_KEY KEYCLOAK_CONTROL_PLANE_CLIENT_SECRET KEYCLOAK_AGENTIC_CLIENT_SECRET KEYCLOAK_KNOWLEDGE_FLOW_CLIENT_SECRET; do \
+		for key in FRED_POSTGRES_PASSWORD POSTGRES_KNOWLEDGE_FLOW_PASSWORD OPENSEARCH_PASSWORD OPENFGA_API_TOKEN MINIO_SECRET_KEY KEYCLOAK_CONTROL_PLANE_CLIENT_SECRET KEYCLOAK_AGENTIC_CLIENT_SECRET KEYCLOAK_KNOWLEDGE_FLOW_CLIENT_SECRET; do \
 			if grep -q "^$$key=\"\"" "$$f" 2>/dev/null; then \
 				sed -i "s/^$$key=\"\"/$$key=\"Azerty123_\"/" "$$f"; \
 			fi; \
@@ -225,6 +225,7 @@ RT_UV                := libs/fred-runtime/.venv/bin/uv
 db-check-combined-heads: ## assert each migratable backend has exactly one Alembic head (no branch conflicts)
 	$(MAKE) -C apps/control-plane-backend db-check-heads
 	$(MAKE) -C apps/knowledge-flow-backend db-check-heads
+	$(MAKE) -C apps/knowledge-flow-backend db-check-tasks-heads
 	$(MAKE) -C libs/fred-runtime db-check-heads
 
 .PHONY: db-check-combined-postgres-up
@@ -252,6 +253,8 @@ db-check-combined-sqlite: ## upgrade control-plane, knowledge-flow, and fred-run
 	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory libs/fred-runtime alembic downgrade base
 	@rm -f $(SQLITE_COMBINED_DB)
 	@echo "=== Combined SQLite migration check passed ==="
+	@echo "=== Knowledge Flow task-database chain (separate database by design, OPS-04) ==="
+	$(MAKE) -C apps/knowledge-flow-backend db-check-tasks-sqlite
 
 .PHONY: db-check-combined-postgres
 db-check-combined-postgres: db-check-combined-postgres-down db-check-combined-postgres-up ## upgrade control-plane, knowledge-flow, and fred-runtime against the same DB, check for drift, then downgrade
@@ -268,6 +271,12 @@ db-check-combined-postgres: db-check-combined-postgres-down db-check-combined-po
 	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory apps/control-plane-backend alembic downgrade base
 	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory libs/fred-runtime alembic downgrade base
 	@echo "=== Combined migration check passed ==="
+	# Knowledge Flow's task chain owns task_run/task_event_log in a database of its own
+	# (OPS-04, #2170), so it is deliberately NOT part of the combined run above — that run
+	# proves three backends can co-migrate ONE database, and control-plane already creates
+	# task_run there. Run it here, after the downgrades, while the database is empty again.
+	@echo "=== Knowledge Flow task-database chain (separate database by design) ==="
+	$(MAKE) -C apps/knowledge-flow-backend db-check-tasks-postgres
 	$(MAKE) db-check-combined-postgres-down
 
 include scripts/makefiles/help.mk

--- a/apps/control-plane-backend/alembic/versions/a9b0c1d2e3f4_repair_task_run_single_active_migration_index.py
+++ b/apps/control-plane-backend/alembic/versions/a9b0c1d2e3f4_repair_task_run_single_active_migration_index.py
@@ -1,0 +1,112 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""repair task_run single-active-migration index (missing SQLite predicate)
+
+`c1d2e3f4a5b6` created `uq_task_run_single_active_migration` passing only
+`postgresql_where`. SQLAlchemy silently drops dialect-prefixed kwargs on other
+dialects, so on SQLite the predicate vanished and the index landed as an
+unconditional `UNIQUE (kind)` — "at most one task_run row per kind, ever"
+instead of "at most one non-terminal kind='migration' row". Consequences on an
+affected DB: the second task of any already-present kind fails to insert, and
+the second migration task is refused permanently rather than once the first
+reaches a terminal state (its IntegrityError still names this index, so
+`import_export/api.py::_is_concurrent_migration_violation` mistranslates it
+into a misleading 409 "another migration is already running").
+
+Postgres was never affected — the predicate applies there.
+
+Drop-then-recreate unconditionally rather than reusing the name-presence guard
+of `c1d2e3f4a5b6`: the broken index carries the *same name* as the correct one,
+so a presence check cannot tell them apart and would skip the repair on exactly
+the databases that need it. On Postgres this replaces a correct index with an
+identical one; the constraint is briefly absent mid-migration, which is safe
+under the deploy-time migration lock.
+
+Recreating fails with an IntegrityError only if the table genuinely holds two
+non-terminal kind='migration' rows — real corruption that must surface rather
+than be papered over.
+
+Revision ID: a9b0c1d2e3f4
+Revises: f3790013f637
+Create Date: 2026-07-29 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a9b0c1d2e3f4"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = (
+    "f3790013f637"  # pragma: allowlist secret
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "uq_task_run_single_active_migration"
+_WHERE_CLAUSE = (
+    "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
+)
+
+
+def _task_run_indexes() -> set[str]:
+    # No missing-table branch here: both callers return before reaching this helper when
+    # `task_run` is absent. upgrade() must return *before* op.create_index, which a helper
+    # returning a set cannot express, so the check belongs in the callers.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {
+        ix["name"] for ix in inspector.get_indexes("task_run") if ix["name"] is not None
+    }
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    if "task_run" not in sa.inspect(op.get_bind()).get_table_names():
+        return
+
+    if _INDEX_NAME in _task_run_indexes():
+        op.drop_index(_INDEX_NAME, table_name="task_run")
+
+    op.create_index(
+        _INDEX_NAME,
+        "task_run",
+        ["kind"],
+        unique=True,
+        sqlite_where=sa.text(_WHERE_CLAUSE),
+        postgresql_where=sa.text(_WHERE_CLAUSE),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema: drop the index this revision created.
+
+    Deliberately does NOT reinstate the broken unconditional `UNIQUE (kind)` the previous
+    revision left on SQLite — recreating it would fail on any table already holding two rows
+    of the same kind, which is precisely the state this repair exists to make reachable.
+
+    Dropping is still the right revert: it leaves the database in a state the previous
+    revision's own downgrade can complete, and an empty body did not. An empty downgrade
+    stamped the earlier revision while leaving the partial index in place, so the schema
+    matched neither revision and a later `alembic check` or re-upgrade saw state nothing
+    expected.
+    """
+    if "task_run" not in sa.inspect(op.get_bind()).get_table_names():
+        return
+
+    if _INDEX_NAME in _task_run_indexes():
+        op.drop_index(_INDEX_NAME, table_name="task_run")

--- a/apps/control-plane-backend/alembic/versions/c1d2e3f4a5b6_add_task_run_single_active_migration_index.py
+++ b/apps/control-plane-backend/alembic/versions/c1d2e3f4a5b6_add_task_run_single_active_migration_index.py
@@ -68,6 +68,7 @@ def upgrade() -> None:
             "task_run",
             ["kind"],
             unique=True,
+            sqlite_where=sa.text(_WHERE_CLAUSE),
             postgresql_where=sa.text(_WHERE_CLAUSE),
         )
 

--- a/apps/control-plane-backend/config/schema/configuration.schema.json
+++ b/apps/control-plane-backend/config/schema/configuration.schema.json
@@ -736,7 +736,21 @@
               "type": "null"
             }
           ],
+          "default": null,
           "title": "Password"
+        },
+        "password_env": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+          "title": "Password Env"
         },
         "echo": {
           "default": false,

--- a/apps/fred-agents/config/schema/configuration.schema.json
+++ b/apps/fred-agents/config/schema/configuration.schema.json
@@ -586,7 +586,21 @@
               "type": "null"
             }
           ],
+          "default": null,
           "title": "Password"
+        },
+        "password_env": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+          "title": "Password Env"
         },
         "echo": {
           "default": false,

--- a/apps/fred-agents/tests/test_smoke.py
+++ b/apps/fred-agents/tests/test_smoke.py
@@ -210,7 +210,15 @@ def _build_offline_agents_app(monkeypatch, tmp_path, factory) -> FastAPI:
     if sqlite_path:
         upgrade_sqlite_database(sqlite_path)
 
-    return create_app()
+    # config/configuration.yaml points storage.postgres.sqlite_path at a fixed
+    # path under the developer/runner home dir. Every test in this module (and
+    # every other pytest process on the same machine) would otherwise share
+    # that one file, which surfaces as intermittent "database is locked"
+    # errors under aiosqlite. Route each test at its own tmp_path file instead.
+    resolved_config = load_agent_pod_config()
+    resolved_config.storage.postgres.sqlite_path = str(tmp_path / "runtime.sqlite3")
+
+    return create_app(config=resolved_config)
 
 
 def _parse_sse_payloads(stream_text: str) -> list[dict[str, object]]:

--- a/apps/knowledge-flow-backend/Makefile
+++ b/apps/knowledge-flow-backend/Makefile
@@ -18,6 +18,76 @@ export ENV_FILE
 
 PADDLE_MODELS_DIR ?= ./models
 
+##@ Database Migrations — dedicated task database (OPS-04, #2170)
+
+# Knowledge Flow migrates TWO databases: the shared `fred` one (tag/metadata/resource,
+# driven by alembic.mk's db-* targets) and its own task database (task_run/task_event_log).
+# Alembic opens one connection per env.py, so the second database needs its own chain,
+# configured by alembic_tasks.ini. These targets mirror alembic.mk's, suffixed `-tasks`.
+
+# Pin the profile the TASK-chain targets read. Without this, alembic.mk leaves
+# ALEMBIC_CONFIG_FILE empty and CONFIG_FILE falls through to whatever config/.env holds — so
+# `make db-upgrade-tasks` migrated a different database depending on the developer's .env,
+# and only a profile declaring `storage.task_postgres` works at all (the shipped
+# configuration.yaml and configuration_test.yaml do not).
+#
+# TARGET-SPECIFIC, not a file-wide `:=`. A global assignment would also capture the shared
+# chain's db-upgrade/db-migrate/db-downgrade and silently override a CONFIG_FILE the
+# developer deliberately set in config/.env (load_dotenv runs with override=False, so the
+# recipe's value wins) — migrating the wrong database with no indication the profile was
+# substituted. Overridable per invocation:
+#   make db-upgrade-tasks ALEMBIC_CONFIG_FILE=./config/configuration_worker.yaml
+db-upgrade-tasks db-migrate-tasks db-downgrade-tasks db-history-tasks \
+db-check-tasks-heads db-check-tasks-sqlite db-check-tasks-postgres: \
+	ALEMBIC_CONFIG_FILE := ./config/configuration_prod.yaml
+
+TASKS_ALEMBIC := $(UV) run alembic -c alembic_tasks.ini
+TASKS_SQLITE_TEST_DB := $(TARGET)/test_migrations_tasks.db
+
+.PHONY: db-upgrade-tasks
+db-upgrade-tasks: dev ## apply pending migrations to the dedicated task database
+	$(ALEMBIC_CONFIG_ENV) $(TASKS_ALEMBIC) upgrade head
+
+.PHONY: db-migrate-tasks
+db-migrate-tasks: dev ## generate a task-database migration (usage: make db-migrate-tasks MSG="...")
+	$(ALEMBIC_CONFIG_ENV) $(TASKS_ALEMBIC) revision --autogenerate -m "$(MSG)"
+
+.PHONY: db-downgrade-tasks
+db-downgrade-tasks: dev ## roll back the last task-database migration
+	$(ALEMBIC_CONFIG_ENV) $(TASKS_ALEMBIC) downgrade -1
+
+.PHONY: db-history-tasks
+db-history-tasks: dev ## show task-database migration history
+	$(ALEMBIC_CONFIG_ENV) $(TASKS_ALEMBIC) history --verbose
+
+.PHONY: db-check-tasks-heads
+db-check-tasks-heads: dev ## assert the task chain has exactly one Alembic head
+	@echo "Checking for single Alembic head (task database)..."
+	@heads=$$(DATABASE_URL="sqlite+aiosqlite:///unused" $(TASKS_ALEMBIC) heads | grep -c '(head)'); \
+	if [ "$$heads" -ne 1 ]; then \
+		echo "Expected 1 head, found $$heads"; exit 1; \
+	fi
+	@echo "Single head confirmed (task database)."
+
+.PHONY: db-check-tasks-sqlite
+db-check-tasks-sqlite: dev ## validate the task chain against a throwaway SQLite database
+	@echo "SQLite migration checks (task database)..."
+	@mkdir -p $(TARGET)
+	@rm -f $(TASKS_SQLITE_TEST_DB)
+	DATABASE_URL="sqlite+aiosqlite:///$(TASKS_SQLITE_TEST_DB)" $(TASKS_ALEMBIC) upgrade head
+	DATABASE_URL="sqlite+aiosqlite:///$(TASKS_SQLITE_TEST_DB)" $(TASKS_ALEMBIC) check
+	DATABASE_URL="sqlite+aiosqlite:///$(TASKS_SQLITE_TEST_DB)" $(TASKS_ALEMBIC) downgrade base
+	@rm -f $(TASKS_SQLITE_TEST_DB)
+	@echo "SQLite migration checks passed (task database)."
+
+.PHONY: db-check-tasks-postgres
+db-check-tasks-postgres: dev ## validate the task chain against PostgreSQL (assumes the container is running)
+	@echo "PostgreSQL migration checks (task database)..."
+	DATABASE_URL="$(PG_TEST_URL)" $(TASKS_ALEMBIC) upgrade head
+	DATABASE_URL="$(PG_TEST_URL)" $(TASKS_ALEMBIC) check
+	DATABASE_URL="$(PG_TEST_URL)" $(TASKS_ALEMBIC) downgrade base
+	@echo "PostgreSQL migration checks passed (task database)."
+
 ##@ Run
 
 .PHONY: download-models

--- a/apps/knowledge-flow-backend/README.md
+++ b/apps/knowledge-flow-backend/README.md
@@ -70,6 +70,21 @@ The default configuration is developer-friendly and only uses local stores. See 
 - **Core storage (`storage.postgres`)**: used by tags, metadata, resources, pgvector, etc.
   - User/host/db come from `storage.postgres` in `configuration*.yaml`.
   - Password comes from `FRED_POSTGRES_PASSWORD` (or an explicit `password:` in the YAML).
+  - This database is **shared with control-plane**, which is why the task tables below are not in it.
+- **Task storage (`storage.task_postgres`)**: used only by `task_run` / `task_event_log` (OPS-04, issue #2170).
+  - A database of Knowledge Flow's own. The `fred_core` task tables carry no per-service
+    discriminator, so keeping them in the shared database makes each backend's `GET /tasks` return
+    the other's rows — the Activity page then shows every task twice.
+  - Password comes from the variable named by `password_env` (`POSTGRES_KNOWLEDGE_FLOW_PASSWORD`),
+    because this database has its own role.
+  - Migrated by its own Alembic chain: `make db-upgrade-tasks` (config: `alembic_tasks.ini`).
+    The main `make db-upgrade` still migrates tag/metadata/resource in the shared database.
+  - **The API and the worker must agree on this block.** They load different config files
+    (`configuration_prod.yaml` vs `configuration_worker.yaml`); if they diverge, the API creates the
+    task row in one database and the worker writes events to another, so every event raises
+    `TaskNotFoundError` and live SSE silently delivers nothing (`LISTEN`/`NOTIFY` is per-database).
+  - If omitted, Knowledge Flow falls back to `storage.postgres` and logs a warning at startup —
+    the pre-OPS-04 behaviour, which reintroduces the duplicate rows.
 - **Tabular artifacts (`storage.tabular_store` + `content_storage`)**: CSV ingestion writes Parquet artifacts into the shared content store object area.
   - Runtime query limits come from `storage.tabular_store` in `configuration*.yaml`.
   - The CSV-to-Parquet path is DuckDB-native and avoids loading the full dataset into a pandas DataFrame.

--- a/apps/knowledge-flow-backend/alembic/env.py
+++ b/apps/knowledge-flow-backend/alembic/env.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 from logging.config import fileConfig
 
-import fred_core.documents.document_models  # noqa: F401 — registers metadata + tag tables with CoreBase (via fred_core.documents.__init__)
-import fred_core.tasks.orm_models  # noqa: F401 — registers task_run / task_event_log with CoreBase
-from fred_core.models.base import Base as CoreBase
+from fred_core.documents.document_models import DocumentMetadataRow
+from fred_core.documents.tag_models import TagRow
 from fred_core.sql import make_alembic_env
+from sqlalchemy import MetaData
 
 import knowledge_flow_backend.core.stores.resources.resource_models  # noqa: F401
 from alembic import context
@@ -37,9 +37,27 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+# Build a MetaData scoped to the tables Knowledge Flow owns in the SHARED `fred` database.
+#
+# `DocumentMetadataRow`/`TagRow` share CoreBase with tables owned by other backends
+# (session, teammetadata, users — control-plane) and, since OPS-04 / issue #2170, with
+# task_run/task_event_log, which now live in Knowledge Flow's own dedicated database and
+# are migrated by the separate `alembic_tasks` chain. Passing `CoreBase.metadata` directly
+# would make this chain claim all of them: `alembic check` reports drift for tables it does
+# not own, and `--autogenerate` emits spurious create/drop operations for them.
+#
+# Note the include_name/table-name filter in make_alembic_env cannot substitute for this.
+# Alembic filters the *connection* side by name, but builds the metadata side from
+# `sorted_tables` unfiltered, so an unwanted table in the MetaData is still requested.
+# Same reasoning and same pattern as libs/fred-runtime/alembic/env.py.
+_knowledge_flow_metadata = MetaData()
+for _table in Base.metadata.tables.values():
+    _table.to_metadata(_knowledge_flow_metadata)
+DocumentMetadataRow.__table__.to_metadata(_knowledge_flow_metadata)  # type: ignore[attr-defined]
+TagRow.__table__.to_metadata(_knowledge_flow_metadata)  # type: ignore[attr-defined]
+
 run_migrations_offline, run_migrations_online = make_alembic_env(
-    # Both metadata objects so autogenerate sees KFB tables and shared task tables.
-    target_metadata=[Base.metadata, CoreBase.metadata],
+    target_metadata=_knowledge_flow_metadata,
     get_postgres_config=lambda: load_configuration().storage.postgres,
     version_table="alembic_version_knowledge_flow",
 )

--- a/apps/knowledge-flow-backend/alembic/versions/e2f3a4b5c6d7_add_task_run_single_active_migration_index.py
+++ b/apps/knowledge-flow-backend/alembic/versions/e2f3a4b5c6d7_add_task_run_single_active_migration_index.py
@@ -62,6 +62,7 @@ def upgrade() -> None:
             "task_run",
             ["kind"],
             unique=True,
+            sqlite_where=sa.text(_WHERE_CLAUSE),
             postgresql_where=sa.text(_WHERE_CLAUSE),
         )
 

--- a/apps/knowledge-flow-backend/alembic/versions/e2f3a4b5c6d7_add_task_run_single_active_migration_index.py
+++ b/apps/knowledge-flow-backend/alembic/versions/e2f3a4b5c6d7_add_task_run_single_active_migration_index.py
@@ -68,5 +68,16 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
+    # Check the table explicitly rather than reusing `_task_run_indexes()`. That helper
+    # returns the sentinel `{_INDEX_NAME}` when `task_run` is absent, which reads as
+    # "already done, skip" for upgrade() but as "present, drop it" here — the two
+    # directions need opposite answers from the same missing table. Since OPS-04 (#2170)
+    # gave knowledge-flow its own task database, `task_run` is legitimately absent from
+    # this chain's database, so `alembic downgrade` hit `UndefinedObjectError: index
+    # "uq_task_run_single_active_migration" does not exist`. Same guard shape as the
+    # sibling migrations 1c9a54674ebf and d96d9ae21375.
+    inspector = sa.inspect(op.get_bind())
+    if "task_run" not in inspector.get_table_names():
+        return
     if _INDEX_NAME in _task_run_indexes():
         op.drop_index(_INDEX_NAME, table_name="task_run")

--- a/apps/knowledge-flow-backend/alembic/versions/f7a8b9c0d1e2_repair_task_run_single_active_migration_index.py
+++ b/apps/knowledge-flow-backend/alembic/versions/f7a8b9c0d1e2_repair_task_run_single_active_migration_index.py
@@ -1,0 +1,128 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""repair task_run single-active-migration index (missing SQLite predicate)
+
+`e2f3a4b5c6d7` created `uq_task_run_single_active_migration` passing only
+`postgresql_where`. SQLAlchemy silently drops dialect-prefixed kwargs on other
+dialects, so on SQLite the predicate vanished and the index landed as an
+unconditional `UNIQUE (kind)` — "at most one task_run row per kind, ever"
+instead of "at most one non-terminal kind='migration' row". Knowledge-Flow's
+own kinds (e.g. "ingestion") are unaffected by the *intended* predicate but
+very much affected by the degraded one: a second ingestion task cannot be
+inserted at all.
+
+On a DB that already held several same-kind rows the upgrade aborted outright
+(`UNIQUE constraint failed: task_run.kind`), leaving the revision unapplied;
+on an empty or single-kind DB it silently succeeded with the wrong index. This
+migration handles the second case — the first is fixed by the corrected
+`e2f3a4b5c6d7`, which such a database has yet to run.
+
+Postgres was never affected — the predicate applies there — so `upgrade()` runs
+on SQLite only. Since OPS-04 (#2170) this chain no longer owns `task_run`, and
+on a deployment still sharing the `fred` database its DDL would land on
+control-plane's live table for a repair Postgres never needed.
+
+Drop-then-recreate unconditionally rather than reusing the name-presence guard
+of `e2f3a4b5c6d7`: the broken index carries the *same name* as the correct one,
+so a presence check cannot tell them apart and would skip the repair on exactly
+the databases that need it.
+
+Revision ID: f7a8b9c0d1e2
+Revises: e2f3a4b5c6d7
+Create Date: 2026-07-29 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f7a8b9c0d1e2"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e2f3a4b5c6d7"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "uq_task_run_single_active_migration"
+_WHERE_CLAUSE = "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
+
+
+def _task_run_indexes() -> set[str]:
+    # No missing-table branch here: both callers return before reaching this helper when
+    # `task_run` is absent. Same reasoning as the downgrade() comment in the sibling
+    # `e2f3a4b5c6d7` — upgrade() must return *before* op.create_index, which a helper
+    # returning a set cannot express, so the check belongs in the callers.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {ix["name"] for ix in inspector.get_indexes("task_run") if ix["name"] is not None}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # SQLite-only: Postgres never had the defect (the predicate applies there), and since
+    # OPS-04 (#2170) this chain no longer owns `task_run` — on a Postgres deployment still
+    # sharing the `fred` database the DROP INDEX below would take ACCESS EXCLUSIVE on
+    # control-plane's live table, blocking behind any open transaction until the deploy
+    # Job's lock_timeout cancels it.
+    if op.get_bind().dialect.name != "sqlite":
+        return
+
+    if "task_run" not in sa.inspect(op.get_bind()).get_table_names():
+        return
+
+    if _INDEX_NAME in _task_run_indexes():
+        op.drop_index(_INDEX_NAME, table_name="task_run")
+
+    op.create_index(
+        _INDEX_NAME,
+        "task_run",
+        ["kind"],
+        unique=True,
+        sqlite_where=sa.text(_WHERE_CLAUSE),
+        postgresql_where=sa.text(_WHERE_CLAUSE),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema: drop the index this revision created.
+
+    Deliberately does NOT reinstate the broken unconditional `UNIQUE (kind)` the previous
+    revision left on SQLite — recreating it would fail on any table already holding two rows
+    of the same kind, which is precisely the state this repair exists to make reachable.
+
+    Dropping is still the right revert: it leaves the database in a state the previous
+    revision's own downgrade can complete, and an empty body did not. An empty downgrade
+    stamped the earlier revision while leaving the partial index in place, so the schema
+    matched neither revision and a later `alembic check` or re-upgrade saw state nothing
+    expected.
+
+    Gated on SQLite for the same reason as upgrade(), and it must stay symmetric with it:
+    on Postgres upgrade() is a no-op, so a downgrade that still dropped the index would
+    revert something this revision never did. Worse, the index it would drop is the one
+    `e2f3a4b5c6d7` owns, and re-upgrading cannot restore it — upgrade() returns early
+    here — so a `make db-downgrade` + re-upgrade round trip would destroy the
+    single-active-migration constraint permanently, on a shared `fred` database where
+    that constraint is control-plane's.
+    """
+    if op.get_bind().dialect.name != "sqlite":
+        return
+
+    if "task_run" not in sa.inspect(op.get_bind()).get_table_names():
+        return
+
+    if _INDEX_NAME in _task_run_indexes():
+        op.drop_index(_INDEX_NAME, table_name="task_run")

--- a/apps/knowledge-flow-backend/alembic_tasks.ini
+++ b/apps/knowledge-flow-backend/alembic_tasks.ini
@@ -1,0 +1,53 @@
+# Alembic configuration for Knowledge Flow's DEDICATED TASK DATABASE (OPS-04, issue #2170).
+#
+# Why a second config: Alembic opens exactly one connection per env.py, so one chain cannot
+# create tables in two databases. Knowledge Flow's main chain (`alembic/`, configured by
+# [tool.alembic] in pyproject.toml) migrates tag/metadata/resource in the SHARED `fred`
+# database; this chain migrates task_run/task_event_log in a database of Knowledge Flow's
+# own. pyproject.toml can only carry one [tool.alembic] table, hence a real ini file here.
+#
+# Usage:
+#   make db-upgrade-tasks                  (or: uv run alembic -c alembic_tasks.ini upgrade head)
+#
+# The URL is built in alembic_tasks/env.py from storage.task_postgres in CONFIG_FILE, or
+# from DATABASE_URL when set (which takes precedence — used by CI).
+
+[alembic]
+script_location = %(here)s/alembic_tasks
+prepend_sys_path = .
+truncate_slug_length = 80
+
+# Logging configuration (mirrors the root alembic.ini).
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/apps/knowledge-flow-backend/alembic_tasks/env.py
+++ b/apps/knowledge-flow-backend/alembic_tasks/env.py
@@ -1,0 +1,84 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Alembic environment for Knowledge Flow's DEDICATED TASK DATABASE (OPS-04, #2170).
+
+Knowledge Flow shares its main Postgres database with control-plane. Both persist tasks
+through the same `fred_core.tasks` tables, which carry no per-service discriminator, so
+sharing one database makes each backend's `GET /tasks` return the other's rows and the
+Activity page shows every task twice. This chain owns `task_run`/`task_event_log` in a
+database of Knowledge Flow's own; the main chain (`alembic/`) keeps owning
+tag/metadata/resource in the shared database.
+
+Run it with: ``alembic -c alembic_tasks.ini upgrade head`` (or ``make db-upgrade-tasks``).
+"""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from fred_core.common import PostgresStoreConfig
+from fred_core.sql import make_alembic_env
+from fred_core.tasks import task_metadata
+
+from alembic import context
+from knowledge_flow_backend.common.config_loader import load_configuration
+
+# Alembic Config object — provides access to values in alembic_tasks.ini.
+config = context.config
+
+# Set up Python logging from alembic_tasks.ini if present.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+
+def _task_postgres_config() -> PostgresStoreConfig:
+    """Return the dedicated task database's connection config.
+
+    Raises rather than silently falling back to `storage.postgres`: this chain owns the
+    task tables, and pointing it at the shared database would have it manage — and on
+    ``downgrade``, DROP — the copy that control-plane owns there. The runtime fallback in
+    ``ApplicationContext.get_task_pg_async_engine`` is deliberately softer, because a
+    process must still boot before the dedicated database is provisioned; a migration has
+    no such excuse.
+
+    Never called when DATABASE_URL is set — ``make_alembic_env`` checks that first, which
+    is how CI targets a throwaway database without a config file.
+    """
+    task_postgres = load_configuration().storage.task_postgres
+    if task_postgres is None:
+        raise RuntimeError(
+            "storage.task_postgres is not configured. This chain migrates Knowledge Flow's "
+            "dedicated task database (OPS-04, issue #2170) and must not be run against the "
+            "shared 'fred' database, where control-plane owns task_run/task_event_log. "
+            "Configure storage.task_postgres, or set DATABASE_URL to target a database explicitly."
+        )
+    return task_postgres
+
+
+run_migrations_offline, run_migrations_online = make_alembic_env(
+    # Scoped to exactly the tables fred_core.tasks owns — see `task_metadata()` for why
+    # passing the shared `Base.metadata` would make this chain claim other backends'
+    # tables, and why Alembic's name filters cannot substitute for the scoping.
+    target_metadata=task_metadata(),
+    get_postgres_config=_task_postgres_config,
+    # Distinct from the main chain's `alembic_version_knowledge_flow` so that a
+    # mis-pointed URL cannot corrupt the other chain's recorded revision.
+    version_table="alembic_version_knowledge_flow_tasks",
+)
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/knowledge-flow-backend/alembic_tasks/script.py.mako
+++ b/apps/knowledge-flow-backend/alembic_tasks/script.py.mako
@@ -1,0 +1,32 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+# codeql[py/unused-global-variable]
+revision: str = ${repr(up_revision)}
+# codeql[py/unused-global-variable]
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+# codeql[py/unused-global-variable]
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+# codeql[py/unused-global-variable]
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/apps/knowledge-flow-backend/alembic_tasks/versions/4bc9fd97236f_create_knowledge_flow_task_tables.py
+++ b/apps/knowledge-flow-backend/alembic_tasks/versions/4bc9fd97236f_create_knowledge_flow_task_tables.py
@@ -1,0 +1,161 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""create knowledge-flow task tables (dedicated task database)
+
+First revision of Knowledge Flow's dedicated task database (OPS-04, issue #2170).
+
+Creates `task_run` and `task_event_log` at their current schema in one statement. Knowledge
+Flow's main chain never created these tables — it only carried idempotent ALTERs that skip
+when the table is absent, because it had always ridden on control-plane's copy in the shared
+`fred` database. This chain owns them in a database of Knowledge Flow's own; the main chain
+keeps owning tag/metadata/resource in the shared database.
+
+The column set is the accumulated result of control-plane's four task revisions
+(`a3b4c5d6e7f8` create, `a7c1e9d2b4f6` execution_id, `f4a5b6c7d8e9` scheduled_for,
+`9e5074103b67` acknowledgement columns) plus its `c1d2e3f4a5b6` partial unique index. It was
+produced by `alembic revision --autogenerate` against `fred_core.tasks.orm_models`, so it is
+schema-identical to the ORM by construction rather than by hand-transcription.
+
+Idempotent: skips a table that already exists. Knowledge Flow's API also runs
+`create_all` for these two tables against the same engine at boot, and in Kubernetes the
+pods start before the post-install migration Job, so this migration can legitimately find
+the tables already present. Without the guard, `op.create_table` raises DuplicateTable and
+the migration Job fails the release.
+
+Revision ID: 4bc9fd97236f
+Revises:
+Create Date: 2026-08-01 17:20:08.725910
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+# codeql[py/unused-global-variable]
+revision: str = "4bc9fd97236f"  # pragma: allowlist secret
+# codeql[py/unused-global-variable]
+down_revision: Union[str, Sequence[str], None] = None
+# codeql[py/unused-global-variable]
+branch_labels: Union[str, Sequence[str], None] = None
+# codeql[py/unused-global-variable]
+depends_on: Union[str, Sequence[str], None] = None
+
+_JSONB = postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite")
+
+# Partial unique index enforcing "at most one non-terminal migration-kind task".
+# Must be passed for BOTH dialects. Omitting `sqlite_where` does not fail — it silently
+# produces a unique index over EVERY row on `kind`, so a second `ingestion` task is then
+# rejected on SQLite. Both predicates are therefore spelled out and must stay identical.
+# (The equivalent index in the other chains was created with `postgresql_where` only and
+# needed a follow-up repair revision; creating it correctly here avoids repeating that.)
+_ACTIVE_MIGRATION_PREDICATE = "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
+
+
+def _existing_tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    existing = _existing_tables()
+
+    if "task_event_log" not in existing:
+        op.create_table(
+            "task_event_log",
+            sa.Column("id", sa.BigInteger().with_variant(sa.INTEGER(), "sqlite"), autoincrement=True, nullable=False),
+            sa.Column("task_id", sa.String(length=36), nullable=False),
+            sa.Column("kind", sa.String(length=64), nullable=False),
+            sa.Column("seq", sa.Integer(), nullable=False),
+            sa.Column("state", sa.String(length=32), nullable=False),
+            sa.Column("progress", sa.Float(), nullable=True),
+            sa.Column("step", sa.Text(), nullable=True),
+            sa.Column("detail", _JSONB, nullable=True),
+            sa.Column("error", sa.Text(), nullable=True),
+            sa.Column("target", _JSONB, nullable=True),
+            sa.Column("owner", sa.String(length=255), nullable=True),
+            sa.Column("emitted_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("task_id", "seq", name="uq_task_event_log_task_seq"),
+        )
+        with op.batch_alter_table("task_event_log", schema=None) as batch_op:
+            batch_op.create_index(batch_op.f("ix_task_event_log_task_id"), ["task_id"], unique=False)
+
+    if "task_run" not in existing:
+        op.create_table(
+            "task_run",
+            sa.Column("task_id", sa.String(length=36), nullable=False),
+            sa.Column("kind", sa.String(length=64), nullable=False),
+            sa.Column("state", sa.String(length=32), nullable=False),
+            sa.Column("seq", sa.Integer(), nullable=False),
+            sa.Column("progress", sa.Float(), nullable=True),
+            sa.Column("step", sa.Text(), nullable=True),
+            sa.Column("detail", _JSONB, nullable=True),
+            sa.Column("error", sa.Text(), nullable=True),
+            sa.Column("target", _JSONB, nullable=True),
+            sa.Column("execution_id", sa.String(length=255), nullable=True),
+            sa.Column("created_by", sa.String(length=36), nullable=True),
+            sa.Column("team_id", sa.String(length=255), nullable=True),
+            sa.Column("scheduled_for", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("acknowledged_by", sa.String(length=36), nullable=True),
+            sa.PrimaryKeyConstraint("task_id"),
+        )
+        with op.batch_alter_table("task_run", schema=None) as batch_op:
+            batch_op.create_index(batch_op.f("ix_task_run_created_by"), ["created_by"], unique=False)
+            batch_op.create_index(batch_op.f("ix_task_run_kind"), ["kind"], unique=False)
+            batch_op.create_index(batch_op.f("ix_task_run_scheduled_for"), ["scheduled_for"], unique=False)
+            batch_op.create_index(batch_op.f("ix_task_run_state"), ["state"], unique=False)
+            batch_op.create_index("ix_task_run_state_updated", ["state", "updated_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_task_run_team_id"), ["team_id"], unique=False)
+            batch_op.create_index(
+                "uq_task_run_single_active_migration",
+                ["kind"],
+                unique=True,
+                sqlite_where=sa.text(_ACTIVE_MIGRATION_PREDICATE),
+                postgresql_where=sa.text(_ACTIVE_MIGRATION_PREDICATE),
+            )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    existing = _existing_tables()
+
+    if "task_run" in existing:
+        with op.batch_alter_table("task_run", schema=None) as batch_op:
+            batch_op.drop_index(
+                "uq_task_run_single_active_migration",
+                sqlite_where=sa.text(_ACTIVE_MIGRATION_PREDICATE),
+                postgresql_where=sa.text(_ACTIVE_MIGRATION_PREDICATE),
+            )
+            batch_op.drop_index(batch_op.f("ix_task_run_team_id"))
+            batch_op.drop_index("ix_task_run_state_updated")
+            batch_op.drop_index(batch_op.f("ix_task_run_state"))
+            batch_op.drop_index(batch_op.f("ix_task_run_scheduled_for"))
+            batch_op.drop_index(batch_op.f("ix_task_run_kind"))
+            batch_op.drop_index(batch_op.f("ix_task_run_created_by"))
+        op.drop_table("task_run")
+
+    if "task_event_log" in existing:
+        with op.batch_alter_table("task_event_log", schema=None) as batch_op:
+            batch_op.drop_index(batch_op.f("ix_task_event_log_task_id"))
+        op.drop_table("task_event_log")

--- a/apps/knowledge-flow-backend/config/.env.template
+++ b/apps/knowledge-flow-backend/config/.env.template
@@ -56,8 +56,12 @@ GOOGLE_APPLICATION_CREDENTIALS=""
 # 🟢 Postgres storage configuration
 # -----------------------------------------------------------------------------
 
-# Postgres credentials
+# Postgres credentials for the shared `fred` database (tag / metadata / resource).
 FRED_POSTGRES_PASSWORD=""
+# Postgres credentials for Knowledge Flow's dedicated task database
+# (task_run / task_event_log — OPS-04, issue #2170). Named by
+# storage.task_postgres.password_env; leave empty only if that block is not configured.
+POSTGRES_KNOWLEDGE_FLOW_PASSWORD=""
 # -----------------------------------------------------------------------------
 # 🟢 Opensearch storage configuration
 # -----------------------------------------------------------------------------

--- a/apps/knowledge-flow-backend/config/configuration_prod.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_prod.yaml
@@ -412,6 +412,35 @@ storage:
     pool_timeout: 30
     pool_recycle: 1800
     pool_pre_ping: true
+  # Dedicated database for task_run / task_event_log (OPS-04, issue #2170).
+  # The `fred` database above is shared with control-plane, and the fred-core task tables
+  # carry no per-service discriminator — sharing them makes each backend's GET /tasks
+  # return the other's rows, which the Activity page renders as duplicates.
+  #
+  # DISABLED BY DEFAULT — this file cannot create the database. Enabling it requires ALL of:
+  #   1. the `knowledge_flow` database + role provisioned (fred-deployment-factory owns this;
+  #      its initdb hook only runs on an empty Postgres data dir, so an existing local stack
+  #      needs the post-install job run explicitly);
+  #   2. POSTGRES_KNOWLEDGE_FLOW_PASSWORD present in config/.env — note `make setup-env`
+  #      only fills keys that already exist as KEY="", so a .env created before OPS-04 will
+  #      NOT gain it automatically;
+  #   3. `make db-upgrade-tasks` run against that database;
+  #   4. the API and the Temporal worker enabled together — a split leaves them writing task
+  #      rows to two different databases.
+  # Until then the task tables stay in the shared `fred` database (pre-OPS-04 behaviour,
+  # duplicate rows included). Same default and same reasoning as
+  # deploy/charts/fred/values.yaml.
+  # task_postgres:
+  #   host: localhost
+  #   port: 5432
+  #   database: knowledge_flow
+  #   username: knowledge_flow
+  #   password_env: POSTGRES_KNOWLEDGE_FLOW_PASSWORD # pragma: allowlist secret
+  #   pool_size: 2
+  #   max_overflow: 0
+  #   pool_timeout: 30
+  #   pool_recycle: 1800
+  #   pool_pre_ping: true
   opensearch:
     host: https://localhost:9200
     secure: true

--- a/apps/knowledge-flow-backend/config/configuration_worker.yaml
+++ b/apps/knowledge-flow-backend/config/configuration_worker.yaml
@@ -316,6 +316,25 @@ storage:
     pool_timeout: 30
     pool_recycle: 1800
     pool_pre_ping: true
+  # Dedicated database for task_run / task_event_log (OPS-04, issue #2170).
+  # MUST match configuration_prod.yaml's block exactly — enable and disable the two
+  # together. The API creates the task_run row and the worker writes its events: if the two
+  # processes point at different databases, every worker event raises TaskNotFoundError and
+  # live SSE silently delivers nothing (LISTEN/NOTIFY channels are per-database).
+  #
+  # DISABLED BY DEFAULT for the same reason as configuration_prod.yaml — see the enablement
+  # checklist there. See knowledge-flow's README.
+  # task_postgres:
+  #   host: localhost
+  #   port: 5432
+  #   database: knowledge_flow
+  #   username: knowledge_flow
+  #   password_env: POSTGRES_KNOWLEDGE_FLOW_PASSWORD # pragma: allowlist secret
+  #   pool_size: 2
+  #   max_overflow: 0
+  #   pool_timeout: 30
+  #   pool_recycle: 1800
+  #   pool_pre_ping: true
   opensearch:
     host: https://localhost:9200
     secure: true

--- a/apps/knowledge-flow-backend/config/schema/configuration.schema.json
+++ b/apps/knowledge-flow-backend/config/schema/configuration.schema.json
@@ -1560,7 +1560,21 @@
               "type": "null"
             }
           ],
+          "default": null,
           "title": "Password"
+        },
+        "password_env": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+          "title": "Password Env"
         },
         "echo": {
           "default": false,
@@ -2165,6 +2179,18 @@
       "properties": {
         "postgres": {
           "$ref": "#/$defs/PostgresStoreConfig"
+        },
+        "task_postgres": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PostgresStoreConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Dedicated Postgres database for task_run / task_event_log (OPS-04). Knowledge Flow shares `postgres` with control-plane for tag/metadata/resource, so its task tables must live elsewhere or both backends read each other's rows. Unset falls back to `postgres` \u2014 the pre-OPS-04 shared behaviour, which duplicates task rows on the Activity page."
         },
         "opensearch": {
           "anyOf": [

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/application_context.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/application_context.py
@@ -34,7 +34,7 @@ from fred_core import (
     rebac_factory,
     split_realm_url,
 )
-from fred_core.common import DuckdbStoreConfig, LogStoreConfig, ModelConfiguration, OpenSearchIndexConfig, PostgresTableConfig
+from fred_core.common import DuckdbStoreConfig, LogStoreConfig, ModelConfiguration, OpenSearchIndexConfig, PostgresStoreConfig, PostgresTableConfig
 from fred_core.documents import BaseDocumentMetadataStore as BaseMetadataStore
 from fred_core.documents import PostgresDocumentMetadataStore as PostgresMetadataStore
 from fred_core.kpi import BaseKPIStore, BaseKPIWriter, KPIWriter, build_kpi_writer
@@ -294,6 +294,7 @@ class ApplicationContext:
     _rebac_engine: Optional[RebacEngine] = None
     _filesystem_instance: Optional[BaseFilesystem] = None
     _pg_async_engine: Optional[AsyncEngine] = None
+    _task_pg_async_engine: Optional[AsyncEngine] = None
     _task_service_instance: Optional[Any] = None
 
     def __init__(self, configuration: Configuration):
@@ -511,6 +512,64 @@ class ApplicationContext:
         logger.info("[SQL] Shared Postgres async initialized.")
         init_user_store(pg_async_engine)
         return pg_async_engine
+
+    def get_task_pg_config(self) -> PostgresStoreConfig:
+        """Connection config for the database holding `task_run` / `task_event_log`.
+
+        The single place the "dedicated database, else the shared one" rule is expressed.
+        Both the engine and the SSE bus DSN derive from it: they must name the SAME
+        database, because `PostgresEventBus` uses LISTEN/NOTIFY and notification channels
+        are per-database. Deriving them independently is how they drift, and the failure
+        is silent — events still persist and replay while live streaming delivers nothing.
+        """
+        return self.configuration.storage.task_postgres or self.configuration.storage.postgres
+
+    def get_task_pg_async_engine(self) -> AsyncEngine:
+        """Async engine for the task tables (`task_run` / `task_event_log`) only.
+
+        Why a second engine (OPS-04, issue #2170): knowledge-flow shares its main
+        Postgres database with control-plane, and both persist tasks through the same
+        `fred_core.tasks` tables, which carry no per-service discriminator. Sharing one
+        database therefore makes each backend's `GET /tasks` return the other's rows, and
+        the Activity page — which queries both and merges — shows every task twice.
+        `storage.task_postgres` points the task tables at a database of knowledge-flow's
+        own; `metadata_store` / `tag_store` / `resource_store` deliberately keep using the
+        shared engine, because control-plane's platform import/export writes those tables
+        in the same transaction as its own.
+
+        Deliberately does NOT go through `_init_pg_async_engine`: that helper also calls
+        `init_user_store()`, which assigns a module-level global in fred-core. Routing the
+        task engine through it would repoint the process-wide user store at a database
+        that has no `users` table.
+        """
+        if self._task_pg_async_engine is not None:
+            return self._task_pg_async_engine
+
+        task_cfg = self.configuration.storage.task_postgres
+        if task_cfg is None:
+            # Falls back to the shared database so an image can be deployed before the
+            # dedicated database is provisioned. The duplicate-row bug persists until it is.
+            logger.warning(
+                "[SQL] storage.task_postgres is not configured — task_run/task_event_log will "
+                "share the '%s' database with control-plane. The Activity page will keep showing "
+                "duplicate task rows until a dedicated database is provisioned (issue #2170).",
+                self.configuration.storage.postgres.database,
+            )
+            self._task_pg_async_engine = self.get_pg_async_engine()
+            return self._task_pg_async_engine
+
+        task_engine = create_async_engine_from_config(task_cfg)
+
+        def _dispose_task_async_engine():
+            try:
+                asyncio.run(task_engine.dispose())
+            except Exception:
+                logger.debug("[SQL] Task async engine dispose at exit failed", exc_info=True)
+
+        atexit.register(_dispose_task_async_engine)
+        logger.info("[SQL] Dedicated task Postgres async engine initialized (database=%s).", task_cfg.database)
+        self._task_pg_async_engine = task_engine
+        return self._task_pg_async_engine
 
     def get_log_store(self) -> BaseLogStore:
         """
@@ -844,10 +903,11 @@ class ApplicationContext:
         config = self.get_config()
         temporal_provider = TemporalClientProvider(config.scheduler.temporal) if backend == SchedulerBackend.TEMPORAL else None
         self._task_service_instance = TaskService.build(
-            engine=self.get_pg_async_engine(),
+            engine=self.get_task_pg_async_engine(),
             backend=backend,
+            # Same database as the engine, by construction — see get_task_pg_config().
+            postgres_dsn=(self.get_task_pg_config().dsn() if backend == SchedulerBackend.TEMPORAL else None),
             temporal_client_provider=temporal_provider,
-            postgres_dsn=config.storage.postgres.dsn() if backend == SchedulerBackend.TEMPORAL else None,
             # #2279: when Temporal ends an execution on its own (TIMED_OUT because
             # no worker could pick the work up), no worker code runs to record the
             # failure. Reconciliation holds the verdict API-side; this hook is what
@@ -1284,6 +1344,27 @@ class ApplicationContext:
                 await self._rebac_engine.close()
             except Exception:
                 logger.debug("[REBAC] Failed to close ReBAC engine", exc_info=True)
+
+        # Dedicated task PG engine. Disposed before the shared one, and only when it is a
+        # distinct engine — under the `task_postgres`-unset fallback both slots hold the
+        # same object. `dispose()` is idempotent (it replaces the pool rather than
+        # invalidating the engine), so a second call is harmless but not free: it builds a
+        # fresh pool only to abandon it. The guard keeps shutdown to exactly one dispose
+        # per real engine.
+        if self._task_pg_async_engine is not None:
+            try:
+                if self._task_pg_async_engine is not self._pg_async_engine:
+                    await self._task_pg_async_engine.dispose()
+            except Exception:
+                # Never let the newest engine's teardown abort the rest of shutdown. This
+                # block runs FIRST, so a raising dispose() — an asyncpg close error, or
+                # cancellation during a hard SIGTERM — would otherwise skip the shared
+                # engine's dispose and the OpenSearch client close below, cleanup that ran
+                # unconditionally before the task database existed. Same swallow-and-log
+                # shape as the ReBAC engine block above.
+                logger.debug("[SQL] task engine dispose failed during shutdown", exc_info=True)
+            finally:
+                self._task_pg_async_engine = None
 
         # Async PG engine
         if self._pg_async_engine is not None:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -828,8 +828,19 @@ DocumentSourceConfig = Annotated[Union[PushSourceConfig, PullSourceConfig], Fiel
 
 class StorageConfig(BaseModel):
     postgres: PostgresStoreConfig
+    task_postgres: Optional[PostgresStoreConfig] = Field(
+        default=None,
+        description=(
+            "Dedicated Postgres database for task_run / task_event_log (OPS-04). "
+            "Knowledge Flow shares `postgres` with control-plane for tag/metadata/resource, "
+            "so its task tables must live elsewhere or both backends read each other's rows. "
+            "Unset falls back to `postgres` — the pre-OPS-04 shared behaviour, which duplicates "
+            "task rows on the Activity page."
+        ),
+    )
     opensearch: Optional[OpenSearchStoreConfig] = Field(default=None, description="Optional OpenSearch store")
     clickhouse: Optional[ClickHouseStoreConfig] = Field(default=None, description="Optional ClickHouse store")
+
     resource_store: StoreConfig
     tag_store: StoreConfig
     metadata_store: StoreConfig
@@ -839,6 +850,42 @@ class StorageConfig(BaseModel):
     )
     vector_store: VectorStorageConfig
     log_store: Optional[LogStorageConfig] = Field(default=None, description="Optional log store")
+
+    @model_validator(mode="after")
+    def _task_postgres_must_be_a_different_database(self) -> "StorageConfig":
+        """Reject a `task_postgres` block that names the same database as `postgres`.
+
+        The whole point of OPS-04 (#2170) is that the two backends stop sharing one
+        `task_run` table. Copying the `postgres` block and forgetting to change
+        `database` is the obvious way to get this wrong, and every other signal stays
+        green: the engine builds, `/ready` passes, migrations succeed, and the only
+        symptom is duplicated rows on an admin page nobody watches during a rollout.
+        Omitting the block entirely is a supported fallback and warns at startup —
+        naming the shared database explicitly is always a mistake, so fail on it.
+
+        Static and therefore partial: it compares how the two blocks are *spelled*, so
+        normalizing case, whitespace and a trailing FQDN dot is as far as it goes. Two
+        different spellings of one server (`localhost` vs `127.0.0.1`, a CNAME vs its
+        target) pass here and no static check can catch them — real identity is tested at
+        runtime by the advisory `postgres_tasks` probe in `monitoring_controller.py`.
+        """
+        task = self.task_postgres
+        if task is None:
+            return self
+        task_host = (task.host or "").strip().rstrip(".").lower()
+        shared_host = (self.postgres.host or "").strip().rstrip(".").lower()
+        same_sqlite = task.sqlite_path is not None and task.sqlite_path == self.postgres.sqlite_path
+        same_postgres = task.sqlite_path is None and self.postgres.sqlite_path is None and (task_host, task.port, task.database) == (shared_host, self.postgres.port, self.postgres.database)
+        if same_sqlite or same_postgres:
+            target = task.sqlite_path or f"{task.host}:{task.port}/{task.database}"
+            raise ValueError(
+                f"storage.task_postgres points at the same database as storage.postgres ({target}). "
+                "The task tables must live in a database of Knowledge Flow's own, or control-plane "
+                "and Knowledge Flow keep reading each other's task rows and the Activity page shows "
+                "every task twice (OPS-04, issue #2170). Point it at a dedicated database, or remove "
+                "the block entirely to fall back to the shared one deliberately."
+            )
+        return self
 
 
 class TabularQueryConfig(BaseModel):

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/monitoring/monitoring_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/monitoring/monitoring_controller.py
@@ -39,10 +39,53 @@ logger = logging.getLogger(__name__)
 # backend surfaces as a failed check, never as a hung request.
 _READINESS_TIMEOUT_S = 6.0
 
+# Probes that are REPORTED but never make the pod unready.
+#
+# Readiness answers one question: should the Service route traffic here? A dependency
+# only some endpoints need must not answer "no" on behalf of all the others. The task
+# database (OPS-04, issue #2170) backs `GET /tasks`, task SSE and ingestion *start* —
+# document search, upload, tag and metadata reads never touch it. Failing readiness on
+# it would pull every pod out of the Service after ~100s (failureThreshold 10 ×
+# periodSeconds 10) and turn a partial outage into a total one.
+#
+# The signal is not lost: the failing check still appears in the body with ok=false and
+# its error, still logs a warning, and is still what an operator or a status script
+# reads. Only the HTTP status and the Kubernetes verdict are left alone.
+_ADVISORY_PROBES = frozenset({"postgres_tasks"})
+
+# Every probe — advisory or blocking — shares `_READINESS_TIMEOUT_S`.
+#
+# Deliberately NOT a shorter budget for advisory probes. The reasoning that tempts one:
+# `_run_checks` gathers concurrently, so /ready's latency is the slowest probe, and kubelet
+# abandons the request at its own `timeoutSeconds` and records a FAILED probe regardless of
+# the 200 that would have come back — so an advisory probe that is slow takes the pod down
+# via the very response that says "keep routing to me".
+#
+# That failure is real, but the fix belongs in the chart, not here: readinessProbe sets
+# `timeoutSeconds: 8` (> this budget) so a slow advisory probe still answers in time and a
+# blocking one can still spend its full budget before answering 503 honestly. Tightening the
+# budget here instead would fire on load rather than on failure — `_check_postgres_tasks`
+# does byte-identical work to `_check_postgres` but against a 2-connection pool with
+# `pool_pre_ping`, so two concurrent task writes are enough to blow a short budget and emit
+# `ready_degraded` plus a WARNING every `periodSeconds`, indistinguishable from a real outage.
+#
+# If you change `timeoutSeconds` in deploy/charts/fred/values.yaml, keep it above this.
+
+# Server + database identity, for proving the task engine really is a second database.
+# `system_identifier` identifies the *server cluster*; `inet_server_addr()` would not —
+# it reports the address the client connected to, so the same server answers 127.0.0.1
+# in-cluster and its routable IP from outside, and two spellings of one host would look
+# like two servers. Both are readable by an ordinary (non-superuser) login role.
+_PG_IDENTITY_SQL = text("SELECT (SELECT system_identifier FROM pg_control_system()) AS server_id, current_database() AS db")
+
 
 class MonitoringController:
     def __init__(self, app: APIRouter, application_context: Optional[ApplicationContext] = None):
         self._ctx = application_context
+        # None = not yet determined. Identity cannot change under a running process, so it
+        # is resolved once and cached — a per-probe pair of extra connections against a
+        # deliberately small pool would fire on load rather than on failure.
+        self._task_db_is_distinct: Optional[bool] = None
 
         @app.get("/healthz")
         async def healthz():
@@ -51,9 +94,23 @@ class MonitoringController:
         @app.get("/ready")
         async def ready():
             checks = await self._run_checks()
-            all_ok = all(c.get("ok", False) for c in checks.values()) if checks else True
-            body = {"status": "ready" if all_ok else "degraded", "checks": checks}
-            return JSONResponse(status_code=200 if all_ok else 503, content=body)
+            # Only non-advisory failures make the pod unready — see _ADVISORY_PROBES.
+            blocking_ok = all(c.get("ok", False) for name, c in checks.items() if name not in _ADVISORY_PROBES)
+            advisory_failures = [name for name, c in checks.items() if name in _ADVISORY_PROBES and not c.get("ok", False)]
+
+            if not blocking_ok:
+                status = "degraded"
+            elif advisory_failures:
+                # Serving, but a non-essential dependency is down. Distinct from "ready"
+                # so a dashboard or status script can tell the two apart at a glance.
+                status = "ready_degraded"
+            else:
+                status = "ready"
+
+            body: dict = {"status": status, "checks": checks}
+            if advisory_failures:
+                body["advisory_failures"] = advisory_failures
+            return JSONResponse(status_code=200 if blocking_ok else 503, content=body)
 
     async def _run_checks(self) -> dict:
         if self._ctx is None:
@@ -61,6 +118,7 @@ class MonitoringController:
 
         probes: dict[str, Callable[[], Awaitable[object | None]]] = {
             "postgres": self._check_postgres,
+            "postgres_tasks": self._check_postgres_tasks,
             "opensearch": self._check_opensearch,
             "openfga": self._check_openfga,
             "gcs_filesystem": self._check_gcs_filesystem,
@@ -102,6 +160,47 @@ class MonitoringController:
         engine = self._context.get_pg_async_engine()
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
+
+    async def _check_postgres_tasks(self) -> None:
+        """Probe the dedicated task database (OPS-04, issue #2170).
+
+        Without this, a pod whose task database is down — or whose
+        POSTGRES_KNOWLEDGE_FLOW_PASSWORD was rotated — reports nothing at all about it,
+        while every `GET /tasks`, task SSE stream and ingestion start returns 500 and the
+        shared engine that used to be the only thing checked stays perfectly healthy.
+
+        ADVISORY (see `_ADVISORY_PROBES`): a failure here is reported in the body and
+        logged, but does NOT make the pod unready. Document search, upload, tag and
+        metadata reads do not touch this database, and taking every pod out of the
+        Service would convert a partial outage into a total one.
+
+        Skipped rather than duplicated when `storage.task_postgres` is unset: the task
+        engine is then the shared engine, which `_check_postgres` already covers.
+
+        Also the only check that can prove the two engines address *different* databases.
+        `StorageConfig._task_postgres_must_be_a_different_database` compares how the blocks
+        are spelled, so `localhost` and `127.0.0.1` pass it; only asking both servers who
+        they are settles it, and getting it wrong silently restores the duplicate rows this
+        whole change removes.
+        """
+        ctx = self._context
+        if ctx.get_config().storage.task_postgres is None:
+            raise _SkippedCheck("task_postgres not configured; shares the main postgres engine")
+        engine = ctx.get_task_pg_async_engine()
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+            if self._task_db_is_distinct is None and conn.dialect.name == "postgresql":
+                task_identity = (await conn.execute(_PG_IDENTITY_SQL)).one()
+                async with ctx.get_pg_async_engine().connect() as shared_conn:
+                    shared_identity = (await shared_conn.execute(_PG_IDENTITY_SQL)).one()
+                self._task_db_is_distinct = tuple(task_identity) != tuple(shared_identity)
+        if self._task_db_is_distinct is False:
+            raise RuntimeError(
+                "storage.task_postgres resolves to the SAME database as storage.postgres "
+                "(same server system_identifier and current_database), however differently the two "
+                "blocks are spelled. Control-plane and Knowledge Flow are reading each other's task "
+                "rows and the Activity page shows every task twice (OPS-04, issue #2170)."
+            )
 
     async def _check_opensearch(self) -> None:
         try:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
@@ -94,6 +94,50 @@ def _norm_origin(o) -> str:
     return str(o).rstrip("/")
 
 
+async def create_core_tables(application_context: ApplicationContext) -> None:
+    """Create fred-core's tables, routing the task tables to the task database (OPS-04, #2170).
+
+    Before this split, `create_all(CoreBase.metadata)` on the shared engine put
+    `task_run`/`task_event_log` into the database knowledge-flow shares with control-plane —
+    which is what made each backend's `GET /tasks` return the other's rows and the Activity
+    page render every task twice. Every other CoreBase table is created exactly as before.
+
+    The partition is driven by `fred_core.tasks`' own declaration of what it owns, never by a
+    list repeated here: a third task table added there must land in the dedicated database
+    automatically, or it is silently created in the shared one.
+
+    Module-level rather than inlined in the lifespan so it can be tested directly — this is
+    the guard for #2170's core invariant, and a revert to a single `create_all` has to go
+    through this function. See tests/core/test_application_context_task_database.py.
+    """
+    from fred_core.models.base import Base as CoreBase
+    from fred_core.tasks import TASK_TABLE_NAMES
+
+    all_tables = CoreBase.metadata.sorted_tables
+    task_tables = [t for t in all_tables if t.name in TASK_TABLE_NAMES]
+    shared_tables = [t for t in all_tables if t.name not in TASK_TABLE_NAMES]
+
+    async with application_context.get_pg_async_engine().begin() as conn:
+        await conn.run_sync(CoreBase.metadata.create_all, tables=shared_tables)
+
+    # When storage.task_postgres is unset this is the same engine as above, so the
+    # pre-OPS-04 behaviour (task tables in the shared database) is preserved verbatim.
+    #
+    # A dedicated task database is NOT a hard startup dependency: alembic_tasks/ owns the
+    # real schema in production, so this create_all is belt-and-braces, and the
+    # `postgres_tasks` readiness probe is deliberately advisory. Raising here would put the
+    # whole API pod into CrashLoopBackOff — taking document search, upload and metadata down
+    # — for a database only /tasks and ingestion start need. Same treatment as
+    # get_task_service() further down the lifespan.
+    try:
+        async with application_context.get_task_pg_async_engine().begin() as conn:
+            await conn.run_sync(CoreBase.metadata.create_all, tables=task_tables)
+    except Exception:
+        if application_context.get_task_pg_async_engine() is application_context.get_pg_async_engine():
+            raise  # fallback path: this IS the shared database, keep failing fast
+        logger.warning("OPS-04: task database unavailable — task tables not created; /tasks and ingestion start will fail until it recovers", exc_info=True)
+
+
 # -----------------------
 # APP CREATION
 # -----------------------
@@ -132,29 +176,44 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
-        import fred_core.tasks.orm_models  # noqa: F401 — registers ORM models with CoreBase
-        from fred_core.models.base import Base as CoreBase
-
-        async with application_context.get_pg_async_engine().begin() as conn:
-            await conn.run_sync(CoreBase.metadata.create_all)
+        await create_core_tables(application_context)
 
         # SIGUSR1/SIGUSR2 manual triggers + optional periodic gc.collect()+
         # malloc_trim() mitigation (fred_core.diagnostics, ISSUE-010).
         gc_diagnostics = install_gc_diagnostics()
 
         process_kpi_task = None
-        db_pool_kpi_task = None
+        db_pool_kpi_tasks: list[asyncio.Task] = []
         interval_s = float(configuration.observability.kpi.process_metrics_interval_sec)
         if interval_s > 0:
             process_kpi_task = asyncio.create_task(emit_process_kpis(interval_s, application_context.get_kpi_writer()))
-            db_pool_kpi_task = asyncio.create_task(
-                emit_sql_pool_kpis(
-                    interval_s,
-                    application_context.get_kpi_writer(),
-                    application_context.get_pg_async_engine(),
-                    pool_name="knowledge-flow-postgres",
+            db_pool_kpi_tasks.append(
+                asyncio.create_task(
+                    emit_sql_pool_kpis(
+                        interval_s,
+                        application_context.get_kpi_writer(),
+                        application_context.get_pg_async_engine(),
+                        pool_name="knowledge-flow-postgres",
+                    )
                 )
             )
+            # The dedicated task database (OPS-04, #2170) is a second pool, sized
+            # independently, and saturating it stalls every task write and SSE stream for
+            # 30s before raising — invisible on the shared pool's gauges. Sampled only
+            # when it is genuinely a distinct engine: under the `task_postgres`-unset
+            # fallback both accessors return the same object, and emitting it twice would
+            # publish one pool under two names.
+            if application_context.get_task_pg_async_engine() is not application_context.get_pg_async_engine():
+                db_pool_kpi_tasks.append(
+                    asyncio.create_task(
+                        emit_sql_pool_kpis(
+                            interval_s,
+                            application_context.get_kpi_writer(),
+                            application_context.get_task_pg_async_engine(),
+                            pool_name="knowledge-flow-tasks-postgres",
+                        )
+                    )
+                )
 
         # OPS-04: periodically reconcile abandoned tasks (e.g. worker down past the
         # workflow timeout) against their executors so they never stay pending forever.
@@ -180,10 +239,10 @@ def create_app() -> FastAPI:
                 process_kpi_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await process_kpi_task
-            if db_pool_kpi_task:
-                db_pool_kpi_task.cancel()
+            for pool_task in db_pool_kpi_tasks:
+                pool_task.cancel()
                 with suppress(asyncio.CancelledError):
-                    await db_pool_kpi_task
+                    await pool_task
             await gc_diagnostics.stop()
             await application_context.shutdown()
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/main_worker.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/main_worker.py
@@ -55,7 +55,7 @@ def _start_worker_kpi_tasks(configuration, app_context: ApplicationContext) -> l
         return []
 
     kpi_writer = app_context.get_kpi_writer()
-    return [
+    tasks = [
         asyncio.create_task(emit_process_kpis(interval_s, kpi_writer)),
         asyncio.create_task(
             emit_sql_pool_kpis(
@@ -66,6 +66,22 @@ def _start_worker_kpi_tasks(configuration, app_context: ApplicationContext) -> l
             )
         ),
     ]
+    # The worker writes every task event, so the dedicated task pool (OPS-04, #2170) is
+    # if anything hotter here than in the API. Sampled only when it is a distinct engine —
+    # under the `task_postgres`-unset fallback both accessors return the same object, and
+    # emitting it twice would publish one pool under two names.
+    if app_context.get_task_pg_async_engine() is not app_context.get_pg_async_engine():
+        tasks.append(
+            asyncio.create_task(
+                emit_sql_pool_kpis(
+                    interval_s,
+                    kpi_writer,
+                    app_context.get_task_pg_async_engine(),
+                    pool_name="knowledge-flow-tasks-postgres",
+                )
+            )
+        )
+    return tasks
 
 
 async def main() -> None:

--- a/apps/knowledge-flow-backend/tests/core/test_application_context_task_database.py
+++ b/apps/knowledge-flow-backend/tests/core/test_application_context_task_database.py
@@ -1,0 +1,356 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Knowledge Flow's task tables must live in their own database (OPS-04, issue #2170).
+
+Knowledge Flow shares its main Postgres database with control-plane, and the fred-core
+task tables (`task_run` / `task_event_log`) carry no per-service discriminator. Sharing one
+database therefore makes each backend's `GET /tasks` return rows created by the other, and
+the Activity page — which queries both backends and concatenates the results — renders every
+task twice.
+
+These tests pin the wiring that fixes it: `get_task_service()` uses the dedicated task
+engine, every other store keeps the shared one, and the two never get silently swapped.
+Nothing else in the suite asserts which database a task row lands in.
+
+All configs here use `sqlite_path`, so engines are built for real without a server, a
+password, or a socket (the suite runs under --disable-socket).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from fred_core.common import DuckdbStoreConfig, PostgresStoreConfig
+
+from knowledge_flow_backend.application_context import ApplicationContext
+from knowledge_flow_backend.common.structures import (
+    InMemoryVectorStorage,
+    StorageConfig,
+)
+
+
+def _storage(tmp_path, *, with_task_db: bool) -> StorageConfig:
+    """Build a storage config with, or without, a dedicated task database.
+
+    Both branches use SQLite files so `create_async_engine_from_config` takes its
+    laptop-only path — real engines, no server, no credentials.
+    """
+    task_postgres = None
+    if with_task_db:
+        task_postgres = PostgresStoreConfig(sqlite_path=str(tmp_path / "tasks.db"), database="knowledge_flow")
+    return StorageConfig(
+        postgres=PostgresStoreConfig(sqlite_path=str(tmp_path / "shared.db"), database="fred"),
+        task_postgres=task_postgres,
+        resource_store=DuckdbStoreConfig(type="duckdb", duckdb_path=str(tmp_path / "resource.duckdb")),
+        tag_store=DuckdbStoreConfig(type="duckdb", duckdb_path=str(tmp_path / "tag.duckdb")),
+        metadata_store=DuckdbStoreConfig(type="duckdb", duckdb_path=str(tmp_path / "metadata.duckdb")),
+        vector_store=InMemoryVectorStorage(type="in_memory"),
+    )
+
+
+def _context(storage: StorageConfig) -> ApplicationContext:
+    """Return an ApplicationContext bound to `storage` without running __init__.
+
+    `ApplicationContext.__init__` short-circuits when the process-wide singleton already
+    exists — and conftest builds one via an autouse fixture before every test here — so
+    constructing it normally would silently hand back the fixture's context and its
+    storage config, not the one each test needs. Bypassing __init__ is what makes the
+    per-test storage config take effect; the accessors under test read only
+    `self.configuration` and the cached-engine slots, which are class-level defaults.
+    """
+    ctx = object.__new__(ApplicationContext)
+    ctx.configuration = _MinimalConfig(storage)  # type: ignore[assignment]
+    return ctx
+
+
+class _MinimalConfig:
+    """Stand-in for Configuration exposing only what the engine accessors read."""
+
+    def __init__(self, storage: StorageConfig):
+        self.storage = storage
+        self.scheduler = _MemoryScheduler()
+
+
+class _MemoryScheduler:
+    """Scheduler config resolving to the MEMORY backend — `get_scheduler_backend()`
+    short-circuits on `not enabled`, so no Temporal client is ever constructed."""
+
+    enabled = False
+
+
+def _patch_task_service_build(monkeypatch, captured: dict[str, Any]) -> None:
+    """Replace `TaskService.build` with a recorder, so a test can inspect the engine and
+    DSN it was handed without standing up a real store, bus or Temporal client."""
+    from fred_core.tasks import service as task_service_module
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(task_service_module.TaskService, "build", staticmethod(_capture))
+
+
+def test_task_engine_is_distinct_from_the_shared_engine_when_configured(tmp_path):
+    ctx = _context(_storage(tmp_path, with_task_db=True))
+
+    shared = ctx.get_pg_async_engine()
+    tasks = ctx.get_task_pg_async_engine()
+
+    assert tasks is not shared, "task tables must not share the control-plane database"
+    assert "tasks.db" in str(tasks.url)
+    assert "shared.db" in str(shared.url)
+
+
+def test_task_engine_is_cached(tmp_path):
+    ctx = _context(_storage(tmp_path, with_task_db=True))
+
+    assert ctx.get_task_pg_async_engine() is ctx.get_task_pg_async_engine()
+
+
+def test_task_engine_falls_back_to_the_shared_engine_and_warns_when_unconfigured(tmp_path, caplog):
+    """Absent `task_postgres`, the process must still boot — an image can ship before the
+    dedicated database is provisioned. The duplicate-row bug persists until it is, so the
+    fallback has to be loud rather than silent."""
+    ctx = _context(_storage(tmp_path, with_task_db=False))
+
+    with caplog.at_level(logging.WARNING):
+        tasks = ctx.get_task_pg_async_engine()
+
+    assert tasks is ctx.get_pg_async_engine()
+    assert any("task_postgres" in record.message for record in caplog.records), "falling back to the shared database must warn — otherwise #2170 silently persists"
+
+
+def test_task_service_is_built_with_the_task_engine(tmp_path, monkeypatch):
+    """The load-bearing assertion: TaskStore writes through the engine handed to
+    TaskService.build, so this is what decides which database a task row lands in."""
+    ctx = _context(_storage(tmp_path, with_task_db=True))
+    captured: dict[str, Any] = {}
+
+    _patch_task_service_build(monkeypatch, captured)
+
+    ctx.get_task_service()
+
+    assert captured["engine"] is ctx.get_task_pg_async_engine()
+    assert captured["engine"] is not ctx.get_pg_async_engine()
+
+
+def test_event_bus_dsn_names_the_task_database(tmp_path, monkeypatch):
+    """The SSE bus DSN must name the same database as the engine.
+
+    `PostgresEventBus` uses LISTEN/NOTIFY, and notification channels are per-database.
+    A bus pointed at the shared database while rows are written to the task database
+    fails silently: events still persist and replay, but live streaming delivers nothing
+    and no error is raised anywhere.
+    """
+    storage = _storage(tmp_path, with_task_db=True)
+    # A real Postgres target, so the DSN under test is the one production would build.
+    storage.task_postgres = PostgresStoreConfig(
+        host="task-host",
+        database="knowledge_flow",
+        username="kf",
+        password="pw",  # nosec B106 # pragma: allowlist secret
+    )
+
+    ctx = _context(storage)
+    ctx.configuration.scheduler = _TemporalScheduler()  # type: ignore[assignment]
+    captured: dict[str, Any] = {}
+
+    _patch_task_service_build(monkeypatch, captured)
+
+    ctx.get_task_service()
+
+    assert "knowledge_flow" in captured["postgres_dsn"]
+    assert "task-host" in captured["postgres_dsn"]
+    assert "/fred" not in captured["postgres_dsn"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_disposes_the_shared_engine_once_under_fallback():
+    """Under the fallback both slots hold the same engine, so shutdown must dispose it
+    once. `dispose()` is idempotent, so a second call would not corrupt anything — it
+    would just build a fresh pool and abandon it."""
+    ctx = object.__new__(ApplicationContext)
+    engine = _RecordingEngine()
+    ctx._pg_async_engine = engine  # type: ignore[assignment]
+    ctx._task_pg_async_engine = engine  # type: ignore[assignment]
+
+    await ctx.shutdown()
+
+    assert engine.dispose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_disposes_both_engines_when_they_are_distinct():
+    ctx = object.__new__(ApplicationContext)
+    shared, tasks = _RecordingEngine(), _RecordingEngine()
+    ctx._pg_async_engine = shared  # type: ignore[assignment]
+    ctx._task_pg_async_engine = tasks  # type: ignore[assignment]
+
+    await ctx.shutdown()
+
+    assert (shared.dispose_calls, tasks.dispose_calls) == (1, 1)
+
+
+class _RecordingEngine:
+    """Minimal stand-in for AsyncEngine — the real class rejects attribute injection."""
+
+    def __init__(self):
+        self.dispose_calls = 0
+
+    async def dispose(self):
+        self.dispose_calls += 1
+
+
+class _TemporalScheduler:
+    enabled = True
+    backend = "temporal"
+    temporal = None
+
+
+# --------------------------------------------------------------------------------------
+# Boot-time table placement — the invariant #2170 actually turns on.
+# --------------------------------------------------------------------------------------
+
+
+async def _table_names(engine) -> set[str]:
+    """Reflect the table names a real (SQLite) engine sees."""
+    from sqlalchemy import inspect as sa_inspect
+
+    async with engine.begin() as conn:
+        return set(await conn.run_sync(lambda sync_conn: sa_inspect(sync_conn).get_table_names()))
+
+
+@pytest.mark.asyncio
+async def test_create_core_tables_puts_task_tables_only_in_the_task_database(tmp_path):
+    """The task tables must be created in the dedicated database and NOWHERE else.
+
+    This is the regression guard for #2170. Reverting `create_core_tables` to a single
+    `create_all(CoreBase.metadata)` on the shared engine leaves every other test in the
+    suite green while silently recreating task_run/task_event_log in the database shared
+    with control-plane — which is exactly the duplicate-rows bug.
+    """
+    from fred_core.tasks import TASK_TABLE_NAMES
+
+    from knowledge_flow_backend.main import create_core_tables
+
+    ctx = _context(_storage(tmp_path, with_task_db=True))
+    await create_core_tables(ctx)
+
+    shared_tables = await _table_names(ctx.get_pg_async_engine())
+    task_tables = await _table_names(ctx.get_task_pg_async_engine())
+
+    assert TASK_TABLE_NAMES <= task_tables, "task tables missing from the dedicated database"
+    assert not (TASK_TABLE_NAMES & shared_tables), f"task tables leaked into the shared database: {sorted(TASK_TABLE_NAMES & shared_tables)}"
+    # The split must not cost the shared database its own tables.
+    assert shared_tables, "shared database got no tables at all"
+
+
+@pytest.mark.asyncio
+async def test_create_core_tables_keeps_pre_ops_04_behaviour_when_unconfigured(tmp_path):
+    """With `task_postgres` unset both engines are one engine, so everything lands together.
+
+    The fallback has to stay byte-for-byte the old behaviour: an operator who has not
+    provisioned the dedicated database yet gets a working backend, duplicate rows included.
+    """
+    from fred_core.tasks import TASK_TABLE_NAMES
+
+    from knowledge_flow_backend.main import create_core_tables
+
+    ctx = _context(_storage(tmp_path, with_task_db=False))
+    await create_core_tables(ctx)
+
+    assert ctx.get_task_pg_async_engine() is ctx.get_pg_async_engine()
+    assert TASK_TABLE_NAMES <= await _table_names(ctx.get_pg_async_engine())
+
+
+@pytest.mark.asyncio
+async def test_create_core_tables_survives_an_unreachable_task_database(tmp_path):
+    """A dedicated task database that is down must not crash-loop the whole API pod.
+
+    `create_core_tables` is the first statement of the FastAPI lifespan, so raising here
+    exits uvicorn non-zero and takes document search, upload, tag and metadata reads down
+    with it — for a database only `GET /tasks`, task SSE and ingestion start use. That
+    directly contradicts the `postgres_tasks` readiness probe, which is deliberately
+    advisory for exactly this reason, and Alembic (`alembic_tasks/`) owns the real schema
+    anyway. The lifespan already treats `get_task_service()` this way.
+    """
+    storage = _storage(tmp_path, with_task_db=True)
+    # A directory where SQLite expects a file: the engine still builds (an unreachable
+    # server's would too), and the failure lands on connect — `unable to open database
+    # file` — exactly where an unreachable Postgres would raise. Note a merely missing
+    # parent directory would NOT work: `create_async_engine_from_config` mkdirs it.
+    unopenable = tmp_path / "unopenable-tasks.db"
+    unopenable.mkdir()
+    ctx = _context(storage.model_copy(update={"task_postgres": PostgresStoreConfig(sqlite_path=str(unopenable), database="knowledge_flow")}))
+
+    from knowledge_flow_backend.main import create_core_tables
+
+    await create_core_tables(ctx)  # must not raise
+
+    # The shared database is untouched by the task database's outage.
+    assert await _table_names(ctx.get_pg_async_engine()), "shared tables must still be created"
+
+
+# --------------------------------------------------------------------------------------
+# Migration guards for a database WITHOUT task_run.
+# --------------------------------------------------------------------------------------
+
+
+def test_task_run_index_migrations_are_no_ops_when_the_table_is_absent(tmp_path):
+    """`task_run` absent must be a no-op in BOTH directions, for every chain that alters it.
+
+    OPS-04 makes this the normal state: the shared database no longer holds the task tables,
+    so knowledge-flow's own chain now alters a table that is not there. Nothing else covers
+    it — `db-check-combined-sqlite`/`-postgres` upgrade control-plane FIRST into the *same*
+    database, so `task_run` always exists by the time this chain runs and the table-absent
+    branch is never taken. A guard that is correct for upgrade but inverted for downgrade
+    (returning a sentinel that reads as "present, drop it") passed every gate and still
+    raised `UndefinedObjectError` on a real standalone downgrade.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    import sqlalchemy as sa
+
+    versions = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+    modules = sorted(versions.glob("*task_run_single_active_migration*.py")) + sorted(versions.glob("*add_task_run*.py"))
+    assert modules, "expected at least one task_run index/column migration to exist"
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'no_task_run.db'}")
+    with engine.begin() as conn:
+        # A database that has everything EXCEPT task_run — the post-OPS-04 shared database.
+        conn.execute(sa.text("CREATE TABLE metadata (document_uid TEXT PRIMARY KEY)"))
+
+        from alembic.migration import MigrationContext
+        from alembic.operations import Operations
+
+        ctx = MigrationContext.configure(conn)
+        ops = Operations(ctx)
+
+        for path in modules:
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            assert spec and spec.loader
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            if not (hasattr(mod, "upgrade") and hasattr(mod, "downgrade")):
+                continue
+            with Operations.context(ops):
+                # Neither direction may touch a table that is not there.
+                mod.upgrade()
+                mod.downgrade()
+
+        assert "task_run" not in sa.inspect(conn).get_table_names(), "a guard created task_run instead of skipping"

--- a/apps/knowledge-flow-backend/tests/core/test_application_context_task_database.py
+++ b/apps/knowledge-flow-backend/tests/core/test_application_context_task_database.py
@@ -354,3 +354,95 @@ def test_task_run_index_migrations_are_no_ops_when_the_table_is_absent(tmp_path)
                 mod.downgrade()
 
         assert "task_run" not in sa.inspect(conn).get_table_names(), "a guard created task_run instead of skipping"
+
+
+def test_task_run_index_migrations_tolerate_existing_same_kind_rows_on_sqlite(tmp_path):
+    """Two non-terminal rows of one kind must survive the index migrations on SQLite.
+
+    `e2f3a4b5c6d7` passed only `postgresql_where`. SQLAlchemy silently drops
+    dialect-prefixed kwargs on other dialects, so on SQLite the predicate vanished and the
+    index landed as an unconditional `UNIQUE (kind)`. On a database already holding two
+    non-terminal `ingestion` rows the upgrade then aborted with `UNIQUE constraint failed:
+    task_run.kind` — stranding the chain *before* the repair revision `f7a8b9c0d1e2` could
+    ever run, so migrations were permanently blocked rather than merely wrong.
+
+    Nothing else covers this: `db-check-combined-sqlite` migrates an empty database, where
+    an unconditional unique index is created happily and the defect is invisible.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    import sqlalchemy as sa
+
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    versions = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+    # Order matters: the defect is that the FIRST of these aborts, so the second never runs.
+    ordered = [
+        "e2f3a4b5c6d7_add_task_run_single_active_migration_index.py",
+        "f7a8b9c0d1e2_repair_task_run_single_active_migration_index.py",
+    ]
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'seeded.db'}")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE task_run (id TEXT PRIMARY KEY, kind TEXT NOT NULL, state TEXT NOT NULL)"))
+        conn.execute(sa.text("INSERT INTO task_run (id, kind, state) VALUES ('a', 'ingestion', 'running'), ('b', 'ingestion', 'pending')"))
+
+        migration_ctx = MigrationContext.configure(conn)
+        for name in ordered:
+            path = versions / name
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            assert spec and spec.loader
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            with Operations.context(migration_ctx):
+                mod.upgrade()
+
+        assert conn.execute(sa.text("SELECT count(*) FROM task_run")).scalar_one() == 2, "the migrations dropped rows"
+        # And the index that landed is the intended partial one, not `UNIQUE (kind)`: a
+        # third non-terminal ingestion row still inserts.
+        conn.execute(sa.text("INSERT INTO task_run (id, kind, state) VALUES ('c', 'ingestion', 'running')"))
+
+
+def test_repair_migration_is_a_no_op_on_postgres_in_both_directions():
+    """`f7a8b9c0d1e2` must emit nothing on Postgres — and the two directions must agree.
+
+    The repair exists for a SQLite-only defect, and since OPS-04 this chain no longer owns
+    `task_run`: on a deployment still sharing the `fred` database that table is
+    control-plane's, so any DDL here takes ACCESS EXCLUSIVE on another service's live table.
+
+    Gating only `upgrade()` is worse than gating neither. `e2f3a4b5c6d7` owns the index on
+    Postgres, so an ungated `downgrade()` drops it and a gated `upgrade()` then declines to
+    put it back: `make db-downgrade` (a documented operator procedure) followed by a
+    re-upgrade silently and permanently destroys the single-active-migration constraint.
+    Verified against PG 16: ungated, the round trip ends with the index gone and two
+    non-terminal `kind='migration'` rows accepted.
+
+    A mock engine keeps this offline while still presenting a real `postgresql` dialect —
+    the gate is the only thing standing between the call and `sa.inspect()`, which a
+    MockConnection cannot satisfy, so removing it fails this test rather than skipping it.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    import sqlalchemy as sa
+
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    emitted: list[str] = []
+    mock_engine = sa.create_mock_engine("postgresql+psycopg://", lambda sql, *a, **kw: emitted.append(str(sql)))
+
+    path = Path(__file__).resolve().parents[2] / "alembic" / "versions" / "f7a8b9c0d1e2_repair_task_run_single_active_migration_index.py"
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    ctx = MigrationContext.configure(connection=mock_engine)  # type: ignore[arg-type]
+    with Operations.context(ctx):
+        mod.upgrade()
+        mod.downgrade()
+
+    assert emitted == [], f"the repair migration emitted DDL on Postgres: {emitted}"

--- a/apps/knowledge-flow-backend/tests/core/test_main_worker.py
+++ b/apps/knowledge-flow-backend/tests/core/test_main_worker.py
@@ -61,7 +61,7 @@ async def test_main_worker_enables_observability_from_configuration(app_context,
 
     async def fake_emit_sql_pool_kpis(interval_s: float, writer, engine, pool_name: str) -> None:
         """Record SQL pool KPI scheduling inputs without touching a real database."""
-        observed["sql_pool_kpi"] = (interval_s, writer, engine, pool_name)
+        observed.setdefault("sql_pool_kpi", []).append((interval_s, writer, engine, pool_name))
         await asyncio.sleep(0)
 
     async def fake_shutdown(self) -> None:
@@ -81,6 +81,9 @@ async def test_main_worker_enables_observability_from_configuration(app_context,
     monkeypatch.setattr(main_worker_module, "emit_sql_pool_kpis", fake_emit_sql_pool_kpis)
     monkeypatch.setattr(ApplicationContext, "get_kpi_writer", lambda self: writer_sentinel)
     monkeypatch.setattr(ApplicationContext, "get_pg_async_engine", lambda self: engine_sentinel)
+    # A dedicated task engine (OPS-04, #2170) — distinct object, so the second sampler runs.
+    task_engine_sentinel = object()
+    monkeypatch.setattr(ApplicationContext, "get_task_pg_async_engine", lambda self: task_engine_sentinel)
     monkeypatch.setattr(ApplicationContext, "shutdown", fake_shutdown)
 
     ApplicationContext.reset_instance()
@@ -92,8 +95,51 @@ async def test_main_worker_enables_observability_from_configuration(app_context,
     prom_cfg = config.observability.kpi.prometheus
     assert observed["metrics_server"] == (prom_cfg.port, prom_cfg.address)
     assert observed["process_kpi"] == (10.0, writer_sentinel)
-    assert observed["sql_pool_kpi"] == (10.0, writer_sentinel, engine_sentinel, "knowledge-flow-postgres")
+    # Both pools sampled, each under its own name. Without the distinct `pool` label these
+    # two series would collapse onto one Gauge, last write wins (OPS-04, #2170).
+    assert observed["sql_pool_kpi"] == [
+        (10.0, writer_sentinel, engine_sentinel, "knowledge-flow-postgres"),
+        (10.0, writer_sentinel, task_engine_sentinel, "knowledge-flow-tasks-postgres"),
+    ]
     assert observed["temporal_config"] == config.scheduler.temporal
     assert observed["max_concurrent_workflow_tasks"] == 4
     assert observed["max_concurrent_activities"] == 6
     assert observed["shutdown_called"] is True
+
+
+@pytest.mark.asyncio
+async def test_worker_samples_one_pool_when_task_database_is_not_configured(monkeypatch):
+    """Under the `task_postgres`-unset fallback both accessors return the SAME engine.
+
+    Emitting it twice would publish a single pool under two names, so every
+    `process.db_pool.*` series for 'knowledge-flow-tasks-postgres' would silently be a
+    duplicate of the shared one (OPS-04, issue #2170).
+    """
+    from types import SimpleNamespace
+
+    from knowledge_flow_backend import main_worker as main_worker_module
+
+    emitted: list[str] = []
+
+    async def fake_emit_process_kpis(interval_s, writer):
+        await asyncio.sleep(0)
+
+    async def fake_emit_sql_pool_kpis(interval_s, writer, engine, pool_name: str):
+        emitted.append(pool_name)
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(main_worker_module, "emit_process_kpis", fake_emit_process_kpis)
+    monkeypatch.setattr(main_worker_module, "emit_sql_pool_kpis", fake_emit_sql_pool_kpis)
+
+    shared = object()
+    ctx = SimpleNamespace(
+        get_kpi_writer=object,
+        get_pg_async_engine=lambda: shared,
+        get_task_pg_async_engine=lambda: shared,  # the fallback: same object
+    )
+    configuration = SimpleNamespace(observability=SimpleNamespace(kpi=SimpleNamespace(process_metrics_interval_sec=10)))
+
+    tasks = main_worker_module._start_worker_kpi_tasks(configuration, ctx)  # type: ignore[arg-type]
+    await asyncio.gather(*tasks)
+
+    assert emitted == ["knowledge-flow-postgres"], "the fallback must not publish one pool twice"

--- a/apps/knowledge-flow-backend/tests/core/test_monitoring_controller.py
+++ b/apps/knowledge-flow-backend/tests/core/test_monitoring_controller.py
@@ -20,14 +20,18 @@ reports which one is down (503) instead of silently hanging or always returning 
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import yaml
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
-from knowledge_flow_backend.core.monitoring.monitoring_controller import MonitoringController
+from knowledge_flow_backend.core.monitoring.monitoring_controller import _READINESS_TIMEOUT_S, MonitoringController
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 class _AsyncCM:
@@ -59,8 +63,15 @@ def _healthy_context() -> SimpleNamespace:
     gcs_content = MagicMock()
     gcs_content.health_check = MagicMock(return_value={"backend": "gcs", "buckets": ["docs", "objs"]})
 
+    # storage.task_postgres unset → the task-database probe reports "skipped", because the
+    # task engine is then the shared engine that the `postgres` probe already covers
+    # (OPS-04, issue #2170).
+    config = SimpleNamespace(storage=SimpleNamespace(task_postgres=None))
+
     return SimpleNamespace(
         get_pg_async_engine=lambda: engine,
+        get_task_pg_async_engine=lambda: engine,
+        get_config=lambda: config,
         get_opensearch_client=lambda: opensearch,
         get_rebac_engine=lambda: rebac,
         get_filesystem=lambda: gcs_fs,
@@ -124,6 +135,78 @@ def test_ready_skips_non_gcs_backend() -> None:
     fs_check = resp.json()["checks"]["gcs_filesystem"]
     assert fs_check["ok"] is True
     assert "skipped" in fs_check
+
+
+def test_ready_skips_task_postgres_probe_when_not_configured() -> None:
+    """Absent `storage.task_postgres`, the task engine IS the shared engine, so probing it
+    again would only double-count the same dependency."""
+    with _client(_healthy_context()) as client:
+        resp = client.get("/knowledge-flow/v1/ready")
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["checks"]["postgres_tasks"]["ok"] is True
+    assert body["checks"]["postgres_tasks"]["skipped"]
+
+
+def _task_db_down_context() -> SimpleNamespace:
+    ctx = _healthy_context()
+    ctx.get_config = lambda: SimpleNamespace(storage=SimpleNamespace(task_postgres=object()))
+    failing = MagicMock()
+    failing.connect = MagicMock(side_effect=RuntimeError("task database unreachable"))
+    ctx.get_task_pg_async_engine = lambda: failing
+    return ctx
+
+
+def test_task_database_outage_is_reported_but_does_not_make_the_pod_unready() -> None:
+    """The task database is ADVISORY: reported, never fatal to readiness.
+
+    Document search, upload, tag and metadata reads never touch it, so answering 503
+    would pull every pod out of the Service (~100s at failureThreshold 10 ×
+    periodSeconds 10) and turn a partial outage into a total one (OPS-04, #2170).
+    """
+    with _client(_task_db_down_context()) as client:
+        resp = client.get("/knowledge-flow/v1/ready")
+
+    body = resp.json()
+    assert resp.status_code == 200, "an advisory failure must not remove the pod from the Service"
+    assert body["status"] == "ready_degraded", "…but it must be visibly distinct from a clean 'ready'"
+    assert body["advisory_failures"] == ["postgres_tasks"]
+    # The signal is preserved in full: the failure and its cause are still reported.
+    assert body["checks"]["postgres_tasks"]["ok"] is False
+    assert "task database unreachable" in body["checks"]["postgres_tasks"]["error"]
+    # The shared database is fine — only the task database is down.
+    assert body["checks"]["postgres"]["ok"] is True
+
+
+def test_a_blocking_dependency_still_makes_the_pod_unready_alongside_an_advisory_one() -> None:
+    """Advisory handling must not weaken the real gate."""
+    ctx = _task_db_down_context()
+    failing = MagicMock()
+    failing.health_check = MagicMock(side_effect=RuntimeError("GCS bucket unreachable"))
+    ctx.get_content_store = lambda: failing
+
+    with _client(ctx) as client:
+        resp = client.get("/knowledge-flow/v1/ready")
+
+    body = resp.json()
+    assert resp.status_code == 503
+    assert body["status"] == "degraded"
+    assert body["checks"]["gcs_content_store"]["ok"] is False
+    assert body["checks"]["postgres_tasks"]["ok"] is False
+
+
+def test_chart_readiness_timeout_exceeds_probe_budget() -> None:
+    """kubelet's `timeoutSeconds` must stay above the in-process probe budget.
+
+    `_run_checks` gathers concurrently, so /ready costs as much as its slowest probe. If
+    kubelet gives up first it records a FAILED probe regardless of the 200 that was about
+    to come back — and a slow ADVISORY probe would then take the pod out of the Service
+    through the very response that says "keep routing to me", defeating `_ADVISORY_PROBES`
+    entirely. The module comment states this requirement; nothing enforced it.
+    """
+    values = yaml.safe_load((_REPO_ROOT / "deploy/charts/fred/values.yaml").read_text())
+    data = values["applications"]["knowledge-flow-backend"]["probes"]["readinessProbe"]["data"]
+    assert data["timeoutSeconds"] > _READINESS_TIMEOUT_S, "readinessProbe.timeoutSeconds must exceed _READINESS_TIMEOUT_S — see monitoring_controller.py"
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/apps/knowledge-flow-backend/tests/features/kpi/test_prometheus_service.py
+++ b/apps/knowledge-flow-backend/tests/features/kpi/test_prometheus_service.py
@@ -54,7 +54,11 @@ async def test_instant_query_serializes_body_and_auth_header() -> None:
 
 
 @pytest.mark.asyncio
-async def test_targets_uses_basic_auth_when_configured() -> None:
+async def test_targets_uses_basic_auth_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PrometheusConfig defaults bearer_token from PROMETHEUS_BEARER_TOKEN, and
+    # bearer wins over basic auth. A developer .env that sets it would silently
+    # turn this into a bearer-auth test, so pin the ambient environment.
+    monkeypatch.delenv("PROMETHEUS_BEARER_TOKEN", raising=False)
     captured: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -83,7 +87,8 @@ async def test_targets_uses_basic_auth_when_configured() -> None:
 
 
 @pytest.mark.asyncio
-async def test_targets_uses_admin_as_default_basic_auth_username() -> None:
+async def test_targets_uses_admin_as_default_basic_auth_username(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROMETHEUS_BEARER_TOKEN", raising=False)
     captured: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/deploy/charts/fred/values-gcp.yaml
+++ b/deploy/charts/fred/values-gcp.yaml
@@ -101,6 +101,23 @@ applications:
           port: 5432
           database: fred
           username: fred
+        # Dedicated database for task_run / task_event_log (OPS-04, issue #2170).
+        # This overlay sets `storage` inline, so it does NOT inherit the x-kf-storage
+        # anchor in values.yaml — the block has to be repeated here. Uncomment once the
+        # database and role exist, set POSTGRES_KNOWLEDGE_FLOW_PASSWORD, and run the
+        # second Alembic chain; see values.yaml for the full checklist. Until then task
+        # rows stay in the shared `fred` database and the Activity page shows duplicates.
+        # task_postgres:
+        #   host: "<POSTGRES_HOST>"
+        #   port: 5432
+        #   database: knowledge_flow
+        #   username: knowledge_flow
+        #   password_env: POSTGRES_KNOWLEDGE_FLOW_PASSWORD # pragma: allowlist secret
+        #   pool_size: 2
+        #   max_overflow: 0
+        #   pool_timeout: 30
+        #   pool_recycle: 1800
+        #   pool_pre_ping: true
         resource_store:
           type: "postgres"
         tag_store:

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -1366,7 +1366,21 @@
                               "type": "null"
                             }
                           ],
+                          "default": null,
                           "title": "Password"
+                        },
+                        "password_env": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                          "title": "Password Env"
                         },
                         "echo": {
                           "default": false,
@@ -5889,7 +5903,21 @@
                               "type": "null"
                             }
                           ],
+                          "default": null,
                           "title": "Password"
+                        },
+                        "password_env": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                          "title": "Password Env"
                         },
                         "echo": {
                           "default": false,
@@ -5980,6 +6008,193 @@
                       "title": "PostgresStoreConfig",
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "task_postgres": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "type": {
+                              "const": "postgres",
+                              "default": "postgres",
+                              "title": "Type",
+                              "type": "string"
+                            },
+                            "host": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "PostgreSQL host",
+                              "title": "Host"
+                            },
+                            "port": {
+                              "default": 5432,
+                              "title": "Port",
+                              "type": "integer"
+                            },
+                            "sqlite_path": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Path to the SQLite database file (for local dev/testing).",
+                              "title": "Sqlite Path"
+                            },
+                            "database": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "title": "Database"
+                            },
+                            "username": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "title": "Username"
+                            },
+                            "password": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "title": "Password"
+                            },
+                            "password_env": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                              "title": "Password Env"
+                            },
+                            "echo": {
+                              "default": false,
+                              "description": "SQLAlchemy echo flag.",
+                              "title": "Echo",
+                              "type": "boolean"
+                            },
+                            "pool_size": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Optional pool size for the engine.",
+                              "title": "Pool Size"
+                            },
+                            "max_overflow": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Optional max_overflow for SQLAlchemy pool (defaults to SQLAlchemy's 10 if unset).",
+                              "title": "Max Overflow"
+                            },
+                            "pool_timeout": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Seconds to wait for a connection from the pool before timing out.",
+                              "title": "Pool Timeout"
+                            },
+                            "pool_recycle": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Recycle connections after this many seconds (prevents stale TCP / server timeouts).",
+                              "title": "Pool Recycle"
+                            },
+                            "pool_pre_ping": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Enable SQLAlchemy pool_pre_ping to evict stale connections.",
+                              "title": "Pool Pre Ping"
+                            },
+                            "connect_args": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": true,
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Optional connect_args passed to SQLAlchemy.",
+                              "title": "Connect Args"
+                            }
+                          },
+                          "title": "PostgresStoreConfig",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Dedicated Postgres database for task_run / task_event_log (OPS-04). Knowledge Flow shares `postgres` with control-plane for tag/metadata/resource, so its task tables must live elsewhere or both backends read each other's rows. Unset falls back to `postgres` \u2014 the pre-OPS-04 shared behaviour, which duplicates task rows on the Activity page."
                     },
                     "opensearch": {
                       "anyOf": [
@@ -10462,7 +10677,21 @@
                               "type": "null"
                             }
                           ],
+                          "default": null,
                           "title": "Password"
+                        },
+                        "password_env": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                          "title": "Password Env"
                         },
                         "echo": {
                           "default": false,
@@ -10553,6 +10782,193 @@
                       "title": "PostgresStoreConfig",
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "task_postgres": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "type": {
+                              "const": "postgres",
+                              "default": "postgres",
+                              "title": "Type",
+                              "type": "string"
+                            },
+                            "host": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "PostgreSQL host",
+                              "title": "Host"
+                            },
+                            "port": {
+                              "default": 5432,
+                              "title": "Port",
+                              "type": "integer"
+                            },
+                            "sqlite_path": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Path to the SQLite database file (for local dev/testing).",
+                              "title": "Sqlite Path"
+                            },
+                            "database": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "title": "Database"
+                            },
+                            "username": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "title": "Username"
+                            },
+                            "password": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "title": "Password"
+                            },
+                            "password_env": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                              "title": "Password Env"
+                            },
+                            "echo": {
+                              "default": false,
+                              "description": "SQLAlchemy echo flag.",
+                              "title": "Echo",
+                              "type": "boolean"
+                            },
+                            "pool_size": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Optional pool size for the engine.",
+                              "title": "Pool Size"
+                            },
+                            "max_overflow": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Optional max_overflow for SQLAlchemy pool (defaults to SQLAlchemy's 10 if unset).",
+                              "title": "Max Overflow"
+                            },
+                            "pool_timeout": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Seconds to wait for a connection from the pool before timing out.",
+                              "title": "Pool Timeout"
+                            },
+                            "pool_recycle": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Recycle connections after this many seconds (prevents stale TCP / server timeouts).",
+                              "title": "Pool Recycle"
+                            },
+                            "pool_pre_ping": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Enable SQLAlchemy pool_pre_ping to evict stale connections.",
+                              "title": "Pool Pre Ping"
+                            },
+                            "connect_args": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": true,
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null,
+                              "description": "Optional connect_args passed to SQLAlchemy.",
+                              "title": "Connect Args"
+                            }
+                          },
+                          "title": "PostgresStoreConfig",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Dedicated Postgres database for task_run / task_event_log (OPS-04). Knowledge Flow shares `postgres` with control-plane for tag/metadata/resource, so its task tables must live elsewhere or both backends read each other's rows. Unset falls back to `postgres` \u2014 the pre-OPS-04 shared behaviour, which duplicates task rows on the Activity page."
                     },
                     "opensearch": {
                       "anyOf": [
@@ -13055,7 +13471,21 @@
                               "type": "null"
                             }
                           ],
+                          "default": null,
                           "title": "Password"
+                        },
+                        "password_env": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                          "title": "Password Env"
                         },
                         "echo": {
                           "default": false,
@@ -15016,7 +15446,21 @@
                               "type": "null"
                             }
                           ],
+                          "default": null,
                           "title": "Password"
+                        },
+                        "password_env": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Name of the environment variable holding this database's password. Unset means FRED_POSTGRES_PASSWORD. Set it only when one service connects to several Postgres databases under different roles.",
+                          "title": "Password Env"
                         },
                         "echo": {
                           "default": false,

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -314,6 +314,39 @@ x-kf-storage: &kf-storage
     port: 5432
     database: fred
     username: admin
+  # Dedicated database for task_run / task_event_log (OPS-04, issue #2170).
+  #
+  # Left commented out because THIS CHART CANNOT CREATE THE DATABASE — it has no
+  # provisioning hook; `fred-deployment-factory` owns that. Enabling the block below
+  # against a database that does not exist turns a working deploy into a CrashLoop, so
+  # the default stays on the shared `fred` database (knowledge-flow logs a warning at
+  # startup, and the Activity page keeps showing each task twice until this is enabled).
+  #
+  # To enable, all three of these are required together:
+  #   1. uncomment this block and point it at the provisioned database;
+  #   2. set POSTGRES_KNOWLEDGE_FLOW_PASSWORD in the `dotenv` block of BOTH the
+  #      knowledge-flow-backend and knowledge-flow-worker applications below;
+  #   3. run the second Alembic chain, which the default migration Job does NOT run —
+  #      override the knowledge-flow-backend migration command:
+  #        migration:
+  #          enabled: true
+  #          command: ["sh", "-c"]
+  #          args: ["alembic upgrade head && alembic -c alembic_tasks.ini upgrade head"]
+  #
+  # Keep pool_size/max_overflow explicit. Unset, fred-core defaults to 5+10 = 15
+  # connections per pool, and a second pool across backend + worker replicas can push a
+  # default Postgres `max_connections=100` over the edge for every service on the server.
+  # task_postgres:
+  #   host: localhost
+  #   port: 5432
+  #   database: knowledge_flow
+  #   username: knowledge_flow
+  #   password_env: POSTGRES_KNOWLEDGE_FLOW_PASSWORD # pragma: allowlist secret
+  #   pool_size: 2
+  #   max_overflow: 0
+  #   pool_timeout: 30
+  #   pool_recycle: 1800
+  #   pool_pre_ping: true
   opensearch:
     host: https://localhost:9200
     secure: true
@@ -1153,7 +1186,11 @@ applications:
     job:
       enabled: false
     migration:
-      enabled: false    # Enable when knowledge-flow-backend gets Alembic migrations
+      # knowledge-flow HAS Alembic migrations (the comment that used to say otherwise was
+      # stale). Left off by default so an operator opts in deliberately. Note the default
+      # command runs only the shared-database chain; the dedicated task database needs the
+      # second chain too — see the x-kf-storage anchor above for the override.
+      enabled: false
       scaleDown: true
       backoffLimit: 3
     rollingUpdate:
@@ -1259,6 +1296,15 @@ applications:
             path: /knowledge-flow/v1/ready
             port: 8111
           periodSeconds: 10
+          # MUST exceed the server-side probe budget (_READINESS_TIMEOUT_S = 6s in
+          # monitoring_controller.py). Kubernetes defaults timeoutSeconds to 1, which would
+          # record a FAILED probe on any slow dependency regardless of the HTTP status —
+          # including the 200 that the advisory task-database probe deliberately returns
+          # (OPS-04, issue #2170). At the default, a merely *slow* task database would take
+          # knowledge-flow out of the Service in failureThreshold x periodSeconds = 100s,
+          # turning a partial outage into a total one — the exact opposite of the advisory
+          # probe's purpose.
+          timeoutSeconds: 8
       startupProbe:
         enabled: false
     securityContext:
@@ -1336,6 +1382,8 @@ applications:
       PROMETHEUS_BEARER_TOKEN: ""
       OPENFGA_API_TOKEN: ""
       FRED_POSTGRES_PASSWORD: ""
+      # Only used when storage.task_postgres is enabled in the x-kf-storage anchor (#2170).
+      POSTGRES_KNOWLEDGE_FLOW_PASSWORD: ""
 
   # ── 3.4 Knowledge Flow Worker (Temporal) ───────────────────────────
   # Toggle Temporal worker pod deployment.
@@ -1512,6 +1560,8 @@ applications:
       PROMETHEUS_BEARER_TOKEN: ""
       OPENFGA_API_TOKEN: ""
       FRED_POSTGRES_PASSWORD: ""
+      # Only used when storage.task_postgres is enabled in the x-kf-storage anchor (#2170).
+      POSTGRES_KNOWLEDGE_FLOW_PASSWORD: ""
 
   # ── 3.5 Control Plane Backend ─────────────────────────────────────
   control-plane-backend:

--- a/deploy/local/k3d/values-local.yaml
+++ b/deploy/local/k3d/values-local.yaml
@@ -143,6 +143,29 @@ x-kf-storage: &kf-storage
     pool_timeout: 30
     pool_recycle: 1800
     pool_pre_ping: true
+  # Dedicated database for task_run / task_event_log (OPS-04, issue #2170).
+  #
+  # Left commented out because this stack does not itself create the database — the
+  # matching `fred-deployment-factory` k3d chart does, but only when Postgres initialises
+  # an EMPTY data directory: its init SQL is mounted into /docker-entrypoint-initdb.d,
+  # which the Postgres entrypoint runs once, at initdb. On a cluster whose PVC already
+  # exists, a redeploy re-renders that ConfigMap and creates nothing, so the database must
+  # be created by hand (or the cluster wiped) before enabling this.
+  #
+  # Enabling it also requires POSTGRES_KNOWLEDGE_FLOW_PASSWORD in the dotenv blocks below
+  # and a migration command that runs both Alembic chains — see the same block in
+  # deploy/charts/fred/values.yaml for the full checklist.
+  # task_postgres:
+  #   host: postgres
+  #   port: 5432
+  #   database: knowledge_flow
+  #   username: knowledge_flow
+  #   password_env: POSTGRES_KNOWLEDGE_FLOW_PASSWORD # pragma: allowlist secret
+  #   pool_size: 2
+  #   max_overflow: 0
+  #   pool_timeout: 30
+  #   pool_recycle: 1800
+  #   pool_pre_ping: true
   opensearch:
     host: https://opensearch:9200
     secure: true

--- a/docs/swift/ops/DATABASE_MIGRATIONS.md
+++ b/docs/swift/ops/DATABASE_MIGRATIONS.md
@@ -15,6 +15,51 @@ Each backend that owns database tables has its own Alembic setup under `<backend
 ORM models are registered in each backend's `alembic/env.py` so that autogenerate can
 detect differences between the code and the live database.
 
+> **One chain per database, not per backend.** Alembic opens exactly one connection per
+> `env.py`, so a backend that owns tables in two databases needs two chains.
+> `knowledge-flow-backend` is the one such backend today (OPS-04, issue #2170):
+>
+> | Chain | Config | Database | Tables | Version table |
+> | --- | --- | --- | --- | --- |
+> | `alembic/` | `pyproject.toml` `[tool.alembic]` | shared `fred` | `resource`, `tag`, `metadata` | `alembic_version_knowledge_flow` |
+> | `alembic_tasks/` | `alembic_tasks.ini` | dedicated `knowledge_flow` | `task_run`, `task_event_log` | `alembic_version_knowledge_flow_tasks` |
+>
+> `make db-upgrade` runs the first; **`make db-upgrade-tasks` runs the second**. Upgrading
+> only the first leaves the task database un-migrated. The task chain refuses to run when
+> `storage.task_postgres` is unset, rather than falling back to the shared database where
+> control-plane owns those tables.
+>
+> The task chain has its own targets, but **not** a twin of every `db-*` target, and the
+> two naming shapes differ — operational targets take a `-tasks` suffix, check targets
+> infix it:
+>
+> | Shared chain | Task chain |
+> | --- | --- |
+> | `db-upgrade` | `db-upgrade-tasks` |
+> | `db-migrate` | `db-migrate-tasks` |
+> | `db-downgrade` | `db-downgrade-tasks` |
+> | `db-history` | `db-history-tasks` |
+> | `db-check-heads` | `db-check-**tasks**-heads` |
+> | `db-check-sqlite` | `db-check-**tasks**-sqlite` |
+> | `db-check-postgres` | `db-check-**tasks**-postgres` |
+> | `db-stamp`, `db-snapshots`, `db-check-migrations`, `db-check-postgres-full` | *no equivalent* |
+>
+> `db-stamp` has no twin deliberately: it registers a database that predates Alembic, and
+> the task database is always created by the chain itself. Note `make db-check-migrations`
+> covers only the shared chain — CI exercises the task chain through the repo-root
+> `db-check-combined-heads` / `db-check-combined-sqlite` targets instead.
+>
+> Each chain must pass a `MetaData` scoped to the tables it owns, built with
+> `Table.to_metadata()` — `fred_core`'s declarative `Base` is a single registry shared by
+> every backend, and Alembic applies its name filters only to the connection side, never
+> to the metadata side. See `libs/fred-runtime/alembic/env.py` for the reference pattern.
+>
+> The same split applies to the **boot path**, not just to Alembic: `knowledge-flow`'s
+> `main.py` creates the task tables against the task engine and every other `CoreBase`
+> table against the shared engine. A single `create_all(CoreBase.metadata)` on the shared
+> engine — what it did before OPS-04 — recreates `task_run`/`task_event_log` in `fred` on
+> the next restart, undoing the split no matter what the migrations did.
+
 ## Configuration
 
 Alembic connects to the PostgreSQL instance defined in the config file pointed to by
@@ -266,3 +311,100 @@ For each backend, compare the dump of your DB vs dump of the migrations:
 
 - If you have a perfect match -> stamp on the migration id
 - No perfect match -> find the closest one, migrate by hand to the closest one then stamp on the migration id
+
+---
+
+## Moving existing task rows into the Knowledge Flow task database (OPS-04, issue #2170)
+
+Enabling `storage.task_postgres` only changes where rows are written **from then on**. Rows
+already in the shared `fred` database stay there: invisible to Knowledge Flow's `GET /tasks`,
+still returned by control-plane's, and never reached by Knowledge Flow's reconciliation
+sweeper — so a non-terminal row stranded there stays non-terminal forever.
+
+This procedure moves them. It is operator-driven and deliberately not automated: the fred-core
+task tables carry **no per-service discriminator** (that is the premise of #2170), so nothing
+in the schema can tell you which rows belong to which backend.
+
+### Step 1 — decide the allowlist, do not assume it
+
+`kind` is the only usable signal. As of this writing the production emitters are:
+
+| `kind` | Emitted by |
+|---|---|
+| `ingestion` | **Knowledge Flow** (control-plane references it in tests only) |
+| `migration`, `erasure` | control-plane |
+| `evaluation` | the evaluation backend (its own database) |
+| `log` | declared in fred-core, emitted by no application |
+
+**Verify against your own data before trusting that table** — a `kind` added after this was
+written lands in the wrong bucket silently:
+
+```sql
+SELECT kind, state, count(*) FROM task_run GROUP BY kind, state ORDER BY 1,2;
+```
+
+Everything below uses `kind IN ('ingestion')`. Widen it only for kinds you have confirmed are
+Knowledge Flow's. Getting this wrong moves control-plane's rows out of its own database.
+
+### Step 2 — quiesce
+
+Stop ingestion and let non-terminal `task_run` rows reach a terminal state. A task whose
+`task_run` row moves while its worker is still emitting events raises `TaskNotFoundError`,
+which fails the Temporal activity and the workflow with it.
+
+### Step 3 — copy (both databases, one admin role)
+
+The `knowledge_flow` role cannot connect to `fred` by design, so run this as the Postgres
+admin. Three details are not optional:
+
+- **Explicit column lists on both sides.** `\copy` is positional and the column *ordinals
+  differ* between the two databases — a bare `\copy task_run` silently writes values into the
+  wrong columns.
+- **`id` is omitted from `task_event_log`.** It is a generated column; copying it drags the
+  source values in without advancing the target sequence, and the next insert collides.
+- **`task_run` before `task_event_log`**, and delete in the reverse order.
+
+```bash
+RUN_COLS="task_id,kind,state,seq,progress,step,detail,error,target,execution_id,created_by,team_id,scheduled_for,created_at,updated_at,acknowledged_at,acknowledged_by"
+EVT_COLS="task_id,kind,seq,state,progress,step,detail,error,target,owner,emitted_at"
+
+psql -U admin -d fred -Atc \
+  "\\copy (SELECT $RUN_COLS FROM task_run WHERE kind IN ('ingestion')) TO STDOUT WITH (FORMAT csv)" > mv_task_run.csv
+psql -U admin -d fred -Atc \
+  "\\copy (SELECT $EVT_COLS FROM task_event_log WHERE task_id IN (SELECT task_id FROM task_run WHERE kind IN ('ingestion'))) TO STDOUT WITH (FORMAT csv)" > mv_task_event_log.csv
+
+psql -U admin -d knowledge_flow -c "\\copy task_run ($RUN_COLS) FROM STDIN WITH (FORMAT csv)" < mv_task_run.csv
+psql -U admin -d knowledge_flow -c "\\copy task_event_log ($EVT_COLS) FROM STDIN WITH (FORMAT csv)" < mv_task_event_log.csv
+```
+
+### Step 4 — verify BEFORE deleting
+
+Counts must match what you extracted, and the sequence must be healthy:
+
+```sql
+-- in knowledge_flow
+SELECT kind, state, count(*) FROM task_run GROUP BY 1,2 ORDER BY 1,2;
+SELECT count(*) FROM task_event_log;
+-- ids must be freshly assigned, not the source values
+SELECT min(id), max(id) FROM task_event_log;
+```
+
+Do not proceed until these are right. The copy is idempotent to re-run only if you truncate
+the target first — re-running it as-is duplicates rows.
+
+### Step 5 — delete from the shared database
+
+```sql
+-- events first: they reference task_run
+DELETE FROM task_event_log
+ WHERE task_id IN (SELECT task_id FROM task_run WHERE kind IN ('ingestion'));
+DELETE FROM task_run WHERE kind IN ('ingestion');
+```
+
+Reconcile: `fred` should retain exactly the other backends' kinds, and the two databases'
+combined counts should equal what you started with.
+
+> Verified end-to-end against a clean local stack (2026-08-02): 3 `task_run` rows
+> (2 `ingestion`, 1 `migration`) and 4 events in `fred` → 2 rows + 3 events moved to
+> `knowledge_flow` with event ids reassigned from 1 and the sequence still healthy, the
+> `migration` row and its event untouched in `fred`, no row lost or duplicated.

--- a/docs/swift/platform/DEPLOYMENT_GUIDE.md
+++ b/docs/swift/platform/DEPLOYMENT_GUIDE.md
@@ -98,6 +98,15 @@ Files of interest:
 - `knowledge-flow-backend/config/configuration.yaml`
 - Password mapping to remember:
   - **Core Postgres (metadata/tags/vector, etc.)** → `storage.postgres` → `FRED_POSTGRES_PASSWORD` (or `password:` in YAML).
+  - **Knowledge Flow task Postgres** (`task_run` / `task_event_log`) → `storage.task_postgres` → the variable named by its `password_env`, conventionally `POSTGRES_KNOWLEDGE_FLOW_PASSWORD`.
+    - A **second, dedicated database**, because the core one is shared with control-plane and the task tables carry no per-service discriminator — sharing them makes each backend's `GET /tasks` return the other's rows, which the Activity page renders as duplicates (OPS-04, issue #2170).
+    - Provision it like the `evaluation` database, in `fred-deployment-factory`. Set the block identically for the **API and the worker** — they read different config files, and a mismatch makes every task event raise `TaskNotFoundError` while live SSE silently delivers nothing.
+    - Migrate it with `make db-upgrade-tasks`; the plain `make db-upgrade` covers only the shared database.
+    - Omit the block and Knowledge Flow falls back to the shared database, logging a warning at startup — the pre-OPS-04 behaviour, duplicates included. It is **commented out in every shipped config and values file**, because nothing in the `fred` repo can create the database — enabling it against a database that does not exist turns a working deploy into a CrashLoop.
+    - **Cutover is one-way and only fixes rows written from then on.** Task rows already in the shared database stay there. Plan for three consequences before flipping the flag:
+      - **Drain first.** A task whose `task_run` row is in the shared database but whose later events are written to the new one raises `TaskNotFoundError`, failing the Temporal activity and with it the ingestion workflow. Quiesce ingestion and let non-terminal `task_run` rows reach a terminal state before enabling, and enable the API and worker together — a rolling update that leaves them split does the same thing.
+      - **History moves out of view.** Knowledge Flow's `GET /tasks` reads only the new database, so pre-cutover Knowledge Flow tasks disappear from its Activity list while control-plane's `GET /tasks` keeps returning them — now attributed to the wrong service. Deleting the stranded Knowledge Flow rows from the shared database is the operator's call; nothing does it automatically.
+      - **Stale rows are never reconciled.** Knowledge Flow's reconciliation sweeper queries the new database, so a non-terminal row left in the shared one stays non-terminal forever.
 
 **Tabular runtime** → `storage.tabular_store` + shared `content_storage`.
   - In this recommended dataset-centric design, there is no dedicated tabular SQL database.

--- a/docs/swift/platform/ENV_VARIABLES.md
+++ b/docs/swift/platform/ENV_VARIABLES.md
@@ -51,6 +51,7 @@ Note:
 | Variable                    | In templates                  | Purpose                                                      |
 | --------------------------- | ----------------------------- | ------------------------------------------------------------ |
 | `FRED_POSTGRES_PASSWORD`    | agentic, knowledge-flow       | Main Postgres password.                                      |
+| `POSTGRES_KNOWLEDGE_FLOW_PASSWORD` | knowledge-flow         | Password for knowledge-flow's dedicated task database (`task_run` / `task_event_log`, OPS-04 #2170). Named by `storage.task_postgres.password_env`; set the same value for the API and the worker. |
 | `TABULAR_POSTGRES_PASSWORD` | knowledge-flow                | Tabular store Postgres password.                             |
 | `OPENSEARCH_PASSWORD`       | agentic, knowledge-flow       | OpenSearch authentication.                                   |
 | `MINIO_SECRET_KEY`          | knowledge-flow, control-plane | MinIO secret for content storage backends when `type=minio`. Not required for `type=gcs` or `type=local`. |

--- a/docs/swift/rfc/TASK-EVENT-STREAM-RFC.md
+++ b/docs/swift/rfc/TASK-EVENT-STREAM-RFC.md
@@ -1,7 +1,7 @@
 # RFC OPS-04 — Unified Task Event Stream & Worker-Action Audit
 
 **ID:** OPS-04  
-**Status:** confirmed (core: §1–§2, §4–§7) — 2026-06-16 · rev. 2 (2026-07-07): worker-action audit + shared Activity surface — proposed · rev. 3 (2026-07-25): persisted acknowledgement — proposed, driven by OBSERV-02's role-based dashboard finalization (§2.10) · **rev. 4 (2026-07-27): per-service task persistence, rejects rev. 2's central-ownership/`RemoteTaskClient` design (§2.6/§2.9) — confirmed**  
+**Status:** confirmed (core: §1–§2, §4–§7) — 2026-06-16 · rev. 2 (2026-07-07): worker-action audit + shared Activity surface — proposed · rev. 3 (2026-07-25): persisted acknowledgement — proposed, driven by OBSERV-02's role-based dashboard finalization (§2.10) · **rev. 4 (2026-07-27): per-service task persistence, rejects rev. 2's central-ownership/`RemoteTaskClient` design (§2.6/§2.9) — confirmed** · rev. 4.1 (2026-08-01): §2.9's knowledge-flow half shipped with issue #2170 (see `docs/swift/ops/DATABASE_MIGRATIONS.md`); **still open** is the matching `fred-deployment-factory` provisioning — a dedicated `knowledge_flow` database + role across docker-compose, the GKE Helm chart and k3d. The two repos release independently and either order is safe, but neither half fixes the duplicate rows alone  
 **Author:** Dimitri Tombroff  
 **Date:** 2026-06-04  
 
@@ -409,16 +409,15 @@ The correction is emitted as a normal `TaskEvent` via `TaskService.record(...)`,
 
 **Each backend persists its own `task_run`/`task_event_log`, in its own database, and serves its
 own `GET /tasks`/SSE.** No new machinery: this is exactly `TaskStore`/`TaskService` as they exist
-today (`libs/fred-core/fred_core/tasks/store.py`) — the fix is entirely at the infrastructure
-layer, not the application layer. control-plane already correctly owns its copy (the `fred`
-database it was created in). knowledge-flow needs its **own dedicated database**, mirroring the
-one `evaluation` already has: provision `POSTGRES_KNOWLEDGE_FLOW_DB`/`_USER`/`_PASSWORD` the same
-way `86f2c3b` (`fred-deployment-factory`) provisioned `POSTGRES_EVALUATION_DB`, wire a second
+today (`libs/fred-core/fred_core/tasks/store.py`) — `TaskService.build` already takes the engine as
+a parameter. control-plane already correctly owns its copy (the `fred` database it was created
+in). knowledge-flow needs its **own dedicated database**: provision
+`POSTGRES_KNOWLEDGE_FLOW_DB`/`_USER`/`_PASSWORD` in `fred-deployment-factory`, wire a second
 engine in knowledge-flow's `ApplicationContext` (its `metadata_store`/`tag_store`/`resource_store`
-keep using the existing shared engine — only `get_task_service()` moves), and give knowledge-flow's
-Alembic chain a real `CREATE TABLE` for `task_run`/`task_event_log` on that new database (today it
-only carries `ALTER` migrations, because it has always silently ridden on control-plane's copy —
-see the rev. 4 amendment above).
+keep using the existing shared engine — only `get_task_service()` moves), and give knowledge-flow a
+**second** Alembic chain carrying a real `CREATE TABLE` for `task_run`/`task_event_log` on that new
+database (its existing chain only carries `ALTER` migrations, because it has always silently ridden
+on control-plane's copy — see the rev. 4 amendment above).
 
 **Why not co-locate knowledge-flow's task tables with its `tag`/`document_metadata` tables in the
 shared database instead of a second dedicated one?** Because nothing requires it: unlike
@@ -428,6 +427,9 @@ rev. 4 amendment above), `task_run` writes always go through `TaskService.record
 any such transaction, in every producer, today. There is no atomicity requirement pulling task
 rows into the shared database — keeping them there was simply an infrastructure default nobody
 had reconsidered.
+
+Implemented (issue #2170) — see `docs/swift/ops/DATABASE_MIGRATIONS.md` and
+`docs/swift/platform/DEPLOYMENT_GUIDE.md` for what actually ships.
 
 **The Activity page stays multi-source, by design, not as a stopgap** (corrects §3.4's "Rev. 2:
 single-source" text below): the frontend already queries each backend's own `GET /tasks`

--- a/libs/fred-core/fred_core/common/__init__.py
+++ b/libs/fred-core/fred_core/common/__init__.py
@@ -24,6 +24,7 @@ from .gcs_client import build_gcs_client
 from .lru_cache import ThreadSafeLRUCache
 from .resilient_sink import ResilientSinkStore
 from .structures import (
+    DEFAULT_POSTGRES_PASSWORD_ENV,
     BaseModelWithId,
     DuckdbStoreConfig,
     KpiLogSinkConfig,
@@ -44,6 +45,7 @@ from .team_id import TeamId, is_personal_team_id, personal_team_id
 from .utils import raise_internal_error
 
 __all__ = [
+    "DEFAULT_POSTGRES_PASSWORD_ENV",
     "BaseModelWithId",
     "ConfigFiles",
     "DuckdbStoreConfig",

--- a/libs/fred-core/fred_core/common/structures.py
+++ b/libs/fred-core/fred_core/common/structures.py
@@ -15,6 +15,7 @@
 import os
 from enum import Enum
 from typing import Annotated, Any, Dict, Literal, Optional, Union
+from urllib.parse import quote
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -121,6 +122,11 @@ class DuckdbStoreConfig(BaseModel):
     duckdb_path: str = Field(..., description="Path to the DuckDB database file.")
 
 
+# Password env var used by every service that talks to a single Postgres database.
+# Per-database overrides go through PostgresStoreConfig.password_env.
+DEFAULT_POSTGRES_PASSWORD_ENV = "FRED_POSTGRES_PASSWORD"  # nosec B105 # pragma: allowlist secret - env var name, not a secret
+
+
 class PostgresStoreConfig(BaseModel):
     type: Literal["postgres"] = "postgres"
     host: Optional[str] = Field(default=None, description="PostgreSQL host")
@@ -131,8 +137,14 @@ class PostgresStoreConfig(BaseModel):
     )
     database: Optional[str] = None
     username: Optional[str] = None
-    password: Optional[str] = Field(
-        default_factory=lambda: os.getenv("FRED_POSTGRES_PASSWORD")
+    password: Optional[str] = None
+    password_env: Optional[str] = Field(
+        default=None,
+        description=(
+            "Name of the environment variable holding this database's password. "
+            "Unset means FRED_POSTGRES_PASSWORD. Set it only when one service "
+            "connects to several Postgres databases under different roles."
+        ),
     )
     echo: bool = Field(default=False, description="SQLAlchemy echo flag.")
     pool_size: Optional[int] = Field(
@@ -158,11 +170,64 @@ class PostgresStoreConfig(BaseModel):
         default=None, description="Optional connect_args passed to SQLAlchemy."
     )
 
+    @model_validator(mode="after")
+    def _resolve_password_from_env(self) -> "PostgresStoreConfig":
+        """Fill ``password`` from the environment when the config does not carry one.
+
+        Why: passwords are never written into config files — they arrive as env vars.
+        A service that talks to a single database reads ``FRED_POSTGRES_PASSWORD``
+        (unchanged behaviour). A service that talks to several databases under
+        different roles sets ``password_env`` per block, e.g.::
+
+            storage:
+              postgres:                       # reads FRED_POSTGRES_PASSWORD
+                database: fred
+              task_postgres:
+                database: knowledge_flow
+                password_env: POSTGRES_KNOWLEDGE_FLOW_PASSWORD
+
+        An explicit ``password`` in the config always wins — including an explicit
+        ``None``, which means "no password", not "go and find one".
+
+        This reproduces the semantics of the ``default_factory`` it replaced, which a
+        plain ``if self.password is None`` would not:
+
+        - it resolves only when the field was genuinely **unset**, so an explicit
+          ``password=None`` stays ``None``;
+        - it writes through ``__dict__`` rather than by attribute assignment, so the
+          field does not join ``model_fields_set``. Assigning normally would make
+          ``model_dump(exclude_unset=True)`` — "dump only what was configured" —
+          start emitting the live secret for every backend using this model.
+        """
+        if "password" not in self.__pydantic_fields_set__:
+            self.__dict__["password"] = os.getenv(
+                self.password_env or DEFAULT_POSTGRES_PASSWORD_ENV
+            )
+        return self
+
+    def _userinfo(self) -> str:
+        """Percent-encoded ``user:password`` for the DSN's userinfo section.
+
+        Credentials are operator-chosen and routinely contain URL-reserved characters.
+        Interpolated raw, they do not fail loudly — they re-parse the URL: a password of
+        ``p@ss/wo:rd`` makes everything after the first ``@`` look like the host, so the
+        connection silently targets the wrong server with a truncated password.
+
+        ``None`` becomes an empty password rather than the literal string ``"None"``.
+        The engine factory rejects a missing password before it gets here, but
+        ``dsn()`` is also consumed directly by ``PostgresEventBus``, which bypasses that
+        factory — an empty password fails authentication loudly, ``"None"`` would be
+        offered as a real one.
+        """
+        return f"{quote(self.username or '', safe='')}:{quote(self.password or '', safe='')}"
+
     def dsn(self) -> str:
-        return f"postgresql://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
+        return (
+            f"postgresql://{self._userinfo()}@{self.host}:{self.port}/{self.database}"
+        )
 
     def async_dsn(self) -> str:
-        return f"postgresql+asyncpg://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
+        return f"postgresql+asyncpg://{self._userinfo()}@{self.host}:{self.port}/{self.database}"
 
 
 class PostgresTableConfig(BaseModel):

--- a/libs/fred-core/fred_core/kpi/prometheus_kpi_store.py
+++ b/libs/fred-core/fred_core/kpi/prometheus_kpi_store.py
@@ -57,8 +57,22 @@ logger = logging.getLogger(__name__)
 #   `_pdf_kpi_timer` call sites) — deliberately a distinct label from
 #   `runtime_stage` so a Grafana `runtime_stage` variable/query never mixes
 #   TURN-01's auth stages with Knowledge Flow's PDF pipeline stages.
+#   `pool` names a SQLAlchemy connection pool ("knowledge-flow-postgres",
+#   "knowledge-flow-tasks-postgres", …) on the `process.db_pool.*` gauges: a closed,
+#   deployment-time set of a handful of values, no tenancy or user data, only meaningful
+#   in aggregate. Listed here so the label is not silently stripped IF those gauges ever
+#   reach this sink.
+#   NOTE they do not today: `index_event` below drops every `process.*` metric before
+#   Prometheus (they are considered covered by the prometheus_client process collector),
+#   so db_pool telemetry currently lands only in logs/OpenSearch. That exclusion is
+#   pre-existing and applies to every pool equally — lifting it is its own decision, not
+#   OPS-04's. What this entry guarantees is that when it is lifted, a process owning more
+#   than one pool (Knowledge Flow since issue #2170) does not silently collapse both onto
+#   one Gauge whose value is whichever sampler wrote last — worse than no metric, because
+#   it reads healthy while alternating between two unrelated pools.
 PROMETHEUS_ALLOWED_LABELS = frozenset(
     {
+        "pool",
         "tool_name",
         "status",
         "error_code",

--- a/libs/fred-core/fred_core/sql/base_sql.py
+++ b/libs/fred-core/fred_core/sql/base_sql.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import logging
-import os
 import re
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Sequence
@@ -35,7 +34,7 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.sql import ClauseElement
 
-from fred_core.common import PostgresStoreConfig
+from fred_core.common import DEFAULT_POSTGRES_PASSWORD_ENV, PostgresStoreConfig
 
 logger = logging.getLogger(__name__)
 
@@ -201,11 +200,28 @@ def create_async_engine_from_config(config: PostgresStoreConfig):
             )
             raise
 
-    if not os.getenv("FRED_POSTGRES_PASSWORD"):
+    # PostgresStoreConfig resolves `password` from the environment at validation time —
+    # from FRED_POSTGRES_PASSWORD, or from `password_env` when this config names its own
+    # database's role. Check the resolved value, not one hard-coded variable, or a config
+    # pointing at a second database fails whenever the first one's password is unset.
+    if not config.password:
+        # Which database and which variable are carried by the RuntimeError below, not by
+        # this log line. Not because it hides them — this is fatal, so the traceback lands
+        # in the same log a moment later — but because CodeQL's
+        # py/clear-text-logging-sensitive-data rule flags any `password*` identifier
+        # reaching an explicit log sink, and the rule is right to be blunt: a static
+        # analyser cannot safely tell "the secret" from "the name of the secret".
+        # The values themselves are safe to surface (an env var NAME and a database name,
+        # both already in values.yaml and ENV_VARIABLES.md) and naming them is what makes
+        # the error actionable, now that knowledge-flow has two Postgres configs.
+        env_var = config.password_env or DEFAULT_POSTGRES_PASSWORD_ENV
         logger.error(
-            "[TASKS][STORE] Missing FRED_POSTGRES_PASSWORD environment variable (required for Postgres task store)"
+            "[SQL][AsyncEngine] No password configured for the Postgres database; "
+            "its required environment variable is unset"
         )
-        raise RuntimeError("FRED_POSTGRES_PASSWORD is required for Postgres task store")
+        raise RuntimeError(
+            f"{env_var} is required to connect to Postgres database {config.database!r}"
+        )
     missing = [
         name
         for name in ("host", "database", "username")

--- a/libs/fred-core/fred_core/tasks/__init__.py
+++ b/libs/fred-core/fred_core/tasks/__init__.py
@@ -42,7 +42,12 @@ from fred_core.tasks.models import (
     TaskTarget,
     needs_attention,
 )
-from fred_core.tasks.orm_models import TaskEventLogRow, TaskRunRow
+from fred_core.tasks.orm_models import (
+    TASK_TABLE_NAMES,
+    TaskEventLogRow,
+    TaskRunRow,
+    task_metadata,
+)
 from fred_core.tasks.service import (
     TaskNotAcknowledgeableError,
     TaskService,
@@ -87,6 +92,8 @@ __all__ = [
     "AcknowledgeTaskResponse",
     "needs_attention",
     # orm models
+    "TASK_TABLE_NAMES",
+    "task_metadata",
     "TaskRunRow",
     "TaskEventLogRow",
     # bus

--- a/libs/fred-core/fred_core/tasks/orm_models.py
+++ b/libs/fred-core/fred_core/tasks/orm_models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     Float,
     Index,
     Integer,
+    MetaData,
     String,
     Text,
     UniqueConstraint,
@@ -138,3 +139,46 @@ class TaskEventLogRow(Base):
     emitted_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utcnow
     )
+
+
+# ── canonical ownership of the task tables ────────────────────────────────────
+#
+# The single answer to "which tables does fred_core.tasks own?". Consumers must not
+# re-enumerate the classes: a backend that persists tasks in a database of its own
+# (knowledge-flow, OPS-04 / issue #2170) has to partition its schema on exactly this
+# set — once to decide which tables its Alembic chain migrates, and again to decide
+# which tables its boot-time `create_all` puts in which database. Two hand-written
+# enumerations drift the moment a third task table is added here: the new table gets
+# created in the shared database and migrated in the dedicated one, silently
+# reintroducing the split this ownership boundary exists to prevent.
+# Private: the two public entry points below (`TASK_TABLE_NAMES`, `task_metadata()`) are
+# what consumers need. Exporting the ORM classes as a tuple as well would be a third way
+# to ask the same question, with no caller.
+_TASK_TABLES: tuple[type[Base], ...] = (TaskRunRow, TaskEventLogRow)
+
+TASK_TABLE_NAMES: frozenset[str] = frozenset(m.__tablename__ for m in _TASK_TABLES)
+
+
+def task_metadata() -> MetaData:
+    """A `MetaData` holding only the task tables, for an Alembic chain that owns them.
+
+    Why this exists: `fred_core`'s declarative `Base` is one registry shared by every
+    backend, so passing `Base.metadata` to Alembic makes a chain claim tables it does
+    not own. Alembic applies its name filters only to the *connection* side and builds
+    the metadata side from `sorted_tables` unfiltered, so an unwanted table left in the
+    MetaData is still emitted as a create — `include_name` cannot substitute for this.
+
+    Usage, in an `alembic/env.py`::
+
+        run_migrations_offline, run_migrations_online = make_alembic_env(
+            target_metadata=task_metadata(),
+            get_postgres_config=...,
+            version_table="alembic_version_<backend>_tasks",
+        )
+    """
+    scoped = MetaData()
+    for name in sorted(TASK_TABLE_NAMES):
+        # Via the registry rather than `Model.__table__`: declarative types the latter as
+        # FromClause, which has no `to_metadata`.
+        Base.metadata.tables[name].to_metadata(scoped)
+    return scoped

--- a/libs/fred-core/fred_core/tests/common/test_structures.py
+++ b/libs/fred-core/fred_core/tests/common/test_structures.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import pytest
-from fred_core.common import OpenSearchStoreConfig
+from fred_core.common import OpenSearchStoreConfig, PostgresStoreConfig
 from pydantic import ValidationError
 
 
@@ -44,3 +44,155 @@ def test_opensearch_config_explicit_password_wins(monkeypatch) -> None:
     )
 
     assert cfg.password == "inline"  # nosec B105  # pragma: allowlist secret
+
+
+# ── PostgresStoreConfig password resolution (OPS-04, issue #2170) ──────────────
+#
+# `password` is resolved from the environment because passwords never live in config
+# files. Knowledge Flow connects to two Postgres databases under different roles, so a
+# config block can name its own variable via `password_env`. These tests pin the exact
+# semantics of the `default_factory` this replaced — a naive `if password is None` check
+# would silently differ on two of them, and one of those differences leaks a live secret
+# into `model_dump(exclude_unset=True)`.
+
+
+def test_postgres_password_defaults_to_fred_postgres_password(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "FRED_POSTGRES_PASSWORD", "shared-secret"
+    )  # pragma: allowlist secret
+
+    cfg = PostgresStoreConfig(host="localhost", database="fred", username="fred")
+
+    assert cfg.password == "shared-secret"  # nosec B105  # pragma: allowlist secret
+
+
+def test_postgres_password_env_names_a_different_variable(monkeypatch) -> None:
+    """A second database under its own role reads its own variable."""
+    monkeypatch.setenv(
+        "FRED_POSTGRES_PASSWORD", "shared-secret"
+    )  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "POSTGRES_KNOWLEDGE_FLOW_PASSWORD", "task-secret"
+    )  # pragma: allowlist secret
+
+    cfg = PostgresStoreConfig(
+        host="localhost",
+        database="knowledge_flow",
+        username="knowledge_flow",
+        password_env="POSTGRES_KNOWLEDGE_FLOW_PASSWORD",  # nosec B106 # pragma: allowlist secret
+    )
+
+    assert cfg.password == "task-secret"  # nosec B105  # pragma: allowlist secret
+
+
+def test_postgres_explicit_password_wins_over_env(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "FRED_POSTGRES_PASSWORD", "shared-secret"
+    )  # pragma: allowlist secret
+
+    cfg = PostgresStoreConfig(
+        host="localhost",
+        database="fred",
+        password="inline",  # nosec B106  # pragma: allowlist secret
+    )
+
+    assert cfg.password == "inline"  # nosec B105  # pragma: allowlist secret
+
+
+def test_postgres_explicit_none_password_is_not_resolved_from_env(monkeypatch) -> None:
+    """An explicit None means "no password", not "go and find one".
+
+    This is what `default_factory` did: it applies only to an absent field, never to one
+    the caller passed. A caller that deliberately passes None must not silently receive
+    another database's credential.
+    """
+    monkeypatch.setenv(
+        "FRED_POSTGRES_PASSWORD", "shared-secret"
+    )  # pragma: allowlist secret
+
+    cfg = PostgresStoreConfig(host="localhost", database="fred", password=None)
+
+    assert cfg.password is None
+
+
+def test_postgres_resolved_password_never_enters_exclude_unset_dump(
+    monkeypatch,
+) -> None:
+    """Resolution must not mark `password` as explicitly set.
+
+    `model_dump(exclude_unset=True)` means "only what was configured". If env resolution
+    joined `model_fields_set`, every such dump of a storage block would start emitting a
+    live database password — for every backend, since this model is shared.
+    """
+    monkeypatch.setenv(
+        "FRED_POSTGRES_PASSWORD", "shared-secret"
+    )  # pragma: allowlist secret
+
+    cfg = PostgresStoreConfig(host="localhost", database="fred", username="fred")
+
+    assert "password" not in cfg.model_dump(exclude_unset=True)
+    assert "password" not in cfg.model_fields_set
+    # ...while the value is still usable for connecting.
+    assert cfg.password == "shared-secret"  # nosec B105  # pragma: allowlist secret
+
+
+def test_postgres_password_missing_env_resolves_to_none(monkeypatch) -> None:
+    """Engine construction raises on this; the config itself must not."""
+    monkeypatch.delenv("FRED_POSTGRES_PASSWORD", raising=False)
+    monkeypatch.delenv("POSTGRES_KNOWLEDGE_FLOW_PASSWORD", raising=False)
+
+    cfg = PostgresStoreConfig(
+        host="localhost",
+        database="knowledge_flow",
+        password_env="POSTGRES_KNOWLEDGE_FLOW_PASSWORD",  # nosec B106 # pragma: allowlist secret
+    )
+
+    assert cfg.password is None
+
+
+def test_postgres_dsn_percent_encodes_url_reserved_characters(monkeypatch) -> None:
+    """A password is operator-chosen and may hold `@`, `:`, `/` or `#`.
+
+    Interpolated raw these do not fail loudly — they re-parse the URL, so the connection
+    silently targets a different host with a truncated password. This became a live risk
+    when `postgresql.knowledgeFlow.password` turned into a required, human-chosen value.
+    """
+    from sqlalchemy.engine import make_url
+
+    monkeypatch.delenv("FRED_POSTGRES_PASSWORD", raising=False)
+    hostile = "p@ss/wo:rd#1"  # nosec B105  # pragma: allowlist secret
+
+    cfg = PostgresStoreConfig(
+        host="postgres",
+        database="knowledge_flow",
+        username="knowledge_flow",
+        password=hostile,
+    )
+
+    for dsn in (cfg.dsn(), cfg.async_dsn()):
+        url = make_url(dsn)
+        assert url.host == "postgres"
+        assert url.database == "knowledge_flow"
+        assert url.username == "knowledge_flow"
+        assert url.password == hostile
+
+
+def test_postgres_dsn_renders_unresolved_password_as_empty_not_none(
+    monkeypatch,
+) -> None:
+    """`dsn()` is consumed directly by PostgresEventBus, which bypasses the engine
+    factory's password check. An unresolved password must not become the literal
+    string "None" and get offered as a real credential."""
+    monkeypatch.delenv("FRED_POSTGRES_PASSWORD", raising=False)
+    monkeypatch.delenv("POSTGRES_KNOWLEDGE_FLOW_PASSWORD", raising=False)
+
+    cfg = PostgresStoreConfig(
+        host="postgres",
+        database="knowledge_flow",
+        username="knowledge_flow",
+        password_env="POSTGRES_KNOWLEDGE_FLOW_PASSWORD",  # nosec B106 # pragma: allowlist secret
+    )
+
+    assert cfg.password is None
+    assert "None" not in cfg.dsn()
+    assert cfg.dsn() == "postgresql://knowledge_flow:@postgres:5432/knowledge_flow"

--- a/scripts/check_chart_values.py
+++ b/scripts/check_chart_values.py
@@ -41,6 +41,31 @@ def _strip_helm_anchors(values: object) -> object:
     return values
 
 
+def _deep_merge(base: object, overlay: object) -> object:
+    """Merge `overlay` over `base` the way Helm merges successive -f files.
+
+    Helm's rule: maps merge key-by-key, everything else (scalars, lists) is replaced
+    wholesale by the later file. Overlays like values-gcp.yaml and values-local.yaml are
+    *partial* — they carry only the keys they change — so validating one on its own reports
+    every required property that lives in the base as missing. What ships is the merge, so
+    that is what has to satisfy the schema.
+
+    An explicit null in the overlay DELETES the key rather than setting it to None — that
+    is Helm's documented behaviour, and without it this merge validates a document Helm
+    would never render (an overlay clearing an inherited `duckdb_path` would be checked
+    with the key still present).
+    """
+    if isinstance(base, dict) and isinstance(overlay, dict):
+        merged = dict(base)
+        for key, value in overlay.items():
+            if value is None:
+                merged.pop(key, None)
+            else:
+                merged[key] = _deep_merge(merged[key], value) if key in merged else value
+        return merged
+    return overlay
+
+
 def _validate(instance: object, schema: dict) -> list[str]:
     from jsonschema import Draft7Validator
 
@@ -56,22 +81,35 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Validate Helm values.yaml against values.schema.json")
     parser.add_argument("schema", help="Path to values.schema.json")
     parser.add_argument("values", help="Path to values.yaml")
+    parser.add_argument(
+        "--merge-over",
+        metavar="BASE_VALUES",
+        help=(
+            "Treat `values` as a partial Helm overlay and validate it merged over BASE_VALUES, "
+            "as `helm -f BASE_VALUES -f values` would render it."
+        ),
+    )
     args = parser.parse_args()
 
     schema = _load_json(Path(args.schema))
-    raw = _load_yaml(Path(args.values))
-    values = _strip_helm_anchors(raw)
+    values = _strip_helm_anchors(_load_yaml(Path(args.values)))
+
+    label = args.values
+    if args.merge_over:
+        base = _strip_helm_anchors(_load_yaml(Path(args.merge_over)))
+        values = _deep_merge(base, values)
+        label = f"{args.values} (merged over {args.merge_over})"
 
     errors = _validate(values, schema)
 
     if errors:
-        print(f"FAIL  {args.values}")
+        print(f"FAIL  {label}")
         for err in errors:
             print(err)
         print("\nValues validation failed. Fix the errors above or update the schema.")
         sys.exit(1)
 
-    print(f"OK    {args.values}")
+    print(f"OK    {label}")
     print("\nValues file is valid.")
 
 

--- a/scripts/makefiles/chart-schema.mk
+++ b/scripts/makefiles/chart-schema.mk
@@ -48,3 +48,35 @@ check-chart-values: $(SCRIPTS_UV_READY) ## Validate deploy/charts/fred/values.ya
 	$(if $(_ALL_BACKEND_SCHEMAS_PRESENT), \
 		$(SCRIPTS_UV) run $(_CHECK_CHART_VALUES_SCRIPT) "$(_CHART_SCHEMA_FILE)" "$(_CHART_VALUES_FILE)", \
 		echo "Skipping chart values check: not all backend schemas are present.")
+
+# The two deployment overlays are the files an operator actually edits, yet nothing
+# validated them (issue #2170 review). They are PARTIAL — Helm merges them over values.yaml
+# — so they only mean anything merged, hence `--merge-over`.
+#
+# This target FAILS on error, like every other check here — it is simply not wired into
+# `code-quality` or CI yet.
+#
+# BLOCKED ON a schema-generation defect, which is the real root cause and needs its own
+# issue: `generate_chart_schema.py` emits a schema STRICTER than the Pydantic models it is
+# generated from. Helm merges maps key-by-key, so an overlay flipping `metadata_store.type`
+# from duckdb to postgres leaves the base's `duckdb_path` behind; the generated schema
+# rejects that leftover key while Pydantic's discriminated union ignores it (verified:
+# PostgresTableConfig validates fine with a stray duckdb_path). So the overlays are correct
+# and the schema is wrong. Until that is fixed this target reports failures the application
+# does not share.
+#
+# TO PROMOTE once the schema defect is fixed: add `check-chart-overlays` to the
+# `check-chart-values` prerequisites (and to Check-config-schema.yml alongside it). Nothing
+# else needs to change — the target already exits non-zero on a real failure.
+_CHART_OVERLAY_FILES := \
+	$(_CHART_REPO_ROOT)/deploy/charts/fred/values-gcp.yaml \
+	$(_CHART_REPO_ROOT)/deploy/local/k3d/values-local.yaml
+
+.PHONY: check-chart-overlays
+check-chart-overlays: $(SCRIPTS_UV_READY) ## Validate values-gcp/values-local MERGED over values.yaml (not yet in CI — see comment)
+	$(if $(_ALL_BACKEND_SCHEMAS_PRESENT), \
+		set -e; for f in $(_CHART_OVERLAY_FILES); do \
+			$(SCRIPTS_UV) run $(_CHECK_CHART_VALUES_SCRIPT) "$(_CHART_SCHEMA_FILE)" "$$f" \
+				--merge-over "$(_CHART_VALUES_FILE)"; \
+		done, \
+		echo "Skipping chart overlay check: not all backend schemas are present.")


### PR DESCRIPTION
## Summary

- `libs/fred-core`: add `password_env` to `PostgresStoreConfig` so a second database can name its own role's variable instead of every Postgres block sharing `FRED_POSTGRES_PASSWORD`; percent-encode credentials in `dsn()`/`async_dsn()`. An unencoded `@` in a password previously produced a malformed DSN that parsed to a *different host* and defeated `_mask_dsn`, leaking the password tail into logs.
- `libs/fred-core`: add `TASK_TABLE_NAMES` and `task_metadata()` — the single answer to "which tables does `fred_core.tasks` own?". `Base.metadata` is one registry shared by every backend and Alembic applies name filters only to the connection side, so `include_name` cannot substitute for a scoped `MetaData`.
- `apps/knowledge-flow-backend`: a second Alembic chain (`alembic_tasks/`) with its own version table, owning a real `CREATE TABLE` for `task_run`/`task_event_log`. Alembic opens one connection per `env.py`, so a second database needs a second chain.
- `apps/knowledge-flow-backend`: extract `create_core_tables()` and split boot-time `create_all` on `TASK_TABLE_NAMES`. Without this the task tables were recreated in the shared database on every restart, silently undoing the split whatever the migrations did.
- `apps/knowledge-flow-backend/.../main.py`: `create_core_tables()` no longer aborts boot when the *dedicated* task database is unreachable (`main.py:132-138`) — it logs and keeps serving. The call is the first statement of the lifespan, so an outage in a database only `/tasks`, task SSE and ingestion-start use previously crash-looped the whole API pod, taking document search, upload, tag and metadata reads down with it. The unconfigured fallback still fails fast, guarded by `get_task_pg_async_engine() is get_pg_async_engine()` — exact, because the fallback returns the same object.
- `apps/knowledge-flow-backend`: a second cached engine used only by `get_task_service()`; metadata/tag/resource keep the shared one. `/ready` gains an **advisory** `postgres_tasks` probe — reported but never making the pod unready. The probe now also proves the two engines address *different* databases at runtime, comparing `(pg_control_system().system_identifier, current_database())` across both (`monitoring_controller.py:79`, `:192-201`): `localhost` vs `127.0.0.1`, or a CNAME vs its target, passes every static check while silently restoring the duplicate Activity rows this PR exists to remove. Resolved once and cached (`:88`), so it costs one extra connection pair per process against a deliberately 2-connection pool, not one per probe.
- `apps/knowledge-flow-backend/.../common/structures.py`: reject a `task_postgres` naming the same database as `postgres`, normalizing case, surrounding whitespace and a trailing FQDN dot before comparing (`:875-878`) so `LOCALHOST` vs `localhost` is caught. The docstring states plainly that this check is spelling-based and partial, and defers real identity to the runtime probe above.
- `deploy/charts/fred/values.yaml`: `readinessProbe.timeoutSeconds: 8` (`:1307`), above the 6s server-side probe budget. At Kubernetes' 1s default, kubelet records a FAILED probe regardless of the 200 the advisory probe returns, taking every pod out of the Service in 100s — the exact opposite of the advisory intent. (`values-gcp.yaml` and `values-local.yaml` set no timeout; they are touched only for the commented `task_postgres` block, alongside the regenerated `values.schema.json`.)
- `apps/control-plane-backend`, `apps/knowledge-flow-backend`: repair `uq_task_run_single_active_migration`, created with `postgresql_where` only. SQLAlchemy drops dialect-prefixed kwargs on other dialects, so on SQLite the predicate vanished and the index landed as an unconditional `UNIQUE (kind)` — a second task of any existing kind could not be inserted at all. Two-pronged now: the *add* migrations pass `sqlite_where` alongside `postgresql_where` (`e2f3a4b5c6d7:65`, `c1d2e3f4a5b6:71`) so databases that have not yet run them never acquire the defect, and the repair revisions fix the ones that have.
- knowledge-flow's repair `f7a8b9c0d1e2` is gated to SQLite in **both** directions (`:81`, `:121`). Postgres never had the defect, and since OPS-04 this chain no longer owns `task_run` — on a deployment still sharing `fred`, the `DROP INDEX` would take `ACCESS EXCLUSIVE` on control-plane's live table. control-plane's `a9b0c1d2e3f4` is deliberately **not** gated: it genuinely owns `task_run` in `fred`, so the drop/recreate under the deploy-time migration lock is correct there. The asymmetry is the point, not an oversight.
- `libs/fred-core/fred_core/kpi/prometheus_kpi_store.py`: allow the `pool` label, so the two pools produce distinct series instead of collapsing onto one last-writer-wins gauge. `main.py`/`main_worker.py` emit pool KPIs for the task engine only when it is a distinct object, so the unconfigured fallback does not double-count.
- `apps/knowledge-flow-backend/.../application_context.py`: `shutdown()` no longer aborts the remaining cleanup when the task engine's `dispose()` raises — that block runs first, so a raising dispose previously skipped the shared engine and the OpenSearch client.
- `apps/knowledge-flow-backend/Makefile`, root `Makefile`: `db-*-tasks` targets for the new chain, wired into `db-check-combined-heads`/`-sqlite`/`-postgres` (those aggregators are hardcoded, not discovery — a new chain is exercised by nothing until added by hand), and `POSTGRES_KNOWLEDGE_FLOW_PASSWORD` in `setup-env`'s backfill list. The `ALEMBIC_CONFIG_FILE` pin listed `db-revision-tasks`, **a target that does not exist**; the real one is `db-migrate-tasks` (`:52`), so autogenerate ran unpinned and generated task-chain revisions against whatever profile `config/.env` happened to name.
- `scripts/check_chart_values.py`, `scripts/makefiles/chart-schema.mk`: `--merge-over` and a new `check-chart-overlays` target, because `values-gcp.yaml` and `values-local.yaml` — the two files an operator actually edits — were validated by nothing. The merge honours Helm's null-deletes-key rule. **Not wired into CI**; see Honest gaps.
- `apps/fred-agents/tests/test_smoke.py`: give each smoke test its own SQLite file. `config/configuration.yaml` points `storage.postgres.sqlite_path` at one fixed path, so every test in the module — and any other pytest process on the same machine — shared a single database, which surfaced as intermittent `database is locked` under aiosqlite. Also drops a duplicated `load_agent_pod_config` import that `ruff --select F` reports as `F811`.
- Alembic housekeeping: `# codeql[py/unused-global-variable]` on the new task chain's mandatory module globals (matching the six other `script.py.mako` files in the repo), and `# type: ignore[attr-defined]` on the two `__table__.to_metadata(...)` calls in `alembic/env.py:56-57` — load-bearing, since SQLAlchemy types `DeclarativeBase.__table__` as `FromClause` and basedpyright reports `reportAttributeAccessIssue` without it.
- `docs/swift`: a verified `psql` cutover runbook in `ops/DATABASE_MIGRATIONS.md` (now also documenting that the split applies to the **boot path**, not only to Alembic), the drain procedure in `platform/DEPLOYMENT_GUIDE.md`, `platform/ENV_VARIABLES.md`, and knowledge-flow's `README.md`.

Refs #2170. Deliberately **not** `Closes` — see Honest gaps.

## Review passes, and the regression the second one introduced

Two passes, different events and different outcomes, so both are stated:

1. **First pass — nine `/code-review ultra` findings applied**, folded into the existing commits rather than appended. Most material: the readiness `timeoutSeconds` above; a `check-chart-overlays` that could never fail; and an `ALEMBIC_CONFIG_FILE` that retargeted the *shared* chain's `db-upgrade` out from under a developer's `.env`.
2. **Second pass — adversarial re-verification of 14 findings: 3 refuted, 11 applied.** The refutations matter as much as the fixes; three "defects" did not survive checking.
3. **An independent check agent then caught a fix from pass 2 that introduced a worse bug.** Gating `f7a8b9c0d1e2.upgrade()` to SQLite left `downgrade()` ungated — which is *worse than gating neither direction*, because `e2f3a4b5c6d7` owns that index on Postgres: the ungated `downgrade()` dropped control-plane's `uq_task_run_single_active_migration` and the gated `upgrade()` declined to put it back. A `make db-downgrade` plus re-upgrade turned a self-healing round trip into permanent destruction of the invariant. Proven on real PG 16 both ways — with the symmetric gate the index survives the round trip and the invariant holds; without it the index is gone and two active `kind='migration'` rows are accepted. Fixed by gating `downgrade()` symmetrically, plus the bite-verified offline regression test below.

One earlier fix was **reverted** in this pass and is worth calling out because the published body advertised it: `StorageConfig._task_postgres_inherits_pool_sizing` (a validator making an unset `task_postgres` inherit `postgres`' pool sizing) was deleted, 42 lines, with no replacement. See Honest gaps.

## Test plan

- [x] `make test` — `libs/fred-core` **463 passed / 22 deselected**; `apps/knowledge-flow-backend` **860 passed / 2 deselected** (202.6s); `apps/control-plane-backend` **718 passed**; `apps/fred-agents` **47 passed**
- [x] `make code-quality` — clean on all four touched packages; knowledge-flow basedpyright **0 errors, 0 warnings, 0 notes**
- [x] `ruff check --select I` (what `make import-order` runs) — "All checks passed!" on all **four** touched packages: `libs/fred-core`, `apps/knowledge-flow-backend`, `apps/control-plane-backend`, `apps/fred-agents`
- [x] `make db-check-combined-heads` — exit 0, 4/4 chains single head (control-plane, knowledge-flow, knowledge-flow-tasks, fred-runtime)
- [x] `make db-check-combined-sqlite` — exit 0, both chains upgrade → check → downgrade clean
- [x] `make db-check-combined-postgres` — exit 0, re-run against the current tree. It matters more than usual now that `f7a8b9c0d1e2` short-circuits on Postgres in both directions; the PG-16 round-trip proof described above was additionally run by hand.
- [x] New regression tests: `pytest tests/core/test_monitoring_controller.py tests/core/test_application_context_task_database.py` → **21 passed in 0.41s**
- [x] `make check-chart-schema-drift` — exit 0, regenerated schema byte-identical to the committed one, so `values.schema.json` is not hand-edited
- [x] `make check-chart-values` — exit 0, `values.yaml` valid against the generated schema
- [x] Per-app `check-config-schema-drift` + `check-config-files` — pass
- [x] Activity page verified in a browser — platform-scope view (`/admin/tasks`) on a wiped-and-reseeded stack shows **COMPLETED 3**: two knowledge-flow ingestions and one control-plane import, **each exactly once**. Ground truth `knowledge_flow=2`, `fred=1`, total 3, and `comm -12` on the two databases' `task_id` sets returns **0** shared ids.
- [x] `GET /tasks?scope=platform` — exercised as platform_admin. Network layer confirms `GET /knowledge-flow/v1/tasks?scope=platform` **200** and `GET /control-plane/v1/tasks?scope=platform` **200**.

### What the new tests actually prove

- `test_repair_migration_is_a_no_op_on_postgres_in_both_directions` (`test_application_context_task_database.py:408`) — runs `f7a8b9c0d1e2`'s `upgrade()` then `downgrade()` against a `create_mock_engine("postgresql+psycopg://")` and asserts **zero** DDL. **Bite-verified**: with both `dialect.name != "sqlite"` guards neutralized it does not silently pass — it fails on the next statement (`sa.inspect()` → `NoInspectionAvailable`).
- `test_task_run_index_migrations_tolerate_existing_same_kind_rows_on_sqlite` (`:359`) — seeds a real SQLite `task_run` with two non-terminal `ingestion` rows, runs `e2f3a4b5c6d7` **then** `f7a8b9c0d1e2` in order, asserts both survive and a third `ingestion` row still inserts. **Bite-verified**: the pre-fix form raises `IntegrityError: UNIQUE constraint failed: task_run.kind` on exactly this fixture. `db-check-combined-sqlite` cannot catch this — it migrates an empty database.
- `test_create_core_tables_survives_an_unreachable_task_database` (`:281`) — points `task_postgres` at a directory where SQLite expects a file, asserts boot continues and the shared tables are still created. **Non-vacuity checked**: that path really does raise `OperationalError: unable to open database file` on connect, where an unreachable Postgres would land.
- `test_chart_readiness_timeout_exceeds_probe_budget` (`test_monitoring_controller.py:198`) — asserts `values.yaml`'s `readinessProbe.timeoutSeconds > _READINESS_TIMEOUT_S` (today `8 > 6.0`), turning a module comment into an enforced invariant. Reviewer note: it couples the app's unit suite to repo layout via `parents[4]` and will `FileNotFoundError` if the package is ever tested without the `deploy/` tree.
- **Not covered by any test:** the `structures.py` host normalization, the `monitoring_controller.py` identity check, and `main.py`'s re-raise-on-fallback branch (only the tolerate-and-continue branch is exercised).

## Live verification

Run against a wiped and reseeded local stack with the companion factory branch applied, **on an earlier revision of this branch** — before the runtime identity check (`monitoring_controller.py:192-201`) and the `create_core_tables` tolerance (`main.py:132-138`) existed. It has not been repeated since.

- The provisioning job created the `knowledge_flow` database **and its own role** from empty; `has_database_privilege('knowledge_flow','fred','CONNECT')` is `false`.
- After both chains: task tables **only** in `knowledge_flow`, shared tables **only** in `fred`, `task_run` with all 17 columns, separate version tables.
- A real ingestion driven over HTTP and completed by the Temporal worker landed in `knowledge_flow` with **0 rows in `fred`**; the two backends' `GET /tasks` sets are disjoint. `/ready` returned 200 `"ready"` with `postgres_tasks ok=true` and no `skipped` key, i.e. the probe really executed against the dedicated database.
- **Upgrade path**, using a pre-wipe dump of real data: `create_core_tables()` added only shared tables to a populated `fred` and nothing task-related — but the pre-existing task row stayed behind, confirming the stranding the cutover runbook exists to resolve.
- **Parallel ingestion**, 48 concurrent creators across multiple processes: 48/48 tasks and 240/240 events persisted, 0 leaked into `fred`, per-task `seq` contiguous.

## Honest gaps

- **Acceptance criteria 3 and 4 are not met by any default in this repo.** `storage.task_postgres` ships commented out everywhere (`configuration_prod.yaml:433`, `configuration_worker.yaml:327`, `values.yaml:339`, `values-gcp.yaml:110`, `values-local.yaml:158`), because nothing here can create the database and enabling it where the role does not exist turns a working deploy into a CrashLoop. They need the `fred-deployment-factory` provisioning deployed plus a default flip in a later release. **Land this repo first** — the factory ships a ConfigMap containing `task_postgres`, and an image predating it cannot parse the field.
- Criterion 4 is now evidenced at three levels — datastore (disjoint task sets, including the negative), API (`?scope=platform` on both backends), and the rendered Activity page. The stack it was proven on still runs `task_postgres` from an operator-supplied config, not a repo default; see the bullet above.
- **Pool sizing on a hand-written `task_postgres` block is now defended by documentation only.** The validator that made an unset block inherit `postgres`' sizing was deleted in this branch's second review pass. The hazard it addressed is real and unchanged — `create_async_engine_from_config` still falls back to `pool_size or 5` / `max_overflow … else 10` (`libs/fred-core/fred_core/sql/base_sql.py:76`), so a block naming only host/port/database/username takes 15 connections *per process* against a `postgres` block deliberately sized `2 + 0`. What stands in its place: every shipped `task_postgres` block spells `pool_size: 2` / `max_overflow: 0` out explicitly, and `values.yaml` carries a comment saying so. Nothing enforces it for a hand-edited config.
- **The advisory-probe decision is a policy choice worth ratifying, and it is now broader than a probe.** A task-database outage returns HTTP 200 `ready_degraded` rather than 503 (`monitoring_controller.py:106`); the same-database *misconfiguration* — the exact regression #2170 exists to fix — also only degrades, because the identity check raises inside an advisory probe (`:197-201`); and boot no longer fails when the task database is unreachable (`main.py:132-138`). Derouting every pod would not help when all pods share one task database, but this is fail-open in three places now and should be a conscious call.
- **`check-chart-overlays` ships out of CI, deliberately.** Re-run this session: exit 1 with **5** failures, not 3 — three leftover-`duckdb_path` cases (`metadata_store`, `resource_store`, `tag_store`) *and* two `content_storage type: gcs` cases carrying a leftover `root_path`. Same class: `generate_chart_schema.py` emits a schema *stricter* than the Pydantic models it is generated from, so a Helm key-by-key merge that leaves a stale key behind is rejected by the schema while the discriminated union ignores it. Root cause is unrelated to OPS-04 and needs its own issue; the target exits non-zero on real failures and the promotion step is documented in the recipe.

## Deliberately not in this PR — still-real follow-ups

Verified against the current tree this session; anything the audit proved already fixed has been dropped from this list.

- **P1 — `TaskStore.record_event` loses concurrent events on one task.** `libs/fred-core/fred_core/tasks/store.py:127-130` does an unguarded read-modify-write on `task_run.seq` (`next_seq = run.seq + 1`, no `with_for_update`, no `IntegrityError` retry) against `uq_task_event_log_task_seq` (`orm_models.py:125`) under default READ COMMITTED. The repo itself documents that concurrent `record_event` on one task is expected (`store.py:182-183`), and no test in `fred_core/tests/tasks/` exercises two concurrent events on one task. Reproduced earlier through the real Temporal activity at the shipped `ingestion_workflow_parallelism: 3` (1 of 3 lost, 5/5 repeats). Predates #2170, lives on a shared write path.
- **P1 — control-plane `make run` dies replaying alembic from zero.** `alembic.mk:7` makes `run-local` depend on `db-upgrade`; `c789f5ab40fe` creates the `gcu_version_type` enum implicitly via `op.create_table` and there is no `DROP TYPE` anywhere in `apps/control-plane-backend/alembic/versions/`, so a replay over a database that already holds the type dies on `DuplicateObject`. Static mechanism confirmed; the seeded-stack repro was **not** re-run today. Not from this branch — neither file is touched here.
- **P2 — `gcu_version_type` is never dropped on downgrade.** `c789f5ab40fe.downgrade()` (`:38-41`) drops `users` and leaves the enum, so the downgrade→upgrade round trip is non-idempotent. Same defect class as the `f7a8b9c0d1e2` asymmetry fixed above, and the concrete in-repo cause of the `DuplicateObject` symptom.
- **P2 — knowledge-flow's "modern" pgvector adapter is unreachable, and says so loudly on every call.** `pgvector_store.py:496-537` passes `connection_string` only if `inspect.signature` shows that parameter; installed `langchain_postgres` 0.0.17 takes `connection`, so `NewPGVector(**kwargs)` gets `connection=None` and raises `ValueError` (reproduced against the venv), is swallowed by a bare `except Exception`, logs a full traceback, and falls back to `langchain_community.PGVector` — which warns it is pending deprecation. So the migration everyone assumes happened never has. Fixing the kwarg alone is unsafe: the two implementations use different table schemas, so it needs a data migration or a re-ingest. The dead-branch deletion was staged here and **removed from this PR** for that reason.
- **P3 — no HTTP-level coverage of knowledge-flow's `GET /knowledge-flow/v1/tasks`** against the dedicated task engine (`features/tasks/controller.py:28-41`). Narrow gap: `list_tasks_scoped` *is* unit-tested (`fred_core/tests/tasks/test_authz.py:150-230`) and control-plane's route *is* exercised (`test_import_export_task_observability.py:81`) — it is KF's route only.
- **P3 — a new test uses `Operations.context(ops)` with an ops object where a `MigrationContext` belongs** (`test_application_context_task_database.py:351`; the sibling cases at `:399` and `:444` are correct). It works by accident: `self.impl = ops.impl` resolves, so `get_bind()` happens to return the right bind. Any op reaching another `MigrationContext` attribute would `AttributeError`. basedpyright does not flag it. Latent, not a live failure.

RFC: `docs/swift/rfc/TASK-EVENT-STREAM-RFC.md` §2.9 — **trimmed, not amended**. Per CLAUDE.md's RFC-vs-doc rule, the settled what/why moved out to `ops/DATABASE_MIGRATIONS.md` and `platform/DEPLOYMENT_GUIDE.md`, and the RFC now records only what is still open: the matching `fred-deployment-factory` provisioning. One claim from the old amendment survives in code and test but in no compact doc — that the SSE bus DSN must name the task engine's database, because `PostgresEventBus` LISTEN/NOTIFY channels are per-database and a mismatch loses live streaming silently (`application_context.py:516-525`, `test_event_bus_dsn_names_the_task_database`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)