### PR TITLE
fix(frontend): anchor fixed-position popovers to the layout viewport (Edge classic scrollbars)

### DIFF
--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
@@ -26,6 +26,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { viewportWidth } from "@shared/utils/viewport.ts";
 import styles from "./Tooltip.module.scss";
 
 interface TooltipProps {
@@ -155,7 +156,7 @@ export const Tooltip = ({ text, content, children }: TooltipProps) => {
 
     const idealLeft = triggerRect.left + triggerRect.width / 2;
     const minLeft = VIEWPORT_MARGIN_PX + width / 2;
-    const maxLeft = window.innerWidth - VIEWPORT_MARGIN_PX - width / 2;
+    const maxLeft = viewportWidth() - VIEWPORT_MARGIN_PX - width / 2;
     const left = Math.min(Math.max(idealLeft, minLeft), maxLeft);
 
     setContentStyle({ top, left, transform: `translate(-50%, ${translateY})` });

--- a/apps/frontend/src/rework/components/shared/molecules/IconButtonMenu/IconButtonMenu.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/IconButtonMenu/IconButtonMenu.tsx
@@ -18,6 +18,7 @@ import { CSSProperties, useCallback, useEffect, useId, useLayoutEffect, useRef, 
 import { createPortal } from "react-dom";
 import Menu from "@shared/molecules/Menu/Menu.tsx";
 import { OptionModel } from "@models/Option.model.ts";
+import { viewportHeight, viewportWidth } from "@shared/utils/viewport.ts";
 
 // Gap between the button and the popover (matches --spacing-3xs).
 const MENU_GAP = 4;
@@ -45,12 +46,12 @@ export default function IconButtonMenu<T>({ iconButton, options, onSelect }: Ico
     const anchor = containerRef.current;
     if (!anchor) return;
     const rect = anchor.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceBelow = viewportHeight() - rect.bottom;
     const openUp = spaceBelow < MIN_MENU_SPACE && rect.top > spaceBelow;
     setPopoverStyle({
       position: "fixed",
-      right: window.innerWidth - rect.right,
-      ...(openUp ? { bottom: window.innerHeight - rect.top + MENU_GAP } : { top: rect.bottom + MENU_GAP }),
+      right: viewportWidth() - rect.right,
+      ...(openUp ? { bottom: viewportHeight() - rect.top + MENU_GAP } : { top: rect.bottom + MENU_GAP }),
     });
   }, []);
 

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.test.tsx
@@ -142,6 +142,39 @@ describe("Select keyboard navigation — disabled options", () => {
     expect(onChange).toHaveBeenCalledWith("b");
   });
 
+  it("popover flipped upward anchors to the layout viewport, not window.innerHeight", () => {
+    // Windows/Edge regression: with classic scrollbars, window.innerHeight
+    // includes the horizontal scrollbar while position:fixed offsets exclude
+    // it — computing `bottom` from innerHeight floats the menu ~17px above
+    // the trigger. The popover must use documentElement.clientHeight.
+    const options: OptionModel<string>[] = [
+      { key: "20", value: "20", label: "20" },
+      { key: "50", value: "50", label: "50" },
+    ];
+    render(<Select options={options} value="50" onChange={() => {}} size="small" />);
+
+    const originalClientHeight = Object.getOwnPropertyDescriptor(Element.prototype, "clientHeight");
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 700, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 717, configurable: true, writable: true });
+
+    const anchor = container.querySelector("div") as HTMLDivElement;
+    anchor.getBoundingClientRect = () =>
+      ({ top: 650, bottom: 690, left: 100, right: 180, width: 80, height: 40, x: 100, y: 650 }) as DOMRect;
+
+    try {
+      pressKey("ArrowDown"); // open — only 10px below the trigger, so the menu flips upward
+
+      const popover = document.querySelector('[id$="-menu"]') as HTMLDivElement;
+      expect(popover).not.toBeNull();
+      // 700 (layout viewport) − 650 (trigger top) + 4 (gap); the buggy
+      // innerHeight-based math would yield 71px.
+      expect(popover.style.bottom).toBe("54px");
+    } finally {
+      delete (document.documentElement as { clientHeight?: number }).clientHeight;
+      if (originalClientHeight) Object.defineProperty(Element.prototype, "clientHeight", originalClientHeight);
+    }
+  });
+
   it("Arrow navigation wraps around while skipping disabled options", () => {
     const options: OptionModel<string>[] = [
       { key: "a", value: "a", label: "A" },

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
@@ -28,6 +28,7 @@ import { OptionModel } from "@models/Option.model.ts";
 import Menu from "@shared/molecules/Menu/Menu.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import { ComponentSize } from "@shared/utils/Type.ts";
+import { viewportHeight } from "@shared/utils/viewport.ts";
 
 // Gap between the trigger and the popover (matches --spacing-3xs).
 const MENU_GAP = 4;
@@ -76,13 +77,13 @@ export default function Select<T>({
     const anchor = containerRef.current;
     if (!anchor) return;
     const rect = anchor.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceBelow = viewportHeight() - rect.bottom;
     const openUp = spaceBelow < MIN_MENU_SPACE && rect.top > spaceBelow;
     setPopoverStyle({
       position: "fixed",
       left: rect.left,
       width: rect.width,
-      ...(openUp ? { bottom: window.innerHeight - rect.top + MENU_GAP } : { top: rect.bottom + MENU_GAP }),
+      ...(openUp ? { bottom: viewportHeight() - rect.top + MENU_GAP } : { top: rect.bottom + MENU_GAP }),
     });
   }, []);
 

--- a/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx
@@ -23,6 +23,7 @@ import { TaskProgressBar } from "../../atoms/TaskProgressBar/TaskProgressBar";
 import { TaskStateBadge } from "../../atoms/TaskStateBadge/TaskStateBadge";
 import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
+import { viewportWidth } from "@shared/utils/viewport.ts";
 import styles from "./TaskDetailPopover.module.css";
 
 interface TaskDetailPopoverProps {
@@ -52,7 +53,7 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
     const top = rect.bottom + 6;
     // Prefer left-aligned; flip to right-aligned when it would overflow the viewport.
     const left =
-      rect.left + POPOVER_WIDTH + MARGIN > window.innerWidth ? Math.max(MARGIN, rect.right - POPOVER_WIDTH) : rect.left;
+      rect.left + POPOVER_WIDTH + MARGIN > viewportWidth() ? Math.max(MARGIN, rect.right - POPOVER_WIDTH) : rect.left;
     setPos({ top, left });
   }, [open, anchorEl]);
 

--- a/apps/frontend/src/rework/components/shared/organisms/TaskTray/TaskTray.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TaskTray/TaskTray.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import { useClickOutside } from "../../hooks/UseClickOutside";
 import { TaskCard } from "../../molecules/TaskCard/TaskCard";
 import { Portal } from "../../utils/Portal";
+import { viewportHeight, viewportWidth } from "../../utils/viewport";
 import {
   EVICTION_DELAY_MS,
   selectVisibleTasks,
@@ -47,8 +48,8 @@ export function TaskTray() {
     if (!isOpen && triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect();
       setPanelPos({
-        bottom: window.innerHeight - rect.top + 8,
-        left: Math.min(rect.left, window.innerWidth - 296),
+        bottom: viewportHeight() - rect.top + 8,
+        left: Math.min(rect.left, viewportWidth() - 296),
       });
     }
     setIsOpen((v) => !v);

--- a/apps/frontend/src/rework/components/shared/utils/viewport.ts
+++ b/apps/frontend/src/rework/components/shared/utils/viewport.ts
@@ -1,0 +1,32 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Size of the layout viewport that `position: fixed` offsets are resolved
+ * against. Never use `window.innerWidth`/`innerHeight` for popover math:
+ * those include classic (non-overlay) scrollbars — the default on
+ * Windows/Edge — while `position: fixed; bottom/right` exclude them, so a
+ * portaled popover computed from `innerWidth`/`innerHeight` lands shifted by
+ * the scrollbar thickness (~17px) whenever the document has a scrollbar.
+ * `documentElement.clientWidth`/`clientHeight` match the fixed-position
+ * containing block on every platform, and are identical to
+ * `innerWidth`/`innerHeight` where scrollbars are overlay (Linux, macOS).
+ */
+export function viewportWidth(): number {
+  return document.documentElement.clientWidth;
+}
+
+export function viewportHeight(): number {
+  return document.documentElement.clientHeight;
+}


### PR DESCRIPTION
Closes #2233

## Problem

In prod on Microsoft Edge (Windows), the rows-per-page menu of the resources table opens detached ~20px above its trigger, floating over the table rows. Not reproducible on Linux/macOS dev machines.

## Root cause

All portaled popovers computed `position: fixed` offsets from `window.innerHeight` / `window.innerWidth`. Those metrics **include classic (non-overlay) scrollbars** — the Windows/Edge default — while `position: fixed; bottom/right` offsets are resolved against the layout viewport **excluding** them. With a document scrollbar present, every popover placed via `bottom:` (flip-up) or `right:` (right-aligned) lands shifted by the scrollbar thickness (~17px). Overlay-scrollbar platforms have `innerHeight === documentElement.clientHeight`, which is why dev never saw it.

## Fix

- New shared helper `@shared/utils/viewport.ts`: `viewportWidth()` / `viewportHeight()` backed by `document.documentElement.clientWidth/clientHeight` — identical to the fixed-position containing block on every platform, and equal to `innerWidth/innerHeight` where scrollbars are overlay.
- Switched all five fixed-position popover call sites to it: `Select` (the reported case), `IconButtonMenu` (row ⋮ menus — `bottom` **and** `right`), `TaskTray`, `Tooltip` (horizontal clamp), `TaskDetailPopover` (horizontal flip threshold).

`usePickerMenuMaxHeight` already uses `visualViewport` (scrollbar-exclusive) and needed no change.

## Tests

- Regression test in `Select.test.tsx`: simulates a classic-scrollbar viewport (`innerHeight` 17px larger than `documentElement.clientHeight`), opens the menu near the bottom edge, and asserts the flipped-up popover anchors to the layout viewport (`bottom: 54px`, where the buggy math yielded `71px`).
- `make code-quality` (tsc + prettier + eslint) and `make test` green: 104 files, 1002 passed / 2 skipped.