### PR TITLE
fix(frontend): clarify agents empty state when no agent capability is enabled (#2238)

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1636,8 +1636,8 @@
     "save": "Save",
     "serviceNotice": {
       "agentTemplates": {
-        "description": "Start a runtime pod to enroll managed agents.",
-        "title": "No agent runtime available"
+        "description": "Ask a platform admin to enable an agent capability, or check that an agent runtime is connected.",
+        "title": "No agents available yet"
       },
       "controlPlane": {
         "description": "Check that the control-plane service is running.",
@@ -2042,7 +2042,7 @@
             "hint": "Every new conversation with this agent starts with the composer's reasoning toggle already on. Users can still switch it off per question. Reasoning is slower and, on agents that call tools, can make the model repeat calls."
           }
         },
-        "noTemplates": "No agent templates available — start a runtime pod.",
+        "noTemplates": "No agent templates available — ask a platform admin to enable an agent capability, or check the agent runtime.",
         "templateBrowser": {
           "title": "Select an agent template",
           "subtitle": "Each template is designed and optimized to create an agent for a specific mission."

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1636,8 +1636,8 @@
     "save": "Sauvegarder",
     "serviceNotice": {
       "agentTemplates": {
-        "description": "Démarrez un pod runtime pour inscrire des agents.",
-        "title": "Aucun runtime d'agents disponible"
+        "description": "Demandez à un administrateur d'activer une capability d'agent, ou vérifiez qu'un runtime d'agents est connecté.",
+        "title": "Aucun agent disponible pour le moment"
       },
       "controlPlane": {
         "description": "Vérifiez que le service de contrôle est en cours d'exécution.",
@@ -2042,7 +2042,7 @@
             "hint": "Chaque nouvelle conversation avec cet agent démarre avec le bouton de raisonnement déjà activé. Les utilisateurs peuvent toujours le désactiver question par question. Le raisonnement est plus lent et, sur les agents qui appellent des outils, peut amener le modèle à répéter des appels."
           }
         },
-        "noTemplates": "Aucun modèle d'agent disponible — démarrez un pod runtime.",
+        "noTemplates": "Aucun modèle d'agent disponible — demandez à un administrateur d'activer une capability d'agent, ou vérifiez le runtime d'agents.",
         "templateBrowser": {
           "title": "Sélectionner un template d'agent",
           "subtitle": "Chaque template permet de créer un agent pensé et optimisé pour une mission spécifique."


### PR DESCRIPTION
## What

Rewrites the Agents-tab empty state and the create-modal `noTemplates` string (en + fr). The old copy ("No agent runtime available — start a runtime pod to enroll managed agents") read as a backend outage, when the common cause is simply that no agent capability is enabled yet.

New copy states the user-facing situation first and both actionable causes, mirroring the existing model-routing phrasing:

> **No agents available yet**
> Ask a platform admin to enable an agent capability, or check that an agent runtime is connected.

Copy-only — no component or logic change. 3 strings × 2 locales.

Closes #2238