### PR TITLE
2221 chat composer input lag on long conversations full message thread re render markdown re parse per keystroke

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
@@ -15,7 +15,7 @@
 // Page-local composition of organisms for ManagedChatPage.
 // Lives under pages/ so it may import from shared/organisms freely.
 
-import type { ReactNode, RefObject } from "react";
+import { memo, type ReactNode, type RefObject } from "react";
 import type { RuntimeAwaitingHumanEvent } from "@hooks/useChatSse";
 import type { ThreadMessage } from "@rework/types/thread";
 import { HitlPrompt } from "@shared/molecules/HitlPrompt/HitlPrompt.tsx";
@@ -33,7 +33,11 @@ interface ConversationThreadProps {
   onHitlAnswer: (answer: string | boolean | undefined, freeText?: string) => void;
 }
 
-export function ConversationThread({
+// Memoized: ManagedChatPage re-renders on every composer keystroke (the input
+// state lives above this tree). Without this boundary, every historical
+// message — including its full markdown re-parse — re-rendered on every
+// character typed, with cost scaling with conversation length (#2221).
+export const ConversationThread = memo(function ConversationThread({
   messages,
   pendingHitl,
   isLoading,
@@ -87,4 +91,4 @@ export function ConversationThread({
       {pendingHitl && <HitlPrompt event={pendingHitl} onAnswer={onHitlAnswer} />}
     </ChatMessagesArea>
   );
-}
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
@@ -94,13 +94,19 @@ const abortMock = vi.fn();
 const replaceAllMessagesMock = vi.fn();
 let capturedFlushPendingWrites: ((sid: string | null) => Promise<boolean>) | undefined;
 let capturedOnTurnStarted: (() => void) | undefined;
+let capturedOnError: ((msg: string) => void) | undefined;
+let capturedOnAwaitingHuman: ((event: unknown) => void) | undefined;
 vi.mock("@hooks/useChatSse", () => ({
   useChatSse: (params: {
     flushPendingWrites?: (sid: string | null) => Promise<boolean>;
     onTurnStarted?: () => void;
+    onError?: (msg: string) => void;
+    onAwaitingHuman?: (event: unknown) => void;
   }) => {
     capturedFlushPendingWrites = params.flushPendingWrites;
     capturedOnTurnStarted = params.onTurnStarted;
+    capturedOnError = params.onError;
+    capturedOnAwaitingHuman = params.onAwaitingHuman;
     return {
       messages: [],
       waitResponse: false,
@@ -277,6 +283,39 @@ describe("useManagedChat — session write reliability", () => {
       root.unmount();
     });
     container.remove();
+  });
+
+  // #2221: ConversationThread is React.memo'd to stop it re-rendering (and
+  // re-parsing every historical message's markdown) on every composer
+  // keystroke. That memo only holds if the callbacks useManagedChat hands
+  // to useChatSse — and everything derived from them, like handleHitlAnswer
+  // — keep a stable identity across a keystroke-only render. An inline
+  // arrow at the useChatSse() call site would defeat this silently (no
+  // test failure anywhere else would catch it, since behavior stays
+  // correct — only the render count regresses).
+  it("callbacks passed to useChatSse, and handleHitlAnswer, keep referential identity across a composer keystroke", async () => {
+    mount();
+    const firstOnError = capturedOnError;
+    const firstOnAwaitingHuman = capturedOnAwaitingHuman;
+    const firstOnTurnStarted = capturedOnTurnStarted;
+    const firstHandleHitlAnswer = latest.handleHitlAnswer;
+    expect(firstOnError).toBeDefined();
+    expect(firstOnAwaitingHuman).toBeDefined();
+    expect(firstOnTurnStarted).toBeDefined();
+
+    act(() => {
+      latest.setInput("o");
+    });
+    rerender();
+    act(() => {
+      latest.setInput("ok");
+    });
+    rerender();
+
+    expect(capturedOnError).toBe(firstOnError);
+    expect(capturedOnAwaitingHuman).toBe(firstOnAwaitingHuman);
+    expect(capturedOnTurnStarted).toBe(firstOnTurnStarted);
+    expect(latest.handleHitlAnswer).toBe(firstHandleHitlAnswer);
   });
 
   it("selecting a context prompt persists it and a send proceeds", async () => {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
@@ -228,6 +228,22 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     }
   }, []);
 
+  // Stabilized (not inlined at the useChatSse call site below): useChatSse's
+  // own send()/sendHitlResume() memoize around these callbacks, so an inline
+  // arrow here — recreated on every useManagedChat render, including every
+  // composer keystroke — would silently invalidate that memoization on every
+  // keystroke too, cascading into handleHitlAnswer below and defeating
+  // ConversationThread's React.memo (#2221).
+  const handleAwaitingHuman = useCallback((event: RuntimeAwaitingHumanEvent) => setPendingHitl(event), []);
+  const handleChatError = useCallback((msg: string) => showError({ summary: "Agent error", detail: msg }), [showError]);
+  // Fires only once prepare-execution has actually succeeded and the turn is
+  // really starting — clearing the composer any earlier would lose the
+  // user's text/attachments on a prepare-execution failure (404/503/network).
+  const handleTurnStarted = useCallback(() => {
+    setInput("");
+    attachments.clearReadyAttachments();
+  }, [attachments.clearReadyAttachments]);
+
   const {
     messages,
     waitResponse,
@@ -244,15 +260,9 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     flushPendingWrites: flushSessionWrites,
     onBindDraftAgentToSessionId: bindSessionId,
     onTurnPersisted: touchSessionActivity,
-    onAwaitingHuman: (event) => setPendingHitl(event),
-    onError: (msg) => showError({ summary: "Agent error", detail: msg }),
-    // Fires only once prepare-execution has actually succeeded and the turn
-    // is really starting — clearing the composer any earlier would lose the
-    // user's text/attachments on a prepare-execution failure (404/503/network).
-    onTurnStarted: () => {
-      setInput("");
-      attachments.clearReadyAttachments();
-    },
+    onAwaitingHuman: handleAwaitingHuman,
+    onError: handleChatError,
+    onTurnStarted: handleTurnStarted,
   });
 
   // Chat controls are resolved per agent instance/config, not per session — a

--- a/apps/frontend/src/rework/components/shared/organisms/AssistantTurn/AssistantTurn.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AssistantTurn/AssistantTurn.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { ChatMessage, VectorSearchHit } from "../../../../../slices/agentic/agenticOpenApi";
 import type { RawUiPart } from "@rework/types/parts";
 import { ThoughtTrace } from "@shared/molecules/ThoughtTrace/ThoughtTrace";
@@ -40,7 +40,10 @@ interface AssistantTurnProps {
   pendingToolCallIds?: readonly string[] | null;
 }
 
-export function AssistantTurn({
+// Memoized: sibling turns in a long thread must not re-render on unrelated
+// parent renders (e.g. a composer keystroke, or a streaming delta on a
+// different message) — see #2221.
+export const AssistantTurn = memo(function AssistantTurn({
   text,
   traceMessages,
   sources,
@@ -133,4 +136,4 @@ export function AssistantTurn({
       )}
     </div>
   );
-}
+});

--- a/apps/frontend/src/rework/components/shared/organisms/UserTurn/UserTurn.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/UserTurn/UserTurn.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback } from "react";
+import { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { UserMessage } from "@shared/molecules/UserMessage/UserMessage";
 import IconButton from "@shared/atoms/IconButton/IconButton";
@@ -26,7 +26,8 @@ interface UserTurnProps {
   onEdit?: (text: string) => void;
 }
 
-export function UserTurn({ text, onEdit }: UserTurnProps) {
+// Memoized alongside AssistantTurn — see #2221.
+export const UserTurn = memo(function UserTurn({ text, onEdit }: UserTurnProps) {
   const { t } = useTranslation();
   const { showSuccess } = useToast();
 
@@ -67,4 +68,4 @@ export function UserTurn({ text, onEdit }: UserTurnProps) {
       <UserMessage text={text} />
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary

Fixes composer input lag on long conversations (observed live in production: typing a single character and hitting Enter took several seconds). Severity scaled with conversation length.

**Root cause:** the composer's `input` state lives in `useManagedChat`, so every keystroke re-rendered the whole `ManagedChatPage` tree. `ConversationThread`/`AssistantTurn`/`UserTurn` had no `React.memo`, so every keystroke re-rendered every historical message — including a full `react-markdown` + `remark-gfm`/`remark-math`/`remark-directive` + `rehype-katex`/`rehype-sanitize` parse per assistant message. Cost was O(number of messages) per character typed.

**Fix, two parts:**

1. `React.memo` on `ConversationThread`, `AssistantTurn`, `UserTurn` — a keystroke no longer touches the message-thread subtree at all, since its props (`threadMessages`, `pendingHitl`, `waitResponse`, `isLoadingHistory`, `handleHitlAnswer`) are already memoized/`useCallback`'d upstream.
2. That memo only holds if those upstream callbacks are actually stable. They weren't: `onAwaitingHuman`/`onError`/`onTurnStarted` were passed to `useChatSse` as inline arrow functions, recreated on every render. `useChatSse`'s own `processEvent` → `streamToMessages` → `sendHitlResume` memoization chains off those, so `sendHitlResume` — and `handleHitlAnswer` built from it — got a new identity every keystroke, silently defeating step 1's memo (`onHitlAnswer` is one of `ConversationThread`'s props). Wrapped all three in `useCallback` with correct deps in `useManagedChat.ts`.

Pure render-optimization + a stale-closure fix — no behavior change.

## Test plan

- `make code-quality` (tsc, prettier, eslint) — clean
- `npm run test:coverage` — 105 files / 1002 passing, no regressions
- Added a regression test (`useManagedChat.test.tsx`) asserting the callbacks handed to `useChatSse`, and `handleHitlAnswer` derived from them, keep referential identity across a composer keystroke. Confirmed it fails against the pre-fix code (`expected [Function onError] to be [Function onError]`) and passes after the `useCallback` stabilization — proves part 2 was load-bearing, not just part 1.
- Manual verification of typing responsiveness on a long conversation still pending (recommend before merge).

Closes #2221
