### PR TITLE
feat(migration): config-driven new-version banner with links

### DIFF
--- a/agentic-backend/agentic_backend/common/structures.py
+++ b/agentic-backend/agentic_backend/common/structures.py
@@ -385,6 +385,33 @@ class UploadWarning(BaseModel):
     )
 
 
+class MigrationBannerLink(BaseModel):
+    url: str = Field(description="Link target URL.")
+    labels: Dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → label map (e.g. {"en": "...", "fr": "..."}).',
+    )
+
+
+class MigrationBanner(BaseModel):
+    color: str = Field(
+        default="#00BBDD",
+        description="Banner background CSS color.",
+    )
+    titles: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Locale → emphasized lead sentence map, rendered in bold before the message.",
+    )
+    messages: Dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → message map (e.g. {"en": "...", "fr": "..."}).',
+    )
+    links: List[MigrationBannerLink] = Field(
+        default_factory=list,
+        description="Links rendered on the right side of the banner.",
+    )
+
+
 class FrontendFlags(BaseModel):
     enableK8Features: bool = False
     enableElecWarfare: bool = False
@@ -421,6 +448,10 @@ class Properties(BaseModel):
     uploadWarning: Optional[UploadWarning] = Field(
         default=None,
         description="Optional alert shown in the document upload drawer. Omit to show nothing.",
+    )
+    migrationBanner: Optional[MigrationBanner] = Field(
+        default=None,
+        description="Optional new-version banner overlaid on the page content. Omit to show nothing.",
     )
 
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1581,8 +1581,5 @@
       "title": "Privacy policy",
       "backToApp": "Back to app"
     }
-  },
-  "migrationBanner": {
-    "message": "From now on, the files and agents you create will not be kept when we switch to the new version."
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1581,8 +1581,5 @@
       "title": "Politique de confidentialité",
       "backToApp": "Retourner à l'application"
     }
-  },
-  "migrationBanner": {
-    "message": "À partir de maintenant, les fichiers et les agents que vous créez ne seront pas conservés lors de la bascule vers la nouvelle version."
   }
 }

--- a/frontend/src/migration/MigrationBanner.module.css
+++ b/frontend/src/migration/MigrationBanner.module.css
@@ -1,6 +1,11 @@
 /* KEA MIGRATION (throwaway) — overlay banner, see MigrationBanner.tsx */
 
+/* Background color comes from configuration (inline style); the fixed dark
+   text assumes the configured color stays light, like the default #00BBDD. */
+
 .banner {
+  --banner-text: #00222c;
+
   display: flex;
   position: absolute;
   top: var(--spacing-m);
@@ -14,23 +19,44 @@
   margin: 0 auto;
   box-shadow: var(--shadow-s);
   border-radius: var(--radius-s);
-  background-color: var(--red-40);
   padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) var(--spacing-m);
   max-width: 1100px;
 }
 
 .message {
   margin: 0;
-  color: var(--red-99);
+  color: var(--banner-text);
+  font: var(--font-body-medium);
+}
+
+.message strong {
   font: var(--font-body-medium-emphasized);
+}
+
+.actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.link {
+  color: var(--banner-text);
+  font: var(--font-body-medium-emphasized);
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.separator {
+  color: var(--banner-text);
 }
 
 /* IconButton sets --main-color on the button itself via [data-color], so the
    override has to target the button too — inheriting from .banner would lose. */
 .banner button {
-  --main-color: var(--red-99);
-  --state-on-surface-hover: rgb(255 255 255 / 20%);
-  --state-on-surface-pressed: rgb(255 255 255 / 30%);
+  --main-color: var(--banner-text);
+  --state-on-surface-hover: rgb(0 0 0 / 10%);
+  --state-on-surface-pressed: rgb(0 0 0 / 20%);
 }
 
 @keyframes slide-in {

--- a/frontend/src/migration/MigrationBanner.tsx
+++ b/frontend/src/migration/MigrationBanner.tsx
@@ -14,14 +14,16 @@
 
 // ---------------------------------------------------------------------------
 // KEA MIGRATION (one-shot, throwaway-on-kea).
-// Warns every user, once per session (i.e. once per login), that the content
-// they create now will not survive the switch to the new version.
+// Announces, once per session (i.e. once per login), that the new version is
+// available. Color, texts and links come from the platform-managed
+// frontend_settings.properties.migrationBanner; without it, nothing renders.
 // Rendered as an overlay over the page content only — never over the sidebar.
 // ---------------------------------------------------------------------------
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import { useFrontendProperties } from "../hooks/useFrontendProperties";
 import styles from "./MigrationBanner.module.css";
 
 const DISMISSED_KEY = "kea-migration-banner-dismissed";
@@ -43,8 +45,12 @@ const markDismissed = () => {
   }
 };
 
+const resolveLocalized = (map: { [key: string]: string } | undefined | null, lang: string): string | null =>
+  map ? (map[lang] ?? map["en"] ?? null) : null;
+
 export default function MigrationBanner() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { migrationBanner } = useFrontendProperties();
   const [open, setOpen] = useState(() => !wasDismissed());
 
   useEffect(() => {
@@ -56,7 +62,11 @@ export default function MigrationBanner() {
     return () => window.clearTimeout(timer);
   }, [open]);
 
-  if (!open) return null;
+  const lang = i18n.language?.split("-")[0] ?? "en";
+  const title = resolveLocalized(migrationBanner?.titles, lang);
+  const message = resolveLocalized(migrationBanner?.messages, lang);
+
+  if (!open || !migrationBanner || (!title && !message)) return null;
 
   const close = () => {
     markDismissed();
@@ -64,16 +74,34 @@ export default function MigrationBanner() {
   };
 
   return (
-    <div className={styles.banner} role="status" aria-live="polite">
-      <p className={styles.message}>{t("migrationBanner.message")}</p>
-      <IconButton
-        color="on-surface"
-        variant="icon"
-        size="xs"
-        icon={{ category: "outlined", type: "close" }}
-        onClick={close}
-        aria-label={t("common.close")}
-      />
+    <div className={styles.banner} style={{ backgroundColor: migrationBanner.color }} role="status" aria-live="polite">
+      <p className={styles.message}>
+        {title && <strong>{title}</strong>}
+        {title && message ? " " : null}
+        {message}
+      </p>
+      <div className={styles.actions}>
+        {(migrationBanner.links ?? []).map((link, index) => (
+          <Fragment key={link.url}>
+            {index > 0 && (
+              <span className={styles.separator} aria-hidden="true">
+                ·
+              </span>
+            )}
+            <a className={styles.link} href={link.url} target="_blank" rel="noopener noreferrer">
+              {resolveLocalized(link.labels, lang) ?? link.url}
+            </a>
+          </Fragment>
+        ))}
+        <IconButton
+          color="on-surface"
+          variant="icon"
+          size="xs"
+          icon={{ category: "outlined", type: "close" }}
+          onClick={close}
+          aria-label={t("common.close")}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -1379,6 +1379,28 @@ export type UploadWarning = {
     [key: string]: string;
   };
 };
+export type MigrationBannerLink = {
+  /** Link target URL. */
+  url: string;
+  /** Locale → label map (e.g. {"en": "...", "fr": "..."}). */
+  labels?: {
+    [key: string]: string;
+  };
+};
+export type MigrationBanner = {
+  /** Banner background CSS color. */
+  color?: string;
+  /** Locale → emphasized lead sentence map, rendered in bold before the message. */
+  titles?: {
+    [key: string]: string;
+  };
+  /** Locale → message map (e.g. {"en": "...", "fr": "..."}). */
+  messages?: {
+    [key: string]: string;
+  };
+  /** Links rendered on the right side of the banner. */
+  links?: MigrationBannerLink[];
+};
 export type Properties = {
   logoName?: string;
   logoNameDark?: string;
@@ -1407,6 +1429,8 @@ export type Properties = {
   gcuVersion?: string | null;
   /** Optional alert shown in the document upload drawer. Omit to show nothing. */
   uploadWarning?: UploadWarning | null;
+  /** Optional new-version banner overlaid on the page content. Omit to show nothing. */
+  migrationBanner?: MigrationBanner | null;
 };
 export type FrontendSettings = {
   feature_flags: FrontendFlags;


### PR DESCRIPTION
Replace the hardcoded red migration warning banner with a blue new-version announcement driven by configuration.

- New optional frontend_settings.properties.migrationBanner block (color, localized title/message, links); omit it to hide the banner
- Banner keeps its once-per-session display, 30s auto-hide and close
- Localized texts resolved per locale with English fallback
- Old migrationBanner translation keys removed (texts come from config)

# Pull Request

> **Read this before you type anything.**
>
> Opening a PR is the _last_ step, not the first. If you designed this alone,
> implemented it without sharing the plan, and are now hoping the review will
> validate the approach — stop. Close this tab. Go read
> [`docs/swift/platform/DEVELOPER_CONTRACT.md`](../docs/swift/platform/DEVELOPER_CONTRACT.md)
> and come back when the steps below are already done.
>
> This is not process theater. Every question below exists because something
> went wrong when it was skipped. Fill them in honestly. A short honest answer
> beats a long evasive one every time.

---

## 1. What problem does this solve — and where is it tracked?

<!-- GitHub issue # this PR closes/addresses (title, label, milestone are the
     tracking unit — there is no separate ID registry). If there is no issue,
     explain why this work exists at all. -->

**Issue:** <!-- #1234 / … / "no issue — mechanical fix because …" -->

**Problem in one sentence:**

**Backlog ref:** <!-- link to the [ ] checkbox in the relevant backlog file -->

---

## 2. Before you wrote a single line of code

This section cannot be skipped. If the answer to any question is "no" or
"I didn't", explain why — do not leave it blank.

**RFC written?**

<!-- For any design choice, schema change, new endpoint, or new component:
     paste the link to the RFC in docs/swift/rfc/.
     For a purely mechanical fix (one-function bug, typo, missing field
     already agreed on): write "not required — mechanical fix" and explain. -->

**Plan presented to the team before implementation?**

<!-- Did you share what you were going to build, which files you'd touch,
     which tests you'd add, which docs you'd update — and wait for a
     confirmation before starting? Yes / No + one line of context. -->

**Confirmation received?**

<!-- Who confirmed ("yes go ahead" / "ok" / "looks good")?
     If you were explicitly told "implement immediately", say so. -->

---

## 3. What you built

<!-- Be concrete. Not "updated the service" — say which function, which model,
     which endpoint, which component, and what it now does differently.
     Two or three sentences is enough. Ten vague words is not. -->

---

## 4. Proof of quality

**Tests added or updated:**

<!-- List exact test function names and the file they live in.
     If you added none, explain why none were needed. -->

| Test | File | What it covers |
| ---- | ---- | -------------- |
|      |      |                |

**`make code-quality` output (paste the last line or "all checks passed"):**

```

```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```

```

**`make test` output (paste the summary line — pass count, 0 failures):**

```

```

If you touched multiple packages, paste one block per package.

---

## 5. Docs updated

Work through this line by line. If an item does not apply, write "n/a" and say why.

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    |              |
| New behaviour, API field, or contract change                      |              |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) |              |
| UX component implemented or visual status changed                 |              |
| Phase progress row exists for this area                           |              |
| WORKPLAN sprint item finished                                     |              |
| Code and a design doc now diverge                                 |              |

---

## 6. Close-out statement

<!--
Copy the exact block from the end of your implementation session.
If you don't have one, write it now — and wonder why you don't have it.
-->

```
## Task close-out
- Code:
- Tests:
- Docs updated:
- Backlog:
- Skipped steps:
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

**How do we roll back?**
