### PR TITLE
delete eval

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2333,7 +2333,11 @@
           "upload": "Import",
           "manual": "Manual",
           "capture": "Capture"
-        }
+        },
+        "deleteTitle": "Delete evaluation",
+        "deleteMessage": "Delete evaluation {{id}}? This permanently removes it and every one of its runs, cases, metrics and events.",
+        "deleteSuccess": "Evaluation deleted",
+        "deleteError": "Failed to delete evaluation"
       },
       "evaluationCreate": {
         "title": "New evaluation",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2333,7 +2333,11 @@
           "upload": "Import",
           "manual": "Manuel",
           "capture": "Capture"
-        }
+        },
+        "deleteTitle": "Supprimer l'évaluation",
+        "deleteMessage": "Supprimer l'évaluation {{id}} ? Cela supprime définitivement l'évaluation ainsi que toutes ses exécutions, cas, métriques et événements.",
+        "deleteSuccess": "Évaluation supprimée",
+        "deleteError": "Échec de la suppression de l'évaluation"
       },
       "evaluationCreate": {
         "title": "Nouvelle évaluation",

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/Evaluations.tsx
@@ -23,9 +23,15 @@ import TextInput from "@shared/atoms/TextInput/TextInput";
 import PageHeader from "@shared/molecules/PageHeader/PageHeader";
 import Select from "@shared/molecules/Select/Select";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice";
+import { ConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialog";
+import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import type { OptionModel } from "@models/Option.model.ts";
 import { StatusPill } from "./EvaluationShared";
-import { useListEvaluationsQuery } from "../../../../../../../slices/evaluation/evaluationApiEnhancements";
+import {
+  useDeleteEvaluationMutation,
+  useListEvaluationsQuery,
+} from "../../../../../../../slices/evaluation/evaluationApiEnhancements";
+import type { EvaluationSummaryResponse } from "../../../../../../../slices/evaluation/evaluationOpenApi";
 import styles from "./Evaluations.module.css";
 
 interface EvaluationsProps {
@@ -42,11 +48,13 @@ type SortValue = "created_at:desc" | "created_at:asc" | "name:asc";
 
 export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation }: EvaluationsProps) {
   const { t } = useTranslation();
+  const { showSuccess, showError } = useToast();
 
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [sort, setSort] = useState<SortValue>("created_at:desc");
   const [offset, setOffset] = useState(0);
+  const [deleteTarget, setDeleteTarget] = useState<EvaluationSummaryResponse | null>(null);
 
   // Debounce the search box so each keystroke doesn't fire a request.
   useEffect(() => {
@@ -64,11 +72,26 @@ export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation 
     { teamId, q: debouncedSearch || undefined, sort, offset, limit: PAGE_SIZE },
     { skip: !teamId },
   );
+  const [deleteEvaluation, { isLoading: isDeleting }] = useDeleteEvaluationMutation();
 
   const evaluations = data?.evaluations ?? [];
   const total = data?.total ?? 0;
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteEvaluation({ evaluationId: deleteTarget.evaluation_id }).unwrap();
+      showSuccess({ summary: t("rework.evaluation.evaluations.deleteSuccess") });
+      setDeleteTarget(null);
+    } catch (e) {
+      const detail = (e as { data?: { detail?: unknown } })?.data?.detail;
+      showError({
+        summary: typeof detail === "string" ? detail : t("rework.evaluation.evaluations.deleteError"),
+      });
+    }
+  };
 
   const sortOptions: OptionModel<SortValue>[] = [
     { value: "created_at:desc", key: "newest", label: t("rework.evaluation.controls.sort.newest") },
@@ -166,6 +189,9 @@ export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation 
                 >
                   {t("rework.evaluation.evaluations.openRuns")}
                 </Button>
+                <Button color="error" variant="outlined" size="small" onClick={() => setDeleteTarget(evaluation)}>
+                  {t("common.delete")}
+                </Button>
               </div>
             </div>
           ))}
@@ -195,6 +221,19 @@ export default function Evaluations({ teamId, onNewEvaluation, onOpenEvaluation 
           </Button>
         </div>
       )}
+
+      <ConfirmationDialog
+        open={!!deleteTarget}
+        title={t("rework.evaluation.evaluations.deleteTitle")}
+        message={t("rework.evaluation.evaluations.deleteMessage", {
+          id: deleteTarget?.evaluation_id.slice(0, 12) ?? "",
+        })}
+        confirmLabel={isDeleting ? t("common.deleting") : t("common.delete")}
+        cancelLabel={t("common.cancel")}
+        criticalAction
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/slices/evaluation/evaluationApiEnhancements.ts
+++ b/apps/frontend/src/slices/evaluation/evaluationApiEnhancements.ts
@@ -9,10 +9,14 @@ export const enhancedEvaluationApi = api.enhanceEndpoints({
     createEvaluationEvaluationV1EvaluationsPost: {
       invalidatesTags: [{ type: "Evaluation", id: "LIST" }],
     },
+    deleteEvaluationEvaluationV1EvaluationsEvaluationIdDelete: {
+      invalidatesTags: [{ type: "Evaluation", id: "LIST" }],
+    },
   },
 });
 
 export const {
   useListEvaluationsEvaluationV1EvaluationsGetQuery: useListEvaluationsQuery,
   useCreateEvaluationEvaluationV1EvaluationsPostMutation: useCreateEvaluationMutation,
+  useDeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteMutation: useDeleteEvaluationMutation,
 } = enhancedEvaluationApi;


### PR DESCRIPTION
# Pull Request

## 1. What problem does this solve — and where is it tracked?

**Issue:** #2247 — "fix(frontend): add delete action for Evaluations (only Runs can be deleted today)"

**Problem in one sentence:** In the team Evaluations UI, a Run can be deleted but an Evaluation cannot — the Evaluations list has no delete action at all, even though the backend (`fred-agent-evaluator`) already implements and tests `DELETE /evaluations/{evaluation_id}` and the frontend's generated RTK mutation for it already existed, unused.

**Backlog ref:** n/a — `docs/swift/backlog/AGENT-EVALUATION-BACKLOG.md` has no checkbox covering this granular UI action (it tracks the evaluation *toolchain* design, not this app's row-level UI affordances). `BACKLOG.md`/`WORKPLAN.md` are frozen and `PMO-BOARD.md`/`sprint.yaml` were removed — GitHub issue #2247 is the tracking unit per current convention.

---

## 2. Before you wrote a single line of code

**RFC written?**

Not required — mechanical fix. Before touching any code I read both sides: the backend `DELETE /evaluations/{id}` endpoint (`fred-agent-evaluator/apps/fred-evaluation-backend/.../evaluations/{api.py,service.py,store.py}`) was already implemented and already covered by tests (`test_datasets_api.py`: happy-path 204 + run cascade, 409 while a run is still running, 403 for a non-member, 404 for an unknown id). The frontend's generated mutation (`useDeleteEvaluationEvaluationV1EvaluationsEvaluationIdDeleteMutation`) already existed in `evaluationOpenApi.ts`, just never imported anywhere. No new design decision, schema, or endpoint — this only wires an already-shipped, already-tested contract into the UI, mirroring the identical, already-shipped delete pattern already live in `EvaluationRuns.tsx`.

**Plan presented to the team before implementation?**

Yes. I presented the full analysis — what already existed on both sides, what was missing, the exact file to mirror, the proposed fix, files to touch, and acceptance criteria — as a ready-to-file GitHub issue draft, before writing any code. `gh` CLI isn't installed in this environment, so I asked the developer how they wanted the issue itself created rather than skip that step.

**Confirmation received?**

Yes — the developer created issue #2247 from that draft, created branch `2247-fixfrontend-add-delete-action-for-evaluations-only-runs-can-be-deleted-today`, and replied "vasy" (go ahead) before implementation started.

---

## 3. What you built

Added a delete action to the team Evaluations list. `Evaluations.tsx` gets a per-row "Delete" button that opens a `ConfirmationDialog`; on confirm it calls the previously-unused generated mutation, now re-exported as `useDeleteEvaluationMutation` from `evaluationApiEnhancements.ts` with `invalidatesTags: [{ type: "Evaluation", id: "LIST" }]` so the list auto-refreshes with no manual `refetch()`. Shows a success/error toast, surfacing the backend's 409 detail (e.g. "N run(s) currently running") when present instead of a generic message. Added `deleteTitle` / `deleteMessage` / `deleteSuccess` / `deleteError` i18n keys in `en` and `fr`, matching the existing `runs.delete*` keys exactly.

---

## 4. Proof of quality

**Tests added or updated:**

None. `Evaluations.tsx` has no unit tests today (neither does `EvaluationRuns.tsx`, whose pattern this mirrors) — this PR follows the existing convention for this file rather than introducing ad hoc coverage for one component. The backend `delete_evaluation` path this UI now calls is already covered by `fred-agent-evaluator`'s own suite (untouched by this PR):

| Test | File | What it covers |
| ---- | ---- | -------------- |
| `test_deleting_an_evaluation_also_removes_its_runs` | `fred-agent-evaluator/.../tests/test_datasets_api.py` | Happy path: 204, evaluation + its runs deleted |
| `test_deleting_is_refused_while_one_of_its_runs_is_still_running` | same | 409 when a run is `running` |
| `test_non_member_cannot_delete_another_teams_evaluation` | same | 403 — membership resolved from the row's own team |
| `test_deleting_an_unknown_evaluation_is_a_404` | same | 404 for unknown id |

**`make code-quality` output:**

```
npx tsc --noEmit
npx prettier . --check
Checking formatting...
All matched files use Prettier code style!
npx eslint "src/**/*.{ts,tsx}"
All frontend code quality checks completed
```

**Raw `basedpyright` output:** n/a — frontend-only (TypeScript) change, no Python package touched.

**`make test` output (`apps/frontend`):**

```
 Test Files  105 passed | 1 skipped (106)
      Tests  1016 passed | 2 skipped (1018)
   Duration  18.77s
```

Single package touched (`apps/frontend`) — one block above covers it.

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — no matching checkbox exists for this UI action (see §1) |
| New behaviour, API field, or contract change                      | n/a — no backend/contract change; wires an already-existing, already-documented endpoint into the UI |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — no controller/model changed, OpenAPI not regenerated (the generated client already had this type) |
| UX component implemented or visual status changed                 | n/a — `docs/swift/ux/COMPONENT-UX.md`'s `Evaluations` `PageHeader` entry (title/subtitle/actions) is unaffected; a row-level button doesn't change its documented slots |
| Phase progress row exists for this area                           | n/a |
| WORKPLAN sprint item finished                                     | n/a — `WORKPLAN.md` is frozen, not used for tracking |
| Code and a design doc now diverge                                 | none introduced |

Only non-doc files touched: `Evaluations.tsx`, `evaluationApiEnhancements.ts`, `locales/en/translation.json`, `locales/fr/translation.json`.

---

## 6. Close-out statement

```
## Task close-out
- Code: added delete action for Evaluations (button + ConfirmationDialog + toast) in Evaluations.tsx, wired useDeleteEvaluationMutation with LIST-tag invalidation in evaluationApiEnhancements.ts, added delete i18n keys in en/fr
- Tests: no new unit tests (none exist for this file or its EvaluationRuns.tsx sibling); make code-quality clean (tsc/prettier/eslint); make test: 1016 passed | 2 skipped, 0 failed
- Docs updated: none — mechanical fix wiring an already-shipped, already-tested backend contract into the UI; no design/contract change
- Backlog: n/a — no backlog checkbox covers this; tracked via GitHub issue #2247 only
- Skipped steps: RFC (§2) — not required, mechanical fix mirroring an already-shipped pattern
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

Worst case is a broken button: it does nothing (misconfigured mutation) or fails silently if `evaluationId` were wired incorrectly — it cannot delete more than the backend's own endpoint already allows, since the backend independently enforces team membership and the running-run guard. It touches only the Evaluations list; the Runs delete path (`EvaluationRuns.tsx`) is a separate, unmodified code path. No schema change, no new backend endpoint, no data migration.

**How do we roll back?**

Revert this PR. It's four files (`Evaluations.tsx`, `evaluationApiEnhancements.ts`, `locales/en/translation.json`, `locales/fr/translation.json`), no feature flag, no backend change, no DB migration to undo.