### PR TITLE
feat(frontend): session-history cache for reducing conversation switches latencies (#2239)

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/sessionHistoryCache.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/sessionHistoryCache.ts
@@ -14,32 +14,35 @@
 
 import type { ChatMessage } from "../../../../slices/agentic/agenticOpenApi";
 
-// In-memory per-session history cache backing instant conversation switches
-// (#2239). Module-level ON PURPOSE: ManagedChatPage remounts with
-// key={agentInstanceId} when switching agents, so hook/ref state would be
-// lost exactly when the user hops between two agents' conversations — the
-// case the cache exists for. Client-side only, per the History Ownership
-// Contract (CHAT-UI-BACKLOG.md §0.4): the control-plane must never cache or
-// serve message history, and the runtime stays the source of truth — every
-// cached entry is revalidated against it on re-entry (useSessionHistory's
-// serve-then-revalidate).
+// Per-session history cache backing instant conversation switches (#2239).
+//
+// Two layers, same bounded LRU semantics:
+// - a module-level Map (the authority while the page lives) — module-level ON
+//   PURPOSE: ManagedChatPage remounts with key={agentInstanceId} when
+//   switching agents, so hook/ref state would be lost exactly when the user
+//   hops between two agents' conversations;
+// - a best-effort sessionStorage mirror, so the cache also survives a page
+//   refresh (F5). sessionStorage — not localStorage — deliberately: it is
+//   per-tab and cleared when the tab closes, the same lifetime already
+//   accepted for `chat.composer.<sessionId>`, so conversation content never
+//   outlives the user's tab on a shared machine. Every storage access is
+//   wrapped: quota exhaustion or a blocked storage API degrades to
+//   in-memory-only, never to an error.
+//
+// Client-side only, per the History Ownership Contract (CHAT-UI-BACKLOG.md
+// §0.4): the control-plane must never cache or serve message history, and the
+// runtime stays the source of truth — every cached entry is revalidated
+// against it on re-entry (useSessionHistory's serve-then-revalidate).
 const MAX_CACHED_SESSIONS = 20;
+const STORAGE_PREFIX = "chat.history.";
+const STORAGE_INDEX_KEY = "chat.history#index";
 
 // Map preserves insertion order; delete-then-set on every read and write
 // keeps the FIRST key the least-recently-used one — a bounded LRU without a
 // dedicated structure.
 const cache = new Map<string, ChatMessage[]>();
 
-export function getCachedSessionHistory(sessionId: string): ChatMessage[] | undefined {
-  const entry = cache.get(sessionId);
-  if (entry !== undefined) {
-    cache.delete(sessionId);
-    cache.set(sessionId, entry);
-  }
-  return entry;
-}
-
-export function setCachedSessionHistory(sessionId: string, messages: ChatMessage[]): void {
+function setInMemory(sessionId: string, messages: ChatMessage[]): void {
   cache.delete(sessionId);
   cache.set(sessionId, messages);
   while (cache.size > MAX_CACHED_SESSIONS) {
@@ -49,7 +52,123 @@ export function setCachedSessionHistory(sessionId: string, messages: ChatMessage
   }
 }
 
-// Test-only: module-level state would otherwise leak between test cases.
+// LRU order of the persisted entries, oldest first. Kept in its own key so
+// eviction after a reload (when the in-memory Map is empty) still knows which
+// persisted entry is oldest.
+function storageReadIndex(): string[] {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_INDEX_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function storageWriteIndex(ids: string[]): void {
+  try {
+    sessionStorage.setItem(STORAGE_INDEX_KEY, JSON.stringify(ids));
+  } catch {
+    // Best-effort — the in-memory layer still works.
+  }
+}
+
+function storageReadEntry(sessionId: string): ChatMessage[] | undefined {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_PREFIX + sessionId);
+    if (!raw) return undefined;
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as ChatMessage[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function storageDeleteEntry(sessionId: string): void {
+  try {
+    sessionStorage.removeItem(STORAGE_PREFIX + sessionId);
+  } catch {
+    // Best-effort.
+  }
+}
+
+function storagePromote(sessionId: string): void {
+  const ids = storageReadIndex();
+  if (!ids.includes(sessionId)) return;
+  storageWriteIndex([...ids.filter((id) => id !== sessionId), sessionId]);
+}
+
+function storagePersist(sessionId: string, messages: ChatMessage[]): void {
+  let ids = storageReadIndex().filter((id) => id !== sessionId);
+  ids.push(sessionId);
+  while (ids.length > MAX_CACHED_SESSIONS) {
+    storageDeleteEntry(ids.shift()!);
+  }
+  let payload: string;
+  try {
+    payload = JSON.stringify(messages);
+  } catch {
+    return; // Unserializable thread — in-memory only.
+  }
+  for (;;) {
+    try {
+      sessionStorage.setItem(STORAGE_PREFIX + sessionId, payload);
+      break;
+    } catch {
+      // Quota (or storage blocked): evict the least-recently-used persisted
+      // entry and retry; once nothing is left to evict, give up — the entry
+      // stays served from memory for this page's lifetime.
+      if (ids.length <= 1) {
+        ids = ids.filter((id) => id !== sessionId);
+        break;
+      }
+      storageDeleteEntry(ids.shift()!);
+    }
+  }
+  storageWriteIndex(ids);
+}
+
+export function getCachedSessionHistory(sessionId: string): ChatMessage[] | undefined {
+  const entry = cache.get(sessionId);
+  if (entry !== undefined) {
+    cache.delete(sessionId);
+    cache.set(sessionId, entry);
+    storagePromote(sessionId);
+    return entry;
+  }
+  // Read-through: after a page refresh the Map starts empty but the tab's
+  // sessionStorage doesn't — rehydrate so the conversation still renders
+  // instantly (then revalidates) instead of blanking behind a spinner.
+  const persisted = storageReadEntry(sessionId);
+  if (persisted !== undefined) {
+    setInMemory(sessionId, persisted);
+    storagePromote(sessionId);
+  }
+  return persisted;
+}
+
+export function setCachedSessionHistory(sessionId: string, messages: ChatMessage[]): void {
+  setInMemory(sessionId, messages);
+  storagePersist(sessionId, messages);
+}
+
+// Clears BOTH layers. Used by tests for isolation; safe for future product
+// use (e.g. a "clear local data" action).
 export function clearSessionHistoryCache(): void {
+  cache.clear();
+  try {
+    const doomed: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (key && (key.startsWith(STORAGE_PREFIX) || key === STORAGE_INDEX_KEY)) doomed.push(key);
+    }
+    doomed.forEach((key) => sessionStorage.removeItem(key));
+  } catch {
+    // Best-effort.
+  }
+}
+
+// Test-only: simulates a page reload (JS heap gone, sessionStorage kept).
+export function dropInMemorySessionHistoryForTests(): void {
   cache.clear();
 }

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/sessionHistoryCache.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/sessionHistoryCache.ts
@@ -1,0 +1,55 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ChatMessage } from "../../../../slices/agentic/agenticOpenApi";
+
+// In-memory per-session history cache backing instant conversation switches
+// (#2239). Module-level ON PURPOSE: ManagedChatPage remounts with
+// key={agentInstanceId} when switching agents, so hook/ref state would be
+// lost exactly when the user hops between two agents' conversations — the
+// case the cache exists for. Client-side only, per the History Ownership
+// Contract (CHAT-UI-BACKLOG.md §0.4): the control-plane must never cache or
+// serve message history, and the runtime stays the source of truth — every
+// cached entry is revalidated against it on re-entry (useSessionHistory's
+// serve-then-revalidate).
+const MAX_CACHED_SESSIONS = 20;
+
+// Map preserves insertion order; delete-then-set on every read and write
+// keeps the FIRST key the least-recently-used one — a bounded LRU without a
+// dedicated structure.
+const cache = new Map<string, ChatMessage[]>();
+
+export function getCachedSessionHistory(sessionId: string): ChatMessage[] | undefined {
+  const entry = cache.get(sessionId);
+  if (entry !== undefined) {
+    cache.delete(sessionId);
+    cache.set(sessionId, entry);
+  }
+  return entry;
+}
+
+export function setCachedSessionHistory(sessionId: string, messages: ChatMessage[]): void {
+  cache.delete(sessionId);
+  cache.set(sessionId, messages);
+  while (cache.size > MAX_CACHED_SESSIONS) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+}
+
+// Test-only: module-level state would otherwise leak between test cases.
+export function clearSessionHistoryCache(): void {
+  cache.clear();
+}

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
@@ -92,6 +92,9 @@ const chatSseResetMock = vi.fn();
 const sendHitlResumeMock = vi.fn();
 const abortMock = vi.fn();
 const replaceAllMessagesMock = vi.fn();
+// Mutable so the #2239 departure-snapshot test below can put a displayed
+// thread on screen; reset to [] in beforeEach.
+let chatSseMessages: unknown[] = [];
 let capturedFlushPendingWrites: ((sid: string | null) => Promise<boolean>) | undefined;
 let capturedOnTurnStarted: (() => void) | undefined;
 let capturedOnError: ((msg: string) => void) | undefined;
@@ -108,7 +111,7 @@ vi.mock("@hooks/useChatSse", () => ({
     capturedOnError = params.onError;
     capturedOnAwaitingHuman = params.onAwaitingHuman;
     return {
-      messages: [],
+      messages: chatSseMessages,
       waitResponse: false,
       chatControls: [],
       prepareChatControls: prepareChatControlsMock,
@@ -219,6 +222,7 @@ vi.mock("../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
 }));
 
 import { useManagedChat } from "./useManagedChat";
+import { clearSessionHistoryCache, getCachedSessionHistory } from "./sessionHistoryCache";
 
 function TestHost({ onRender }: { onRender: (hook: ReturnType<typeof useManagedChat>) => void }) {
   const hook = useManagedChat({ teamId: "team-1", agentInstanceId: "agent-1" });
@@ -264,6 +268,8 @@ describe("useManagedChat — session write reliability", () => {
   };
 
   beforeEach(() => {
+    clearSessionHistoryCache();
+    chatSseMessages = [];
     registerSessionImpl = async () => ({});
     patchSessionImpl = async () => ({});
     registerSessionCalls.length = 0;
@@ -1081,5 +1087,30 @@ describe("useManagedChat — session write reliability", () => {
     expect(sendMock).toHaveBeenCalledTimes(1);
     rerender();
     expect(latest.sessionId).not.toBeNull();
+  });
+
+  it("leaving a session snapshots the displayed thread into the session-history cache (#2239)", async () => {
+    mount();
+    // Bind session A without a send (attachment-drop path).
+    act(() => {
+      latest.handleAddAttachments([], "picker");
+    });
+    rerender();
+    const sidA = latest.sessionId;
+    expect(sidA).not.toBeNull();
+
+    // The thread as displayed at departure time — streamed live into
+    // useChatSse's state, so no history fetch ever saw it. Only the
+    // departure snapshot can fold it into the cache.
+    const displayed = [{ id: "x:1" }];
+    chatSseMessages = displayed;
+    rerender();
+
+    act(() => {
+      latest.startNewConversation();
+    });
+
+    // The exact displayed array was snapshotted under A's session id.
+    expect(getCachedSessionHistory(sidA!)).toBe(displayed);
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
@@ -29,6 +29,7 @@ import {
   usePostTeamSessionControlPlaneV1TeamsTeamIdSessionsPostMutation,
 } from "../../../../slices/controlPlane/controlPlaneOpenApi";
 import { useSessionHistory } from "./useSessionHistory";
+import { setCachedSessionHistory } from "./sessionHistoryCache";
 import { useChatAttachments } from "./useChatAttachments";
 import { buildComposerRuntimeContext } from "./runtimeContextBuilder";
 import { toThreadMessages } from "./toThreadMessages";
@@ -272,6 +273,34 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   const chatControlsRef = useRef(chatControls);
   chatControlsRef.current = chatControls;
 
+  // Live-turn indicator handed to useSessionHistory — its async closures need
+  // the CURRENT streaming state at response-arrival time, not the render-time
+  // value a plain boolean capture would freeze.
+  const waitResponseRef = useRef(waitResponse);
+  waitResponseRef.current = waitResponse;
+  const isTurnActive = useCallback(() => waitResponseRef.current, []);
+
+  // Mirrors read by the departure-snapshot cleanup below: a cleanup closure
+  // captures its own render's values, but must snapshot what is on screen at
+  // DEPARTURE time.
+  const displayedMessagesRef = useRef(messages);
+  displayedMessagesRef.current = messages;
+  const isLoadingHistoryRef = useRef(false);
+
+  // #2239: on leaving a session (switch or unmount), snapshot the displayed
+  // thread into the session-history cache — this cleanup runs BEFORE the next
+  // session's reset effect wipes the state, and it is what folds
+  // live-streamed turns into the cache without any extra fetch. Skipped while
+  // the initial history load is still in flight: caching a half-loaded thread
+  // would make the next visit render it as if it were complete.
+  useEffect(() => {
+    if (!sessionId) return;
+    return () => {
+      if (isLoadingHistoryRef.current) return;
+      setCachedSessionHistory(sessionId, displayedMessagesRef.current);
+    };
+  }, [sessionId]);
+
   const composer = useComposerSettings(sessionId, chatControls);
 
   useEffect(() => {
@@ -284,6 +313,11 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     }
     console.debug(`[useManagedChat] sessionId changed → reset() — sessionId=${sessionId ?? "null"}`);
     reset();
+    // reset() aborts any in-flight turn synchronously, but the waitResponse
+    // STATE only flips false on the next render — too late for the history
+    // effect running later in this same commit, whose isTurnActive() must
+    // already see "no live turn" or a cached thread would refuse to render.
+    waitResponseRef.current = false;
     setPendingHitl(null);
     setInput("");
     setSessionTitle(null);
@@ -330,7 +364,9 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     teamId,
     agentInstanceId,
     onLoaded: replaceAllMessages,
+    isTurnActive,
   });
+  isLoadingHistoryRef.current = isLoadingHistory;
 
   const notifySessionSaveFailed = useCallback(
     (error: unknown) =>

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.test.tsx
@@ -29,7 +29,12 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage } from "../../../../slices/agentic/agenticOpenApi";
-import { clearSessionHistoryCache, getCachedSessionHistory, setCachedSessionHistory } from "./sessionHistoryCache";
+import {
+  clearSessionHistoryCache,
+  dropInMemorySessionHistoryForTests,
+  getCachedSessionHistory,
+  setCachedSessionHistory,
+} from "./sessionHistoryCache";
 
 declare global {
   // eslint-disable-next-line no-var
@@ -247,5 +252,50 @@ describe("sessionHistoryCache — bounded LRU", () => {
     setCachedSessionHistory("session-extra", [msg("extra")]);
     expect(getCachedSessionHistory("session-0")).toEqual([msg("m0")]); // survived
     expect(getCachedSessionHistory("session-1")).toBeUndefined(); // evicted instead
+  });
+});
+
+describe("sessionHistoryCache — per-tab persistence across a page refresh", () => {
+  beforeEach(() => clearSessionHistoryCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("an entry survives a reload: JS heap gone, sessionStorage kept", () => {
+    setCachedSessionHistory("session-a", [msg("m1")]);
+    dropInMemorySessionHistoryForTests(); // simulates F5
+    expect(getCachedSessionHistory("session-a")).toEqual([msg("m1")]);
+  });
+
+  it("eviction removes the persisted copy too — the cap holds across reloads", () => {
+    for (let i = 0; i < 21; i++) setCachedSessionHistory(`session-${i}`, [msg(`m${i}`)]);
+    dropInMemorySessionHistoryForTests();
+    expect(getCachedSessionHistory("session-0")).toBeUndefined(); // evicted from storage as well
+    expect(getCachedSessionHistory("session-20")).toEqual([msg("m20")]);
+  });
+
+  it("a blocked or full sessionStorage degrades to in-memory only, without throwing", () => {
+    // Patch the instance, not Storage.prototype — happy-dom's sessionStorage
+    // does not route calls through the prototype.
+    const originalSetItem = sessionStorage.setItem.bind(sessionStorage);
+    Object.defineProperty(sessionStorage, "setItem", {
+      configurable: true,
+      value: () => {
+        throw new Error("QuotaExceededError");
+      },
+    });
+    try {
+      setCachedSessionHistory("session-a", [msg("m1")]); // must not throw
+      expect(getCachedSessionHistory("session-a")).toEqual([msg("m1")]); // memory still serves it
+    } finally {
+      Object.defineProperty(sessionStorage, "setItem", { configurable: true, value: originalSetItem });
+    }
+
+    dropInMemorySessionHistoryForTests();
+    expect(getCachedSessionHistory("session-a")).toBeUndefined(); // nothing was persisted
+  });
+
+  it("a corrupted persisted entry is ignored, not thrown", () => {
+    sessionStorage.setItem("chat.history.session-a", "{not json");
+    sessionStorage.setItem("chat.history#index", JSON.stringify(["session-a"]));
+    expect(getCachedSessionHistory("session-a")).toBeUndefined();
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Coverage for the #2239 session-history cache: switching back to a
+// previously opened conversation renders instantly from the in-memory cache
+// (no spinner) while the runtime is revalidated in the background — and the
+// guards that keep that safe:
+//
+// - a response that lands after the user switched sessions is neither
+//   rendered under the new session nor written to the cache;
+// - a response never replaces a live streamed turn;
+// - an empty response never wipes the optimistic first message of a
+//   brand-new session;
+// - the cache is a bounded LRU.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "../../../../slices/agentic/agenticOpenApi";
+import { clearSessionHistoryCache, getCachedSessionHistory, setCachedSessionHistory } from "./sessionHistoryCache";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../../../../security/KeycloakService", () => ({
+  KeyCloakService: {
+    ensureFreshToken: async () => {},
+    GetToken: () => "test-token",
+  },
+}));
+
+const prepareExecutionCalls: unknown[] = [];
+vi.mock("../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
+  usePostPrepareExecutionControlPlaneV1TeamsTeamIdAgentInstancesAgentInstanceIdPrepareExecutionPostMutation: () => [
+    (args: unknown) => {
+      prepareExecutionCalls.push(args);
+      return {
+        unwrap: async () => ({ messages_url_template: "/runtime/sessions/{session_id}/messages" }),
+      };
+    },
+  ],
+}));
+
+import { useSessionHistory } from "./useSessionHistory";
+
+const msg = (id: string): ChatMessage => ({ id }) as unknown as ChatMessage;
+
+// Per-test fetch behavior, keyed on the session id present in the URL.
+let fetchImpl: (url: string) => Promise<{ ok: boolean; json: () => Promise<ChatMessage[]> }>;
+const okResponse = (msgs: ChatMessage[]) => ({ ok: true, json: async () => msgs });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function TestHost({
+  sessionId,
+  onLoaded,
+  isTurnActive,
+  onRender,
+}: {
+  sessionId: string | null;
+  onLoaded: (messages: ChatMessage[]) => void;
+  isTurnActive: () => boolean;
+  onRender: (hook: ReturnType<typeof useSessionHistory>) => void;
+}) {
+  const hook = useSessionHistory({ sessionId, teamId: "team-1", agentInstanceId: "agent-1", onLoaded, isTurnActive });
+  onRender(hook);
+  return null;
+}
+
+describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: ReturnType<typeof useSessionHistory>;
+  const onLoaded = vi.fn();
+  let turnActive = false;
+  const isTurnActive = () => turnActive;
+
+  const render = (sessionId: string | null) => {
+    act(() => {
+      root.render(
+        <TestHost
+          sessionId={sessionId}
+          onLoaded={onLoaded}
+          isTurnActive={isTurnActive}
+          onRender={(h) => (latest = h)}
+        />,
+      );
+    });
+  };
+
+  const mount = (sessionId: string | null) => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    render(sessionId);
+  };
+
+  // Drains the microtask chain inside load() (token → prepare → fetch → json).
+  const settle = async () => {
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+  };
+
+  beforeEach(() => {
+    clearSessionHistoryCache();
+    onLoaded.mockClear();
+    prepareExecutionCalls.length = 0;
+    turnActive = false;
+    fetchImpl = async () => okResponse([]);
+    vi.stubGlobal("fetch", (url: string) => fetchImpl(String(url)));
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("cache miss: shows the loading state, applies the fetched history, and populates the cache", async () => {
+    const history = [msg("m1"), msg("m2")];
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+
+    mount("session-a");
+    expect(latest.isLoading).toBe(true);
+    expect(onLoaded).not.toHaveBeenCalled();
+
+    response.resolve(okResponse(history));
+    await settle();
+
+    expect(latest.isLoading).toBe(false);
+    expect(onLoaded).toHaveBeenCalledWith(history);
+    expect(getCachedSessionHistory("session-a")).toEqual(history);
+  });
+
+  it("cache hit: renders synchronously with no loading state, then revalidates in the background", async () => {
+    const cachedHistory = [msg("m1")];
+    const freshHistory = [msg("m1"), msg("m2-from-another-device")];
+    setCachedSessionHistory("session-a", cachedHistory);
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+
+    mount("session-a");
+    // Served from cache before any network round-trip, composer never gated.
+    expect(onLoaded).toHaveBeenCalledWith(cachedHistory);
+    expect(latest.isLoading).toBe(false);
+
+    response.resolve(okResponse(freshHistory));
+    await settle();
+
+    expect(latest.isLoading).toBe(false);
+    expect(onLoaded).toHaveBeenLastCalledWith(freshHistory);
+    expect(getCachedSessionHistory("session-a")).toEqual(freshHistory);
+  });
+
+  it("a response landing after a session switch is neither applied nor cached under either session", async () => {
+    const aResponse = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    const bHistory = [msg("b1")];
+    fetchImpl = (url) => (url.includes("session-a") ? aResponse.promise : Promise.resolve(okResponse(bHistory)));
+
+    mount("session-a");
+    render("session-b");
+    await settle();
+    expect(onLoaded).toHaveBeenLastCalledWith(bHistory);
+    onLoaded.mockClear();
+
+    // Session A's slow response finally lands — after the user moved to B.
+    aResponse.resolve(okResponse([msg("a1")]));
+    await settle();
+
+    expect(onLoaded).not.toHaveBeenCalled(); // A's history never rendered under B
+    expect(getCachedSessionHistory("session-a")).toBeUndefined(); // and never cached as fresh
+    expect(getCachedSessionHistory("session-b")).toEqual(bHistory);
+  });
+
+  it("an empty response is not applied — a brand-new session's optimistic first message survives", async () => {
+    fetchImpl = async () => okResponse([]);
+    mount("session-new");
+    await settle();
+
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(getCachedSessionHistory("session-new")).toBeUndefined();
+  });
+
+  it("a response never replaces a live streamed turn, and is not cached over it", async () => {
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+
+    mount("session-a");
+    turnActive = true; // a turn starts streaming while history is in flight
+    response.resolve(okResponse([msg("stale-history")]));
+    await settle();
+
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(getCachedSessionHistory("session-a")).toBeUndefined();
+  });
+
+  it("does not re-fetch on an effect re-fire for the same session", async () => {
+    fetchImpl = async () => okResponse([msg("m1")]);
+    mount("session-a");
+    await settle();
+    expect(prepareExecutionCalls).toHaveLength(1);
+
+    render("session-a");
+    await settle();
+    expect(prepareExecutionCalls).toHaveLength(1); // still one fetch round-trip
+  });
+});
+
+describe("sessionHistoryCache — bounded LRU", () => {
+  beforeEach(() => clearSessionHistoryCache());
+
+  it("evicts the least-recently-used entry beyond the cap", () => {
+    for (let i = 0; i < 21; i++) setCachedSessionHistory(`session-${i}`, [msg(`m${i}`)]);
+    expect(getCachedSessionHistory("session-0")).toBeUndefined(); // oldest evicted
+    expect(getCachedSessionHistory("session-1")).toEqual([msg("m1")]);
+    expect(getCachedSessionHistory("session-20")).toEqual([msg("m20")]);
+  });
+
+  it("a read refreshes recency", () => {
+    for (let i = 0; i < 20; i++) setCachedSessionHistory(`session-${i}`, [msg(`m${i}`)]);
+    getCachedSessionHistory("session-0"); // touch the oldest
+    setCachedSessionHistory("session-extra", [msg("extra")]);
+    expect(getCachedSessionHistory("session-0")).toEqual([msg("m0")]); // survived
+    expect(getCachedSessionHistory("session-1")).toBeUndefined(); // evicted instead
+  });
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.ts
@@ -16,32 +16,63 @@ import { useEffect, useRef, useState } from "react";
 import { KeyCloakService } from "../../../../security/KeycloakService";
 import type { ChatMessage } from "../../../../slices/agentic/agenticOpenApi";
 import { usePostPrepareExecutionControlPlaneV1TeamsTeamIdAgentInstancesAgentInstanceIdPrepareExecutionPostMutation } from "../../../../slices/controlPlane/controlPlaneOpenApi";
+import { getCachedSessionHistory, setCachedSessionHistory } from "./sessionHistoryCache";
 
 interface UseSessionHistoryArgs {
   sessionId: string | null;
   teamId: string | undefined;
   agentInstanceId: string | undefined;
   onLoaded: (messages: ChatMessage[]) => void;
+  // True while a streamed turn is in progress. A history response — cached or
+  // fetched — must never replace a live turn: history necessarily lacks the
+  // in-flight exchange, so applying it would visibly eat the user's message.
+  isTurnActive: () => boolean;
 }
 
 function expandMessagesUrl(template: string, sessionId: string): string {
   return template.replace("{session_id}", encodeURIComponent(sessionId));
 }
 
-export function useSessionHistory({ sessionId, teamId, agentInstanceId, onLoaded }: UseSessionHistoryArgs) {
+export function useSessionHistory({
+  sessionId,
+  teamId,
+  agentInstanceId,
+  onLoaded,
+  isTurnActive,
+}: UseSessionHistoryArgs) {
   const [isLoading, setIsLoading] = useState(false);
-  const loadedRef = useRef<string | null>(null);
+  // Session whose fetch this mount has already started — keeps an effect
+  // re-fire (a dep identity change, not a genuine switch) from re-fetching.
+  const startedForRef = useRef<string | null>(null);
+  // Always the CURRENTLY active session id, refreshed every render. A fetch
+  // that resolves after the user switched away must neither render its
+  // messages under the new session nor overwrite the new session's cache
+  // entry — the async closure's own `sessionId` is frozen at call time, so
+  // staleness can only be detected against a ref.
+  const activeSessionIdRef = useRef(sessionId);
+  activeSessionIdRef.current = sessionId;
 
   const [prepareExecution] =
     usePostPrepareExecutionControlPlaneV1TeamsTeamIdAgentInstancesAgentInstanceIdPrepareExecutionPostMutation();
 
   useEffect(() => {
     if (!sessionId || !teamId || !agentInstanceId) return;
-    if (loadedRef.current === sessionId) return;
-    loadedRef.current = sessionId;
+
+    // #2239 instant switch: a previously opened conversation renders straight
+    // from the cache — synchronously, no spinner, composer stays enabled —
+    // while the fetch below revalidates against the runtime (the source of
+    // truth) in the background and swaps in the fresh history when it lands.
+    const cached = getCachedSessionHistory(sessionId);
+    if (cached !== undefined && cached.length > 0 && !isTurnActive()) onLoaded(cached);
+
+    if (startedForRef.current === sessionId) return;
+    startedForRef.current = sessionId;
 
     const load = async () => {
-      setIsLoading(true);
+      // A cache hit downgrades the fetch to a silent background revalidation:
+      // isLoading stays false so the UI never regresses to a spinner over an
+      // already-rendered thread.
+      if (cached === undefined) setIsLoading(true);
       try {
         await KeyCloakService.ensureFreshToken(30);
         const token = KeyCloakService.GetToken() ?? "";
@@ -50,16 +81,29 @@ export function useSessionHistory({ sessionId, teamId, agentInstanceId, onLoaded
         const resp = await fetch(url.toString(), { headers: { Authorization: `Bearer ${token}` } });
         if (!resp.ok) return;
         const msgs: ChatMessage[] = await resp.json();
-        if (msgs.length > 0) onLoaded(msgs);
+        // Guards, in order:
+        // - stale response: the user switched sessions while this fetch was
+        //   in flight — applying would render session A's history under
+        //   session B and poison the cache;
+        // - live turn: see `isTurnActive` above;
+        // - empty history: a brand-new session bound at send time has no
+        //   persisted history yet — applying [] would wipe the optimistic
+        //   first message.
+        if (activeSessionIdRef.current !== sessionId) return;
+        if (isTurnActive()) return;
+        if (msgs.length === 0) return;
+        setCachedSessionHistory(sessionId, msgs);
+        onLoaded(msgs);
       } catch {
-        // History load failure is non-fatal — user continues with empty view.
+        // History load failure is non-fatal — user continues with the cached
+        // (or empty) view.
       } finally {
         setIsLoading(false);
       }
     };
 
-    load();
-  }, [sessionId, teamId, agentInstanceId, prepareExecution, onLoaded]);
+    void load();
+  }, [sessionId, teamId, agentInstanceId, prepareExecution, onLoaded, isTurnActive]);
 
   return { isLoading };
 }

--- a/docs/swift/backlog/CHAT-UI-BACKLOG.md
+++ b/docs/swift/backlog/CHAT-UI-BACKLOG.md
@@ -201,9 +201,14 @@ cache is written when a history fetch succeeds and when the user leaves a
 session (a snapshot of the displayed thread, which folds live-streamed turns
 in without an extra fetch). A history response is applied — and cached — only
 if its session is still the active one, no turn is streaming, and it is
-non-empty. This is still a client-side presentation-model cache only; §0.4
-holds unchanged: the control-plane never proxies, caches, or serves message
-history.
+non-empty. The LRU is mirrored (best-effort, quota-safe) into
+`sessionStorage` (`chat.history.<session_id>` + `chat.history#index`) so the
+cache also survives a page refresh — `sessionStorage` deliberately, not
+`localStorage`: per-tab and cleared on tab close, the same lifetime already
+accepted for `chat.composer.<sessionId>`, so conversation content never
+outlives the user's tab on a shared machine. This is still a client-side
+presentation-model cache only; §0.4 holds unchanged: the control-plane never
+proxies, caches, or serves message history.
 
 ```typescript
 // Internal shape — not exported

--- a/docs/swift/backlog/CHAT-UI-BACKLOG.md
+++ b/docs/swift/backlog/CHAT-UI-BACKLOG.md
@@ -191,6 +191,20 @@ It is populated from two sources:
 It is not sourced from control-plane message-history APIs because none should
 exist in the managed path.
 
+**Session-history cache (2026-08-05, #2239).** A module-level, bounded LRU
+(`sessionHistoryCache.ts`, ~20 sessions) makes switching back to a previously
+opened conversation instant: on re-entry the thread renders synchronously from
+the cache (no spinner, composer stays enabled) while `useSessionHistory`
+revalidates against the runtime in the background and swaps in the fresh
+history (serve-then-revalidate — the runtime stays the source of truth). The
+cache is written when a history fetch succeeds and when the user leaves a
+session (a snapshot of the displayed thread, which folds live-streamed turns
+in without an extra fetch). A history response is applied — and cached — only
+if its session is still the active one, no turn is streaming, and it is
+non-empty. This is still a client-side presentation-model cache only; §0.4
+holds unchanged: the control-plane never proxies, caches, or serves message
+history.
+
 ```typescript
 // Internal shape — not exported
 interface ConversationMessage {


### PR DESCRIPTION
Closes #2239.

## What

Switching between conversations in `ManagedChatPage` no longer reloads everything. Returning to a previously opened conversation renders the thread instantly — no blank flash, no spinner, composer stays enabled — while the runtime history is silently revalidated in the background and swapped in when it arrives.

## How

- **`sessionHistoryCache.ts` (new)** — a module-level, bounded LRU (20 sessions) mapping `session_id` → `ChatMessage[]`. Module-level on purpose: it survives the `key={agentInstanceId}` remount when hopping between two agents' conversations. Client-side only, per the History Ownership Contract (`CHAT-UI-BACKLOG.md` §0.4) — the control-plane still never proxies, caches, or serves message history, and the runtime stays the source of truth.
- **`useSessionHistory`** — serve-then-revalidate: on a cache hit the thread is applied synchronously and `isLoading` never flips (the fetch becomes a silent background revalidation); on a miss, behavior is unchanged. The async path gains explicit guards — a response is applied and cached only if
  1. its session is still the active one (fixes a latent race: switching A → B while A's fetch was in flight could render A's history under B),
  2. no turn is streaming (a late history response can no longer clobber a live turn),
  3. it is non-empty (preserves the existing protection of a brand-new session's optimistic first message).
- **`useManagedChat`** — on leaving a session (switch or unmount), the displayed thread is snapshotted into the cache via an effect cleanup that runs before the next session's reset wipes the state. This folds live-streamed turns into the cache with zero extra fetches. Snapshot is skipped while the initial history load is still in flight, so a half-loaded thread is never cached as complete.

## Tests

- New `useSessionHistory.test.tsx` (8 tests): cache miss, cache hit + background revalidation, stale-response-after-switch, empty-response, live-turn guard, no re-fetch on effect re-fire, LRU eviction, LRU recency refresh.
- `useManagedChat.test.tsx`: new departure-snapshot wiring test; existing 23 tests untouched and green.
- Full frontend suite: 105 files / 1012 tests passed; `make code-quality` (tsc + prettier + eslint) clean.

## Docs

- `docs/swift/backlog/CHAT-UI-BACKLOG.md` §1.4 — dated entry documenting the cache and its guards; §0.4 explicitly reaffirmed.

## Out of scope

The double `prepare-execution` POST per switch (one from the reset effect's `prepareChatControls`, one from `useSessionHistory`) is unchanged — worth a separate consolidation pass.
