### PR TITLE
Fix session-scoped attachment delete: ReBAC denial on own upload, 403 masked as 502, invisible frontend error (#2223)

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -2372,18 +2372,34 @@ async def _delete_knowledge_flow_attachment(
                 params=params,
                 headers={"Authorization": authorization},
             )
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        detail = exc.response.text.strip() or str(exc)
-        raise SessionAttachmentRequestError(
-            f"Knowledge Flow cleanup failed for attachment document {document_uid!r}: {detail}",
-            http_status=502,
-        ) from exc
     except httpx.RequestError as exc:
         raise SessionAttachmentRequestError(
             f"Knowledge Flow cleanup request failed for attachment document {document_uid!r}: {exc}",
             http_status=502,
         ) from exc
+
+    if 400 <= response.status_code < 500:
+        # Relay the downstream client-error status (401/403/404/422/...) verbatim
+        # so the frontend sees the real reason instead of a generic gateway error.
+        try:
+            detail = response.json().get("detail") or response.text
+        except ValueError:
+            detail = response.text
+        detail = (
+            str(detail).strip()
+            or response.reason_phrase
+            or f"HTTP {response.status_code}"
+        )
+        raise SessionAttachmentRequestError(
+            f"Knowledge Flow cleanup failed for attachment document {document_uid!r}: {detail}",
+            http_status=response.status_code,
+        )
+    if response.status_code >= 500:
+        raise SessionAttachmentRequestError(
+            f"Knowledge Flow cleanup failed for attachment document {document_uid!r}: "
+            f"Knowledge Flow returned {response.status_code}.",
+            http_status=502,
+        )
 
 
 async def enroll_agent_instance(

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -2378,28 +2378,40 @@ async def _delete_knowledge_flow_attachment(
             http_status=502,
         ) from exc
 
+    if 200 <= response.status_code < 300:
+        return
+
     if 400 <= response.status_code < 500:
         # Relay the downstream client-error status (401/403/404/422/...) verbatim
         # so the frontend sees the real reason instead of a generic gateway error.
         try:
-            detail = response.json().get("detail") or response.text
+            parsed = response.json()
+            detail = parsed.get("detail") if isinstance(parsed, dict) else None
         except ValueError:
-            detail = response.text
+            detail = None
         detail = (
             str(detail).strip()
-            or response.reason_phrase
-            or f"HTTP {response.status_code}"
+            if detail
+            else (
+                response.text.strip()
+                or response.reason_phrase
+                or f"HTTP {response.status_code}"
+            )
         )
         raise SessionAttachmentRequestError(
             f"Knowledge Flow cleanup failed for attachment document {document_uid!r}: {detail}",
             http_status=response.status_code,
         )
-    if response.status_code >= 500:
-        raise SessionAttachmentRequestError(
-            f"Knowledge Flow cleanup failed for attachment document {document_uid!r}: "
-            f"Knowledge Flow returned {response.status_code}.",
-            http_status=502,
-        )
+
+    # Anything else -- 5xx, or a 1xx/3xx this client never asked for (it does not
+    # follow redirects) -- is not a client error to relay; a redirect in particular
+    # must not be read as success, or a misconfigured/canonicalizing Knowledge Flow
+    # URL could make control-plane believe cleanup succeeded when it never ran.
+    raise SessionAttachmentRequestError(
+        f"Knowledge Flow cleanup failed for attachment document {document_uid!r}: "
+        f"Knowledge Flow returned {response.status_code}.",
+        http_status=502,
+    )
 
 
 async def enroll_agent_instance(

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -4797,6 +4797,30 @@ def _fake_async_client_returning(status_code: int, *, detail: str) -> type:
     return _FakeAsyncClient
 
 
+def _fake_async_client_returning_raw(
+    status_code: int, *, content: bytes = b"", json_body: Any = None
+) -> type:
+    class _FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def delete(
+            self, url: str, *, params: dict[str, str], headers: dict[str, str]
+        ) -> httpx.Response:
+            request = httpx.Request("DELETE", url, params=params, headers=headers)
+            if json_body is not None:
+                return httpx.Response(status_code, json=json_body, request=request)
+            return httpx.Response(status_code, content=content, request=request)
+
+    return _FakeAsyncClient
+
+
 @pytest.mark.asyncio
 async def test_delete_knowledge_flow_attachment_relays_downstream_403(
     monkeypatch: pytest.MonkeyPatch,
@@ -4848,6 +4872,59 @@ async def test_delete_knowledge_flow_attachment_maps_downstream_5xx_to_502(
         )
 
     assert excinfo.value.http_status == 502
+
+
+@pytest.mark.asyncio
+async def test_delete_knowledge_flow_attachment_maps_downstream_redirect_to_502(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 3xx from Knowledge Flow (e.g. gateway canonicalization) must not be read
+    as success -- this client never follows redirects, so cleanup never actually
+    ran and control-plane must not delete its own attachment metadata."""
+    monkeypatch.setattr(
+        "control_plane_backend.product.service.httpx.AsyncClient",
+        _fake_async_client_returning_raw(307),
+    )
+    app = create_app()
+    container = get_application_container_from_app(app)
+    deps = build_product_service_dependencies(container)
+
+    with pytest.raises(SessionAttachmentRequestError) as excinfo:
+        await _delete_knowledge_flow_attachment(
+            authorization="Bearer test-token",
+            document_uid="doc-1",
+            storage_key=None,
+            session_id="session-1",
+            deps=deps,
+        )
+
+    assert excinfo.value.http_status == 502
+
+
+@pytest.mark.asyncio
+async def test_delete_knowledge_flow_attachment_relays_403_with_non_dict_json_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-dict JSON error body (e.g. a bare list/string) must not crash detail
+    extraction and turn a relayable 4xx into an opaque 500."""
+    monkeypatch.setattr(
+        "control_plane_backend.product.service.httpx.AsyncClient",
+        _fake_async_client_returning_raw(403, json_body=["not", "a", "dict"]),
+    )
+    app = create_app()
+    container = get_application_container_from_app(app)
+    deps = build_product_service_dependencies(container)
+
+    with pytest.raises(SessionAttachmentRequestError) as excinfo:
+        await _delete_knowledge_flow_attachment(
+            authorization="Bearer test-token",
+            document_uid="doc-1",
+            storage_key=None,
+            session_id="session-1",
+            deps=deps,
+        )
+
+    assert excinfo.value.http_status == 403
 
 
 @pytest.mark.asyncio

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -39,6 +39,7 @@ from control_plane_backend.product.dependencies import (
 )
 from control_plane_backend.product.schemas import CreateSessionRequest
 from control_plane_backend.product.service import (
+    SessionAttachmentRequestError,
     _delete_knowledge_flow_attachment,
     _RuntimeTemplatePayload,
 )
@@ -4774,6 +4775,79 @@ async def test_delete_knowledge_flow_attachment_uses_fast_delete_route(
         "storage_key": "uploads/notes.md",
     }
     assert captured["headers"] == {"Authorization": "Bearer test-token"}
+
+
+def _fake_async_client_returning(status_code: int, *, detail: str) -> type:
+    class _FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def delete(
+            self, url: str, *, params: dict[str, str], headers: dict[str, str]
+        ) -> httpx.Response:
+            request = httpx.Request("DELETE", url, params=params, headers=headers)
+            return httpx.Response(status_code, json={"detail": detail}, request=request)
+
+    return _FakeAsyncClient
+
+
+@pytest.mark.asyncio
+async def test_delete_knowledge_flow_attachment_relays_downstream_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2223: a ReBAC denial from Knowledge Flow must surface as a 403 with the
+    real reason, not a generic 502 that hides the failure from the frontend."""
+    monkeypatch.setattr(
+        "control_plane_backend.product.service.httpx.AsyncClient",
+        _fake_async_client_returning(
+            403, detail="Not authorized to delete document doc-1"
+        ),
+    )
+    app = create_app()
+    container = get_application_container_from_app(app)
+    deps = build_product_service_dependencies(container)
+
+    with pytest.raises(SessionAttachmentRequestError) as excinfo:
+        await _delete_knowledge_flow_attachment(
+            authorization="Bearer test-token",
+            document_uid="doc-1",
+            storage_key=None,
+            session_id="session-1",
+            deps=deps,
+        )
+
+    assert excinfo.value.http_status == 403
+    assert "Not authorized to delete document doc-1" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_delete_knowledge_flow_attachment_maps_downstream_5xx_to_502(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "control_plane_backend.product.service.httpx.AsyncClient",
+        _fake_async_client_returning(500, detail="internal error"),
+    )
+    app = create_app()
+    container = get_application_container_from_app(app)
+    deps = build_product_service_dependencies(container)
+
+    with pytest.raises(SessionAttachmentRequestError) as excinfo:
+        await _delete_knowledge_flow_attachment(
+            authorization="Bearer test-token",
+            document_uid="doc-1",
+            storage_key=None,
+            session_id="session-1",
+            deps=deps,
+        )
+
+    assert excinfo.value.http_status == 502
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -384,7 +384,10 @@
       "sessionSaveFailedSummary": "Conversation not saved",
       "sessionSaveFailedDetail": "Could not save this conversation. Please try again.",
       "contextPromptSaveFailedSummary": "Prompt selection not saved",
-      "contextPromptSaveFailedDetail": "Could not save the selected prompts — reverted to the last saved selection. Please try again."
+      "contextPromptSaveFailedDetail": "Could not save the selected prompts — reverted to the last saved selection. Please try again.",
+      "attachmentDeleteFailedSummary": "File not deleted",
+      "attachmentDeleteFailedDetail": "Could not delete this file. Please try again.",
+      "attachmentDeleteForbiddenDetail": "You don't have permission to delete this file."
     },
     "loadingHistory": "Loading conversation history...",
     "markdownPreview": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -384,7 +384,10 @@
       "sessionSaveFailedSummary": "Conversation non enregistrée",
       "sessionSaveFailedDetail": "Impossible d'enregistrer cette conversation. Veuillez réessayer.",
       "contextPromptSaveFailedSummary": "Sélection de prompts non enregistrée",
-      "contextPromptSaveFailedDetail": "Impossible d'enregistrer les prompts sélectionnés — la dernière sélection enregistrée a été restaurée. Veuillez réessayer."
+      "contextPromptSaveFailedDetail": "Impossible d'enregistrer les prompts sélectionnés — la dernière sélection enregistrée a été restaurée. Veuillez réessayer.",
+      "attachmentDeleteFailedSummary": "Fichier non supprimé",
+      "attachmentDeleteFailedDetail": "Impossible de supprimer ce fichier. Veuillez réessayer.",
+      "attachmentDeleteForbiddenDetail": "Vous n'avez pas la permission de supprimer ce fichier."
     },
     "loadingHistory": "Chargement de l'historique...",
     "markdownPreview": {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
+import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useFastIngestKnowledgeFlowV1FastIngestPostMutation } from "../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 import {
   useDeleteTeamSessionAttachmentControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsAttachmentIdDeleteMutation,
@@ -137,6 +138,7 @@ interface UseChatAttachmentsParams {
 export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsParams) {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const { notifyApiError } = useApiErrorToast();
   const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
   const [deletedAttachmentIds, setDeletedAttachmentIds] = useState<ReadonlySet<string>>(new Set());
 
@@ -199,10 +201,15 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
           next.delete(attachmentId);
           return next;
         });
+        notifyApiError(error, {
+          summary: t("chatbot.errors.attachmentDeleteFailedSummary"),
+          fallbackDetail: t("chatbot.errors.attachmentDeleteFailedDetail"),
+          forbiddenDetail: t("chatbot.errors.attachmentDeleteForbiddenDetail"),
+        });
         throw error;
       }
     },
-    [deletePersistedAttachmentMutation, sessionId, teamId],
+    [deletePersistedAttachmentMutation, notifyApiError, sessionId, t, teamId],
   );
 
   const addFiles = useCallback(

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
@@ -206,7 +206,10 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
           fallbackDetail: t("chatbot.errors.attachmentDeleteFailedDetail"),
           forbiddenDetail: t("chatbot.errors.attachmentDeleteForbiddenDetail"),
         });
-        throw error;
+        // Both call sites (chip removal, drawer delete) invoke this with `void`
+        // and don't await it -- the error is already surfaced via the toast
+        // above and local state is already rolled back, so don't rethrow: an
+        // unawaited rejection here becomes an unhandled promise rejection.
       }
     },
     [deletePersistedAttachmentMutation, notifyApiError, sessionId, t, teamId],

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/base_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/base_vector_store.py
@@ -22,6 +22,19 @@ from pydantic import BaseModel
 CHUNK_ID_FIELD = "chunk_uid"  # your canonical per-chunk id in metadata
 
 
+def is_own_session_chunk(chunk: Dict[str, Any], user_id: str) -> bool:
+    """True if a vector chunk is a session-scoped attachment chunk owned by `user_id`.
+
+    Session attachments (fast-ingest) carry no ReBAC tuple and no metadata-store
+    record — this chunk-level marker (`scope`, `user_id`) is the only ownership
+    signal that exists for them, so every authorization decision over that scope
+    (read reconstruction, delete) must go through this same check rather than a
+    document-level ReBAC lookup, which can never resolve for an untagged document.
+    """
+    metadata = chunk.get("metadata") or {}
+    return metadata.get("scope") == "session" and metadata.get("user_id") == user_id
+
+
 @dataclass(frozen=True)
 class SearchFilter:
     """
@@ -92,6 +105,19 @@ class BaseVectorStore(ABC):
     def get_chunks_for_document(self, document_uid: str) -> List[Dict[str, Any]]:
         """Optional capability: fetch raw chunk data for all chunks of a document."""
         raise NotImplementedError("This vector store does not support fetching raw chunks.")
+
+    def owns_session_document(self, document_uid: str, user_id: str) -> bool:
+        """True if `document_uid` has at least one session-scoped chunk owned by `user_id`.
+
+        Backed by `get_chunks_for_document`; fails closed (returns False rather
+        than raising) when the store can't fetch chunks by document, so callers
+        that gate access on this treat an unsupported backend as "not owned".
+        """
+        try:
+            chunks = self.get_chunks_for_document(document_uid)
+        except NotImplementedError:
+            return False
+        return any(is_own_session_chunk(c, user_id) for c in chunks)
 
     def get_chunk(self, document_uid: str, chunk_uid: str) -> Dict[str, Any]:
         """Optional capability: fetch raw chunk data for all chunks of a document."""

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/base_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/base_vector_store.py
@@ -106,17 +106,28 @@ class BaseVectorStore(ABC):
         """Optional capability: fetch raw chunk data for all chunks of a document."""
         raise NotImplementedError("This vector store does not support fetching raw chunks.")
 
-    def owns_session_document(self, document_uid: str, user_id: str) -> bool:
-        """True if `document_uid` has at least one session-scoped chunk owned by `user_id`.
+    def may_delete_session_document(self, document_uid: str, user_id: str) -> bool:
+        """True if `user_id` may delete `document_uid` as a session-scoped attachment.
 
-        Backed by `get_chunks_for_document`; fails closed (returns False rather
-        than raising) when the store can't fetch chunks by document, so callers
-        that gate access on this treat an unsupported backend as "not owned".
+        True when the user owns at least one chunk of the document, OR the
+        document has no chunks at all. The empty case matters for retry
+        safety: deleting a session document's vectors is itself idempotent
+        (deleting nothing is a no-op), so if an earlier delete attempt already
+        removed every chunk before failing on a later cleanup step, a retry
+        must still be allowed to reach that step rather than being denied
+        forever because there is nothing left to prove ownership over.
+
+        Fails closed (returns False) when chunks exist but none belong to
+        `user_id`, or when the backend can't fetch chunks by document at all
+        (an unsupported backend can't distinguish "nothing to delete" from
+        "someone else's document").
         """
         try:
             chunks = self.get_chunks_for_document(document_uid)
         except NotImplementedError:
             return False
+        if not chunks:
+            return True
         return any(is_own_session_chunk(c, user_id) for c in chunks)
 
     def get_chunk(self, document_uid: str, chunk_uid: str) -> Dict[str, Any]:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
@@ -103,11 +103,14 @@ async def _authorize_fast_ingest_delete(rebac: RebacEngine, user: KeycloakUser, 
     ReBAC check can never resolve to True for them, denying even the uploader.
     Ownership is instead proven the same way ``summarize_document`` already
     proves it for reads on this same document class: via the chunk's own
-    ``scope``/``user_id`` metadata (``base_vector_store.owns_session_document``).
+    ``scope``/``user_id`` metadata (``base_vector_store.may_delete_session_document``),
+    which also allows a document with no chunks left at all — so a retry after
+    an earlier attempt already deleted the vectors but failed on a later
+    cleanup step can still converge instead of being denied forever.
     """
     if await rebac.has_user_permission(user, OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID):
         return
-    if await asyncio.to_thread(vector_store.owns_session_document, document_uid, user.uid):
+    if await asyncio.to_thread(vector_store.may_delete_session_document, document_uid, user.uid):
         return
     raise AuthorizationError(user.uid, DocumentPermission.DELETE.value, Resource.DOCUMENTS)
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/ingestion/ingestion_controller.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import dataclasses
 import json
 import json as _json
@@ -25,7 +26,7 @@ from typing import Dict, List, Optional, Type
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response, StreamingResponse
-from fred_core import ORGANIZATION_ID, DocumentPermission, KeycloakUser, OrganizationPermission, RebacEngine, TagPermission, TeamMetadataStore, get_current_user
+from fred_core import ORGANIZATION_ID, AuthorizationError, DocumentPermission, KeycloakUser, OrganizationPermission, RebacEngine, Resource, TagPermission, TeamMetadataStore, get_current_user
 from fred_core.common.team_id import TeamId
 from fred_core.kpi import KPIActor, KPIWriter
 from fred_core.scheduler import SchedulerBackend
@@ -86,20 +87,29 @@ from knowledge_flow_backend.features.scheduler.scheduler_structures import (
 logger = logging.getLogger(__name__)
 
 
-async def _authorize_fast_ingest_delete(rebac: RebacEngine, user: KeycloakUser, document_uid: str) -> None:
-    """Authorize a fast-ingest artifact delete (CTRLP-12 C1 admin branch).
+async def _authorize_fast_ingest_delete(rebac: RebacEngine, user: KeycloakUser, document_uid: str, vector_store: BaseVectorStore) -> None:
+    """Authorize a fast-ingest artifact delete.
 
     A platform service principal holding org-level ``can_manage_platform`` — e.g.
     the control-plane lifecycle worker erasing a session's fast-ingest attachments
     at window expiry — bypasses the per-document ownership check. Authentication is
     still enforced by the endpoint dependency (``get_current_user``); only the
-    ``DocumentPermission.DELETE`` ownership check is waived. Everyone else must own
-    the document. Reuses the AUTHZ-01 ``can_manage_platform`` permission — no second
-    bypass is forked.
+    ownership check is waived for that principal. Reuses the AUTHZ-01
+    ``can_manage_platform`` permission — no second bypass is forked.
+
+    Everyone else must own the document. Fast-ingested (session-scoped) documents
+    carry no ``parent`` tag and no ReBAC tuple at all — they were deliberately left
+    "resource-less" and authentication-gated, so a ``DocumentPermission.DELETE``
+    ReBAC check can never resolve to True for them, denying even the uploader.
+    Ownership is instead proven the same way ``summarize_document`` already
+    proves it for reads on this same document class: via the chunk's own
+    ``scope``/``user_id`` metadata (``base_vector_store.owns_session_document``).
     """
     if await rebac.has_user_permission(user, OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID):
         return
-    await rebac.check_user_permission_or_raise(user, DocumentPermission.DELETE, document_uid)
+    if await asyncio.to_thread(vector_store.owns_session_document, document_uid, user.uid):
+        return
+    raise AuthorizationError(user.uid, DocumentPermission.DELETE.value, Resource.DOCUMENTS)
 
 
 STEP_UPLOAD_PREPARATION = "upload preparation"
@@ -1141,7 +1151,7 @@ class IngestionController:
             ),
             user: KeycloakUser = Depends(get_current_user),
         ):
-            await _authorize_fast_ingest_delete(get_rebac_engine(), user, document_uid)
+            await _authorize_fast_ingest_delete(get_rebac_engine(), user, document_uid, self.vector_store)
             try:
                 logger.info(
                     "[FAST TEXT][INGEST][DELETE] user=%s doc_uid=%s session=%s storage_key=%s backend=%s",

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/summarize/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/summarize/service.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from knowledge_flow_backend.application_context import ApplicationContext
 from knowledge_flow_backend.core.processors.output.summarizer.smart_llm_summarizer import SmartDocSummarizer
+from knowledge_flow_backend.core.stores.vector.base_vector_store import is_own_session_chunk
 
 logger = logging.getLogger(__name__)
 
@@ -122,11 +123,7 @@ class SummarizeService:
             # Backend can't fetch chunks by document -- nothing we can do here.
             return ""
 
-        def _is_own_session_chunk(chunk: dict) -> bool:
-            metadata = chunk.get("metadata") or {}
-            return metadata.get("scope") == "session" and metadata.get("user_id") == user.uid
-
-        owned = [c for c in chunks if _is_own_session_chunk(c)]
+        owned = [c for c in chunks if is_own_session_chunk(c, user.uid)]
         if not owned:
             return ""
 

--- a/apps/knowledge-flow-backend/tests/features/ingestion/test_fast_delete_authz.py
+++ b/apps/knowledge-flow-backend/tests/features/ingestion/test_fast_delete_authz.py
@@ -60,14 +60,18 @@ class _FakeRebac:
 
 
 class _FakeVectorStore:
-    """Records the delete-authorization check the authorizer makes."""
+    """Records the delete-authorization check the authorizer makes, including
+    the exact user_id it was asked to check -- a wrong-identifier bug (e.g.
+    forwarding username instead of uid) would otherwise still pass these tests."""
 
     def __init__(self, *, may_delete: bool) -> None:
         self._may_delete = may_delete
         self.checked = False
+        self.checked_user_id: str | None = None
 
     def may_delete_session_document(self, document_uid: str, user_id: str) -> bool:
         self.checked = True
+        self.checked_user_id = user_id
         assert document_uid == "doc-1"
         return self._may_delete
 
@@ -87,6 +91,7 @@ async def test_non_admin_owner_passes_ownership_check() -> None:
     vector_store = _FakeVectorStore(may_delete=True)
     await _authorize_fast_ingest_delete(rebac, _user("alice"), "doc-1", vector_store)
     assert vector_store.checked is True
+    assert vector_store.checked_user_id == "alice"
 
 
 @pytest.mark.asyncio
@@ -96,6 +101,7 @@ async def test_non_admin_non_owner_is_refused() -> None:
     with pytest.raises(AuthorizationError):
         await _authorize_fast_ingest_delete(rebac, _user("mallory"), "doc-1", vector_store)
     assert vector_store.checked is True
+    assert vector_store.checked_user_id == "mallory"
 
 
 @pytest.mark.asyncio

--- a/apps/knowledge-flow-backend/tests/features/ingestion/test_fast_delete_authz.py
+++ b/apps/knowledge-flow-backend/tests/features/ingestion/test_fast_delete_authz.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CTRLP-12 C1: fast-ingest delete authorization (can_manage_platform bypass).
+"""Fast-ingest delete authorization (#2223: session-scoped attachments have no
+ReBAC tuple, so a document-level ReBAC check can never resolve to True for
+them -- ownership must be proven via the vector chunk's own scope/user_id
+metadata instead, the same mechanism `summarize_document` already uses for
+reads on this document class).
 
-The `/fast/delete/{document_uid}` endpoint lets a platform service principal
-(org `can_manage_platform`) erase a session's fast-ingest attachments at window
-expiry without owning each document. These tests pin the authorization decision:
+These tests pin the authorization decision:
 - an admin (holds can_manage_platform) skips the per-document ownership check;
-- a non-admin owner passes the ownership check;
-- a non-admin non-owner is refused (the ownership check raises).
+- a non-admin owner (their own session-scoped chunks exist) passes;
+- a non-admin non-owner is refused.
 Authentication itself is enforced by the endpoint dependency and is not waived.
 """
 
@@ -29,11 +31,9 @@ import pytest
 from fred_core import (
     ORGANIZATION_ID,
     AuthorizationError,
-    DocumentPermission,
     KeycloakUser,
     OrganizationPermission,
 )
-from fred_core.security.models import Resource
 
 from knowledge_flow_backend.features.ingestion.ingestion_controller import (
     _authorize_fast_ingest_delete,
@@ -45,44 +45,51 @@ def _user(uid: str = "svc-control-plane") -> KeycloakUser:
 
 
 class _FakeRebac:
-    """Records the permission checks the authorizer makes."""
+    """Records the platform-admin bypass check the authorizer makes."""
 
-    def __init__(self, *, is_platform_admin: bool, owns_document: bool) -> None:
+    def __init__(self, *, is_platform_admin: bool) -> None:
         self._is_platform_admin = is_platform_admin
-        self._owns_document = owns_document
-        self.ownership_checked = False
 
     async def has_user_permission(self, user, permission, resource_id, **_kw) -> bool:
         assert permission == OrganizationPermission.CAN_MANAGE_PLATFORM
         assert resource_id == ORGANIZATION_ID
         return self._is_platform_admin
 
-    async def check_user_permission_or_raise(self, user, permission, resource_id, **_kw) -> None:
+
+class _FakeVectorStore:
+    """Records the ownership check the authorizer makes."""
+
+    def __init__(self, *, owns_document: bool) -> None:
+        self._owns_document = owns_document
+        self.ownership_checked = False
+
+    def owns_session_document(self, document_uid: str, user_id: str) -> bool:
         self.ownership_checked = True
-        assert permission == DocumentPermission.DELETE
-        assert resource_id == "doc-1"
-        if not self._owns_document:
-            raise AuthorizationError(user.uid, permission.value, Resource.DOCUMENTS)
+        assert document_uid == "doc-1"
+        return self._owns_document
 
 
 @pytest.mark.asyncio
 async def test_platform_admin_bypasses_document_ownership() -> None:
-    rebac = _FakeRebac(is_platform_admin=True, owns_document=False)
+    rebac = _FakeRebac(is_platform_admin=True)
+    vector_store = _FakeVectorStore(owns_document=False)
     # Admin: allowed even though it owns nothing, and the ownership check is skipped.
-    await _authorize_fast_ingest_delete(rebac, _user(), "doc-1")
-    assert rebac.ownership_checked is False
+    await _authorize_fast_ingest_delete(rebac, _user(), "doc-1", vector_store)
+    assert vector_store.ownership_checked is False
 
 
 @pytest.mark.asyncio
 async def test_non_admin_owner_passes_ownership_check() -> None:
-    rebac = _FakeRebac(is_platform_admin=False, owns_document=True)
-    await _authorize_fast_ingest_delete(rebac, _user("alice"), "doc-1")
-    assert rebac.ownership_checked is True
+    rebac = _FakeRebac(is_platform_admin=False)
+    vector_store = _FakeVectorStore(owns_document=True)
+    await _authorize_fast_ingest_delete(rebac, _user("alice"), "doc-1", vector_store)
+    assert vector_store.ownership_checked is True
 
 
 @pytest.mark.asyncio
 async def test_non_admin_non_owner_is_refused() -> None:
-    rebac = _FakeRebac(is_platform_admin=False, owns_document=False)
+    rebac = _FakeRebac(is_platform_admin=False)
+    vector_store = _FakeVectorStore(owns_document=False)
     with pytest.raises(AuthorizationError):
-        await _authorize_fast_ingest_delete(rebac, _user("mallory"), "doc-1")
-    assert rebac.ownership_checked is True
+        await _authorize_fast_ingest_delete(rebac, _user("mallory"), "doc-1", vector_store)
+    assert vector_store.ownership_checked is True

--- a/apps/knowledge-flow-backend/tests/features/ingestion/test_fast_delete_authz.py
+++ b/apps/knowledge-flow-backend/tests/features/ingestion/test_fast_delete_authz.py
@@ -21,7 +21,10 @@ reads on this document class).
 These tests pin the authorization decision:
 - an admin (holds can_manage_platform) skips the per-document ownership check;
 - a non-admin owner (their own session-scoped chunks exist) passes;
-- a non-admin non-owner is refused.
+- a non-admin non-owner is refused;
+- a document with no chunks at all is allowed (idempotent no-op), so a retry
+  after an earlier attempt already deleted the vectors but failed on a later
+  cleanup step can still converge.
 Authentication itself is enforced by the endpoint dependency and is not waived.
 """
 
@@ -57,39 +60,50 @@ class _FakeRebac:
 
 
 class _FakeVectorStore:
-    """Records the ownership check the authorizer makes."""
+    """Records the delete-authorization check the authorizer makes."""
 
-    def __init__(self, *, owns_document: bool) -> None:
-        self._owns_document = owns_document
-        self.ownership_checked = False
+    def __init__(self, *, may_delete: bool) -> None:
+        self._may_delete = may_delete
+        self.checked = False
 
-    def owns_session_document(self, document_uid: str, user_id: str) -> bool:
-        self.ownership_checked = True
+    def may_delete_session_document(self, document_uid: str, user_id: str) -> bool:
+        self.checked = True
         assert document_uid == "doc-1"
-        return self._owns_document
+        return self._may_delete
 
 
 @pytest.mark.asyncio
 async def test_platform_admin_bypasses_document_ownership() -> None:
     rebac = _FakeRebac(is_platform_admin=True)
-    vector_store = _FakeVectorStore(owns_document=False)
+    vector_store = _FakeVectorStore(may_delete=False)
     # Admin: allowed even though it owns nothing, and the ownership check is skipped.
     await _authorize_fast_ingest_delete(rebac, _user(), "doc-1", vector_store)
-    assert vector_store.ownership_checked is False
+    assert vector_store.checked is False
 
 
 @pytest.mark.asyncio
 async def test_non_admin_owner_passes_ownership_check() -> None:
     rebac = _FakeRebac(is_platform_admin=False)
-    vector_store = _FakeVectorStore(owns_document=True)
+    vector_store = _FakeVectorStore(may_delete=True)
     await _authorize_fast_ingest_delete(rebac, _user("alice"), "doc-1", vector_store)
-    assert vector_store.ownership_checked is True
+    assert vector_store.checked is True
 
 
 @pytest.mark.asyncio
 async def test_non_admin_non_owner_is_refused() -> None:
     rebac = _FakeRebac(is_platform_admin=False)
-    vector_store = _FakeVectorStore(owns_document=False)
+    vector_store = _FakeVectorStore(may_delete=False)
     with pytest.raises(AuthorizationError):
         await _authorize_fast_ingest_delete(rebac, _user("mallory"), "doc-1", vector_store)
-    assert vector_store.ownership_checked is True
+    assert vector_store.checked is True
+
+
+@pytest.mark.asyncio
+async def test_retry_after_vectors_already_deleted_converges() -> None:
+    """A retry that reaches this check after an earlier attempt already deleted
+    every chunk (but failed on a later cleanup step) must not be denied forever
+    just because there is nothing left to prove ownership over."""
+    rebac = _FakeRebac(is_platform_admin=False)
+    vector_store = _FakeVectorStore(may_delete=True)
+    await _authorize_fast_ingest_delete(rebac, _user("alice"), "doc-1", vector_store)
+    assert vector_store.checked is True

--- a/apps/knowledge-flow-backend/tests/stores/test_base_vector_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/test_base_vector_store.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from knowledge_flow_backend.core.stores.vector.base_vector_store import (
+    BaseVectorStore,
+    is_own_session_chunk,
+)
+
+
+def test_is_own_session_chunk_requires_session_scope_and_matching_user():
+    owned = {"metadata": {"scope": "session", "user_id": "alice"}}
+    other_user = {"metadata": {"scope": "session", "user_id": "mallory"}}
+    corpus_chunk = {"metadata": {"scope": "library", "user_id": "alice"}}
+    no_metadata = {}
+
+    assert is_own_session_chunk(owned, "alice") is True
+    assert is_own_session_chunk(other_user, "alice") is False
+    assert is_own_session_chunk(corpus_chunk, "alice") is False
+    assert is_own_session_chunk(no_metadata, "alice") is False
+
+
+class _FakeChunkStore(BaseVectorStore):
+    def __init__(self, chunks: List[Dict[str, Any]] | None = None, *, unsupported: bool = False):
+        self._chunks = chunks or []
+        self._unsupported = unsupported
+
+    def add_documents(self, documents, *, ids=None):
+        raise NotImplementedError
+
+    def delete_vectors_for_document(self, *, document_uid: str) -> None:
+        raise NotImplementedError
+
+    def ann_search(self, query, *, k, search_filter=None):
+        raise NotImplementedError
+
+    def get_chunks_for_document(self, document_uid: str) -> List[Dict[str, Any]]:
+        if self._unsupported:
+            raise NotImplementedError
+        return self._chunks
+
+
+def test_owns_session_document_true_when_a_chunk_matches():
+    store = _FakeChunkStore([{"metadata": {"scope": "session", "user_id": "alice"}}])
+    assert store.owns_session_document("doc-1", "alice") is True
+
+
+def test_owns_session_document_false_for_different_user():
+    store = _FakeChunkStore([{"metadata": {"scope": "session", "user_id": "mallory"}}])
+    assert store.owns_session_document("doc-1", "alice") is False
+
+
+def test_owns_session_document_fails_closed_when_unsupported():
+    store = _FakeChunkStore(unsupported=True)
+    assert store.owns_session_document("doc-1", "alice") is False

--- a/apps/knowledge-flow-backend/tests/stores/test_base_vector_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/test_base_vector_store.py
@@ -40,16 +40,23 @@ class _FakeChunkStore(BaseVectorStore):
         return self._chunks
 
 
-def test_owns_session_document_true_when_a_chunk_matches():
+def test_may_delete_session_document_true_when_a_chunk_matches():
     store = _FakeChunkStore([{"metadata": {"scope": "session", "user_id": "alice"}}])
-    assert store.owns_session_document("doc-1", "alice") is True
+    assert store.may_delete_session_document("doc-1", "alice") is True
 
 
-def test_owns_session_document_false_for_different_user():
+def test_may_delete_session_document_false_for_different_user():
     store = _FakeChunkStore([{"metadata": {"scope": "session", "user_id": "mallory"}}])
-    assert store.owns_session_document("doc-1", "alice") is False
+    assert store.may_delete_session_document("doc-1", "alice") is False
 
 
-def test_owns_session_document_fails_closed_when_unsupported():
+def test_may_delete_session_document_true_when_no_chunks_left():
+    """Idempotent-retry case: an earlier delete already removed every chunk,
+    so there is nothing left to prove ownership over -- must not deny forever."""
+    store = _FakeChunkStore([])
+    assert store.may_delete_session_document("doc-1", "alice") is True
+
+
+def test_may_delete_session_document_fails_closed_when_unsupported():
     store = _FakeChunkStore(unsupported=True)
-    assert store.owns_session_document("doc-1", "alice") is False
+    assert store.may_delete_session_document("doc-1", "alice") is False


### PR DESCRIPTION
## Summary

Fixes #2223. Three compounding bugs made deleting a session-scoped chat attachment silently fail:

- **knowledge-flow-backend**: the fast-ingest delete route checked `DocumentPermission.DELETE` via ReBAC, but session-scoped fast-ingest documents carry no `parent` tag and therefore no ReBAC tuple — the check could never resolve to `true` for anyone, including the uploader. `summarize_document` already has to work around the equivalent gap on the read side by falling back to proving ownership from the vector chunk's own `scope`/`user_id` metadata; delete now reuses that same mechanism (extracted into `BaseVectorStore.may_delete_session_document` / `is_own_session_chunk`, shared by both call sites) instead of a ReBAC check that could never pass. No OpenFGA schema change and no data migration needed — the ownership signal already exists on every previously-ingested chunk. `may_delete_session_document` also allows a document with no chunks left at all, so a delete retry after an earlier attempt already removed the vectors but failed on a later cleanup step can still converge instead of being denied forever.
- **control-plane-backend**: the attachment-delete proxy collapsed every downstream failure (including that 403) into a hardcoded 502, hiding the real reason from the frontend. It now checks for an explicit 2xx success and relays the downstream status code/detail for 4xx responses (guarding against a non-dict JSON error body); anything else, including a 3xx redirect this client doesn't follow, is treated as a failure rather than silently read as success.
- **frontend**: even once the backend returns a real error, `deletePersistedAttachment` rolled back its optimistic UI removal but never signaled the user — the rejection was rethrown and then discarded with `void` at both call sites (composer chip list and attachments drawer), becoming an invisible unhandled promise rejection. Wired the existing `useApiErrorToast`/`notifyApiError` pattern (already used elsewhere in this same feature) into the one function both entry points funnel through, without rethrowing afterward (nothing awaits the call, so rethrowing only added a second, unhandled rejection on top of the toast).

## Test plan

- [x] `make code-quality` and `make test` green in `apps/knowledge-flow-backend`
- [x] `make code-quality` and `make test` green in `apps/control-plane-backend`
- [x] `make code-quality` and `make test` green in `apps/frontend`
- [x] New/updated unit tests pin both authorization decisions (admin bypass, owner passes, non-owner refused, retry-after-vectors-gone converges) and the status-code relay paths (4xx relayed, 5xx/3xx/non-dict-JSON handled)
- [x] All CI checks green; Codex + Copilot automated review findings addressed and replied to inline
- [ ] Manual verification in the browser (reproduce the original repro: upload a session attachment, summarize it, delete it) — owed by the reporter before closing #2223