### PR TITLE
fix(control-plane-backend): cache per-capability ReBAC relation reads (#2181)

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
@@ -325,22 +325,31 @@ async def enable_capability_for_team(
     )
     # 2. Authorization half: anchor, clear any opt-out, then grant.
     await ensure_capability_anchor(rebac, catalog_entry.id)
-    await rebac.delete_relation(
-        Relation(
-            subject=_team_ref(team_id),
-            relation=RelationType.DISABLED,
-            resource=cap_ref(catalog_entry.id),
+    try:
+        await rebac.delete_relation(
+            Relation(
+                subject=_team_ref(team_id),
+                relation=RelationType.DISABLED,
+                resource=cap_ref(catalog_entry.id),
+            )
         )
-    )
-    await rebac.add_relation(
-        Relation(
-            subject=_team_ref(team_id),
-            relation=RelationType.ENABLED,
-            resource=cap_ref(catalog_entry.id),
-        ),
-        actor_uid=updated_by,
-    )
-    invalidate_capability_relations_cache(catalog_entry.id)
+        await rebac.add_relation(
+            Relation(
+                subject=_team_ref(team_id),
+                relation=RelationType.ENABLED,
+                resource=cap_ref(catalog_entry.id),
+            ),
+            actor_uid=updated_by,
+        )
+    finally:
+        # Codex review (#2181 PR): the `delete` above can succeed and the
+        # `add` still raise — invalidating only after both means a cached
+        # reader keeps reporting the pre-write (disabled) state for a full
+        # TTL despite OpenFGA's state having already changed. `finally`
+        # covers that half-failure the same way a full success does; an
+        # extra invalidate on the (rarer) all-writes-failed path just costs
+        # one avoidable refetch, never a correctness problem.
+        invalidate_capability_relations_cache(catalog_entry.id)
     logger.info(
         "[capability-enablement] enabled capability=%s team=%s by=%s",
         catalog_entry.id,
@@ -371,22 +380,27 @@ async def disable_capability_for_team(
     instances suspended.
     """
 
-    await rebac.delete_relation(
-        Relation(
-            subject=_team_ref(team_id),
-            relation=RelationType.ENABLED,
-            resource=cap_ref(catalog_entry.id),
+    try:
+        await rebac.delete_relation(
+            Relation(
+                subject=_team_ref(team_id),
+                relation=RelationType.ENABLED,
+                resource=cap_ref(catalog_entry.id),
+            )
         )
-    )
-    await rebac.add_relation(
-        Relation(
-            subject=_team_ref(team_id),
-            relation=RelationType.DISABLED,
-            resource=cap_ref(catalog_entry.id),
-        ),
-        actor_uid=updated_by,
-    )
-    invalidate_capability_relations_cache(catalog_entry.id)
+        await rebac.add_relation(
+            Relation(
+                subject=_team_ref(team_id),
+                relation=RelationType.DISABLED,
+                resource=cap_ref(catalog_entry.id),
+            ),
+            actor_uid=updated_by,
+        )
+    finally:
+        # See `enable_capability_for_team`'s matching comment (Codex review,
+        # #2181 PR): a half-failure between the two writes must not leave a
+        # cached reader reporting the pre-write (enabled) state for a TTL.
+        invalidate_capability_relations_cache(catalog_entry.id)
     del settings_store  # settings row is intentionally retained (re-enable restores)
     return await suspend_dependent_instances(
         agent_instance_store=agent_instance_store,
@@ -416,21 +430,26 @@ async def reset_capability_for_team(
     number of instances suspended.
     """
 
-    await rebac.delete_relation(
-        Relation(
-            subject=_team_ref(team_id),
-            relation=RelationType.ENABLED,
-            resource=cap_ref(catalog_entry.id),
+    try:
+        await rebac.delete_relation(
+            Relation(
+                subject=_team_ref(team_id),
+                relation=RelationType.ENABLED,
+                resource=cap_ref(catalog_entry.id),
+            )
         )
-    )
-    await rebac.delete_relation(
-        Relation(
-            subject=_team_ref(team_id),
-            relation=RelationType.DISABLED,
-            resource=cap_ref(catalog_entry.id),
+        await rebac.delete_relation(
+            Relation(
+                subject=_team_ref(team_id),
+                relation=RelationType.DISABLED,
+                resource=cap_ref(catalog_entry.id),
+            )
         )
-    )
-    invalidate_capability_relations_cache(catalog_entry.id)
+    finally:
+        # See `enable_capability_for_team`'s matching comment (Codex review,
+        # #2181 PR): a half-failure between the two deletes must not leave a
+        # cached reader reporting the pre-write state for a TTL.
+        invalidate_capability_relations_cache(catalog_entry.id)
     if default_on:
         return 0
     return await suspend_dependent_instances(
@@ -674,25 +693,29 @@ async def set_capability_default_on(
                 "cannot be default-on."
             )
         await ensure_capability_anchor(rebac, catalog_entry.id)
-        await rebac.add_relation(
+        try:
+            await rebac.add_relation(
+                Relation(
+                    subject=ORG_REF,
+                    relation=RelationType.DEFAULT_ON,
+                    resource=cap_ref(catalog_entry.id),
+                ),
+                actor_uid=updated_by,
+            )
+        finally:
+            invalidate_capability_relations_cache(catalog_entry.id)
+        return 0
+
+    try:
+        await rebac.delete_relation(
             Relation(
                 subject=ORG_REF,
                 relation=RelationType.DEFAULT_ON,
                 resource=cap_ref(catalog_entry.id),
-            ),
-            actor_uid=updated_by,
+            )
         )
+    finally:
         invalidate_capability_relations_cache(catalog_entry.id)
-        return 0
-
-    await rebac.delete_relation(
-        Relation(
-            subject=ORG_REF,
-            relation=RelationType.DEFAULT_ON,
-            resource=cap_ref(catalog_entry.id),
-        )
-    )
-    invalidate_capability_relations_cache(catalog_entry.id)
     # Teams with an explicit grant keep access; everyone else loses inherited
     # use — whether they used it as a tool or as a `kind="agent"` template
     # (2026-07-19, GitHub #2004 item 1).
@@ -816,16 +839,22 @@ async def _apply_personal_scope_tuples(
         relation=RelationType.PERSONAL_DISABLED,
         resource=cap_ref(capability_id),
     )
-    if want_on:
-        await rebac.add_relation(on_relation, actor_uid=updated_by)
-        await rebac.delete_relation(disabled_relation)
-    elif want_disabled:
-        await rebac.add_relation(disabled_relation, actor_uid=updated_by)
-        await rebac.delete_relation(on_relation)
-    else:  # default → clear both
-        await rebac.delete_relation(on_relation)
-        await rebac.delete_relation(disabled_relation)
-    invalidate_capability_relations_cache(capability_id)
+    try:
+        if want_on:
+            await rebac.add_relation(on_relation, actor_uid=updated_by)
+            await rebac.delete_relation(disabled_relation)
+        elif want_disabled:
+            await rebac.add_relation(disabled_relation, actor_uid=updated_by)
+            await rebac.delete_relation(on_relation)
+        else:  # default → clear both
+            await rebac.delete_relation(on_relation)
+            await rebac.delete_relation(disabled_relation)
+    finally:
+        # See `enable_capability_for_team`'s matching comment (Codex review,
+        # #2181 PR): each branch here is two writes — a half-failure between
+        # them must not leave a cached reader reporting the pre-write
+        # personal-scope state for a TTL.
+        invalidate_capability_relations_cache(capability_id)
 
 
 _CAPABILITY_RELATIONS_CACHE_TTL_SECONDS = 45
@@ -944,9 +973,17 @@ async def has_org_relation(
     multi-replica admin actions. Still backed by `list_direct_relations`
     (a `Read`) rather than `lookup_subjects` (`ListUsers`) — cheaper per call
     even uncached (#2065's finding: `Read` is the cheaper primitive).
+
+    Codex review (#2181 PR): narrowed to `subject=ORG_REF` so OpenFGA filters
+    server-side to the handful of org-subject tuples instead of transferring
+    and paginating through every team's `enabled`/`disabled` grant merely to
+    answer one org-marker question — matters once a capability has grants
+    across many teams.
     """
 
-    relations = await rebac.list_direct_relations(cap_ref(capability_id))
+    relations = await rebac.list_direct_relations(
+        cap_ref(capability_id), subject=ORG_REF
+    )
     return ORGANIZATION_ID in capability_relation_subjects(
         relations, relation, Resource.ORGANIZATION
     )

--- a/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
@@ -33,9 +33,10 @@ here so the RFC invariants hold in exactly one spot:
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterable, Literal, Mapping
+import time
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping
 
-from fred_core.common import TeamId, is_personal_team_id
+from fred_core.common import TeamId, ThreadSafeLRUCache, is_personal_team_id
 from fred_core.kpi.base_kpi_writer import BaseKPIWriter
 from fred_core.security.models import Resource
 from fred_core.security.rebac.rebac_engine import (
@@ -62,6 +63,14 @@ from control_plane_backend.capabilities.authz import usable_capability_ids
 from control_plane_backend.capabilities.settings_store import (
     TeamCapabilitySettingsStore,
 )
+
+if TYPE_CHECKING:
+    # Only ever imported lazily at runtime (see `has_org_relation`/
+    # `capability_relation_subjects` below) to avoid a `fred_core` import
+    # cycle; a `TYPE_CHECKING`-guarded import is enough for the type
+    # annotations that reference it (`__future__` annotations mean the
+    # annotation is never evaluated at runtime either way).
+    from fred_core import RebacDisabledResult
 
 logger = logging.getLogger(__name__)
 
@@ -331,6 +340,7 @@ async def enable_capability_for_team(
         ),
         actor_uid=updated_by,
     )
+    invalidate_capability_relations_cache(catalog_entry.id)
     logger.info(
         "[capability-enablement] enabled capability=%s team=%s by=%s",
         catalog_entry.id,
@@ -376,6 +386,7 @@ async def disable_capability_for_team(
         ),
         actor_uid=updated_by,
     )
+    invalidate_capability_relations_cache(catalog_entry.id)
     del settings_store  # settings row is intentionally retained (re-enable restores)
     return await suspend_dependent_instances(
         agent_instance_store=agent_instance_store,
@@ -419,6 +430,7 @@ async def reset_capability_for_team(
             resource=cap_ref(catalog_entry.id),
         )
     )
+    invalidate_capability_relations_cache(catalog_entry.id)
     if default_on:
         return 0
     return await suspend_dependent_instances(
@@ -670,6 +682,7 @@ async def set_capability_default_on(
             ),
             actor_uid=updated_by,
         )
+        invalidate_capability_relations_cache(catalog_entry.id)
         return 0
 
     await rebac.delete_relation(
@@ -679,6 +692,7 @@ async def set_capability_default_on(
             resource=cap_ref(catalog_entry.id),
         )
     )
+    invalidate_capability_relations_cache(catalog_entry.id)
     # Teams with an explicit grant keep access; everyone else loses inherited
     # use — whether they used it as a tool or as a `kind="agent"` template
     # (2026-07-19, GitHub #2004 item 1).
@@ -811,24 +825,131 @@ async def _apply_personal_scope_tuples(
     else:  # default → clear both
         await rebac.delete_relation(on_relation)
         await rebac.delete_relation(disabled_relation)
+    invalidate_capability_relations_cache(capability_id)
+
+
+_CAPABILITY_RELATIONS_CACHE_TTL_SECONDS = 45
+_CAPABILITY_RELATIONS_CACHE: ThreadSafeLRUCache[
+    str, tuple[float, list[Relation] | RebacDisabledResult]
+] = ThreadSafeLRUCache(max_size=2000)
+# Mirrors `teams/service.py`'s `_TEAM_RELATIONS_LAST_INVALIDATED` (#2160
+# review): a read in flight when a write invalidates must not resurrect the
+# pre-write snapshot it already had in hand — see the race-guard comment in
+# `get_capability_relations_cached` below.
+_CAPABILITY_RELATIONS_LAST_INVALIDATED: ThreadSafeLRUCache[str, float] = (
+    ThreadSafeLRUCache(max_size=2000)
+)
+
+
+def invalidate_capability_relations_cache(capability_id: str) -> None:
+    """Drop the cached `list_direct_relations` result for one capability
+    (#2181).
+
+    Every relation-mutating call in this module (enable/disable/reset a
+    team's grant, the default-on toggle, the personal-scope toggle) calls
+    this right after its write succeeds, mirroring `teams/service.py`'s
+    `invalidate_team_relations_cache`.
+    """
+
+    _CAPABILITY_RELATIONS_CACHE.delete(capability_id)
+    _CAPABILITY_RELATIONS_LAST_INVALIDATED.set(capability_id, time.time())
+
+
+async def get_capability_relations_cached(
+    rebac: RebacEngine, capability_id: str
+) -> "list[Relation] | RebacDisabledResult":
+    """Cached `list_direct_relations(capability:<capability_id>)`, TTL-bounded
+    (#2181, follow-up to #2089).
+
+    #2089 made `GET /admin/capabilities`'s per-row ReBAC reads concurrent but
+    did not reduce their count: each row still fired up to 5 individual
+    `lookup_subjects` (OpenFGA `ListUsers`) round-trips — `enabled`/`disabled`
+    team grants plus `default_on`/`personal_on`/`personal_disabled` org
+    markers — for ~87 catalog capabilities, ~175 calls per page load. All 5
+    answers live on the SAME literal tuple set (this one capability as
+    object, no relation filter), so — mirroring `_bulk_team_membership`'s
+    #2065/#2148 fix for the equivalent team-membership fan-out — one exact
+    `list_direct_relations` `Read` per capability replaces them all; callers
+    fold the returned tuples locally (`capability_relation_subjects`) instead
+    of letting OpenFGA filter server-side. Layered with the same short TTL
+    (45s) write-invalidated cache shape as `_get_team_relations_cached`.
+
+    Race guard, identical to `_get_team_relations_cached`: `read_started_at`
+    is captured before the `await`; if `invalidate_capability_relations_cache`
+    ran for this capability at or after that moment, the freshly fetched
+    result is provably stale and is returned without being published into the
+    cache, so a concurrent write's invalidation is never silently undone for
+    a full TTL.
+    """
+
+    read_started_at = time.time()
+    cached = _CAPABILITY_RELATIONS_CACHE.get(capability_id)
+    if cached is not None:
+        expires_at, relations = cached
+        if expires_at > read_started_at:
+            return relations
+        _CAPABILITY_RELATIONS_CACHE.delete(capability_id)
+
+    relations = await rebac.list_direct_relations(cap_ref(capability_id))
+
+    last_invalidated = _CAPABILITY_RELATIONS_LAST_INVALIDATED.get(capability_id)
+    if last_invalidated is not None and last_invalidated >= read_started_at:
+        return relations
+
+    _CAPABILITY_RELATIONS_CACHE.set(
+        capability_id,
+        (read_started_at + _CAPABILITY_RELATIONS_CACHE_TTL_SECONDS, relations),
+    )
+    return relations
+
+
+def capability_relation_subjects(
+    relations: "list[Relation] | RebacDisabledResult",
+    relation: RelationType,
+    subject_type: Resource,
+) -> set[str]:
+    """Fold one capability's already-fetched relation set down to the subject
+    ids holding `relation`, filtered to `subject_type` (#2181) — the
+    local-filter counterpart of a `lookup_subjects` call, over a
+    `list_direct_relations` result. Empty when ReBAC is disabled."""
+
+    from fred_core import RebacDisabledResult
+
+    if isinstance(relations, RebacDisabledResult):
+        return set()
+    return {
+        rel.subject.id
+        for rel in relations
+        if rel.relation == relation and rel.subject.type == subject_type
+    }
 
 
 async def has_org_relation(
     rebac: RebacEngine, capability_id: str, relation: RelationType
 ) -> bool:
     """True when the singleton org holds `relation` on the capability (used to
-    read back the class/default-on org-subject markers)."""
+    read back the class/default-on org-subject markers).
 
-    from fred_core import RebacDisabledResult
+    #2181: every remaining caller of this function is a write-path
+    peek-before-mutate decision (`reset_team_capability`'s suspend/revive
+    branch, `set_personal_scope`'s access-transition detection, the
+    `depends_on` dependency gate, `set_capability_personal_scope`'s
+    had_access/has_access peek) — the read-only listing path
+    (`_build_enablement_item`) fetches and folds the relation set directly and
+    never calls this. Deliberately NOT routed through
+    `get_capability_relations_cached`: those decisions must see the current
+    OpenFGA state, not a state up to 45s stale from another replica's write —
+    caching here would buy the listing endpoint nothing (it doesn't call this)
+    while risking a wrong suspend/revive/reject call under concurrent
+    multi-replica admin actions. Still backed by `list_direct_relations`
+    (a `Read`) rather than `lookup_subjects` (`ListUsers`) — cheaper per call
+    even uncached (#2065's finding: `Read` is the cheaper primitive).
+    """
 
-    subjects = await rebac.lookup_subjects(
-        cap_ref(capability_id),
-        relation,
-        Resource.ORGANIZATION,
+    relations = await rebac.list_direct_relations(cap_ref(capability_id))
+    return ORGANIZATION_ID in capability_relation_subjects(
+        relations, relation, Resource.ORGANIZATION
     )
-    if isinstance(subjects, RebacDisabledResult):
-        return False
-    return any(ref.id == ORGANIZATION_ID for ref in subjects)
 
 
 async def _suspend_personal_dependents(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -29,7 +29,12 @@ from typing import Any, Mapping
 from fred_core import CapabilityPermission, KeycloakUser, RebacDisabledResult
 from fred_core.common import TeamId, is_personal_team_id
 from fred_core.security.models import Resource
-from fred_core.security.rebac.rebac_engine import RebacEngine, RelationType
+from fred_core.security.rebac.rebac_engine import (
+    ORGANIZATION_ID,
+    RebacEngine,
+    Relation,
+    RelationType,
+)
 from fred_sdk.contracts.capability import CapabilityCatalogEntry
 from fred_sdk.contracts.capability.manifest import (
     MODEL_CAPABILITY_NAMESPACE_PREFIX,
@@ -41,9 +46,11 @@ from control_plane_backend.capabilities.enablement import (
     CapabilityNotFound,
     ReasoningNotSupported,
     cap_ref,
+    capability_relation_subjects,
     disable_capability_for_team,
     enable_capability_for_team,
     ensure_capability_anchor,
+    get_capability_relations_cached,
     has_org_relation,
     is_template_capability_instance,
     reset_capability_for_team,
@@ -146,27 +153,41 @@ def _catalog_entry_for_revoke(
     )
 
 
-async def _teams_with_relation(
-    rebac: RebacEngine, capability_id: str, relation: RelationType
-) -> list[str]:
-    subjects = await rebac.lookup_subjects(
-        cap_ref(capability_id), relation, Resource.TEAM
-    )
-    if isinstance(subjects, RebacDisabledResult):
-        return []
-    return sorted(ref.id for ref in subjects)
+def _fold_personal_scope(
+    relations: list[Relation] | RebacDisabledResult,
+) -> PersonalScope:
+    """Derive the personal-space class tri-state from the two org-subject
+    tuples (RFC §8.4), folded from an already-fetched relation set. `enabled`
+    wins if both are somehow present (matches the FGA setter, which never
+    leaves both)."""
+
+    if ORGANIZATION_ID in capability_relation_subjects(
+        relations, RelationType.PERSONAL_ON, Resource.ORGANIZATION
+    ):
+        return "enabled"
+    if ORGANIZATION_ID in capability_relation_subjects(
+        relations, RelationType.PERSONAL_DISABLED, Resource.ORGANIZATION
+    ):
+        return "disabled"
+    return "default"
 
 
 async def _read_personal_scope(rebac: RebacEngine, capability_id: str) -> PersonalScope:
-    """Derive the personal-space class tri-state from the two org-subject tuples
-    (RFC §8.4). `enabled` wins if both are somehow present (matches the FGA
-    setter, which never leaves both)."""
+    """Derive the personal-space class tri-state for one capability (RFC §8.4).
 
-    if await has_org_relation(rebac, capability_id, RelationType.PERSONAL_ON):
-        return "enabled"
-    if await has_org_relation(rebac, capability_id, RelationType.PERSONAL_DISABLED):
-        return "disabled"
-    return "default"
+    #2181: its only caller left is `set_personal_scope`'s peek-before-mutate
+    (`scope_before`, used to detect the access-transition that decides
+    whether to revive suspended dependents) — a write-path decision, so this
+    deliberately does NOT go through `get_capability_relations_cached` (see
+    `has_org_relation`'s docstring for why: caching here would risk acting on
+    up to 45s-stale state from another replica's write, for no benefit to the
+    read-only listing path, which never calls this). Still `list_direct_
+    relations` (a `Read`), not `lookup_subjects` (`ListUsers`) — cheaper per
+    call even uncached.
+    """
+
+    relations = await rebac.list_direct_relations(cap_ref(capability_id))
+    return _fold_personal_scope(relations)
 
 
 async def _build_enablement_item(
@@ -178,24 +199,31 @@ async def _build_enablement_item(
     impact: Mapping[str, CapabilityImpact],
     reasoning_enabled_ids: frozenset[str],
 ) -> CapabilityEnablementItem:
-    """Build one row's ReBAC-derived fields (#2089).
+    """Build one row's ReBAC-derived fields.
 
-    The 4 lookups below are independent `lookup_subjects` reads on different
-    relations of the same capability — gathering them turns 4 sequential
-    OpenFGA round-trips per row into 1.
+    #2089: originally 4 concurrent `lookup_subjects` reads per row. #2181
+    follow-up: `enabled`/`disabled` team grants and `default_on`/personal-scope
+    org markers all live on the SAME literal tuple set for this capability, so
+    they no longer need 4 separate OpenFGA round-trips (5, counting
+    `_read_personal_scope`'s own pair) — one cached `list_direct_relations`
+    Read (`get_capability_relations_cached`) is fetched ONCE here and folded
+    locally, the same "fetch once, derive many" shape `_bulk_team_membership`/
+    `_fold_team_role_relations` already use for teams. Fetching once (instead
+    of gathering several calls that would each independently race the same
+    cache key) also avoids a per-row thundering herd on a cold cache.
     """
 
-    (
-        default_on,
-        enabled_team_ids,
-        disabled_team_ids,
-        personal_scope,
-    ) = await asyncio.gather(
-        has_org_relation(rebac, entry.id, RelationType.DEFAULT_ON),
-        _teams_with_relation(rebac, entry.id, RelationType.ENABLED),
-        _teams_with_relation(rebac, entry.id, RelationType.DISABLED),
-        _read_personal_scope(rebac, entry.id),
+    relations = await get_capability_relations_cached(rebac, entry.id)
+    default_on = ORGANIZATION_ID in capability_relation_subjects(
+        relations, RelationType.DEFAULT_ON, Resource.ORGANIZATION
     )
+    enabled_team_ids = sorted(
+        capability_relation_subjects(relations, RelationType.ENABLED, Resource.TEAM)
+    )
+    disabled_team_ids = sorted(
+        capability_relation_subjects(relations, RelationType.DISABLED, Resource.TEAM)
+    )
+    personal_scope = _fold_personal_scope(relations)
     entry_impact = impact.get(entry.id)
     return CapabilityEnablementItem(
         id=entry.id,
@@ -281,7 +309,11 @@ async def list_capability_enablement(
         )
     reasoning_enabled_ids = frozenset(reasoning_enabled_ids)
     # Per-row ReBAC reads are independent across rows too (#2089) — gather
-    # every row's build instead of awaiting them one at a time.
+    # every row's build instead of awaiting them one at a time. #2181: each
+    # row's build is now also a single cached `list_direct_relations` Read
+    # (see `_build_enablement_item`) instead of several `lookup_subjects`
+    # calls, so this outer gather now bounds ~87 concurrent Reads on a cold
+    # cache (0 on a warm one) rather than ~175 concurrent ListUsers calls.
     items = list(
         await asyncio.gather(
             *(
@@ -305,7 +337,6 @@ async def _require_manage_any(rebac: RebacEngine, user: KeycloakUser) -> None:
     """Org-admin gate for the aggregate list (equivalent to `can_manage`)."""
 
     from fred_core import OrganizationPermission
-    from fred_core.security.rebac.rebac_engine import ORGANIZATION_ID
 
     await rebac.check_user_permission_or_raise(
         user, OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -43,6 +43,7 @@ from fred_sdk.contracts.capability.manifest import (
 
 from control_plane_backend.capabilities.catalog import aggregate_capability_catalog
 from control_plane_backend.capabilities.enablement import (
+    ORG_REF,
     CapabilityNotFound,
     ReasoningNotSupported,
     cap_ref,
@@ -184,9 +185,15 @@ async def _read_personal_scope(rebac: RebacEngine, capability_id: str) -> Person
     read-only listing path, which never calls this). Still `list_direct_
     relations` (a `Read`), not `lookup_subjects` (`ListUsers`) — cheaper per
     call even uncached.
+
+    Codex review (#2181 PR): narrowed to `subject=ORG_REF`, same reasoning as
+    `has_org_relation` — this only ever needs the org-subject tuples, not
+    every team's grant on the capability.
     """
 
-    relations = await rebac.list_direct_relations(cap_ref(capability_id))
+    relations = await rebac.list_direct_relations(
+        cap_ref(capability_id), subject=ORG_REF
+    )
     return _fold_personal_scope(relations)
 
 

--- a/apps/control-plane-backend/tests/conftest.py
+++ b/apps/control-plane-backend/tests/conftest.py
@@ -53,7 +53,7 @@ def _clear_module_level_caches() -> None:
     module-level singletons with a real TTL (45s / 5min) — without this, a
     test asserting a real fan-out call count (e.g.
     `test_teams_bulk_membership_call_count.py`,
-    `test_capability_relations_cache.py`) could silently pass fewer calls
+    `test_capability_relations_cache_2181.py`) could silently pass fewer calls
     than expected because an earlier test in the same session already warmed
     the cache for an overlapping team/capability id (both use predictable ids
     like `team-0`, `corp_drive`, ...).

--- a/apps/control-plane-backend/tests/conftest.py
+++ b/apps/control-plane-backend/tests/conftest.py
@@ -45,19 +45,24 @@ def _setup_test_schema() -> None:
 
 @pytest.fixture(autouse=True)
 def _clear_module_level_caches() -> None:
-    """Reset the #2148 team-membership/user-summary caches before every test.
+    """Reset the #2148/#2181 relation/user-summary caches before every test.
 
-    Both `control_plane_backend.teams.service._TEAM_RELATIONS_CACHE` and
-    `control_plane_backend.users.service._USER_SUMMARY_CACHE` are
+    `control_plane_backend.teams.service._TEAM_RELATIONS_CACHE`,
+    `control_plane_backend.capabilities.enablement._CAPABILITY_RELATIONS_CACHE`,
+    and `control_plane_backend.users.service._USER_SUMMARY_CACHE` are
     module-level singletons with a real TTL (45s / 5min) — without this, a
     test asserting a real fan-out call count (e.g.
-    `test_teams_bulk_membership_call_count.py`) could silently pass fewer
-    calls than expected because an earlier test in the same session already
-    warmed the cache for an overlapping team/user id (both use predictable
-    ids like `team-0`, `team-1`, ...).
+    `test_teams_bulk_membership_call_count.py`,
+    `test_capability_relations_cache.py`) could silently pass fewer calls
+    than expected because an earlier test in the same session already warmed
+    the cache for an overlapping team/capability id (both use predictable ids
+    like `team-0`, `corp_drive`, ...).
     """
+    from control_plane_backend.capabilities import enablement as capabilities_enablement
     from control_plane_backend.teams import service as teams_service
     from control_plane_backend.users import service as users_service
 
     teams_service._TEAM_RELATIONS_CACHE.clear()
+    capabilities_enablement._CAPABILITY_RELATIONS_CACHE.clear()
+    capabilities_enablement._CAPABILITY_RELATIONS_LAST_INVALIDATED.clear()
     users_service._USER_SUMMARY_CACHE.clear()

--- a/apps/control-plane-backend/tests/test_capability_enablement_1980.py
+++ b/apps/control-plane-backend/tests/test_capability_enablement_1980.py
@@ -125,6 +125,36 @@ class _FakeRebac:
                 out.append(RebacReference(type=subject_type, id=user.split(":", 1)[1]))
         return out
 
+    async def list_direct_relations(
+        self, resource, *, subject=None, consistency_token=None
+    ):
+        """#2181: `has_org_relation`/`_read_personal_scope`/`_build_enablement_item`
+        now read the exact-object `Read` shape instead of `lookup_subjects` —
+        same recorded `self.tuples` state, filtered locally exactly like
+        `capability_relation_subjects` does against the real engine."""
+        if not self._enabled:
+            return RebacDisabledResult()
+        obj = f"{resource.type.value}:{resource.id}"
+        out = []
+        for user, rel, o in self.tuples:
+            if o != obj:
+                continue
+            subject_type_str, subject_id = user.split(":", 1)
+            if subject is not None and (
+                subject.type.value != subject_type_str or subject.id != subject_id
+            ):
+                continue
+            out.append(
+                Relation(
+                    subject=RebacReference(
+                        type=Resource(subject_type_str), id=subject_id
+                    ),
+                    relation=RelationType(rel),
+                    resource=resource,
+                )
+            )
+        return out
+
     async def lookup_resources(
         self, subject, permission, resource_type, *, contextual_relations=None
     ):

--- a/apps/control-plane-backend/tests/test_capability_relations_cache_2181.py
+++ b/apps/control-plane-backend/tests/test_capability_relations_cache_2181.py
@@ -1,0 +1,252 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression coverage for #2181: `GET /admin/capabilities` was firing up to 5
+individual `lookup_subjects` (OpenFGA `ListUsers`) round-trips per row
+(`enabled`/`disabled` team grants, `default_on`/`personal_on`/
+`personal_disabled` org markers) — ~175 calls for the ~87-capability catalog.
+
+Mirrors `test_teams_bulk_membership_call_count.py`'s shape for the equivalent
+#2065/#2148 team-membership fan-out: a real, call-counting `RebacEngine`
+(`CountingRebacEngine`, which raises if `lookup_subjects`/`ListUsers` is ever
+called) proves the row build now uses exactly one exact
+`list_direct_relations` `Read` per capability, cached with a 45s
+write-invalidated TTL.
+
+Also covers the performance-review correction on top of the first pass at this
+fix: `has_org_relation` (and `_read_personal_scope`) ended up used ONLY by
+write-path peek-before-mutate decisions once `_build_enablement_item` was
+rewritten to fold its own single fetch locally — caching those would have
+bought the read-only listing path nothing while risking a stale suspend/
+revive/reject decision under concurrent multi-replica admin actions. They
+deliberately bypass the cache (still `list_direct_relations`, never
+`lookup_subjects` — cheaper per call even uncached).
+"""
+
+# pyright: reportArgumentType=false
+# ^ this suite passes a minimal settings-store fake into `enable_capability_for_team`
+#   on purpose (only `upsert` is ever called on this code path).
+from __future__ import annotations
+
+import time as time_module
+
+import pytest
+from _rebac_test_doubles import CountingRebacEngine
+from control_plane_backend.capabilities import enablement
+from control_plane_backend.capabilities.enablement import (
+    cap_ref,
+    enable_capability_for_team,
+)
+from control_plane_backend.capabilities.service import _build_enablement_item
+from fred_core import ORGANIZATION_ID, RebacReference, Relation, RelationType, Resource
+from fred_core.common import TeamId
+from fred_sdk.contracts.capability import CapabilityCatalogEntry
+from fred_sdk.contracts.capability.manifest import TeamScopePolicy
+
+
+class _NullSettingsStore:
+    async def upsert(self, *, team_id, capability_id, settings, updated_by):
+        return None
+
+
+def _entry(cap_id: str = "corp_drive") -> CapabilityCatalogEntry:
+    return CapabilityCatalogEntry(
+        id=cap_id,
+        version="1.0.0",
+        name=f"cap.{cap_id}.name",
+        description=f"cap.{cap_id}.desc",
+        icon="Icon",
+        team_scope=TeamScopePolicy.ADMIN_GATED,
+        team_settings_fields=[],
+        kind="tool",
+    )
+
+
+def _seed_relations(cap_id: str) -> list[Relation]:
+    resource = cap_ref(cap_id)
+    return [
+        Relation(
+            subject=RebacReference(Resource.TEAM, "team-enabled"),
+            relation=RelationType.ENABLED,
+            resource=resource,
+        ),
+        Relation(
+            subject=RebacReference(Resource.TEAM, "team-disabled"),
+            relation=RelationType.DISABLED,
+            resource=resource,
+        ),
+        Relation(
+            subject=RebacReference(Resource.ORGANIZATION, ORGANIZATION_ID),
+            relation=RelationType.DEFAULT_ON,
+            resource=resource,
+        ),
+        Relation(
+            subject=RebacReference(Resource.ORGANIZATION, ORGANIZATION_ID),
+            relation=RelationType.PERSONAL_ON,
+            resource=resource,
+        ),
+    ]
+
+
+async def _build_item(engine: CountingRebacEngine, cap_id: str):
+    return await _build_enablement_item(
+        _entry(cap_id),
+        rebac=engine,
+        total_team_count=10,
+        total_personal_space_count=5,
+        impact={},
+        reasoning_enabled_ids=frozenset(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_enablement_item_uses_one_read_never_list_users() -> None:
+    """#2181: one row's ReBAC-derived fields must resolve from a SINGLE
+    `list_direct_relations` Read — never `lookup_subjects` (`CountingRebacEngine`
+    raises if it's called), regardless of how many distinct relations the row
+    reports (`enabled`/`disabled`/`default_on`/`personal_on`)."""
+
+    engine = CountingRebacEngine(direct_relations=_seed_relations("corp_drive"))
+
+    item = await _build_item(engine, "corp_drive")
+
+    assert len(engine.list_direct_relations_calls) == 1
+    assert engine.list_direct_relations_calls[0][0] == cap_ref("corp_drive")
+    assert engine.lookup_subjects_calls == 0
+    assert item.default_on is True
+    assert item.enabled_team_ids == ["team-enabled"]
+    assert item.disabled_team_ids == ["team-disabled"]
+    assert item.personal_scope == "enabled"
+
+
+@pytest.mark.asyncio
+async def test_build_enablement_item_serves_repeat_calls_from_cache() -> None:
+    """#2181: within the 45s TTL, a second row build for the same capability
+    must not re-hit OpenFGA."""
+
+    engine = CountingRebacEngine(direct_relations=_seed_relations("corp_drive"))
+
+    await _build_item(engine, "corp_drive")
+    assert len(engine.list_direct_relations_calls) == 1
+
+    await _build_item(engine, "corp_drive")
+    assert len(engine.list_direct_relations_calls) == 1, (
+        "second call within the TTL window must be served entirely from cache"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capability_relations_cache_refetches_after_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = CountingRebacEngine(direct_relations=_seed_relations("corp_drive"))
+
+    fake_now = 1_000_000.0
+    monkeypatch.setattr(time_module, "time", lambda: fake_now)
+
+    await _build_item(engine, "corp_drive")
+    assert len(engine.list_direct_relations_calls) == 1
+
+    # still within the 45s TTL: cache hit, no new call
+    fake_now += enablement._CAPABILITY_RELATIONS_CACHE_TTL_SECONDS - 1
+    await _build_item(engine, "corp_drive")
+    assert len(engine.list_direct_relations_calls) == 1
+
+    # past the TTL: must be re-read
+    fake_now += 2
+    await _build_item(engine, "corp_drive")
+    assert len(engine.list_direct_relations_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_enable_capability_for_team_invalidates_cache() -> None:
+    """A grant must be visible on the very next read, not wait out the TTL —
+    `enable_capability_for_team` calls `invalidate_capability_relations_cache`
+    right after its write, mirroring the team-membership write paths."""
+
+    engine = CountingRebacEngine()
+    cap_id = "corp_drive"
+
+    item_before = await _build_item(engine, cap_id)
+    assert item_before.enabled_team_ids == []
+    assert len(engine.list_direct_relations_calls) == 1
+
+    await enable_capability_for_team(
+        rebac=engine,
+        settings_store=_NullSettingsStore(),
+        catalog_entry=_entry(cap_id),
+        team_id=TeamId("team-new"),
+        settings={},
+        updated_by="admin",
+    )
+
+    item_after = await _build_item(engine, cap_id)
+    assert item_after.enabled_team_ids == ["team-new"]
+    assert len(engine.list_direct_relations_calls) == 2, (
+        "the write must have invalidated the cache entry for this capability"
+    )
+
+
+@pytest.mark.asyncio
+async def test_has_org_relation_always_reads_fresh_never_cached() -> None:
+    """`has_org_relation` (used by the write-path pre-checks in
+    `reset_team_capability`/`set_personal_scope`) deliberately bypasses the
+    cache — see its docstring: those are write-path peek-before-mutate
+    decisions that must see live OpenFGA state, not up to 45s of another
+    replica's stale write, and caching them would buy the read-only listing
+    path nothing since it no longer calls this function at all. It still
+    uses the cheaper `list_direct_relations` (`Read`) primitive rather than
+    `lookup_subjects` (`ListUsers`) — just never caches the result."""
+
+    engine = CountingRebacEngine(direct_relations=_seed_relations("corp_drive"))
+
+    assert await enablement.has_org_relation(
+        engine, "corp_drive", RelationType.DEFAULT_ON
+    )
+    assert await enablement.has_org_relation(
+        engine, "corp_drive", RelationType.PERSONAL_ON
+    )
+    assert not await enablement.has_org_relation(
+        engine, "corp_drive", RelationType.PERSONAL_DISABLED
+    )
+    assert len(engine.list_direct_relations_calls) == 3, (
+        "has_org_relation must read fresh every call, never from the "
+        "45s cache — it's a write-path correctness check now, and the "
+        "listing endpoint no longer calls it"
+    )
+    assert engine.lookup_subjects_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_has_org_relation_sees_a_write_immediately_on_the_same_pod() -> None:
+    """The flip side of the above: because `has_org_relation` never caches,
+    a write is visible on the very next call with no invalidation needed —
+    proving the bypass is actually live, not just uncounted."""
+
+    engine = CountingRebacEngine()
+    cap_id = "corp_drive"
+
+    assert not await enablement.has_org_relation(
+        engine, cap_id, RelationType.DEFAULT_ON
+    )
+
+    await engine.add_relation(
+        Relation(
+            subject=RebacReference(Resource.ORGANIZATION, ORGANIZATION_ID),
+            relation=RelationType.DEFAULT_ON,
+            resource=cap_ref(cap_id),
+        )
+    )
+
+    assert await enablement.has_org_relation(engine, cap_id, RelationType.DEFAULT_ON)


### PR DESCRIPTION
## Summary

Fixes #2181 — `GET /admin/capabilities` was consistently 1-2.5s.

- **Root cause**: #2089 made the per-row ReBAC reads *concurrent* but never reduced their *count*. `_build_enablement_item` still fired up to 5 individual `lookup_subjects` (OpenFGA `ListUsers`) calls per row — `enabled`/`disabled` team grants plus `default_on`/`personal_on`/`personal_disabled` org markers — across ~87 catalog capabilities: ~175 OpenFGA calls per page load.
- **Fix**: all 5 answers live on the exact same literal tuple set for one capability, so this mirrors `_bulk_team_membership`'s existing #2065/#2148 fix for the identical team-membership fan-out shape — one `list_direct_relations` `Read` per capability, with a 45s TTL, write-invalidated cache (`get_capability_relations_cached`), same shape and race-guard as `_get_team_relations_cached`. `_build_enablement_item` now does a single cached fetch per row and folds the 4 fields locally, instead of gathering 4 lookups that would otherwise race the same cache key.
- **Self-review correction** (via the `fred-performance-reviewer` skill): `has_org_relation`/`_read_personal_scope` turned out to be used *only* by write-path peek-before-mutate decisions once the row builder folded its own fetch locally (`reset_team_capability`, `set_personal_scope`, the `depends_on` dependency gate, `set_capability_personal_scope`'s access-transition check). Caching those would have bought the read path nothing while risking a stale suspend/revive/reject decision under concurrent multi-replica admin writes — they deliberately bypass the cache (still the cheaper `list_direct_relations` `Read`, just never cached).

Net effect: ~175 `ListUsers` calls per page load → up to 87 `Read` calls on a cold cache, 0 on a warm one (45s TTL).

## Files touched

- `capabilities/enablement.py` — cache primitives + invalidation at the 5 write sites that mutate a capability's tuples
- `capabilities/service.py` — `_build_enablement_item`/`_read_personal_scope` rewritten to fold one fetch instead of gathering several
- `tests/test_capability_relations_cache_2181.py` (new) — call-count + TTL + invalidation + never-cached-on-write-path coverage
- `tests/test_capability_enablement_1980.py` — `_FakeRebac` gains `list_direct_relations`
- `tests/conftest.py` — the new module-level cache joins the existing autouse per-test cache-clear fixture

`explicitly_enabled_team_ids` (enablement.py) was deliberately left untouched — its only callers are write-path, out of scope for this read-latency issue.

## Test plan

- [x] `make code-quality` (ruff, bandit, basedpyright) — clean
- [x] `make test` — 713 passed (712 existing + 1 net new file)
- [x] Reviewed with `fred-performance-reviewer` skill; one correction applied (see above) before this PR