### PR TITLE
fix(frontend): stop composer pickers just below the chat session top bar (#2245)

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -349,8 +349,11 @@ export default function ManagedChatPage() {
             </div>
           )}
           {/* Session title bar — full-width surface; the inner row is capped to
-              the composer field width so title and composer stay aligned. */}
-          <div className={styles.topBar}>
+              the composer field width so title and composer stay aligned.
+              data-picker-top-boundary: the composer's anchored pickers
+              (usePickerMenuMaxHeight) stop just below this bar instead of
+              sliding under it. */}
+          <div className={styles.topBar} data-picker-top-boundary>
             <div className={styles.topBarInner}>
               <div className={styles.topBarTitle}>
                 {chat.sessionId && chat.sessionTitle != null && (

--- a/apps/frontend/src/rework/components/shared/molecules/MenuPopover/usePickerMenuMaxHeight.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/MenuPopover/usePickerMenuMaxHeight.ts
@@ -18,8 +18,15 @@
 // `pickerMenu` at `bottom: 0` that grows upward, so a tall list would overflow
 // past the top of the viewport without this clamp. Shared so every anchored
 // "dialog" row (capability-driven or not) gets the same behavior.
+//
+// A page can lower the top limit below the viewport edge by marking one element
+// with `data-picker-top-boundary` (e.g. the chat session title bar): the picker
+// then stops just below that element instead of sliding under it. Without a
+// marked element the viewport top stays the limit.
 
 import { type CSSProperties, type RefObject, useEffect, useState } from "react";
+
+export const PICKER_TOP_BOUNDARY_SELECTOR = "[data-picker-top-boundary]";
 
 const PICKER_VIEWPORT_MARGIN_PX = 16;
 const PICKER_MOBILE_MAX_HEIGHT_PX = 480;
@@ -39,14 +46,22 @@ export function usePickerMenuMaxHeight(
       const rect = wrapRef.current?.getBoundingClientRect();
       if (!rect) return;
 
+      const boundary = document.querySelector(PICKER_TOP_BOUNDARY_SELECTOR);
+      const topLimit = boundary ? Math.max(0, boundary.getBoundingClientRect().bottom) : 0;
       const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
       const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
       const heightCap = viewportWidth <= 720 ? PICKER_MOBILE_MAX_HEIGHT_PX : desktopMaxHeightPx;
-      const availableHeight = Math.floor(Math.min(rect.bottom, viewportHeight) - PICKER_VIEWPORT_MARGIN_PX);
+      const availableHeight = Math.floor(Math.min(rect.bottom, viewportHeight) - topLimit - PICKER_VIEWPORT_MARGIN_PX);
       setMaxHeight(Math.min(heightCap, Math.max(PICKER_MIN_HEIGHT_PX, availableHeight)));
     };
 
     update();
+
+    // The boundary's height can change while the picker is open (the session
+    // title appears once the first answer names the conversation).
+    const boundary = document.querySelector(PICKER_TOP_BOUNDARY_SELECTOR);
+    const boundaryObserver = boundary ? new ResizeObserver(update) : null;
+    if (boundary && boundaryObserver) boundaryObserver.observe(boundary);
 
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);
@@ -54,6 +69,7 @@ export function usePickerMenuMaxHeight(
     window.visualViewport?.addEventListener("scroll", update);
 
     return () => {
+      boundaryObserver?.disconnect();
       window.removeEventListener("resize", update);
       window.removeEventListener("scroll", update, true);
       window.visualViewport?.removeEventListener("resize", update);

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -186,6 +186,13 @@ sibling. Uses the profile-menu token set (`--surface-container-*`, `--on-surface
   `groups` entry; a `pickerSurface` className adds internal scroll for tall content. Applied to
   `ComposerControlSlot` (prompt library) and `DocumentScopeControl` (document/library picker).
 
+- **Pickers stop below the session top bar (2026-08-05, #2245)** — `usePickerMenuMaxHeight`
+  clamped the upward-growing pickers against the viewport top, so once the session top bar
+  landed (#2214/#2218) an expanded document tree slid under it and got clipped. The hook now
+  honors an optional boundary element marked `data-picker-top-boundary` (measured from its
+  bottom edge, tracked with a `ResizeObserver` while open); `ManagedChatPage` marks its
+  `.topBar`. Pages without a marked boundary keep the viewport-top clamp.
+
 ---
 
 ### `SearchConfig`


### PR DESCRIPTION
Closes #2245

## Problem

The chat composer's document/library picker (`DocumentScopeControl`) anchors at `bottom: 0` and grows upward. `usePickerMenuMaxHeight` clamped its height against the **viewport top**, but the session top bar (#2214/#2218) now occupies the top of the chat column — expanding folders in the document tree made the picker slide under the bar and get clipped. The prompt-library picker (`ComposerControlSlot`) shared the same latent issue.

## Change

- `usePickerMenuMaxHeight`: honors an optional top boundary element marked `data-picker-top-boundary`; available height is measured from the boundary's bottom edge instead of the viewport top. A `ResizeObserver` follows boundary height changes while a picker is open (the session title appears once the first answer names the conversation). No marked boundary → unchanged viewport-top behavior.
- `ManagedChatPage`: marks `.topBar` with `data-picker-top-boundary`.

Both composer pickers get the fix through the shared hook; no capability-control contract change.

## Verification

- `make code-quality` from monorepo root: all modules pass (tsc, prettier, eslint included).
- `make test` in `apps/frontend`: 1016 passed, 2 skipped, 0 failed.