### PR TITLE
Chat page: composer/top-bar polish, chain-of-thought redesign, per-step token usage (TRACE-01)

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -296,6 +296,10 @@
       "geoSummary_other": "Map data ({{count}} features)"
     },
     "aiDisclaimer": "This assistant is powered by AI and can make mistakes. Please verify important information.",
+    "conversationTokenUsage": {
+      "total_one": "Total: {{count}} token",
+      "total_other": "Total: {{count}} tokens"
+    },
     "attachFiles": "Attach files",
     "attachmentChip": {
       "ariaLabel": "Attached files",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -296,6 +296,10 @@
       "geoSummary_other": "Données cartographiques ({{count}} entités)"
     },
     "aiDisclaimer": "Cet assistant s'appuie sur l'IA et peut se tromper. Vérifiez les informations importantes.",
+    "conversationTokenUsage": {
+      "total_one": "Total : {{count}} token",
+      "total_other": "Total : {{count}} tokens"
+    },
     "attachFiles": "Joindre des fichiers",
     "attachmentChip": {
       "ariaLabel": "Fichiers joints",

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
@@ -51,7 +51,6 @@ export function ConversationThread({
       emptyState={emptyState}
       scrollContainerRef={scrollContainerRef}
       turnKey={turnKey}
-      isStreaming={isStreaming}
     >
       {messages.map((msg) => {
         if (msg.role === "user" || msg.role === "hitl_response") {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -72,11 +72,14 @@
 }
 
 /* Capped to the composer field width and centered, so title + actions sit
-   directly above the composer field at every viewport width. */
+   directly above the composer field at every viewport width. Gap is a hard
+   flex minimum (not padding on either side), so even a maxed-out truncated
+   title always leaves room for the absolutely-positioned rename button
+   (editButtonSlot) to pop out without overlapping topBarRight. */
 .topBarInner {
   display: flex;
   align-items: center;
-  gap: var(--spacing-s);
+  gap: var(--spacing-2xl);
   margin: 0 auto;
   width: 100%;
   min-width: 0;

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -136,6 +136,12 @@
   white-space: nowrap;
 }
 
+.topBarRight {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
 .topBarActions {
   display: flex;
   align-items: center;

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -216,6 +216,7 @@
 
 .initialComposer {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   padding: 0 var(--spacing-l);
   width: 100%;

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -28,6 +28,7 @@ import { findTraceEntry, traceEntryKey, type TraceEntry } from "../../../utils/t
 import { ComposerActionsMenu } from "@shared/molecules/ComposerActionsMenu/ComposerActionsMenu";
 import { UploadWarningAckDialog } from "@shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog";
 import IconButton from "@shared/atoms/IconButton/IconButton";
+import { TokenUsageBadge } from "@shared/molecules/TokenUsageBadge/TokenUsageBadge";
 import { CapabilitySidePanelHost } from "../../../features/capabilities/CapabilitySidePanelHost";
 import { ComposerControlSlot } from "../../../features/capabilities/ComposerControlSlot";
 import { selectSidePanelOpenRequest } from "../../../features/capabilities/sidePanelOpenRequestSlice";
@@ -132,6 +133,22 @@ export default function ManagedChatPage() {
     chat.threadMessages.length === 0 && !chat.waitResponse && !chat.isLoadingHistory && chat.pendingHitl == null;
 
   const attachmentsCount = chat.persistedAttachments.length;
+
+  const conversationTokenUsage = useMemo(
+    () =>
+      chat.threadMessages.reduce(
+        (acc, m) => {
+          if (m.tokenUsage) {
+            acc.input_tokens += m.tokenUsage.input_tokens;
+            acc.output_tokens += m.tokenUsage.output_tokens;
+            acc.total_tokens += m.tokenUsage.total_tokens;
+          }
+          return acc;
+        },
+        { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+      ),
+    [chat.threadMessages],
+  );
   // CAPAB-01 #1976: attachments are allowed when the resolved chat controls
   // (ExecutionPreparation.chat_controls) include an `attach_files` descriptor —
   // supersedes the retired `EffectiveChatOptions.attach_files`.
@@ -349,28 +366,33 @@ export default function ManagedChatPage() {
                 )}
                 <div className={styles.topBarAgentName}>{chat.agentDisplayName}</div>
               </div>
-              <div className={styles.topBarActions}>
-                {attachmentsCount > 0 && (
-                  <button
-                    type="button"
-                    className={styles.conversationFilesButton}
-                    onClick={() =>
-                      setActivePushDrawer((v) => (v?.kind === "attachments" ? null : { kind: "attachments" }))
-                    }
-                  >
-                    <span className={styles.conversationFilesLabel}>{t("chatbot.conversationFiles")}</span>
-                    <span className={styles.conversationFilesBadge}>{attachmentsCount}</span>
-                  </button>
+              <div className={styles.topBarRight}>
+                {conversationTokenUsage.total_tokens > 0 && (
+                  <TokenUsageBadge usage={conversationTokenUsage} variant="stacked" />
                 )}
-                {isAdmin && (
-                  <IconButton
-                    variant="icon"
-                    size="small"
-                    icon={{ category: "outlined", type: "build" }}
-                    aria-label={t("chatbot.toggleDebugDrawer")}
-                    onClick={() => setDebugOpen((v) => !v)}
-                  />
-                )}
+                <div className={styles.topBarActions}>
+                  {attachmentsCount > 0 && (
+                    <button
+                      type="button"
+                      className={styles.conversationFilesButton}
+                      onClick={() =>
+                        setActivePushDrawer((v) => (v?.kind === "attachments" ? null : { kind: "attachments" }))
+                      }
+                    >
+                      <span className={styles.conversationFilesLabel}>{t("chatbot.conversationFiles")}</span>
+                      <span className={styles.conversationFilesBadge}>{attachmentsCount}</span>
+                    </button>
+                  )}
+                  {isAdmin && (
+                    <IconButton
+                      variant="icon"
+                      size="small"
+                      icon={{ category: "outlined", type: "build" }}
+                      aria-label={t("chatbot.toggleDebugDrawer")}
+                      onClick={() => setDebugOpen((v) => !v)}
+                    />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/apps/frontend/src/rework/components/shared/molecules/NavigationMenu/NavigationMenuItem/NavigationMenuItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/NavigationMenu/NavigationMenuItem/NavigationMenuItem.module.scss
@@ -9,7 +9,7 @@
   align-items: center;
   gap: var(--spacing-s);
   cursor: pointer;
-  border-radius: var(--spacing-xs);
+  border-radius: var(--radius-xs);
   padding: 0 var(--spacing-xs);
   height: 2rem;
   color: var(--on-surface-retreat);

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
@@ -79,7 +79,6 @@
   padding-right: var(--spacing-xs);
   padding-left: var(--spacing-xs);
   width: 100%;
-  min-height: 36px;
   max-height: 200px;
   overflow-y: hidden; /* JS switches to auto at maxHeight */
   resize: none;

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
@@ -110,6 +110,7 @@
   display: flex;
   flex-shrink: 0;
   align-items: center;
+  gap: var(--spacing-2xs);
 }
 
 .rightSlot {

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/ReasoningBlock/ReasoningBlock.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/ReasoningBlock/ReasoningBlock.module.css
@@ -30,8 +30,8 @@
   bottom: 0;
   left: var(--trace-rail-x, 0);
   transform: translateX(-50%);
-  background: var(--outline-variant);
-  width: 2px;
+  background: var(--outline-retreat);
+  width: 1px;
   content: "";
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/ThoughtTrace.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/ThoughtTrace.module.css
@@ -56,18 +56,22 @@
   }
 }
 
-/* Body: reasoning lane, then step lane. No cards, no fills — the trace is
-   secondary UI and must stay lighter than the answer below it. The one piece of
-   chrome kept is the timeline rail: it is what makes the turn read as a process
-   unfolding, from the reasoning marker down through the numbered tool steps.
+/* Body: reasoning lane, then step lane. The reasoning card stays chrome-free —
+   the trace is secondary UI and must stay lighter than the answer below it.
+   The one piece of chrome kept throughout is the timeline rail: it is what
+   makes the turn read as a process unfolding, from the reasoning marker down
+   through the numbered tool steps.
 
-   `--trace-rail-x` is the shared geometry: step-number column (18px) + row gap
-   (4px) + half a status dot (3px) = 25px. It cascades to ReasoningBlock and
-   TraceEntryRow, which align their markers on it, so the rail threads every
-   marker with no per-component magic. Deliberately whole pixels: at 24.6px the
-   2px rail straddled a half pixel and rendered as a blurred grey smear. */
+   `--trace-rail-x` is the shared geometry: the status dot is the first item
+   in a TraceEntryRow, offset by the row's own left padding (--spacing-s,
+   12px) before the rail sits on its center — half a status dot (9px / 2 =
+   4.5px), so 12 + 4.5 = 16.5px. That half-pixel value is deliberate: the 1px
+   rail is centered on it via translateX(-50%), so its rendered edges land on
+   whole pixels (16.5 ± 0.5 = 16 and 17) instead of blurring. It cascades to
+   ReasoningBlock and TraceEntryRow, which align their markers on it, so the
+   rail threads every marker with no per-component magic. */
 .body {
-  --trace-rail-x: calc(18px + var(--spacing-2xs) + 3px);
+  --trace-rail-x: 16.5px;
 
   display: flex;
   flex-direction: column;
@@ -77,10 +81,17 @@
   padding-top: var(--spacing-2xs);
 }
 
+/* The one card in the trace: visually groups the tool-step rows, distinct
+   from the chrome-free reasoning lane above it. Horizontal breathing room
+   comes from each row's own left/right padding, not from this container —
+   that's why only top/bottom padding is set here. */
 .entries {
   display: flex;
   flex-direction: column;
   gap: 0;
+  border-radius: var(--radius-s);
+  background: var(--surface-container-low);
+  padding: var(--spacing-2xs) 0;
 }
 
 /* Nothing above the first step: the rail must start AT its marker, not float

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.module.css
@@ -1,4 +1,4 @@
-/* One tool step of the trace: [n] ● label · discriminator ....... latency */
+/* One tool step of the trace: ● [n] label · discriminator ....... latency */
 .row {
   display: flex;
   position: relative;
@@ -7,22 +7,24 @@
   transition: background 150ms ease;
   cursor: pointer;
   border-radius: var(--radius-xs);
-  padding: var(--spacing-2xs) var(--spacing-xs) var(--spacing-2xs) 0;
+  padding: var(--spacing-2xs) var(--spacing-s);
+  height: 32px;
   user-select: none;
 }
 
 /* Timeline rail — drawn per row rather than as one absolute line, so each
-   segment is exactly as tall as its own row and the segment of the step that is
-   still running can pulse on its own (that blink IS the "tool in progress"
-   signal). Rows are gapless, so the segments read as one continuous line. */
+   segment is exactly as tall as its own row. Static regardless of step status
+   — "tool in progress" is signalled by the dot alone, never by the rail
+   blinking or changing colour. Rows are gapless, so the segments read as one
+   continuous line. */
 .row::before {
   position: absolute;
   top: 0;
   bottom: 0;
   left: var(--trace-rail-x, 0);
   transform: translateX(-50%);
-  background: var(--outline-variant);
-  width: 2px;
+  background: var(--outline-retreat);
+  width: 1px;
   content: "";
 }
 
@@ -31,43 +33,31 @@
   bottom: 50%;
 }
 
-/* Running step: the segment ARRIVING at its marker runs an indeterminate flow —
-   a highlight travelling down the rail — for exactly as long as the call is in
-   flight (status `pending` = a tool_call with no tool_result yet). It stops by
-   itself the moment the result lands and the row flips to ok/error.
-
-   The segment still stops at the marker (`.row:last-child` rule above): a tail
-   hanging below the last dot read as a broken line, not as progress. */
-.row_pending::before {
-  animation: railFlow 1.2s linear infinite;
-  background: linear-gradient(to bottom, var(--outline-variant) 0%, var(--primary) 50%, var(--outline-variant) 100%);
-  background-size: 100% 200%;
-}
-
-@keyframes railFlow {
-  from {
-    background-position: 0 100%;
-  }
-  to {
-    background-position: 0 0%;
-  }
-}
-
 .row:hover,
 .row:focus-visible {
   outline: none;
   background: var(--surface-container);
 }
 
+/* Status dot + step number cluster — its own gap, wider than the gap before
+   the label, so the two read as one marker distinct from the row's content. */
+.marker {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 /* Step number — the only thing that tells two identical tool labels apart at
-   a glance; always visible (a hover-reveal index was too subtle). */
+   a glance; always visible (a hover-reveal index was too subtle). Fixed width
+   keeps the label column aligned whether or not the row carries a number. */
 .index {
   flex-shrink: 0;
   width: 18px;
   color: var(--on-surface-retreat);
   font: var(--font-label-medium);
   font-variant-numeric: tabular-nums;
-  text-align: right;
+  text-align: left;
 }
 
 /* Status dot */
@@ -80,8 +70,8 @@
      the timeline into dashes instead of one line threading the dots. */
   box-shadow: 0 0 0 1.5px var(--surface-container-lowest);
   border-radius: 50%;
-  width: 6px;
-  height: 6px;
+  width: 9px;
+  height: 9px;
 }
 
 .dot_ok {
@@ -90,11 +80,16 @@
 .dot_error {
   background: var(--error);
 }
+/* In-progress dots pulse by fading their own colour toward
+   surface-container-low, never through opacity — opacity would let the
+   timeline rail show through the dot underneath it. */
 .dot_pending {
+  --pulse-color: var(--warning);
   animation: pulse 1.2s ease-in-out infinite;
   background: var(--warning);
 }
 .dot_streaming {
+  --pulse-color: var(--primary);
   animation: pulse 1.2s ease-in-out infinite;
   background: var(--primary);
 }
@@ -102,10 +97,10 @@
 @keyframes pulse {
   0%,
   100% {
-    opacity: 1;
+    background-color: var(--pulse-color);
   }
   50% {
-    opacity: 0.25;
+    background-color: var(--surface-container-low);
   }
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.tsx
@@ -20,9 +20,11 @@ import {
   primaryTextForEntry,
   secondaryTextForEntry,
   statusForEntry,
+  tokenUsageForEntry,
   toolDiscriminator,
 } from "../../../../../utils/traceUtils";
 import { useTraceDrawer } from "../traceDrawerContext";
+import { TokenUsageBadge } from "@shared/molecules/TokenUsageBadge/TokenUsageBadge";
 import phaseStyles from "../phaseBadge.module.css";
 import styles from "./TraceEntryRow.module.css";
 
@@ -44,6 +46,7 @@ export function TraceEntryRow({ entry, index = null }: TraceEntryRowProps) {
   const phase = phaseKeyForEntry(entry);
   const primary = primaryTextForEntry(entry);
   const secondary = secondaryTextForEntry(entry);
+  const tokenUsage = tokenUsageForEntry(entry);
   const isPending = status === "pending";
 
   // Curated volume metadata (never raw args/content) so two calls to the same
@@ -88,6 +91,8 @@ export function TraceEntryRow({ entry, index = null }: TraceEntryRowProps) {
       </span>
 
       {secondary && <span className={styles.secondary}>{secondary}</span>}
+
+      {tokenUsage && <TokenUsageBadge usage={tokenUsage} />}
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.tsx
@@ -55,20 +55,24 @@ export function TraceEntryRow({ entry, index = null }: TraceEntryRowProps) {
 
   return (
     <div
-      className={`${styles.row} ${styles[`row_${status}`]}`}
+      className={styles.row}
       role="button"
       tabIndex={0}
       aria-label={`${index !== null ? `${index}. ` : ""}${label}${primary ? `: ${primary}` : ""}`}
       onClick={() => openTrace(entry)}
       onKeyDown={(e) => e.key === "Enter" && openTrace(entry)}
     >
-      {/* Always rendered, empty for unnumbered notes, so the status dots of every
-          row stay on the same vertical line as the timeline guideline. */}
-      <span className={styles.index} aria-hidden="true">
-        {index ?? ""}
-      </span>
+      {/* Own gap from .row's, so the marker cluster (dot + number) can sit
+          closer together than the wider spacing before the label. */}
+      <div className={styles.marker}>
+        <DotStatus status={status} />
 
-      <DotStatus status={status} />
+        {/* Always rendered, empty for unnumbered notes, so the label of every
+            row starts at the same x whether or not it carries a step number. */}
+        <span className={styles.index} aria-hidden="true">
+          {index ?? ""}
+        </span>
+      </div>
 
       <span
         className={phase ? `${phaseStyles.phaseBadge} ${styles.phaseBadge}` : styles.label}

--- a/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.module.css
@@ -1,11 +1,23 @@
-.root {
+.tokensUsage {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-2xs);
   color: var(--on-surface-retreat);
   font: var(--font-label-small);
   font-variant-numeric: tabular-nums;
   user-select: none;
+}
+
+.stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-3xs);
+}
+
+.breakdownRow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
 }
 
 .segment {

--- a/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.tsx
@@ -37,9 +37,7 @@ export function TokenUsageBadge({ usage, variant = "inline" }: TokenUsageBadgePr
   if (variant === "stacked") {
     return (
       <div className={`${styles.tokensUsage} ${styles.stacked}`}>
-        <span className={styles.total}>
-          {t("chatbot.conversationTokenUsage.total", { count: usage.total_tokens })}
-        </span>
+        <span className={styles.total}>{t("chatbot.conversationTokenUsage.total", { count: usage.total_tokens })}</span>
         <div className={styles.breakdownRow}>{breakdown}</div>
       </div>
     );

--- a/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.tsx
@@ -12,19 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useTranslation } from "react-i18next";
 import type { TokenUsage } from "@rework/types/conversation";
 import styles from "./TokenUsageBadge.module.css";
 
 interface TokenUsageBadgeProps {
   usage: TokenUsage;
+  /** "inline" (default): single row, used next to a message. "stacked": total on its
+   *  own line above the in/out breakdown, used for conversation-level aggregates. */
+  variant?: "inline" | "stacked";
 }
 
-export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
-  return (
-    <div className={styles.root}>
+export function TokenUsageBadge({ usage, variant = "inline" }: TokenUsageBadgeProps) {
+  const { t } = useTranslation();
+
+  const breakdown = (
+    <>
       <span className={styles.segment}>↑{usage.input_tokens.toLocaleString()}</span>
       <span className={styles.sep}>·</span>
       <span className={styles.segment}>↓{usage.output_tokens.toLocaleString()}</span>
+    </>
+  );
+
+  if (variant === "stacked") {
+    return (
+      <div className={`${styles.tokensUsage} ${styles.stacked}`}>
+        <span className={styles.total}>
+          {t("chatbot.conversationTokenUsage.total", { count: usage.total_tokens })}
+        </span>
+        <div className={styles.breakdownRow}>{breakdown}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.tokensUsage}>
+      {breakdown}
       <span className={styles.sep}>·</span>
       <span className={styles.total}>{usage.total_tokens.toLocaleString()} tokens</span>
     </div>

--- a/apps/frontend/src/rework/components/shared/organisms/ChatMessagesArea/ChatMessagesArea.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatMessagesArea/ChatMessagesArea.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { type ReactNode, type RefObject, useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { type ReactNode, type RefObject, useCallback, useLayoutEffect } from "react";
 import { useTranslation } from "react-i18next";
 import styles from "./ChatMessagesArea.module.css";
 
@@ -24,17 +24,13 @@ interface ChatMessagesAreaProps {
   /** Explicit scroll container passed from ManagedChatPage — never use parentElement. */
   scrollContainerRef: RefObject<HTMLDivElement>;
   /**
-   * Increments when a new user exchange starts. Resets tail mode and jumps to
-   * bottom. Must NOT change on every streaming token — only on new turns.
+   * Increments when a new user exchange starts (including the initial mount,
+   * e.g. when opening a session with history). Jumps to bottom once for that
+   * turn. Must NOT change on every streaming token — while the agent writes
+   * its response, the viewport must never move on its own; only the user's
+   * own scrolling may move it.
    */
   turnKey: number;
-  isStreaming: boolean;
-}
-
-const BOTTOM_THRESHOLD_PX = 120;
-
-function distanceFromBottom(el: HTMLElement): number {
-  return el.scrollHeight - el.scrollTop - el.clientHeight;
 }
 
 export function ChatMessagesArea({
@@ -44,61 +40,20 @@ export function ChatMessagesArea({
   emptyState,
   scrollContainerRef,
   turnKey,
-  isStreaming,
 }: ChatMessagesAreaProps) {
   const { t } = useTranslation();
-
-  // true  → follow the bottom during streaming (tail -f behaviour)
-  // false → user scrolled up to read history; stop moving the viewport
-  const tailModeRef = useRef(true);
-  const lastScrollTopRef = useRef(0);
 
   const scrollToBottomInstant = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-    lastScrollTopRef.current = el.scrollTop;
   }, [scrollContainerRef]);
 
-  // Attach scroll listener to the external container once.
-  // Scrolling UP  → disable tail mode immediately.
-  // Scrolling DOWN + near bottom → re-enable tail mode.
-  useEffect(() => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-
-    const onScroll = () => {
-      const scrollingUp = el.scrollTop < lastScrollTopRef.current;
-      lastScrollTopRef.current = el.scrollTop;
-
-      if (scrollingUp) {
-        tailModeRef.current = false;
-        return;
-      }
-
-      if (distanceFromBottom(el) <= BOTTOM_THRESHOLD_PX) {
-        tailModeRef.current = true;
-      }
-    };
-
-    el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [scrollContainerRef]);
-
-  // New user turn → always reset tail mode and jump to bottom.
-  // Deliberately NOT triggered by streaming tokens.
+  // New user turn (or initial mount) → jump to bottom once. Deliberately not
+  // re-run on streaming tokens — see turnKey doc above.
   useLayoutEffect(() => {
-    tailModeRef.current = true;
     scrollToBottomInstant();
   }, [turnKey, scrollToBottomInstant]);
-
-  // During streaming: follow the bottom on every render, but only when tail
-  // mode is active (i.e. user hasn't scrolled up).
-  // No dep array — intentionally runs after every render.
-  useLayoutEffect(() => {
-    if (!isStreaming || !tailModeRef.current) return;
-    scrollToBottomInstant();
-  });
 
   return (
     <div className={styles.area} role="log" aria-live="polite" aria-label={t("chatbot.conversationAriaLabel")}>

--- a/apps/frontend/src/rework/core/hooks/useChatSse.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.ts
@@ -328,6 +328,15 @@ export function useChatSse(
                 args: event.arguments ?? {},
               },
             ],
+            metadata: event.token_usage
+              ? {
+                  token_usage: {
+                    input_tokens: event.token_usage["input_tokens"] ?? 0,
+                    output_tokens: event.token_usage["output_tokens"] ?? 0,
+                    total_tokens: event.token_usage["total_tokens"] ?? 0,
+                  },
+                }
+              : undefined,
           });
           break;
         }

--- a/apps/frontend/src/rework/utils/traceUtils.ts
+++ b/apps/frontend/src/rework/utils/traceUtils.ts
@@ -15,6 +15,7 @@
 import type { Channel, ChatMessage, ToolCallPart, ToolResultPart } from "../../slices/agentic/agenticOpenApi";
 import type { VectorSearchHit } from "../../slices/runtime/runtimeOpenApi";
 import type { RawUiPart } from "@rework/types/parts";
+import type { TokenUsage } from "@rework/types/conversation";
 
 export const TRACE_CHANNELS: Channel[] = [
   "plan",
@@ -206,6 +207,18 @@ export function toolResultOk(result: ChatMessage): boolean {
 
 export function toolResultLatencyMs(result: ChatMessage): number | null {
   return toolResultPart(result)?.latency_ms ?? null;
+}
+
+// Usage of the model call that decided to make this tool call (TRACE-01) —
+// carried on the tool_call message's metadata, not the result's.
+export function toolCallTokenUsage(call: ChatMessage): TokenUsage | null {
+  const tu = call.metadata?.token_usage;
+  if (!tu) return null;
+  return {
+    input_tokens: tu.input_tokens ?? 0,
+    output_tokens: tu.output_tokens ?? 0,
+    total_tokens: tu.total_tokens ?? 0,
+  };
 }
 
 export function toolResultContent(result: ChatMessage): string {
@@ -473,6 +486,13 @@ export function secondaryTextForEntry(entry: TraceEntry): string {
     return formatLatencyMs(toolResultLatencyMs(entry.result));
   }
   return "";
+}
+
+// Token usage to show alongside the latency (TRACE-01). Only tool steps
+// carry it — reasoning/note/error entries don't have a paired tool_call.
+export function tokenUsageForEntry(entry: TraceEntry): TokenUsage | null {
+  if (entry.kind === "combo") return toolCallTokenUsage(entry.call);
+  return null;
 }
 
 export function statusForEntry(entry: TraceEntry): TraceStatus {

--- a/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
+++ b/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
@@ -643,6 +643,9 @@ export type ToolCallRuntimeEvent = {
   call_id: string;
   kind?: "tool_call";
   sequence?: number;
+  token_usage?: {
+    [key: string]: number;
+  } | null;
   tool_name: string;
 };
 export type ToolResultRuntimeEvent = {

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -2168,7 +2168,57 @@ independently-tracked bug where `FinalRuntimeEvent.token_usage` (and
 anything summing it, e.g. the chat top-bar total) reflects only the
 **last** model call of a multi-tool-round-trip exchange, not the true sum
 (per-provider `usage_metadata` is per-call, not cumulative) — see the RFC's
-§1 for detail.
+§1 for detail. **Fixed same day, see §8.39.**
+
+---
+
+### 8.39 ✅ `FinalRuntimeEvent.token_usage` now sums every model call in the turn, not just the last (2026-08-04)
+
+**Closes the gap §8.38 explicitly deferred.** Confirmed live: with §8.38
+shipped, summing a turn's per-step token figures in the chat trace gave a
+larger number than the chat top-bar total — the top bar sums each
+exchange's `FinalRuntimeEvent.token_usage`, and that value was a
+last-write-wins rolling variable (`last_token_usage` in `react_runtime.py`;
+`_last_token_usage` on both `_GraphNodeExecutionContext` and
+`_DeterministicGraphExecutor` in `graph_runtime.py`), overwritten by every
+model call rather than summed. A ReAct/Graph turn commonly makes several
+model calls (tool-deciding calls, then the final answer — or several calls
+inside one Graph node) and each provider's `usage_metadata` is per-call, not
+cumulative, so only the last call's tokens ever reached the final event.
+
+**Fix — sum instead of overwrite, at exactly one point per model call.**
+New shared helper `sum_token_usage(a, b)`
+(`fred_runtime/runtime_support/model_metadata.py`, re-exported through
+`react_stream_adapter.py` → `react_langchain_adapter.py` for ReAct).
+Accumulation happens once per model call, not once per observation of it:
+
+- **ReAct** (`react_runtime.py`): the `"messages"` streaming mode no longer
+  writes into the accumulator — it observes the same AIMessage the
+  `"updates"` mode later delivers as a complete message, and summing both
+  would double-count every call. `total_token_usage` is now folded in
+  exactly at the two `"updates"`-mode capture points: the tool-deciding
+  `AIMessage` branch and the final-answer `AIMessage` branch.
+- **Graph** (`graph_runtime.py`), two layers, same shape of fix:
+  - Node level (`_GraphNodeExecutionContext`): a new `_total_token_usage`
+    field sums every model call the node makes; the pre-existing
+    `_last_token_usage` (last call only) is kept **unchanged** and still
+    feeds `ToolCallRuntimeEvent.token_usage` (TRACE-01 per-step display) —
+    summing there would have turned each step's figure into a running
+    total instead of "the cost of the call that decided this step".
+    `last_model_metadata` (the property the executor reads) now returns
+    the node's *summed* usage, not its last call.
+  - Turn level (`_DeterministicGraphExecutor`): `_last_token_usage` renamed
+    `_total_token_usage`, `_record_model_metadata` now sums each node's
+    (already-summed) contribution instead of overwriting.
+
+**Verified non-breaking** the same way as §8.38: nothing re-parses these
+events strictly. Regression tests added: `test_react_token_usage_totals.py`
+(turn sums every call; a step still shows only its own triggering call, not
+a running total) and `test_graph_runtime_token_usage_totals.py` (same two
+properties at the node level).
+
+**Still out of scope:** backfilling this corrected total into history
+persisted before this fix.
 
 ---
 

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -2130,6 +2130,48 @@ consumes context tokens the previous strip-everything behavior did not).
 
 ---
 
+### 8.38 ✅ `ToolCallRuntimeEvent.token_usage` — per-step token usage in the chat trace (TRACE-01, issue #2217, 2026-08-04)
+
+**New optional field.** `ToolCallRuntimeEvent` (`fred_sdk.contracts.runtime`)
+gains `token_usage: dict[str, int] | None = None` — the usage of the model
+call that decided to make that tool call, not a per-tool split. Additive,
+backward-compatible: only ever *constructed* with kwargs by the two
+producers (`react_runtime.py`, `graph_runtime.py`); no consumer in the
+monorepo re-parses it via `.model_validate()`, so `FrozenModel`'s
+`extra="forbid"` never gets a chance to reject it.
+
+**Both execution engines, symmetric fix:**
+
+- ReAct (`react_runtime.py:486-518`): captured directly off the
+  tool-deciding `AIMessage` via `_runtime_metadata_from_message`, once per
+  message (not per parallel tool call).
+- Graph (`graph_runtime.py:627-636`, `701-710`): the node's own
+  `_last_token_usage` (whatever `record_model_metadata` last recorded on
+  that node) is attached at `invoke_tool`/`invoke_runtime_tool` time — a
+  graph node can call several models before invoking a tool, so this is the
+  most recent one, not necessarily that exact call's own usage.
+
+**Live stream and persisted history both carry it — deliberately, not just
+the SSE payload.** Every turn is written to the history store at the end of
+the exchange (`_write_turn_history` → `make_tool_call`,
+`fred_core.history.history_schema`); that persisted `ChatMessage.metadata`
+is what a page refresh or session reopen reads (`useSessionHistory.ts`), a
+different path from the live SSE stream. Wiring only the live event would
+have made the figure vanish on refresh for a conversation created the same
+day — corrected during implementation, see
+`docs/swift/rfc/TRACE-TOKEN-USAGE-RFC.md` §2.1.
+
+**Out of scope (unchanged by this entry):** conversations whose history was
+already persisted *before* this shipped — no retroactive backfill; the
+separate `ThoughtRecord` eval-harness format; and a pre-existing,
+independently-tracked bug where `FinalRuntimeEvent.token_usage` (and
+anything summing it, e.g. the chat top-bar total) reflects only the
+**last** model call of a multi-tool-round-trip exchange, not the true sum
+(per-provider `usage_metadata` is per-call, not cumulative) — see the RFC's
+§1 for detail.
+
+---
+
 ## 8. Developer CLI — `fred-agents-cli`
 
 > **Platform convention:** every Fred backend exposes `make cli`.

--- a/docs/swift/rfc/TRACE-TOKEN-USAGE-RFC.md
+++ b/docs/swift/rfc/TRACE-TOKEN-USAGE-RFC.md
@@ -1,6 +1,6 @@
 # Per-step token usage in the chat trace
 
-**Status:** Implemented 2026-08-04 — see `RUNTIME-EXECUTION-CONTRACT.md` §8.38. Tracked in [GitHub issue #2217](https://github.com/ThalesGroup/fred/issues/2217)
+**Status:** Implemented 2026-08-04 — see `RUNTIME-EXECUTION-CONTRACT.md` §8.38. The deferred rolling-overwrite undercount (§2.1) was also fixed the same day — see §8.39. Tracked in [GitHub issue #2217](https://github.com/ThalesGroup/fred/issues/2217)
 **ID:** `TRACE-01` (informal)
 **Author:** Maxime Daragon / Claude Code
 **Date:** 2026-08-04
@@ -89,12 +89,15 @@ to fix in the same change or track separately.
     distinct from the `ChatMessage` history above) is still intentionally
     left untouched — genuinely a different, larger change, and not needed
     for the chat UI to work correctly.
-- **The rolling-overwrite undercount (see §1) is explicitly out of scope
-  here — tracked separately, not bundled into this change.** It changes the
-  *meaning* of `FinalRuntimeEvent.token_usage` for existing consumers (CLI
-  `tokens` field, eval trace `usage`, the top-bar total badge), so it
-  deserves its own explicitly-scoped follow-up rather than riding along with
-  an additive UI feature. No decision yet on whether/when to fix it.
+- **The rolling-overwrite undercount (see §1) was explicitly out of scope
+  for the initial change — tracked separately, not bundled in.** It changes
+  the *meaning* of `FinalRuntimeEvent.token_usage` for existing consumers
+  (CLI `tokens` field, eval trace `usage`, the top-bar total badge), so it
+  got its own explicitly-scoped follow-up rather than riding along with an
+  additive UI feature. **Fixed the same day**, once the shipped per-step
+  feature made the discrepancy directly observable (summing the trace's
+  per-step tokens gave a larger number than the top-bar total) — see
+  `RUNTIME-EXECUTION-CONTRACT.md` §8.39.
 
 ---
 

--- a/docs/swift/rfc/TRACE-TOKEN-USAGE-RFC.md
+++ b/docs/swift/rfc/TRACE-TOKEN-USAGE-RFC.md
@@ -1,0 +1,149 @@
+# Per-step token usage in the chat trace
+
+**Status:** Implemented 2026-08-04 — see `RUNTIME-EXECUTION-CONTRACT.md` §8.38. Tracked in [GitHub issue #2217](https://github.com/ThalesGroup/fred/issues/2217)
+**ID:** `TRACE-01` (informal)
+**Author:** Maxime Daragon / Claude Code
+**Date:** 2026-08-04
+
+---
+
+## 1. Problem statement
+
+Each row of the chat trace (`TraceEntryRow`, under `ThoughtTrace`) shows the
+latency of that tool step at the end of the line (`secondaryTextForEntry` →
+`latency_ms`). There is no equivalent for token consumption — a user cannot
+tell which tool call or reasoning step was expensive versus cheap, only the
+conversation-level total (the top-bar badge added separately, `TRACE-XX`
+n/a).
+
+The data is *closer than it looks*: `fred-runtime`'s ReAct loop
+(`react_runtime.py`) and Graph loop (`graph_runtime.py`) already capture a
+`token_usage` value off every `AIMessage`/model chunk as it streams —
+including the messages that decide to call a tool, not just the final
+answer. Today that value is held in a rolling `last_token_usage` /
+`_last_token_usage` variable that gets **overwritten at each step** and is
+only ever forwarded once, attached to `FinalRuntimeEvent`. Nothing in the
+runtime-event contract (`fred_sdk.contracts.runtime`) lets a per-step event
+(`ToolCallRuntimeEvent`, `ThoughtStartEvent`) carry its own usage.
+
+One additional, previously-unnoticed consequence of the same rolling
+variable: because each provider's `usage_metadata` is per-call (not
+cumulative — confirmed in `runtime_metadata_from_message`,
+`model_metadata.py`), `FinalRuntimeEvent.token_usage` for an exchange with
+multiple tool round-trips reflects only the **last** LLM call, not the sum
+across the ReAct/Graph loop. The conversation-total badge in the chat top
+bar (`ManagedChatPage`) is built by summing each exchange's final
+`token_usage` across the thread, so it inherits this undercount whenever an
+exchange makes more than one model call. Worth a decision below on whether
+to fix in the same change or track separately.
+
+---
+
+## 2. Proposed solution
+
+1. **Runtime (fred-runtime):** stop discarding the per-call usage. At the
+   point each engine already captures a step's `token_usage` — just before
+   emitting `ToolCallRuntimeEvent`/`ThoughtStartEvent` for a tool-deciding
+   model call — attach it to that event instead of only updating the rolling
+   `last_token_usage`. Done symmetrically in both `react_runtime.py` and
+   `graph_runtime.py` — both engines in scope (see §2.1).
+2. **Contract (fred-sdk):** add `token_usage: dict[str, int] | None = None`
+   to `ToolCallRuntimeEvent` (and `ThoughtStartEvent`, if reasoning-phase
+   usage should also be shown) in `contracts/runtime.py`. Optional, additive
+   — see §4, no breaking-change risk found.
+3. **OpenAPI:** thread the field through to the `tool_call` channel's
+   `ChatMessage.metadata` shape — both on the live SSE payload *and* on the
+   `ChatMessage` persisted by `_write_turn_history`/`make_tool_call`
+   (`agent_app.py`) at the end of every turn, so the figure survives a page
+   refresh or reopening a conversation created after this ships (see §2.1
+   correction). Regenerate the runtime OpenAPI spec and the frontend client
+   (`agenticOpenApi.ts`).
+4. **Frontend:** extend `ToolResultPart`/trace metadata consumption in
+   `traceUtils.ts` (mirroring how `latency_ms` is already read) and render
+   it in `TraceEntryRow`, next to the existing latency in `.secondary`.
+
+### 2.1 Scope — confirmed 2026-08-04
+
+- **ReAct + Graph, both.** Both engines have the identical architectural
+  pattern (confirmed by reading both files), so the fix is symmetric — two
+  call sites, not one, but no feature-parity gap between the two agent
+  types.
+- **Correction (2026-08-04, after starting implementation):** "live stream
+  only" was under-specified — there are two distinct reload paths, not one,
+  and only one of them is actually out of scope:
+  - **Conversations that finished *before* this ships** — their already-
+    persisted history genuinely has no token_usage on the `tool_call`
+    message. Unfixable without a backfill. **Out of scope**, unchanged: they
+    keep showing latency per step (as today), not tokens.
+  - **Conversations created *after* this ships** — every turn is persisted
+    to the history store at the end of the exchange
+    (`_write_turn_history`/`make_tool_call` in `agent_app.py`), which is the same
+    path `useSessionHistory.ts` reads on a page refresh or on reopening a
+    session. If this path isn't also updated, the per-step token figure
+    would only exist while the answer is actively streaming and would
+    silently vanish the moment the user refreshes the page — for a
+    conversation from the same day. That reads as a bug, not a scope
+    choice, and is **in scope**: `make_tool_call` must carry the field too,
+    not just the live `ToolCallRuntimeEvent`.
+  - `ThoughtRecord` (the *separate* durable record used by the eval harness,
+    distinct from the `ChatMessage` history above) is still intentionally
+    left untouched — genuinely a different, larger change, and not needed
+    for the chat UI to work correctly.
+- **The rolling-overwrite undercount (see §1) is explicitly out of scope
+  here — tracked separately, not bundled into this change.** It changes the
+  *meaning* of `FinalRuntimeEvent.token_usage` for existing consumers (CLI
+  `tokens` field, eval trace `usage`, the top-bar total badge), so it
+  deserves its own explicitly-scoped follow-up rather than riding along with
+  an additive UI feature. No decision yet on whether/when to fix it.
+
+---
+
+## 3. Alternatives considered
+
+- **Compute tokens client-side from characters/word count.** Rejected —
+  provider tokenizers are not client-visible, any estimate would be
+  systematically wrong and would misrepresent a number users may reasonably
+  expect to be exact.
+- **Only show the total, not per-step (status quo).** Rejected per the
+  original ask — the value of this feature is pinpointing which *step* was
+  expensive, which the aggregate cannot do.
+
+---
+
+## 4. Impact on existing contracts — breakage check
+
+Verified directly in the source (not assumed):
+
+| Consumer | Parsing style | Risk |
+|---|---|---|
+| `ToolCallRuntimeEvent`/`ThoughtStartEvent`/etc. base class (`FrozenModel`) | `ConfigDict(extra="forbid", frozen=True)` | **None found** — these classes are only ever *constructed* with kwargs in `react_runtime.py` and `graph_runtime.py` (both producers, both in fred-runtime). No consumer anywhere in the monorepo calls `.model_validate()`/`.parse_obj()` on raw event dicts to rehydrate them, so `extra="forbid"` never gets a chance to reject an unrecognized field — the strict-parsing risk flagged earlier does not materialize here. |
+| `fred_runtime/cli/history_display.py`, `cli/repl.py` | Plain `dict.get(...)` on already-serialized JSON | None — tolerant by construction; a new key is silently available, not required |
+| `fred_runtime/eval/collector.py` (`collect_eval_trace`) | Plain `dict.get(...)`, but **hand-picks** which keys go into each `steps[]` entry | None by default (new key silently dropped) — **but** if we choose to also surface per-step tokens in eval traces (§2, optional), `tests/test_eval_collector.py:98-103` does strict dict equality on `steps` and **will need its expected fixtures updated** — a known, not a surprise |
+| `fred_runtime/app/openai_compat_router.py` | No reference to per-step event fields; only reads `token_usage` on the final chunk | None |
+| `graph_runtime.py` (Graph engine) | Same producer-only construction pattern as ReAct | None — confirms both engines can take the identical fix safely |
+| `ThoughtRecord` (persisted/replay) | Only constructed directly (`graph_runtime.py:349,389`), never `.model_validate()`-ed from external data | Not touched — historical replay is out of scope (§2.1) |
+
+**Conclusion:** additive and safe as a field. The only concrete required
+follow-up is `test_eval_collector.py`, and only if the eval-collector
+pass-through (§2, point 3/optional) is included in the same change.
+
+| Contract file | Change |
+|---|---|
+| `RUNTIME-EXECUTION-CONTRACT.md` | New optional field on `ToolCallRuntimeEvent`/`ThoughtStartEvent` — needs a dated §8 entry once implemented |
+| `CONTROL-PLANE-PRODUCT-CONTRACT.md` | No change — historical replay is out of scope |
+
+---
+
+## 5. Out of scope (confirmed 2026-08-04, corrected same day)
+
+- **Conversations that finished before this ships.** No retroactive
+  backfill — see §2.1. Conversations created *after* this ships *are* in
+  scope for persistence (corrected §2.1), only pre-existing history is
+  excluded.
+- **`ThoughtRecord` / eval-harness replay.** Separate durable format, not
+  needed for the chat UI — see §2.1.
+- **The rolling-overwrite undercount fix.** Tracked as a separate,
+  independently-scoped follow-up — not bundled into this change. See §1 for
+  what it is.
+- Cost/CO2e estimation per step (`TokenUsageImpact` is conversation/
+  team-scoped today) — no ask for this at the per-step level.

--- a/libs/fred-core/fred_core/history/history_schema.py
+++ b/libs/fred-core/fred_core/history/history_schema.py
@@ -396,12 +396,16 @@ def make_tool_call(
     call_id: str,
     name: str,
     args: Dict[str, Any],
+    *,
+    token_usage: Optional[Dict[str, int]] = None,
 ) -> ChatMessage:
     """
     Build a tool-call record message.
 
     How to use it:
     - call when a ``ToolCallRuntimeEvent`` is received
+    - ``token_usage``: the model call that decided to make this tool call
+      (TRACE-01), same shape as ``ToolCallRuntimeEvent.token_usage``
     """
     return ChatMessage(
         session_id=session_id,
@@ -411,6 +415,9 @@ def make_tool_call(
         role=Role.assistant,
         channel=Channel.tool_call,
         parts=[ToolCallPart(call_id=call_id, name=name, args=args)],
+        metadata=ChatMetadata(token_usage=ChatTokenUsage(**token_usage))
+        if token_usage
+        else ChatMetadata(),
     )
 
 

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -1953,6 +1953,7 @@ async def _write_turn_history(
                     call_id=payload["call_id"],
                     name=payload["tool_name"],
                     args=payload.get("arguments", {}),
+                    token_usage=payload.get("token_usage"),
                 )
             )
             rank += 1

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -98,7 +98,10 @@ from fred_runtime.runtime_support.checkpoints import (
     AsyncCheckpointReader,
     AsyncCheckpointWriter,
 )
-from fred_runtime.runtime_support.model_metadata import runtime_metadata_from_message
+from fred_runtime.runtime_support.model_metadata import (
+    runtime_metadata_from_message,
+    sum_token_usage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +225,14 @@ class _GraphNodeExecutionContext:
     # being buffered in _events, so the caller receives tokens in real time.
     _live_emit: Callable[[RuntimeEvent], None] | None = None
     _last_model_name: str | None = None
+    # Usage of the single most recent model call in this node — used for
+    # per-step attribution (TRACE-01: attached to each ToolCallRuntimeEvent
+    # a node emits, so a step shows only the call that triggered it).
     _last_token_usage: dict[str, int] | None = None
+    # Summed across every model call this node makes — a node can call the
+    # model more than once (e.g. planning then acting) before invoking a
+    # tool, and the node's real total is their sum, not just the last one.
+    _total_token_usage: dict[str, int] | None = None
     _last_finish_reason: str | None = None
 
     @property
@@ -245,7 +255,9 @@ class _GraphNodeExecutionContext:
 
         Why this exists:
         - graph nodes can invoke multiple model calls across one turn
-        - the runtime needs one reliable place to record the latest token usage
+        - the runtime needs one reliable place to record the latest token
+          usage for per-step attribution, and the summed usage for the
+          node's contribution to the turn total
 
         How to use:
         - call after a model invocation returns or streams its final chunk
@@ -258,6 +270,9 @@ class _GraphNodeExecutionContext:
             self._last_model_name = model_name
         if token_usage:
             self._last_token_usage = token_usage
+            self._total_token_usage = sum_token_usage(
+                self._total_token_usage, token_usage
+            )
         if finish_reason:
             self._last_finish_reason = finish_reason
 
@@ -266,10 +281,15 @@ class _GraphNodeExecutionContext:
         self,
     ) -> tuple[str | None, dict[str, int] | None, str | None]:
         """
-        Return the latest model metadata recorded by this node.
+        Return this node's model metadata, ready for the executor to fold
+        into the turn-level total.
 
         Why this exists:
         - the executor needs a stable readout after the node completes
+        - the token_usage slot is this node's *summed* usage across every
+          model call it made (`_total_token_usage`), not just its last call
+          (`_last_token_usage`, used instead for TRACE-01 per-step display)
+          — the executor sums this across nodes for the turn's real total
 
         How to use:
         - read after the node handler finishes
@@ -280,7 +300,7 @@ class _GraphNodeExecutionContext:
 
         return (
             self._last_model_name,
-            self._last_token_usage,
+            self._total_token_usage,
             self._last_finish_reason,
         )
 
@@ -1047,7 +1067,11 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
             group[0]: (group[1], group[2:]) for group in self._graph.parallel_groups
         }
         self._last_model_name: str | None = None
-        self._last_token_usage: dict[str, int] | None = None
+        # Summed across every node's contribution to this turn — a Graph turn
+        # commonly visits several nodes, each possibly calling the model more
+        # than once, and the turn's real total is their sum, not whichever
+        # node happened to finish last (TRACE-01 follow-up).
+        self._total_token_usage: dict[str, int] | None = None
         self._last_finish_reason: str | None = None
         self._thought_records: list[ThoughtRecord] = []
 
@@ -1067,7 +1091,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         """
 
         self._last_model_name = None
-        self._last_token_usage = None
+        self._total_token_usage = None
         self._last_finish_reason = None
         self._thought_records = []
 
@@ -1079,11 +1103,14 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         finish_reason: str | None,
     ) -> None:
         """
-        Capture the latest model metadata observed in the graph run.
+        Fold one node's model metadata into the turn-level total.
 
         Why this exists:
-        - the final graph event should expose the most recent model usage data
-        - graph nodes can call multiple models; we keep the latest non-empty view
+        - the final graph event should expose the turn's real total usage
+        - graph nodes can call multiple models; `token_usage` here is already
+          that node's own summed usage (`_GraphNodeExecutionContext.last_model_metadata`),
+          so summing it in gives the whole turn's total, not just the last
+          node's contribution
 
         How to use:
         - call after a node finishes executing
@@ -1095,7 +1122,9 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         if model_name:
             self._last_model_name = model_name
         if token_usage:
-            self._last_token_usage = token_usage
+            self._total_token_usage = sum_token_usage(
+                self._total_token_usage, token_usage
+            )
         if finish_reason:
             self._last_finish_reason = finish_reason
 
@@ -1393,7 +1422,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
                 _final_event_from_output(
                     output_model,
                     model_name=self._last_model_name,
-                    token_usage=self._last_token_usage,
+                    token_usage=self._total_token_usage,
                     finish_reason=self._last_finish_reason,
                 )
             )

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -629,6 +629,11 @@ class _GraphNodeExecutionContext:
                 tool_name=tool_ref,
                 call_id=call_id,
                 arguments=payload,
+                # Usage of the most recent model call recorded on this node
+                # (TRACE-01) — the same value `last_model_metadata` reads, not
+                # necessarily this specific call's own usage: a graph node can
+                # invoke several models before invoking a tool.
+                token_usage=self._last_token_usage,
             )
         )
         span = _start_runtime_span(
@@ -703,6 +708,8 @@ class _GraphNodeExecutionContext:
                 tool_name=tool_name,
                 call_id=call_id,
                 arguments=arguments,
+                # See invoke_tool() above — same caveat applies.
+                token_usage=self._last_token_usage,
             )
         )
         span = _start_runtime_span(

--- a/libs/fred-runtime/fred_runtime/react/react_langchain_adapter.py
+++ b/libs/fred-runtime/fred_runtime/react/react_langchain_adapter.py
@@ -70,6 +70,7 @@ from .react_stream_adapter import (
     runtime_metadata_from_message,
     runtime_metadata_from_stream_event,
     split_stream_event_mode,
+    sum_token_usage,
 )
 
 __all__ = [
@@ -96,6 +97,7 @@ __all__ = [
     "runtime_metadata_from_stream_event",
     "split_stream_event_mode",
     "stringify_langchain_content",
+    "sum_token_usage",
     "to_langchain_message",
     "to_runnable_config",
 ]

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -133,6 +133,9 @@ from .react_langchain_adapter import (
     split_stream_event_mode as _split_stream_event_mode,
 )
 from .react_langchain_adapter import (
+    sum_token_usage as _sum_token_usage,
+)
+from .react_langchain_adapter import (
     to_runnable_config as _to_runnable_config,
 )
 from .react_prompting import (
@@ -336,7 +339,12 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         collected_sources: tuple[VectorSearchHit, ...] = ()
         collected_ui_parts: tuple[UiPart, ...] = ()
         last_model_name: str | None = None
-        last_token_usage: dict[str, int] | None = None
+        # Summed across every model call in the turn (tool-deciding calls plus
+        # the final answer), not the last call's usage alone — a ReAct turn
+        # commonly makes several calls, and each provider's usage_metadata is
+        # per-call, not cumulative (TRACE-01 follow-up: the previous
+        # last-write-wins variable silently undercounted any multi-call turn).
+        total_token_usage: dict[str, int] | None = None
         last_finish_reason: str | None = None
         # When any tool returns is_error=True, the error is surfaced directly as
         # the final response.  The LLM is NOT trusted to relay it: its subsequent
@@ -365,13 +373,16 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                 mode, update = _split_stream_event_mode(raw_event)
 
                 if mode == "messages":
-                    model_name, token_usage, finish_reason = (
-                        _runtime_metadata_from_stream_event(update)
+                    # Token usage is deliberately not read here: "updates" mode
+                    # (below) delivers the same completed AIMessage exactly
+                    # once per model call and is the sole accumulation point —
+                    # also reading it from these streaming chunks would double
+                    # -count every call into total_token_usage.
+                    model_name, _, finish_reason = _runtime_metadata_from_stream_event(
+                        update
                     )
                     if model_name is not None:
                         last_model_name = model_name
-                    if token_usage is not None:
-                        last_token_usage = token_usage
                     if finish_reason is not None:
                         last_finish_reason = finish_reason
                     decoded = _decode_stream_chunk(update)
@@ -486,17 +497,19 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                     if isinstance(message, AIMessage) and message.tool_calls:
                         # The usage of the model call that decided to make these
                         # tool calls — attached per-call to ToolCallRuntimeEvent
-                        # (TRACE-01) so the trace UI can show tokens per step.
-                        # When one AIMessage requests several tools in parallel,
-                        # every one of them gets this same total: it is the cost
-                        # of the one decision that produced them, not a per-tool
-                        # split (providers don't expose a per-tool breakdown).
-                        # Deliberately not folded into `last_token_usage`: that
-                        # rolling variable feeds FinalRuntimeEvent and changing
-                        # its semantics is a separate, explicitly out-of-scope
-                        # follow-up (see TRACE-TOKEN-USAGE-RFC.md §2.1).
+                        # (TRACE-01) so the trace UI can show tokens per step,
+                        # AND folded into the turn's running total. When one
+                        # AIMessage requests several tools in parallel, every
+                        # one of them gets this same per-step total (it is the
+                        # cost of the one decision that produced them, not a
+                        # per-tool split — providers don't expose that
+                        # breakdown), but it is only added to the turn total
+                        # once, here, not once per parallel tool call.
                         _, tool_call_token_usage, _ = _runtime_metadata_from_message(
                             message
+                        )
+                        total_token_usage = _sum_token_usage(
+                            total_token_usage, tool_call_token_usage
                         )
                         for tool_call in message.tool_calls:
                             name = str(tool_call.get("name") or "")
@@ -529,8 +542,9 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                         )
                         if model_name is not None:
                             last_model_name = model_name
-                        if token_usage is not None:
-                            last_token_usage = token_usage
+                        total_token_usage = _sum_token_usage(
+                            total_token_usage, token_usage
+                        )
                         if finish_reason is not None:
                             last_finish_reason = finish_reason
                         last_assistant_message = _from_langchain_message_adapter(
@@ -564,7 +578,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                     sources=collected_sources,
                     ui_parts=collected_ui_parts,
                     model_name=last_model_name,
-                    token_usage=last_token_usage,
+                    token_usage=total_token_usage,
                     finish_reason=last_finish_reason,
                 )
         except Exception:

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -484,6 +484,20 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                         continue
 
                     if isinstance(message, AIMessage) and message.tool_calls:
+                        # The usage of the model call that decided to make these
+                        # tool calls — attached per-call to ToolCallRuntimeEvent
+                        # (TRACE-01) so the trace UI can show tokens per step.
+                        # When one AIMessage requests several tools in parallel,
+                        # every one of them gets this same total: it is the cost
+                        # of the one decision that produced them, not a per-tool
+                        # split (providers don't expose a per-tool breakdown).
+                        # Deliberately not folded into `last_token_usage`: that
+                        # rolling variable feeds FinalRuntimeEvent and changing
+                        # its semantics is a separate, explicitly out-of-scope
+                        # follow-up (see TRACE-TOKEN-USAGE-RFC.md §2.1).
+                        _, tool_call_token_usage, _ = _runtime_metadata_from_message(
+                            message
+                        )
                         for tool_call in message.tool_calls:
                             name = str(tool_call.get("name") or "")
                             call_id = str(tool_call.get("id") or "")
@@ -504,6 +518,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                                 arguments=cast(
                                     dict[str, object], tool_call.get("args") or {}
                                 ),
+                                token_usage=tool_call_token_usage,
                             )
                             sequence += 1
                         continue

--- a/libs/fred-runtime/fred_runtime/react/react_stream_adapter.py
+++ b/libs/fred-runtime/fred_runtime/react/react_stream_adapter.py
@@ -53,6 +53,7 @@ from fred_runtime.runtime_support.model_metadata import (  # noqa: F401
     normalize_token_usage,
     runtime_metadata_from_message,
     runtime_metadata_from_stream_event,
+    sum_token_usage,
 )
 from fred_runtime.support.thinking import content_to_text
 

--- a/libs/fred-runtime/fred_runtime/runtime_support/model_metadata.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/model_metadata.py
@@ -214,3 +214,37 @@ def normalize_token_usage(raw: object) -> dict[str, int] | None:
         "output_tokens": output_tokens,
         "total_tokens": total_tokens,
     }
+
+
+def sum_token_usage(
+    a: dict[str, int] | None, b: dict[str, int] | None
+) -> dict[str, int] | None:
+    """
+    Add two normalized token-usage maps together.
+
+    Why this exists:
+    - a turn can make several model calls (tool-deciding calls, then the
+      final answer, or several calls inside one Graph node) — the turn's
+      real total is their sum, not whichever call happened to run last
+    - a caller tracking a running total across a loop needs one place to
+      combine the accumulator with each newly observed call
+
+    How to use:
+    - `total = sum_token_usage(total, newly_observed_usage)` inside a loop;
+      either side may be `None` (treated as zero) — the result is `None`
+      only when both sides are `None`
+
+    Example:
+    - `sum_token_usage({"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}, {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4})`
+      -> `{"input_tokens": 13, "output_tokens": 6, "total_tokens": 19}`
+    """
+
+    if a is None and b is None:
+        return None
+    left = a or {}
+    right = b or {}
+    return {
+        "input_tokens": left.get("input_tokens", 0) + right.get("input_tokens", 0),
+        "output_tokens": left.get("output_tokens", 0) + right.get("output_tokens", 0),
+        "total_tokens": left.get("total_tokens", 0) + right.get("total_tokens", 0),
+    }

--- a/libs/fred-runtime/tests/test_graph_runtime_token_usage_totals.py
+++ b/libs/fred-runtime/tests/test_graph_runtime_token_usage_totals.py
@@ -1,0 +1,132 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Regression test for the Graph-engine token-usage undercount (TRACE-01
+follow-up) — the same bug as react_runtime.py's, at the node level: a node
+that calls the model more than once before invoking a tool must report the
+*sum* of those calls as its contribution to the turn total, not just the
+last one. `last_model_metadata` (what the executor folds into the turn
+total) must carry that sum, while the per-step attribution used by
+`ToolCallRuntimeEvent` (TRACE-01) must keep showing only the most recent
+individual call, not a running total.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fred_runtime.graph.graph_runtime import _GraphNodeExecutionContext
+from fred_sdk.contracts.context import (
+    BoundRuntimeContext,
+    PortableContext,
+    PortableEnvironment,
+    RuntimeContext,
+)
+from fred_sdk.contracts.runtime import RuntimeServices, ToolCallRuntimeEvent
+from langchain_core.tools import tool as lc_tool
+
+
+def _binding() -> BoundRuntimeContext:
+    return BoundRuntimeContext(
+        runtime_context=RuntimeContext(session_id="s", user_id="u", team_id="t"),
+        portable_context=PortableContext(
+            request_id="r",
+            correlation_id="c",
+            actor="u",
+            tenant="t",
+            environment=PortableEnvironment.DEV,
+            session_id="s",
+            user_id="u",
+            team_id="t",
+        ),
+    )
+
+
+def _node_context(runtime_tools: dict) -> _GraphNodeExecutionContext:
+    return _GraphNodeExecutionContext(
+        binding=_binding(),
+        services=RuntimeServices(),
+        model=None,
+        model_resolver=None,
+        graph_agent_id="graph-agent",
+        node_id="node-1",
+        allowed_tool_refs=frozenset(),
+        runtime_tools=runtime_tools,
+        tuning_values={},
+    )
+
+
+@lc_tool("noop_probe")
+async def _noop_probe(x: str) -> str:
+    """A tool whose only job is to let invoke_runtime_tool run."""
+    return x
+
+
+def test_last_model_metadata_sums_every_call_the_node_made() -> None:
+    ctx = _node_context({})
+
+    ctx.record_model_metadata(
+        model_name="gpt-4o",
+        token_usage={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+        finish_reason=None,
+    )
+    ctx.record_model_metadata(
+        model_name="gpt-4o",
+        token_usage={"input_tokens": 5, "output_tokens": 1, "total_tokens": 6},
+        finish_reason="stop",
+    )
+
+    model_name, token_usage, finish_reason = ctx.last_model_metadata
+
+    # The bug: this used to equal just {"input_tokens": 5, ...} (the second
+    # call alone), silently dropping the first call's 120 tokens.
+    assert token_usage == {
+        "input_tokens": 105,
+        "output_tokens": 21,
+        "total_tokens": 126,
+    }
+    assert model_name == "gpt-4o"
+    assert finish_reason == "stop"
+
+
+def test_tool_call_event_keeps_only_the_most_recent_call_not_the_running_total() -> (
+    None
+):
+    """
+    TRACE-01 per-step display must not regress into showing a node-level
+    running total: a tool call right after the node's *second* model call
+    should show only that call's usage, not the sum of both.
+    """
+
+    ctx = _node_context({"noop_probe": _noop_probe})
+
+    ctx.record_model_metadata(
+        model_name="gpt-4o",
+        token_usage={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+        finish_reason=None,
+    )
+    ctx.record_model_metadata(
+        model_name="gpt-4o",
+        token_usage={"input_tokens": 5, "output_tokens": 1, "total_tokens": 6},
+        finish_reason=None,
+    )
+
+    asyncio.run(ctx.invoke_runtime_tool("noop_probe", {"x": "y"}))
+
+    (event,) = [e for e in ctx.events if isinstance(e, ToolCallRuntimeEvent)]
+    assert event.token_usage == {
+        "input_tokens": 5,
+        "output_tokens": 1,
+        "total_tokens": 6,
+    }

--- a/libs/fred-runtime/tests/test_history.py
+++ b/libs/fred-runtime/tests/test_history.py
@@ -163,6 +163,7 @@ def test_write_turn_history_maps_react_turn_to_chat_messages() -> None:
             "call_id": "c1",
             "tool_name": "demo.echo",
             "arguments": {"text": "hi"},
+            "token_usage": {"input_tokens": 20, "output_tokens": 3, "total_tokens": 23},
         },
         {
             "kind": "tool_result",
@@ -205,6 +206,12 @@ def test_write_turn_history_maps_react_turn_to_chat_messages() -> None:
     assert messages[1].channel == Channel.tool_call
     assert messages[1].parts[0].name == "demo.echo"
     assert messages[1].rank == 1
+    # TRACE-01: usage of the model call that decided this tool call must
+    # survive into the persisted record, not just the live SSE payload —
+    # otherwise the chat trace loses its per-step token figure on reload.
+    assert messages[1].metadata.token_usage.input_tokens == 20
+    assert messages[1].metadata.token_usage.output_tokens == 3
+    assert messages[1].metadata.token_usage.total_tokens == 23
 
     # Row 2 — tool result record
     assert messages[2].role == Role.tool

--- a/libs/fred-runtime/tests/test_react_token_usage_totals.py
+++ b/libs/fred-runtime/tests/test_react_token_usage_totals.py
@@ -1,0 +1,173 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Regression test for the ReAct token-usage undercount (TRACE-01 follow-up).
+
+Why this exists:
+- a turn commonly makes several model calls: one or more tool-deciding calls,
+  then the final answer. Each provider's usage_metadata is per-call, not
+  cumulative, so FinalRuntimeEvent.token_usage must sum every call — a
+  previous rolling "last write wins" variable silently reported only the
+  last call's usage, undercounting any turn with more than one model call
+  (spotted live: summing the trace's per-step token figures gave a larger
+  total than the chat top-bar badge, which sums FinalRuntimeEvent.token_usage
+  per exchange)
+- ToolCallRuntimeEvent.token_usage (TRACE-01 per-step display) must NOT
+  become a running total in the same fix — each step should keep showing
+  only the usage of the model call that decided that specific step
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from fred_runtime.react.react_runtime import _TransportBackedReActExecutor
+from fred_sdk.contracts.react_contract import ReActInput, ReActMessage, ReActMessageRole
+from fred_sdk.contracts.runtime import (
+    ExecutionConfig,
+    FinalRuntimeEvent,
+    ToolCallRuntimeEvent,
+)
+from langchain_core.messages import AIMessage, ToolMessage
+
+
+class _FakePortable:
+    agent_id = "agent-1"
+    session_id = "sess-1"
+    team_id = "personal"
+    baggage: dict[str, object] = {}
+
+
+class _FakeRuntimeContext:
+    pass
+
+
+class _FakeBinding:
+    portable_context = _FakePortable()
+    runtime_context = _FakeRuntimeContext()
+
+
+class _FakeServices:
+    tracer = None
+    metrics = None
+
+
+class _FakeCompiledAgent:
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+
+    async def astream(
+        self,
+        graph_input: object,
+        *,
+        config: object = None,
+        stream_mode: object = None,
+    ) -> AsyncIterator[object]:
+        for event in self._events:
+            yield event
+
+
+async def _run_stream(events: list[object]) -> list[object]:
+    executor = _TransportBackedReActExecutor(
+        compiled_agent=_FakeCompiledAgent(events),  # type: ignore[arg-type]
+        binding=_FakeBinding(),  # type: ignore[arg-type]
+        services=_FakeServices(),  # type: ignore[arg-type]
+    )
+    input_model = ReActInput(
+        messages=(ReActMessage(role=ReActMessageRole.USER, content="hi"),)
+    )
+    collected: list[object] = []
+    async for event in executor.stream(input_model, ExecutionConfig()):
+        collected.append(event)
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_final_token_usage_sums_every_model_call_not_just_the_last() -> None:
+    tool_call = AIMessage(
+        content="",
+        tool_calls=[{"id": "call-1", "name": "read_query", "args": {}}],
+        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+    )
+    tool_result = ToolMessage(content="ok", tool_call_id="call-1", name="read_query")
+    final_message = AIMessage(
+        content="done",
+        usage_metadata={"input_tokens": 30, "output_tokens": 10, "total_tokens": 40},
+    )
+
+    events = [
+        ("updates", {"agent": {"messages": [tool_call]}}),
+        ("updates", {"tools": {"messages": [tool_result]}}),
+        ("updates", {"agent": {"messages": [final_message]}}),
+    ]
+
+    collected = await _run_stream(events)
+
+    finals = [e for e in collected if isinstance(e, FinalRuntimeEvent)]
+    assert len(finals) == 1
+    # The bug: this used to equal just {"input_tokens": 30, ...} (the final
+    # call alone), silently dropping the tool-deciding call's 120 tokens.
+    assert finals[0].token_usage == {
+        "input_tokens": 130,
+        "output_tokens": 30,
+        "total_tokens": 160,
+    }
+
+
+@pytest.mark.asyncio
+async def test_tool_call_event_keeps_only_its_own_triggering_call_usage() -> None:
+    """
+    The turn-total fix must not turn the per-step (TRACE-01) figure into a
+    running total: each ToolCallRuntimeEvent should show only the usage of
+    the model call that decided that one step, even once a later step's
+    usage has been folded into the turn total.
+    """
+
+    first_call = AIMessage(
+        content="",
+        tool_calls=[{"id": "call-1", "name": "read_query", "args": {}}],
+        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+    )
+    first_result = ToolMessage(content="ok", tool_call_id="call-1", name="read_query")
+    second_call = AIMessage(
+        content="",
+        tool_calls=[{"id": "call-2", "name": "read_query", "args": {}}],
+        usage_metadata={"input_tokens": 5, "output_tokens": 1, "total_tokens": 6},
+    )
+    second_result = ToolMessage(content="ok", tool_call_id="call-2", name="read_query")
+    final_message = AIMessage(content="done")
+
+    events = [
+        ("updates", {"agent": {"messages": [first_call]}}),
+        ("updates", {"tools": {"messages": [first_result]}}),
+        ("updates", {"agent": {"messages": [second_call]}}),
+        ("updates", {"tools": {"messages": [second_result]}}),
+        ("updates", {"agent": {"messages": [final_message]}}),
+    ]
+
+    collected = await _run_stream(events)
+
+    tool_calls = [e for e in collected if isinstance(e, ToolCallRuntimeEvent)]
+    assert len(tool_calls) == 2
+    assert tool_calls[0].token_usage == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "total_tokens": 120,
+    }
+    assert tool_calls[1].token_usage == {
+        "input_tokens": 5,
+        "output_tokens": 1,
+        "total_tokens": 6,
+    }

--- a/libs/fred-sdk/fred_sdk/contracts/runtime.py
+++ b/libs/fred-sdk/fred_sdk/contracts/runtime.py
@@ -183,6 +183,10 @@ class ToolCallRuntimeEvent(RuntimeEventBase):
     tool_name: str = Field(..., min_length=1)
     call_id: str = Field(..., min_length=1)
     arguments: dict[str, object] = Field(default_factory=dict)
+    # Usage of the model call that decided to make this tool call — the
+    # runtime's per-call `usage_metadata`, captured just before this event is
+    # emitted. None when the provider didn't report usage for that call.
+    token_usage: dict[str, int] | None = None
 
 
 class ToolResultRuntimeEvent(RuntimeEventBase):


### PR DESCRIPTION
## Summary

- Composer polish: initial-state composer stacked vertically, textarea `min-height`/`padding-top` cleanup, tighter gap between the add/tune buttons.
- Chat top bar: total conversation token-usage badge, guaranteed minimum gap between the title and actions so the rename button never overlaps them.
- Auto-scroll fix: the message list no longer follows the bottom while the agent is streaming — only the user's own scroll moves the viewport (still jumps to bottom on a new turn / on open).
- Chain-of-thought redesign: step number moves after the status dot, dot resized so the 1px rail centers on a whole pixel, rows get a fixed height/padding and are wrapped in a card, and the rail no longer blinks — only the dot itself signals an in-progress step.
- **TRACE-01**: per-step token usage in the chain of thought, for both ReAct and Graph agents, live and persisted (so it survives a page refresh, not just the live stream). See `docs/swift/rfc/TRACE-TOKEN-USAGE-RFC.md` and `RUNTIME-EXECUTION-CONTRACT.md` §8.38.
- **Bug fix found while validating TRACE-01 live**: the chat top-bar token total (and `FinalRuntimeEvent.token_usage` generally) only reflected the *last* model call of a turn instead of summing every call — undercounting any turn with more than one model call. Fixed in both engines, see §8.39.
- `libs/fred-runtime`'s `openapi.json` → `apps/frontend/src/slices/runtime/runtimeOpenApi.ts` regenerated via `apps/frontend`'s `make update-runtime-api` for the new `ToolCallRuntimeEvent.token_usage` field.

Closes #2217.

## Test plan

- [x] `make code-quality` green: `fred-sdk`, `fred-core`, `fred-runtime`, `apps/frontend`
- [x] `make test` green: `fred-sdk` (244), `fred-core` (435), `fred-runtime` (718, incl. 2 new regression suites for the token-usage sum fix), `apps/frontend` (985)
- [x] `fred-performance-reviewer` pass on both the TRACE-01 change and the undercount fix: no findings (pure data threading on an already-async hot path, no new I/O/blocking calls/metrics)
- [ ] Manual smoke test in the running app: send a multi-tool-call message, confirm per-step token counts appear in the chain of thought and the top-bar total now equals their sum

🤖 Generated with [Claude Code](https://claude.com/claude-code)