### PR TITLE
Kea → Swift reconciliation: 3a vector-metadata repair action (#2234)

### DIFF
--- a/.claude/skills/seed-synthetic-corpus/SKILL.md
+++ b/.claude/skills/seed-synthetic-corpus/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: seed-synthetic-corpus
+description: Seed (and safely reset) a large synthetic corpus of fake libraries/documents/vectors/content in a LOCAL Fred docker-compose stack, to load-test corpus repair/audit tooling (metadata/vector reconciliation, /corpus/revectorize, MetadataService.audit_stores, the "Audit du corpus" admin page). Use when asked to simulate a big platform locally, stress-test repair/audit tools against volume, or generate bulk fake libraries/documents under a team space.
+user-invocable: true
+argument-hint: [team display name] [library count, default 100] [document count, default 20000]
+---
+
+# Seed a synthetic corpus for local repair/audit testing
+
+Drives `apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py`:
+writes fake libraries (tags), documents (Postgres metadata), vectors (OpenSearch), and small
+fake content objects (Minio/S3) directly into the stores knowledge-flow-backend itself reads —
+no ingestion pipeline, no LLM cost per document (only one real embedding call, to learn the
+configured vector dimension). Comes with a tested `--purge` that removes exactly what it created.
+
+**LOCAL docker-compose only.** Before touching anything, confirm with the developer that
+`apps/knowledge-flow-backend/config/.env`'s `CONFIG_FILE` points at `configuration_prod.yaml`
+(their local full-stack config: `localhost` Postgres/OpenSearch/OpenFGA/Keycloak/Minio) — never
+run this against a shared/staging/prod `CONFIG_FILE`. Run all commands from
+`apps/knowledge-flow-backend`, cwd matters (`.env` is loaded relative to it).
+
+## The one gotcha that will burn you: `--team-id` is NOT the team's display name
+
+Fred team names ("fredlab", "northbridge", ...) and their real `team_id` are different strings.
+`--team-id` writes tag ownership (Postgres `tag.owner_id`) and a ReBAC tuple
+(`team:<id>` OWNER `tag:<id>`) — if you pass the display name literally, you create tags owned by
+a team object that doesn't exist in OpenFGA. Nobody can see them: `schema.fga`'s `tag.read`
+resolves through `team_member from owner`, so zero members on a nonexistent team means zero
+visibility, silently — no error anywhere, the seed step reports success.
+
+Resolve the real id first:
+
+```bash
+docker exec -i app-postgres psql -U fred -d fred -c "SELECT id, name FROM teammetadata;"
+```
+
+Use the `id` column (a 32-char hex string) for `--team-id`, not `name`. If the developer only gave
+you a display name (e.g. "fredlab"), look it up here — don't ask them for the id, they likely
+don't have it memorized either.
+
+To double check a seed actually landed somewhere visible (don't just trust "0 errors" in the
+script's own log), get the developer's Keycloak `user:<uid>` (e.g. from `identity.uploaded_by` on
+one of their real, non-seed documents) and check directly against OpenFGA:
+
+```bash
+STORE_ID=$(curl -s -H "Authorization: Bearer $OPENFGA_API_TOKEN" http://localhost:9080/stores | python3 -c "import sys,json;print(json.load(sys.stdin)['stores'][0]['id'])")
+curl -s -H "Authorization: Bearer $OPENFGA_API_TOKEN" -H "Content-Type: application/json" \
+  -X POST "http://localhost:9080/stores/$STORE_ID/check" \
+  -d '{"tuple_key": {"user": "user:<uid>", "relation": "read", "object": "tag:<one seed tag id>"}}'
+```
+Expect `{"allowed": true}`. **Check a `document:<one seed document_uid>` too, not just the
+tag** — the tag/folder resolving to `allowed: true` does NOT mean its documents do; they're a
+separate ReBAC object (see the parent-tuple gotcha above). A folder that opens empty in the UI
+means you checked the tag and stopped one level too early. `OPENFGA_API_TOKEN` is in
+`apps/knowledge-flow-backend/config/.env`.
+
+## Recommended flow — pilot before scale, every time
+
+Don't jump straight to 100 libraries / 20000 documents. The sequence that actually caught real
+bugs (a dropped-mapping-field purge marker, then the team-id mistake above) was:
+
+1. **Baseline**: record current counts before touching anything —
+   ```bash
+   cd apps/knowledge-flow-backend
+   .venv/bin/python - <<'EOF'
+   import asyncio, logging
+   logging.basicConfig(level=logging.CRITICAL)
+   from knowledge_flow_backend.application_context import ApplicationContext
+   from knowledge_flow_backend.common.config_loader import load_configuration
+
+   async def main():
+       ApplicationContext(load_configuration())
+       app_context = ApplicationContext.get_instance()
+       print("docs:", await app_context.get_metadata_store().count_all())
+       print("tags:", len(await app_context.get_tag_store().list_all_tags()))
+       vs = app_context.get_create_vector_store(app_context.get_embedder())
+       print("vectors:", vs.client.count(index=vs.index_name).get("count"))
+       print("content prefixes:", len(app_context.get_content_store().list_document_uids()))
+
+   asyncio.run(main())
+   EOF
+   ```
+2. **Pilot** at tiny scale (`--libraries 2 --documents 5`) with the real `--team-id`.
+3. **Verify** counts increased by exactly the pilot size, and content is actually readable
+   (`content_store.get_content(document_uid).read()`), not just present.
+4. **Purge** (`--purge`) and re-run step 1's baseline query — must match the original numbers
+   exactly (docs, tags, vectors, *and* content prefixes). If it doesn't, stop and figure out why
+   before scaling up — don't seed 20000 documents on top of an unproven purge.
+5. **Full scale** only after step 4 passes.
+
+## Commands
+
+```bash
+cd apps/knowledge-flow-backend
+
+# Seed (content objects included by default; add --skip-content to skip them: faster,
+# but every document then shows up as `missing_content` in audit tooling)
+.venv/bin/python -m knowledge_flow_backend.scripts.seed_synthetic_corpus \
+  --team-id <real team_id from teammetadata> --libraries 100 --documents 20000
+
+# Reset everything this script created (source_tag=seed-synthetic-corpus /
+# seed-library-* tags/tuples/vectors/content) -- never touches anything else
+.venv/bin/python -m knowledge_flow_backend.scripts.seed_synthetic_corpus --purge
+```
+
+Both commands commonly run past the 120s foreground timeout at full scale (~2-3 min for 20000
+documents) — launch in the background and read the output file rather than waiting inline.
+
+## What it actually writes (so you know what "reset" means)
+
+- Postgres `tag` rows: `owner_id=<team_id>`, `name=seed-library-NNN`, type `document`.
+- ReBAC tuple: `team:<team_id>` OWNER `tag:<tag_id>` (one per library) — makes the *folder* visible.
+- Postgres `metadata` rows: `source.source_tag=seed-synthetic-corpus`, one fake vector chunk id
+  `<document_uid>::seed-chunk-0`, round-robin across the libraries.
+- ReBAC tuple: `tag:<tag_id>` PARENT `document:<document_uid>` (one per document) — makes each
+  *document inside the folder* visible. `schema.fga`: `document.read = read from parent`. Miss
+  this one and the folder itself is visible but opens onto "Ce dossier est vide" / an empty
+  `get_document_metadata_in_tag` result — the tag being readable does not imply its documents are;
+  they're a separate ReBAC object with their own relation. This bit the first real run of this
+  script (folder visible, empty) before the tuple was added — don't skip it.
+- OpenSearch: one random vector per document, dimension read from the *existing* index mapping
+  (never assume a dimension — a mismatch fails loudly at `ensure_ready()`, which is correct).
+- Minio/S3 (unless `--skip-content`): one small text object per document at
+  `<document_uid>/input/<document_name>` — enough for `get_content()`/previews to actually work,
+  not just for the content-store presence check to pass.
+
+`--purge` reverses all four using the Postgres rows found via `source_tag` as the index (matches
+what `MetadataService.audit_stores`-style tooling should also do) — read the script's `_purge`
+docstring/comments if you need the exact matching logic, it documents its own known gaps (e.g. a
+content object orphaned by a run that died mid-way between the content and metadata-delete steps
+won't be found by a later purge, since content objects carry no marker of their own).

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2461,6 +2461,7 @@
           "missing_vectors": "Missing vectors (left untouched)",
           "missing_content": "Missing content (left untouched)",
           "tabular_excluded": "Tabular documents excluded (sql, out of scope)",
+          "failed_or_running_excluded": "Failed or running (left untouched)",
           "errors": "Errors"
         }
       }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2450,6 +2450,19 @@
           "docs_imported": "Documents imported",
           "docs_skipped": "Documents skipped"
         }
+      },
+      "repair": {
+        "detailsTitle": "Repair report",
+        "counter": {
+          "metadata_documents": "Documents matching this source_tag",
+          "already_done": "Already marked done",
+          "eligible_with_vectors_and_content": "Vectors and content confirmed",
+          "repaired": "Repaired",
+          "missing_vectors": "Missing vectors (left untouched)",
+          "missing_content": "Missing content (left untouched)",
+          "tabular_excluded": "Tabular documents excluded (sql, out of scope)",
+          "errors": "Errors"
+        }
       }
     }
   },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2450,6 +2450,19 @@
           "docs_imported": "Documents importés",
           "docs_skipped": "Documents ignorés"
         }
+      },
+      "repair": {
+        "detailsTitle": "Rapport de réparation",
+        "counter": {
+          "metadata_documents": "Documents correspondant à ce source_tag",
+          "already_done": "Déjà marqués terminés",
+          "eligible_with_vectors_and_content": "Vecteurs et contenu confirmés",
+          "repaired": "Réparés",
+          "missing_vectors": "Vecteurs manquants (non touchés)",
+          "missing_content": "Contenu manquant (non touché)",
+          "tabular_excluded": "Documents tabulaires exclus (sql, hors périmètre)",
+          "errors": "Erreurs"
+        }
       }
     }
   },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2461,6 +2461,7 @@
           "missing_vectors": "Vecteurs manquants (non touchés)",
           "missing_content": "Contenu manquant (non touché)",
           "tabular_excluded": "Documents tabulaires exclus (sql, hors périmètre)",
+          "failed_or_running_excluded": "En échec ou en cours (non touchés)",
           "errors": "Erreurs"
         }
       }

--- a/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
@@ -24,6 +24,7 @@
 
 import { useState } from "react";
 import { useDispatch } from "react-redux";
+import { normalizeApiError } from "@core/errors/normalizeApiError.ts";
 import Button from "@shared/atoms/Button/Button.tsx";
 import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
 import { ConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialog";
@@ -37,6 +38,17 @@ import { useCorpusRepairVectorMetadataMutation, useCorpusRevectorizeMutation } f
 import { useResetPlatformRebacMutation } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { KeyCloakService } from "../../../../../security/KeycloakService";
 import styles from "./KeaMigrationPage.module.css";
+
+// RTK Query's `.unwrap()` throws a `FetchBaseQueryError`/`SerializedError` --
+// a plain, non-Error object (`{status, data}` or `{name, message}`) -- never a
+// real `Error` instance. `e instanceof Error ? e.message : String(e)` was
+// silently rendering the literal text "[object Object]" for every API error
+// on this page instead of the backend's actual detail message.
+function describeError(e: unknown): string {
+  const detail = normalizeApiError(e).detail;
+  if (detail) return detail;
+  return e instanceof Error ? e.message : "Erreur inconnue.";
+}
 
 function FileField({
   label,
@@ -129,7 +141,7 @@ export default function KeaMigrationPage() {
       const result = await runKeaDryRun(file, realmFile ?? undefined);
       setReport(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(describeError(e));
       setReport(null);
     } finally {
       setIsDryRunning(false);
@@ -151,7 +163,7 @@ export default function KeaMigrationPage() {
       );
       setApplyResult(`Import lancé — task ${taskId}. Suivre la progression sur /admin/migration.`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(describeError(e));
     } finally {
       setIsApplying(false);
     }
@@ -187,7 +199,7 @@ export default function KeaMigrationPage() {
       setRevectorizeResult(`Lancé — task ${task_id}. Suivre le rapport détaillé sur /admin/tasks.`);
       setSourceTag("");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(describeError(e));
     }
   };
 
@@ -224,7 +236,7 @@ export default function KeaMigrationPage() {
       setRevectorizeResult(`Lancé — task ${task_id}. Suivre la progression sur /admin/tasks.`);
       setSourceTag("");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(describeError(e));
     }
   };
 
@@ -241,7 +253,7 @@ export default function KeaMigrationPage() {
         }),
       );
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(describeError(e));
     }
   };
 

--- a/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
@@ -34,7 +34,10 @@ import { launchPlatformImport } from "../../../../features/migration/launchPlatf
 import { runKeaDryRun } from "../../../../features/migration/runKeaDryRun";
 import { taskRegistered } from "../../../../features/tasks/taskSlice";
 import type { KeaDryRunResponse } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
-import { useCorpusRepairVectorMetadataMutation, useCorpusRevectorizeMutation } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
+import {
+  useCorpusRepairVectorMetadataMutation,
+  useCorpusRevectorizeMutation,
+} from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 import { useResetPlatformRebacMutation } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { KeyCloakService } from "../../../../../security/KeycloakService";
 import styles from "./KeaMigrationPage.module.css";
@@ -193,7 +196,11 @@ export default function KeaMigrationPage() {
         taskRegistered({
           taskId: task_id,
           kind: "ingestion",
-          target: { type: "corpus-repair-vector-metadata", id: task_id, label: `Repair vector metadata · ${sourceTag}` },
+          target: {
+            type: "corpus-repair-vector-metadata",
+            id: task_id,
+            label: `Repair vector metadata · ${sourceTag}`,
+          },
         }),
       );
       setRevectorizeResult(`Lancé — task ${task_id}. Suivre le rapport détaillé sur /admin/tasks.`);
@@ -382,11 +389,11 @@ export default function KeaMigrationPage() {
         <p className={styles.intro}>
           <strong>3a — Réparer uniquement.</strong> Pour tout document où <em>au moins un</em> chunk vectoriel
           (OpenSearch) et <em>au moins un</em> objet de contenu (S3) ont été retrouvés — signal de présence minimale,
-          pas une vérification de complétude totale (aucun nombre attendu fiable de chunks/objets n&apos;existe pour
-          les documents restaurés depuis Kea) : corrige seulement le statut &laquo;&nbsp;en attente&nbsp;&raquo; en
-          base. Un document réellement sans vecteur ou sans contenu n&apos;est jamais touché — juste compté dans le
-          rapport de la tâche. Cette action ne peut structurellement jamais déclencher de reconstruction, de
-          suppression de vecteurs, ou d&apos;appel au modèle d&apos;embeddings, quel que soit le tag saisi.
+          pas une vérification de complétude totale (aucun nombre attendu fiable de chunks/objets n&apos;existe pour les
+          documents restaurés depuis Kea) : corrige seulement le statut &laquo;&nbsp;en attente&nbsp;&raquo; en base. Un
+          document réellement sans vecteur ou sans contenu n&apos;est jamais touché — juste compté dans le rapport de la
+          tâche. Cette action ne peut structurellement jamais déclencher de reconstruction, de suppression de vecteurs,
+          ou d&apos;appel au modèle d&apos;embeddings, quel que soit le tag saisi.
         </p>
         <div className={styles.actions}>
           <Button

--- a/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
@@ -33,7 +33,7 @@ import { launchPlatformImport } from "../../../../features/migration/launchPlatf
 import { runKeaDryRun } from "../../../../features/migration/runKeaDryRun";
 import { taskRegistered } from "../../../../features/tasks/taskSlice";
 import type { KeaDryRunResponse } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
-import { useCorpusRevectorizeMutation } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
+import { useCorpusRepairVectorMetadataMutation, useCorpusRevectorizeMutation } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 import { useResetPlatformRebacMutation } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { KeyCloakService } from "../../../../../security/KeycloakService";
 import styles from "./KeaMigrationPage.module.css";
@@ -100,10 +100,13 @@ export default function KeaMigrationPage() {
   const [applyResult, setApplyResult] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [sourceTag, setSourceTag] = useState("");
+  const [repairVectorMetadata, { isLoading: isRepairing }] = useCorpusRepairVectorMetadataMutation();
   const [revectorizeCorpus, { isLoading: isRevectorizing }] = useCorpusRevectorizeMutation();
   const [revectorizeResult, setRevectorizeResult] = useState<string | null>(null);
   const [resetPlatformRebac, { isLoading: isTearingDown }] = useResetPlatformRebacMutation();
   const [showTeardownConfirm, setShowTeardownConfirm] = useState(false);
+  const [showRebuildConfirm, setShowRebuildConfirm] = useState(false);
+  const isBusy3 = isRepairing || isRevectorizing;
 
   const canRun = file !== null && !isDryRunning && !isApplying;
 
@@ -154,7 +157,43 @@ export default function KeaMigrationPage() {
     }
   };
 
-  const handleRevectorize = async () => {
+  // 3a — dedicated metadata-only repair action (#2234): a small bulk Postgres
+  // reconciliation, structurally incapable of deleting vectors, reading content, or
+  // calling the embedder — never routes through /corpus/revectorize. See
+  // `RepairVectorMetadataWorkflow`'s module docstring on the backend.
+  const handleRepair = async () => {
+    if (!sourceTag.trim()) return;
+    setError(null);
+    setRevectorizeResult(null);
+    const userId = KeyCloakService.GetUserId();
+    if (!userId) {
+      setError("Impossible de déterminer l'utilisateur connecté.");
+      return;
+    }
+    try {
+      const { task_id } = await repairVectorMetadata({
+        repairVectorMetadataRequestV1: {
+          source_tag: sourceTag,
+          team_id: personalTeamId(userId),
+        },
+      }).unwrap();
+      dispatch(
+        taskRegistered({
+          taskId: task_id,
+          kind: "ingestion",
+          target: { type: "corpus-repair-vector-metadata", id: task_id, label: `Repair vector metadata · ${sourceTag}` },
+        }),
+      );
+      setRevectorizeResult(`Lancé — task ${task_id}. Suivre le rapport détaillé sur /admin/tasks.`);
+      setSourceTag("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  // 3b — the real re-vectorization pipeline (MIGR-07), unchanged by the #2234
+  // 3a split other than dropping the now-removed metadata_only option.
+  const handleRebuild = async () => {
     if (!sourceTag.trim()) return;
     setError(null);
     setRevectorizeResult(null);
@@ -179,10 +218,10 @@ export default function KeaMigrationPage() {
         taskRegistered({
           taskId: task_id,
           kind: "ingestion",
-          target: { type: "corpus-revectorize", id: task_id, label: `Rebuild embeddings · ${sourceTag}` },
+          target: { type: "corpus-revectorize", id: task_id, label: `Rebuild missing embeddings · ${sourceTag}` },
         }),
       );
-      setRevectorizeResult(`Reconstruction lancée — task ${task_id}. Suivre la progression sur /admin/migration.`);
+      setRevectorizeResult(`Lancé — task ${task_id}. Suivre la progression sur /admin/tasks.`);
       setSourceTag("");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -204,6 +243,11 @@ export default function KeaMigrationPage() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
+  };
+
+  const handleRebuildConfirmed = () => {
+    setShowRebuildConfirm(false);
+    void handleRebuild();
   };
 
   return (
@@ -308,12 +352,10 @@ export default function KeaMigrationPage() {
       )}
 
       <div className={styles.report}>
-        <span className={styles.reportTitle}>Étape 3 : reconstruire les embeddings</span>
+        <span className={styles.reportTitle}>Étape 3 : réparer le statut des documents</span>
         <p className={styles.intro}>
-          Rattache les vecteurs déjà présents (ou reconstruit ceux qui manquent) pour les documents dont les métadonnées
-          viennent d&apos;être restaurées par l&apos;import — à lancer après l&apos;import réel et le premier login des
-          utilisateurs concernés. Le tag à saisir est celui utilisé côté Kea au moment de l&apos;ingestion des documents
-          (le défaut applicatif pour un upload manuel est <code>fred</code>).
+          Deux actions séparées, à ne jamais confondre. Le tag à saisir est celui utilisé côté Kea au moment de
+          l&apos;ingestion des documents (le défaut applicatif pour un upload manuel est <code>fred</code>).
         </p>
         <div className={styles.uploadRow}>
           <TextInput
@@ -321,18 +363,45 @@ export default function KeaMigrationPage() {
             value={sourceTag}
             onChange={(e) => setSourceTag(e.target.value)}
             placeholder="ex. fred"
-            disabled={isRevectorizing}
+            disabled={isBusy3}
           />
         </div>
+
+        <p className={styles.intro}>
+          <strong>3a — Réparer uniquement.</strong> Pour tout document où <em>au moins un</em> chunk vectoriel
+          (OpenSearch) et <em>au moins un</em> objet de contenu (S3) ont été retrouvés — signal de présence minimale,
+          pas une vérification de complétude totale (aucun nombre attendu fiable de chunks/objets n&apos;existe pour
+          les documents restaurés depuis Kea) : corrige seulement le statut &laquo;&nbsp;en attente&nbsp;&raquo; en
+          base. Un document réellement sans vecteur ou sans contenu n&apos;est jamais touché — juste compté dans le
+          rapport de la tâche. Cette action ne peut structurellement jamais déclencher de reconstruction, de
+          suppression de vecteurs, ou d&apos;appel au modèle d&apos;embeddings, quel que soit le tag saisi.
+        </p>
         <div className={styles.actions}>
           <Button
             color="primary"
             variant="filled"
             size="medium"
-            onClick={() => void handleRevectorize()}
-            disabled={!sourceTag.trim() || isRevectorizing}
+            onClick={() => void handleRepair()}
+            disabled={!sourceTag.trim() || isBusy3}
           >
-            {isRevectorizing ? "Lancement…" : "Reconstruire les embeddings"}
+            {isRepairing ? "Lancement…" : "3a — Réparer uniquement (jamais de reconstruction)"}
+          </Button>
+        </div>
+
+        <p className={styles.intro}>
+          <strong>3b — Reconstruire les documents manquants.</strong> À utiliser séparément, seulement pour les
+          documents que l&apos;étape 3a a signalés comme réellement sans vecteur — reconstruction réelle (coût de
+          calcul, plus long).
+        </p>
+        <div className={styles.actions}>
+          <Button
+            color="secondary"
+            variant="outlined"
+            size="medium"
+            onClick={() => setShowRebuildConfirm(true)}
+            disabled={!sourceTag.trim() || isBusy3}
+          >
+            {isRevectorizing ? "Lancement…" : "3b — Reconstruire les documents manquants"}
           </Button>
         </div>
         {revectorizeResult && <div className={styles.success}>{revectorizeResult}</div>}
@@ -357,6 +426,17 @@ export default function KeaMigrationPage() {
           </Button>
         </div>
       </div>
+
+      <ConfirmationDialog
+        open={showRebuildConfirm}
+        title="Reconstruire les documents manquants ?"
+        message={`Va réellement reconstruire (extraction + embeddings) tout document sans aucun vecteur sous le tag "${sourceTag}". Plus long et plus coûteux que 3a — à utiliser seulement pour les documents que 3a a signalés comme réellement manquants.`}
+        confirmLabel="Reconstruire"
+        cancelLabel="Annuler"
+        criticalAction
+        onConfirm={handleRebuildConfirmed}
+        onCancel={() => setShowRebuildConfirm(false)}
+      />
 
       <ConfirmationDialog
         open={showTeardownConfirm}

--- a/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
@@ -137,7 +137,10 @@ function RepairResultDetails({ result, t }: { result: RepairVectorMetadataResult
   );
 
   return (
-    <Disclosure title={t("rework.taskActivity.repair.detailsTitle")} defaultOpen={(result.missing_vectors ?? 0) + (result.missing_content ?? 0) + (result.errors ?? 0) > 0}>
+    <Disclosure
+      title={t("rework.taskActivity.repair.detailsTitle")}
+      defaultOpen={(result.missing_vectors ?? 0) + (result.missing_content ?? 0) + (result.errors ?? 0) > 0}
+    >
       <dl className={styles.counterList}>
         {counters.map(([key, value]) => (
           <div key={key} className={styles.counterRow}>

--- a/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
@@ -141,7 +141,11 @@ function RepairResultDetails({ result, t }: { result: RepairVectorMetadataResult
     <Disclosure
       title={t("rework.taskActivity.repair.detailsTitle")}
       defaultOpen={
-        (result.missing_vectors ?? 0) + (result.missing_content ?? 0) + (result.failed_or_running_excluded ?? 0) + (result.errors ?? 0) > 0
+        (result.missing_vectors ?? 0) +
+          (result.missing_content ?? 0) +
+          (result.failed_or_running_excluded ?? 0) +
+          (result.errors ?? 0) >
+        0
       }
     >
       <dl className={styles.counterList}>

--- a/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
@@ -118,6 +118,7 @@ const REPAIR_COUNTER_KEYS = [
   "missing_vectors",
   "missing_content",
   "tabular_excluded",
+  "failed_or_running_excluded",
   "errors",
 ] as const satisfies readonly (keyof RepairVectorMetadataResult)[];
 
@@ -139,7 +140,9 @@ function RepairResultDetails({ result, t }: { result: RepairVectorMetadataResult
   return (
     <Disclosure
       title={t("rework.taskActivity.repair.detailsTitle")}
-      defaultOpen={(result.missing_vectors ?? 0) + (result.missing_content ?? 0) + (result.errors ?? 0) > 0}
+      defaultOpen={
+        (result.missing_vectors ?? 0) + (result.missing_content ?? 0) + (result.failed_or_running_excluded ?? 0) + (result.errors ?? 0) > 0
+      }
     >
       <dl className={styles.counterList}>
         {counters.map(([key, value]) => (

--- a/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TaskActivity/TaskActivity.tsx
@@ -52,7 +52,11 @@ import {
   type MigrationResult,
   type TaskSummary,
 } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
-import { useListTasksKnowledgeFlowV1TasksGetQuery } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
+import {
+  useListTasksKnowledgeFlowV1TasksGetQuery,
+  type IngestionDetail,
+  type RepairVectorMetadataResult,
+} from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 import { useListTasksEvaluationV1TasksGetQuery } from "../../../../../slices/evaluation/evaluationOpenApi";
 import styles from "./TaskActivity.module.css";
 
@@ -101,6 +105,49 @@ function migrationResult(task: TaskSummary): MigrationResult | null {
 function hasMigrationWarnings(task: TaskSummary): boolean {
   const result = migrationResult(task);
   return !!result && (result.warnings?.length ?? 0) > 0;
+}
+
+// Counters shown in the vector-metadata repair disclosure ("3a — Réparer
+// uniquement", #2234), in display order. Zero-valued counters are omitted —
+// same filtering spirit as MIGRATION_COUNTER_KEYS above.
+const REPAIR_COUNTER_KEYS = [
+  "metadata_documents",
+  "already_done",
+  "eligible_with_vectors_and_content",
+  "repaired",
+  "missing_vectors",
+  "missing_content",
+  "tabular_excluded",
+  "errors",
+] as const satisfies readonly (keyof RepairVectorMetadataResult)[];
+
+/** Narrow a generic `TaskSummary.detail` to `IngestionDetail` — only valid for
+ *  the vector-metadata repair task specifically (`target.type`), since other
+ *  `kind === "ingestion"` tasks never populate `detail.result`. */
+function repairResult(task: TaskSummary): RepairVectorMetadataResult | null {
+  if (task.kind !== "ingestion" || task.target?.type !== "corpus-repair-vector-metadata" || task.detail == null) {
+    return null;
+  }
+  return (task.detail as IngestionDetail).result ?? null;
+}
+
+function RepairResultDetails({ result, t }: { result: RepairVectorMetadataResult; t: TFunction }) {
+  const counters = REPAIR_COUNTER_KEYS.map((key) => [key, result[key]] as const).filter(
+    ([, value]) => typeof value === "number" && value > 0,
+  );
+
+  return (
+    <Disclosure title={t("rework.taskActivity.repair.detailsTitle")} defaultOpen={(result.missing_vectors ?? 0) + (result.missing_content ?? 0) + (result.errors ?? 0) > 0}>
+      <dl className={styles.counterList}>
+        {counters.map(([key, value]) => (
+          <div key={key} className={styles.counterRow}>
+            <dt className={styles.counterLabel}>{t(`rework.taskActivity.repair.counter.${key}`)}</dt>
+            <dd className={styles.counterValue}>{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </Disclosure>
+  );
 }
 
 function MigrationResultDetails({ result, t }: { result: MigrationResult; t: TFunction }) {
@@ -223,6 +270,7 @@ export default function TaskActivity({ scope, teamId, kind }: TaskActivityProps)
 
   const row = (task: TaskSummary, meta: React.ReactNode, showBadgeLabel = false) => {
     const result = migrationResult(task);
+    const repair = repairResult(task);
     const withWarnings = hasMigrationWarnings(task);
     // Same gate TaskCard/TaskDetailPopover use for the session-local Redux
     // view of this task — the persisted server-side record (this component's
@@ -263,6 +311,11 @@ export default function TaskActivity({ scope, teamId, kind }: TaskActivityProps)
         {result && (
           <div className={styles.rowDisclosure}>
             <MigrationResultDetails result={result} t={t} />
+          </div>
+        )}
+        {repair && (
+          <div className={styles.rowDisclosure}>
+            <RepairResultDetails result={repair} t={t} />
           </div>
         )}
       </li>

--- a/apps/frontend/src/rework/core/errors/normalizeApiError.test.ts
+++ b/apps/frontend/src/rework/core/errors/normalizeApiError.test.ts
@@ -111,7 +111,14 @@ describe("normalizeApiError", () => {
       const error = {
         status: 422,
         data: {
-          detail: [{ type: "value_error", loc: ["body", "source_tag"], msg: "Value error, must not be empty or whitespace-only", input: "" }],
+          detail: [
+            {
+              type: "value_error",
+              loc: ["body", "source_tag"],
+              msg: "Value error, must not be empty or whitespace-only",
+              input: "",
+            },
+          ],
         },
       };
       expect(normalizeApiError(error).detail).toBe("Value error, must not be empty or whitespace-only");

--- a/apps/frontend/src/rework/core/errors/normalizeApiError.test.ts
+++ b/apps/frontend/src/rework/core/errors/normalizeApiError.test.ts
@@ -104,6 +104,19 @@ describe("normalizeApiError", () => {
       expect(normalizeApiError(error).detail).toBe("Bad value");
     });
 
+    it("extracts the first pydantic error's msg from a FastAPI-default detail array", () => {
+      // FastAPI's own validation-error body (a route's request model validated by
+      // FastAPI itself, not re-raised by app code as a plain string) -- distinct
+      // from the array shape under errors[] above.
+      const error = {
+        status: 422,
+        data: {
+          detail: [{ type: "value_error", loc: ["body", "source_tag"], msg: "Value error, must not be empty or whitespace-only", input: "" }],
+        },
+      };
+      expect(normalizeApiError(error).detail).toBe("Value error, must not be empty or whitespace-only");
+    });
+
     it("returns no detail when data has neither detail nor a usable errors array", () => {
       expect(normalizeApiError({ status: 409, data: { errors: "not-an-array" } }).detail).toBeUndefined();
       expect(normalizeApiError({ status: 409, data: {} }).detail).toBeUndefined();

--- a/apps/frontend/src/rework/core/errors/normalizeApiError.ts
+++ b/apps/frontend/src/rework/core/errors/normalizeApiError.ts
@@ -36,6 +36,19 @@ const getDetailFromData = (data: unknown): string | undefined => {
   const directDetail = asString(data.detail);
   if (directDetail) return directDetail;
 
+  // FastAPI's own default validation-error body (any route whose request model
+  // is validated by FastAPI itself, not re-raised by app code as a plain-string
+  // HTTPException) puts a list of pydantic error objects under `detail` --
+  // distinct from the app-level `errors` shape below. Report the first one
+  // rather than falling back to a generic message.
+  if (Array.isArray(data.detail)) {
+    for (const entry of data.detail) {
+      if (!isRecord(entry)) continue;
+      const message = asString(entry.msg) || asString(entry.message);
+      if (message) return message;
+    }
+  }
+
   const errors = data.errors;
   if (!Array.isArray(errors)) return undefined;
 

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -2488,6 +2488,18 @@ export type TaskTarget = {
   id: string;
   label: string;
 };
+export type RepairVectorMetadataResult = {
+  source_tag: string;
+  metadata_documents?: number;
+  already_done?: number;
+  eligible_with_vectors_and_content?: number;
+  repaired?: number;
+  missing_vectors?: number;
+  missing_content?: number;
+  tabular_excluded?: number;
+  failed_or_running_excluded?: number;
+  errors?: number;
+};
 export type IngestionDetail = {
   processed: number;
   total: number;
@@ -2495,6 +2507,7 @@ export type IngestionDetail = {
   preview: number;
   vectorized: number;
   sql_indexed: number;
+  result?: RepairVectorMetadataResult | null;
 };
 export type EvaluationDetail = {
   campaign_id: string;

--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -1727,6 +1727,7 @@ export type RepairVectorMetadataResult = {
   missing_vectors?: number;
   missing_content?: number;
   tabular_excluded?: number;
+  failed_or_running_excluded?: number;
   errors?: number;
 };
 export type IngestionDetail = {

--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -605,6 +605,15 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.revectorizeCorpusRequestV1,
       }),
     }),
+    corpusRepairVectorMetadata: build.mutation<CorpusRepairVectorMetadataApiResponse, CorpusRepairVectorMetadataApiArg>(
+      {
+        query: (queryArg) => ({
+          url: `/knowledge-flow/v1/corpus/repair-vector-metadata`,
+          method: "POST",
+          body: queryArg.repairVectorMetadataRequestV1,
+        }),
+      },
+    ),
     corpusPurgeVectors: build.mutation<CorpusPurgeVectorsApiResponse, CorpusPurgeVectorsApiArg>({
       query: (queryArg) => ({
         url: `/knowledge-flow/v1/corpus/purge-vectors`,
@@ -1380,6 +1389,10 @@ export type CorpusRevectorizeApiResponse = /** status 200 Successful Response */
 export type CorpusRevectorizeApiArg = {
   revectorizeCorpusRequestV1: RevectorizeCorpusRequestV1;
 };
+export type CorpusRepairVectorMetadataApiResponse = /** status 200 Successful Response */ StartTaskResponse;
+export type CorpusRepairVectorMetadataApiArg = {
+  repairVectorMetadataRequestV1: RepairVectorMetadataRequestV1;
+};
 export type CorpusPurgeVectorsApiResponse = /** status 200 Successful Response */ any;
 export type CorpusPurgeVectorsApiArg = {
   purgeVectorsRequestV1: PurgeVectorsRequestV1;
@@ -1705,6 +1718,17 @@ export type TaskTarget = {
   id: string;
   label: string;
 };
+export type RepairVectorMetadataResult = {
+  source_tag: string;
+  metadata_documents?: number;
+  already_done?: number;
+  eligible_with_vectors_and_content?: number;
+  repaired?: number;
+  missing_vectors?: number;
+  missing_content?: number;
+  tabular_excluded?: number;
+  errors?: number;
+};
 export type IngestionDetail = {
   processed: number;
   total: number;
@@ -1712,6 +1736,7 @@ export type IngestionDetail = {
   preview: number;
   vectorized: number;
   sql_indexed: number;
+  result?: RepairVectorMetadataResult | null;
 };
 export type EvaluationDetail = {
   campaign_id: string;
@@ -2413,6 +2438,11 @@ export type RevectorizeCorpusRequestV1 = {
   thread_id?: string | null;
   exchange_id?: string | null;
 };
+export type RepairVectorMetadataRequestV1 = {
+  version?: "v1";
+  source_tag: string;
+  team_id: string;
+};
 export type PurgeVectorsOptionsV1 = {
   purge_scope?: "vectors_only" | "vectors_and_chunks";
   dry_run?: boolean;
@@ -2788,6 +2818,7 @@ export const {
   useLazyCorpusCapabilitiesQuery,
   useCorpusBuildTocMutation,
   useCorpusRevectorizeMutation,
+  useCorpusRepairVectorMetadataMutation,
   useCorpusPurgeVectorsMutation,
   useCorpusTasksGetMutation,
   useCorpusTasksResultMutation,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/base_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/base_content_store.py
@@ -199,13 +199,17 @@ class BaseContentStore(ABC):
         Return a *flat* list of objects under 'prefix' (recursive).
         """
 
-    def list_document_uids(self) -> List[str]:  # pragma: no cover - optional capability
+    def list_document_uids(self, *, strict: bool = False) -> List[str]:  # pragma: no cover - optional capability
         """
         Optional helper: return the list of document_uids known to the content store.
 
         Default implementation returns an empty list so callers can rely on hasattr()
-        or simply call and handle the empty result.
+        or simply call and handle the empty result -- unless `strict=True`, in which
+        case a caller that must never mistake "not implemented" for "genuinely empty"
+        (the vector-metadata repair path, #2234) gets a hard error instead.
         """
+        if strict:
+            raise NotImplementedError(f"{type(self).__name__} does not support strict document_uid listing")
         return []
 
     @abstractmethod

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/filesystem_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/filesystem_content_store.py
@@ -424,15 +424,24 @@ class FileSystemContentStore(BaseContentStore):
         """
         raise NotImplementedError("Presigned URLs are not supported by local filesystem storage. Use MinIO storage backend instead.")
 
-    def list_document_uids(self) -> List[str]:
+    def list_document_uids(self, *, strict: bool = False) -> List[str]:
         """
         Return the list of document UIDs represented as directories in the document root.
+
+        `strict=False` (default): a listing failure logs and returns an empty list
+        (existing best-effort behavior, relied on by `audit_stores`). `strict=True`
+        (the vector-metadata repair path, #2234) never does that -- it re-raises, so
+        a real filesystem error can never be mistaken for "no documents have content".
         """
         if not self.document_root.exists():
+            if strict:
+                raise FileNotFoundError(f"Document root does not exist: {self.document_root}")
             return []
 
         try:
             return sorted([p.name for p in self.document_root.iterdir() if p.is_dir()])
         except Exception as e:
             logger.warning("Failed to list document directories in %s: %s", self.document_root, e)
+            if strict:
+                raise
             return []

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/gcs_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/gcs_content_store.py
@@ -166,7 +166,10 @@ class GcsContentStore(BaseContentStore):
             blob.delete()
             logger.info("[CONTENT][GCS] Deleted object='%s' from document bucket='%s'", blob.name, self.document_bucket_name)
 
-    def list_document_uids(self) -> List[str]:
+    def list_document_uids(self, *, strict: bool = False) -> List[str]:
+        """`strict` is a no-op here: this implementation already propagates any
+        `list_blobs` failure instead of swallowing it (see `BaseContentStore.
+        list_document_uids` for what `strict` means for backends that don't)."""
         doc_uids: set[str] = set()
         for blob in self.client.list_blobs(self.document_bucket_name):
             prefix = blob.name.split("/", 1)[0]

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/minio_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/minio_content_store.py
@@ -191,9 +191,14 @@ class MinioStorageBackend(BaseContentStore):
             logger.error(f"[CONTENT] Failed to delete objects document_uid={document_uid}: {e}")
             raise ValueError(f"Failed to delete document content from MinIO: {e}")
 
-    def list_document_uids(self) -> List[str]:
+    def list_document_uids(self, *, strict: bool = False) -> List[str]:
         """
         Return the set of top-level prefixes (document_uids) stored in the document bucket.
+
+        `strict=False` (default): a listing failure logs and returns an empty list
+        (existing best-effort behavior, relied on by `audit_stores`). `strict=True`
+        (the vector-metadata repair path, #2234) never does that -- it re-raises, so
+        a real S3/MinIO error can never be mistaken for "no documents have content".
         """
         try:
             objects = self.client.list_objects(self.document_bucket, recursive=True)
@@ -207,6 +212,8 @@ class MinioStorageBackend(BaseContentStore):
             return sorted(doc_uids)
         except S3Error as e:
             logger.warning(f"[CONTENT][MINIO] Failed to list document prefixes in bucket '{self.document_bucket}': {e}")
+            if strict:
+                raise
             return []
 
     def get_preview_bytes(self, doc_path: str) -> bytes:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
@@ -219,6 +219,74 @@ class EmbeddingRequestFailure:
     exception_type: str
 
 
+def scan_document_uids_composite(
+    client: OpenSearch,
+    index: str,
+    *,
+    page_size: int = 1000,
+    strict: bool = False,
+    request_timeout: int = 30,
+) -> List[str]:
+    """
+    Page through every distinct `metadata.document_uid` in `index` via a
+    `composite` aggregation (`after_key`), using `client` as given.
+
+    Pure and side-effect-free: takes an already-constructed client and index
+    name and issues only `search` calls -- never touches indices, mappings, or
+    pipelines, and never needs an embedder. This is what lets the
+    vector-metadata repair action (#2234, 3a) list real vector document_uids
+    without ever constructing an `OpenSearchVectorStoreAdapter` (whose
+    `__init__` calls `ensure_ready()`, which calls the embedder and can create
+    or update the index/pipeline/mapping -- forbidden for a metadata-only
+    repair). `OpenSearchVectorStoreAdapter.list_document_uids` delegates here
+    too, so there is exactly one paging implementation.
+
+    Pages through a `composite` aggregation instead of a single `terms`
+    aggregation capped at a fixed bucket count. A one-shot `terms` agg
+    silently truncates once the index holds more distinct document_uids than
+    its `size`, ordered by descending chunk count -- so once a deployment's
+    real document count crosses that cap, correctly-vectorized documents with
+    fewer chunks silently drop out of the list. `page_size` bounds each
+    round-trip only, never the total result. `request_timeout` bounds each
+    individual `search` call so a stuck OpenSearch node fails this scan
+    instead of hanging it indefinitely.
+
+    `strict=False` (default, used by `OpenSearchVectorStoreAdapter.
+    list_document_uids`'s existing callers, e.g. `audit_stores`) is
+    best-effort: any failure -- on the first page or midway through paging --
+    logs and returns whatever was collected so far. `strict=True` (the
+    vector-metadata repair path) never does that: a failure on any page
+    raises instead, so a caller that must never treat "scan failed" as "0
+    vectors" gets a hard error instead of a silently incomplete list.
+    """
+    doc_uids: list[str] = []
+    after: dict[str, object] | None = None
+    try:
+        while True:
+            composite: dict[str, object] = {
+                "size": page_size,
+                "sources": [{"doc_uid": {"terms": {"field": "metadata.document_uid"}}}],
+            }
+            if after is not None:
+                composite["after"] = after
+            body = {"size": 0, "aggs": {"by_doc": {"composite": composite}}}
+            resp = client.search(index=index, body=body, request_timeout=request_timeout)
+            agg = resp.get("aggregations", {}).get("by_doc", {})  # type: ignore[dict-item]
+            buckets = agg.get("buckets", [])
+            if not buckets:
+                break
+            doc_uids.extend(str(b["key"]["doc_uid"]) for b in buckets if b.get("key", {}).get("doc_uid"))
+            after = agg.get("after_key")
+            if after is None:
+                break
+        return doc_uids
+    except Exception:
+        if strict:
+            raise
+        logger.warning("[VECTOR][OPENSEARCH] Could not list document_uids from index=%s", index, exc_info=True)
+        return []
+
+
 class OpenSearchVectorStoreAdapter(BaseVectorStore):
     """
     Fred — OpenSearch-backed Vector Store (LangChain for ANN + OS client for lexical/phrase).
@@ -897,21 +965,26 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
             )
             return 0
 
-    def list_document_uids(self, *, max_buckets: int = 10000) -> List[str]:
+    def list_document_uids(self, *, page_size: int = 1000, strict: bool = False) -> List[str]:
         """
-        Return distinct document_uids known to this vector index (best effort).
+        Return every distinct document_uid known to this vector index.
+
+        `strict=False` (default, used by `audit_stores`) is best-effort: any
+        failure -- on the first page or midway through paging -- logs and
+        returns whatever was collected so far. `strict=True` (used by the
+        vector-metadata repair path, #2234) never does that: a failure on any
+        page raises instead, so a caller that must never treat "scan failed"
+        as "0 vectors" gets a hard error instead of a silently incomplete list.
+
+        Delegates to `scan_document_uids_composite` (module-level, pure) so the
+        same paging logic is available to callers that must never construct a
+        full `OpenSearchVectorStoreAdapter` (whose `__init__` calls
+        `ensure_ready()` -> an embedder call and possible index/pipeline
+        creation) just to page through document_uids -- see that function's
+        docstring, and the repair action's `list_strict_vector_document_uids`
+        activity, which uses it directly against a raw client instead.
         """
-        try:
-            body = {
-                "size": 0,
-                "aggs": {"by_doc": {"terms": {"field": "metadata.document_uid", "size": max_buckets}}},
-            }
-            resp = self._client.search(index=self._index, body=body)
-            buckets = resp.get("aggregations", {}).get("by_doc", {}).get("buckets", [])  # type: ignore[dict-item]
-            return [str(b.get("key")) for b in buckets if b.get("key")]
-        except Exception:
-            logger.warning("[VECTOR][OPENSEARCH] Could not list document_uids from index=%s", self._index, exc_info=True)
-            return []
+        return scan_document_uids_composite(self._client, self._index, page_size=page_size, strict=strict)
 
     def set_document_retrievable(self, *, document_uid: str, value: bool) -> None:
         """

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
@@ -270,7 +270,7 @@ def scan_document_uids_composite(
             if after is not None:
                 composite["after"] = after
             body = {"size": 0, "aggs": {"by_doc": {"composite": composite}}}
-            resp = client.search(index=index, body=body, request_timeout=request_timeout)
+            resp = client.search(index=index, body=body, request_timeout=request_timeout)  # type: ignore[call-arg]  # opensearch-py's @query_params decorator accepts this at runtime; its type stub doesn't reflect that
             agg = resp.get("aggregations", {}).get("by_doc", {})  # type: ignore[dict-item]
             buckets = agg.get("buckets", [])
             if not buckets:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_manager/corpus_manager_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_manager/corpus_manager_controller.py
@@ -17,6 +17,7 @@ from .corpus_manager_service import (
     CorpusManagerService,
     CorpusScopeV1,
     PurgeVectorsRequestV1,
+    RepairVectorMetadataRequestV1,
     RevectorizeCorpusRequestV1,
     TaskGetRequestV1,
     TaskListRequestV1,
@@ -89,6 +90,18 @@ class CorpusManagerController:
         for document_uid in scope.document_uids:
             await rebac.check_user_permission_or_raise(user, DocumentPermission.PROCESS, document_uid)
 
+    async def _authorize_repair_vector_metadata(self, user: KeycloakUser, team_id: str) -> None:
+        """
+        3a's scope is always a bare `source_tag` spanning arbitrary teams (#2234) --
+        the same "no single team to check membership against" situation
+        `_authorize_scope` handles for a source_tag-only `CorpusScopeV1`. Requires
+        both real membership on the filing team (same IDOR protection as
+        `build_toc`/`revectorize`, see `_authorize_team`) and platform-admin (the
+        actual authority to repair documents across arbitrary teams).
+        """
+        await self._authorize_team(user, team_id)
+        await get_rebac_engine().check_user_permission_or_raise(user, OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID)
+
     def _handle_exception(self, e: Exception, context: str) -> NoReturn:
         logger.exception("[CORPUS] %s failed", context)
         raise HTTPException(500, "Internal server error")
@@ -153,6 +166,23 @@ class CorpusManagerController:
                 return await self.service.revectorize_corpus(payload, user)
             except Exception as e:
                 return self._handle_exception(e, "revectorize")
+
+        @router.post(
+            "/corpus/repair-vector-metadata",
+            tags=["CorpusManager"],
+            summary="Repair the vector processing status for documents whose vectors and content already exist",
+            operation_id="corpus_repair_vector_metadata",
+            response_model=StartTaskResponse,
+        )
+        async def repair_vector_metadata(
+            payload: RepairVectorMetadataRequestV1,
+            user: KeycloakUser = Depends(get_current_user),
+        ):
+            await self._authorize_repair_vector_metadata(user, payload.team_id)
+            try:
+                return await self.service.repair_vector_metadata(payload, user)
+            except Exception as e:
+                return self._handle_exception(e, "repair_vector_metadata")
 
         @router.post(
             "/corpus/purge-vectors",

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_manager/corpus_manager_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_manager/corpus_manager_service.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from fred_core import KeycloakUser
 from fred_core.tasks.models import StartIngestionParams, StartIngestionRequest, StartTaskResponse, TaskTarget
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from knowledge_flow_backend.application_context import ApplicationContext
 
@@ -146,6 +146,35 @@ class RevectorizeCorpusRequestV1(BaseModel):
 
     thread_id: Optional[str] = None
     exchange_id: Optional[str] = None
+
+
+class RepairVectorMetadataRequestV1(BaseModel):
+    """3a — "Réparer uniquement" (#2234): repair `processing.stages.vector` for
+    documents whose vectors and content are already confirmed to exist. Always a
+    bare `source_tag` scope (platform-wide by construction, see
+    `CorpusManagerController._authorize_repair_vector_metadata`) -- unlike
+    `RevectorizeCorpusRequestV1`, there is no `tag_ids`/`document_uids` variant and
+    no `options` (this action has exactly one, hard-coded, safe behavior)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal["v1"] = "v1"
+    source_tag: str
+
+    # AUTHZ-05 review finding: see BuildCorpusTocRequestV1.team_id.
+    team_id: str
+
+    @field_validator("source_tag", "team_id")
+    @classmethod
+    def _strip_and_require_non_empty(cls, value: str) -> str:
+        # `list_by_source_tag`/`_authorize_repair_vector_metadata` treat these as
+        # meaningful scope/authorization identifiers -- a blank or whitespace-only
+        # value must never silently resolve to "no filter" or "no team", so reject
+        # it here rather than at the SQL/ReBAC layer.
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be empty or whitespace-only")
+        return stripped
 
 
 class PurgeVectorsOptionsV1(BaseModel):
@@ -356,6 +385,49 @@ class CorpusManagerService:
             await task_svc.bind_execution(resp.task_id, execution_id=handle.workflow_id)
         except Exception:
             logger.warning("Could not bind revectorize task %s to workflow %s", resp.task_id, handle.workflow_id, exc_info=True)
+
+        return StartTaskResponse(task_id=resp.task_id)
+
+    async def repair_vector_metadata(self, req: RepairVectorMetadataRequestV1, user: KeycloakUser) -> StartTaskResponse:
+        """
+        Start the vector-metadata repair action ("3a — Réparer uniquement", #2234).
+
+        Deliberately not `revectorize_corpus`/`RevectorizeCorpusWorkflow`: this
+        action never touches vectors, content, or the embedder -- see
+        `RepairVectorMetadataWorkflow`'s module docstring. `source_tag` is
+        resolved to document_uids inside the workflow's own activities, not here.
+        """
+        if self._ingestion_task_service is None:
+            raise RuntimeError("Vector-metadata repair requires the ingestion scheduler to be enabled.")
+
+        task_svc = ApplicationContext.get_instance().get_task_service()
+        target = TaskTarget(type="corpus-repair-vector-metadata", id=req.source_tag, label=f"Repair vector metadata: {req.source_tag}")
+        start_req = StartIngestionRequest(params=StartIngestionParams(resource_ids=[]))
+        resp = await task_svc.start(start_req, created_by=user.uid, team_id=req.team_id, target=target)
+
+        # A `task_run` row now exists (state pending) with no workflow behind it yet.
+        # If starting the Temporal workflow itself fails, that row must not be left
+        # pending forever -- drive it to `failed` with the real reason before
+        # re-raising, so the API call still surfaces the original error to the
+        # caller and the task is never silently orphaned (contrast `bind_execution`
+        # below, which is best-effort *after* a successful start: at that point the
+        # workflow is genuinely running, so a bind failure only affects OPS-04
+        # reconciliation, not whether the work happens at all).
+        try:
+            handle = await self._ingestion_task_service.start_repair_vector_metadata(
+                source_tag=req.source_tag,
+                task_id=resp.task_id,
+            )
+        except Exception as exc:
+            message = str(exc).strip() or "Failed to start the vector-metadata repair workflow"
+            await task_svc.fail_task(resp.task_id, message[:500])
+            raise
+
+        # OPS-04 reconciliation: see revectorize_corpus.
+        try:
+            await task_svc.bind_execution(resp.task_id, execution_id=handle.workflow_id)
+        except Exception:
+            logger.warning("Could not bind repair-vector-metadata task %s to workflow %s", resp.task_id, handle.workflow_id, exc_info=True)
 
         return StartTaskResponse(task_id=resp.task_id)
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/metadata/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/metadata/service.py
@@ -156,18 +156,21 @@ class MetadataService:
         """
         Return all metadata entries associated with a specific tag.
         """
-        authorized_doc_ref = await self.rebac.lookup_user_resources(user, DocumentPermission.READ)
-
         try:
             docs = await self.metadata_store.get_metadata_in_tag(tag_id)
 
-            if isinstance(authorized_doc_ref, RebacDisabledResult):
-                # if rebac is disabled, do not filter
-                return docs
-
-            # Filter by permission (todo: use rebac ids to filter at store (DB) level)
-            authorized_doc_ids = [d.id for d in authorized_doc_ref]
-            return [d for d in docs if d.identity.document_uid in authorized_doc_ids]
+            # Scoped per-document checks over just this tag's candidates, not a
+            # platform-wide lookup_user_resources() ListObjects enumeration: that
+            # call is capped at OpenFGA's default listObjectsMaxResults (1000) and
+            # is not scoped to this tag, so once a user's total readable-document
+            # count crosses that cap, a folder can silently come back partial or
+            # empty depending on which arbitrary objects OpenFGA returned -- with
+            # no error anywhere. filter_readable_document_uids checks exactly the
+            # tag's own documents, so correctness never depends on platform-wide
+            # document count. Mirrors vector_search_service's use of the same
+            # helper for the same reason.
+            authorized_doc_uids = await self.filter_readable_document_uids(user, [d.identity.document_uid for d in docs])
+            return [d for d in docs if d.identity.document_uid in authorized_doc_uids]
         except Exception as e:
             logger.error(f"Error retrieving metadata for tag {tag_id}: {e}")
             raise MetadataUpdateError(f"Failed to retrieve metadata for tag {tag_id}: {e}")
@@ -268,8 +271,6 @@ class MetadataService:
         """
         Paginated fetch of documents in a given tag.
         """
-        authorized_doc_ref = await self.rebac.lookup_user_resources(user, DocumentPermission.READ)
-
         docs, total = await self.metadata_store.browse_metadata_in_tag(tag_id, offset=offset, limit=limit)
         logger.debug(
             "[PAGINATION] browse_documents_in_tag tag=%s offset=%s limit=%s -> fetched=%s total=%s",
@@ -280,11 +281,18 @@ class MetadataService:
             total,
         )
 
-        if isinstance(authorized_doc_ref, RebacDisabledResult):
-            return docs, total
-
-        authorized_doc_ids = {d.id for d in authorized_doc_ref}
-        filtered = [d for d in docs if d.identity.document_uid in authorized_doc_ids]
+        # Scoped per-document checks over just this page's candidates (<= limit),
+        # not a platform-wide lookup_user_resources() ListObjects enumeration:
+        # that call is capped at OpenFGA's default listObjectsMaxResults (1000)
+        # and is not scoped to this tag, so once a user's total readable-document
+        # count crosses that cap, this page could silently come back partial or
+        # empty depending on which arbitrary objects OpenFGA returned -- with no
+        # error anywhere. filter_readable_document_uids checks exactly this
+        # page's documents, so correctness never depends on platform-wide
+        # document count. Mirrors vector_search_service's use of the same
+        # helper for the same reason.
+        authorized_doc_uids = await self.filter_readable_document_uids(user, [d.identity.document_uid for d in docs])
+        filtered = [d for d in docs if d.identity.document_uid in authorized_doc_uids]
 
         # Total reflects store count; computing an authorized-only total would require
         # scanning all authorized documents. We keep store total to preserve pagination hints.

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/metadata/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/metadata/service.py
@@ -156,21 +156,18 @@ class MetadataService:
         """
         Return all metadata entries associated with a specific tag.
         """
+        authorized_doc_ref = await self.rebac.lookup_user_resources(user, DocumentPermission.READ)
+
         try:
             docs = await self.metadata_store.get_metadata_in_tag(tag_id)
 
-            # Scoped per-document checks over just this tag's candidates, not a
-            # platform-wide lookup_user_resources() ListObjects enumeration: that
-            # call is capped at OpenFGA's default listObjectsMaxResults (1000) and
-            # is not scoped to this tag, so once a user's total readable-document
-            # count crosses that cap, a folder can silently come back partial or
-            # empty depending on which arbitrary objects OpenFGA returned -- with
-            # no error anywhere. filter_readable_document_uids checks exactly the
-            # tag's own documents, so correctness never depends on platform-wide
-            # document count. Mirrors vector_search_service's use of the same
-            # helper for the same reason.
-            authorized_doc_uids = await self.filter_readable_document_uids(user, [d.identity.document_uid for d in docs])
-            return [d for d in docs if d.identity.document_uid in authorized_doc_uids]
+            if isinstance(authorized_doc_ref, RebacDisabledResult):
+                # if rebac is disabled, do not filter
+                return docs
+
+            # Filter by permission (todo: use rebac ids to filter at store (DB) level)
+            authorized_doc_ids = [d.id for d in authorized_doc_ref]
+            return [d for d in docs if d.identity.document_uid in authorized_doc_ids]
         except Exception as e:
             logger.error(f"Error retrieving metadata for tag {tag_id}: {e}")
             raise MetadataUpdateError(f"Failed to retrieve metadata for tag {tag_id}: {e}")
@@ -271,6 +268,8 @@ class MetadataService:
         """
         Paginated fetch of documents in a given tag.
         """
+        authorized_doc_ref = await self.rebac.lookup_user_resources(user, DocumentPermission.READ)
+
         docs, total = await self.metadata_store.browse_metadata_in_tag(tag_id, offset=offset, limit=limit)
         logger.debug(
             "[PAGINATION] browse_documents_in_tag tag=%s offset=%s limit=%s -> fetched=%s total=%s",
@@ -281,18 +280,11 @@ class MetadataService:
             total,
         )
 
-        # Scoped per-document checks over just this page's candidates (<= limit),
-        # not a platform-wide lookup_user_resources() ListObjects enumeration:
-        # that call is capped at OpenFGA's default listObjectsMaxResults (1000)
-        # and is not scoped to this tag, so once a user's total readable-document
-        # count crosses that cap, this page could silently come back partial or
-        # empty depending on which arbitrary objects OpenFGA returned -- with no
-        # error anywhere. filter_readable_document_uids checks exactly this
-        # page's documents, so correctness never depends on platform-wide
-        # document count. Mirrors vector_search_service's use of the same
-        # helper for the same reason.
-        authorized_doc_uids = await self.filter_readable_document_uids(user, [d.identity.document_uid for d in docs])
-        filtered = [d for d in docs if d.identity.document_uid in authorized_doc_uids]
+        if isinstance(authorized_doc_ref, RebacDisabledResult):
+            return docs, total
+
+        authorized_doc_ids = {d.id for d in authorized_doc_ref}
+        filtered = [d for d in docs if d.identity.document_uid in authorized_doc_ids]
 
         # Total reflects store count; computing an authorized-only total would require
         # scanning all authorized documents. We keep store total to preserve pagination hints.

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/activities.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/activities.py
@@ -342,13 +342,22 @@ async def list_documents_in_scope(scope: dict) -> list[str]:
 
 @activity.defn
 async def get_chunk_count(document_uid: str) -> int:
-    """Return the vector chunk count for one document (0 if the store can't report it).
+    """Return the vector chunk count for one document.
 
     `get_document_chunk_count` is a blocking, synchronous call on the
     OpenSearch client (no async client exists in this adapter) — run it in a
     worker thread so it never blocks the Temporal worker's event loop, the
     same pattern already used for the other blocking calls in this module
     (`ingestion_service.get_local_copy`/`process_output` in `output_process`).
+
+    Returns 0 only when the configured vector store genuinely has no
+    chunk-count capability. Any other failure (OpenSearch timeout, index/auth
+    misconfiguration) is left to propagate so this activity's retry policy
+    (`RevectorizeDocument`, `features/scheduler/workflow.py`) actually retries
+    it, and so a document whose count check fails is reported as a real
+    failure instead of being silently treated as "0 chunks" — which used to
+    make `_wf_should_skip_revectorize` fall through to a real, unnecessary
+    re-embed for a document that was never actually empty (#2234).
     """
     from knowledge_flow_backend.application_context import ApplicationContext
 
@@ -357,11 +366,7 @@ async def get_chunk_count(document_uid: str) -> int:
     vector_store = context.get_create_vector_store(embedder)
     if not hasattr(vector_store, "get_document_chunk_count"):
         return 0
-    try:
-        return int(await asyncio.to_thread(vector_store.get_document_chunk_count, document_uid=document_uid))  # type: ignore[attr-defined]
-    except Exception:
-        activity.logger.warning("[SCHEDULER][ACTIVITY][GET_CHUNK_COUNT] failed for %s", document_uid, exc_info=True)
-        return 0
+    return int(await asyncio.to_thread(vector_store.get_document_chunk_count, document_uid=document_uid))  # type: ignore[attr-defined]
 
 
 @activity.defn

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_activities.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_activities.py
@@ -1,0 +1,219 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Activities for the vector-metadata repair action ("3a — Réparer uniquement", #2234).
+
+Kea-restored documents can have real vectors in OpenSearch and real content in the
+content store while Postgres still reads `processing.stages.vector = not_started`
+(the import deliberately resets it, since embeddings aren't transported by the
+bundle). 3a repairs exactly that mismatch: a document is only ever flagged `done`
+here after both its vectors and its content have been positively confirmed to
+exist -- never a re-embed, never a delete, never a content read.
+
+Structural safety guarantee: nothing in this module imports or calls
+`delete_vectors`, `prepare_revectorize_file`, `output_process`/`output_process_trusted`,
+`get_embedder`, `get_create_vector_store`, `OpenSearchVectorStoreAdapter` (whose
+`__init__` calls `ensure_ready()`, which calls the embedder and can create/update
+the index, mapping, or ingest pipeline), or any embedder `.embed_*` method. The
+only OpenSearch call this module makes is a `search` on the already-configured
+index via `ApplicationContext.get_opensearch_client()` (a plain client, built
+without any embedder) and the pure `scan_document_uids_composite` helper. The
+only write is `bulk_mark_vector_done`, which touches exactly
+`processing.stages.vector` and `processing.errors.vector`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from fred_core.documents.document_structures import ProcessingStage, ProcessingStatus
+from temporalio import activity
+
+logger = logging.getLogger(__name__)
+
+_TABULAR_FILE_TYPES = {"csv", "xlsx"}
+
+
+@activity.defn
+async def list_repair_candidates_for_source_tag(source_tag: str) -> list[dict]:
+    """
+    Resolve every metadata document under `source_tag` via one real SQL
+    `WHERE source_tag = ...` query (`list_by_source_tag`) -- never a full-table
+    scan filtered in Python client-side (`get_all_metadata` does that; the
+    corpus-manager route for 3a deliberately does not use it).
+
+    Returns compact plain-data records rather than full `DocumentMetadata`
+    blobs, keeping the Temporal payload small at repair scale (~10k docs):
+    `document_uid`, whether the document is tabular (CSV/XLSX -- excluded from
+    this vector-only repair and reported separately, `sql` reconciliation is
+    out of scope here), and whether `vector` already reads `done`.
+    """
+    from knowledge_flow_backend.application_context import ApplicationContext
+
+    metadata_store = ApplicationContext.get_instance().get_metadata_store()
+    docs = await metadata_store.list_by_source_tag(source_tag)
+    records = []
+    for doc in docs:
+        file_type = doc.file.file_type.value if doc.file and doc.file.file_type else None
+        vector_done = doc.processing.stages.get(ProcessingStage.VECTORIZED) == ProcessingStatus.DONE
+        records.append(
+            {
+                "document_uid": doc.document_uid,
+                "is_tabular": file_type in _TABULAR_FILE_TYPES,
+                "vector_done": vector_done,
+            }
+        )
+    activity.logger.info(
+        "[SCHEDULER][ACTIVITY][REPAIR_VECTOR_METADATA] resolved %d metadata document(s) for source_tag=%s",
+        len(records),
+        source_tag,
+    )
+    return records
+
+
+@activity.defn
+async def list_strict_vector_document_uids() -> list[str]:
+    """
+    Return every document_uid with at least one real vector chunk in
+    OpenSearch, scanned strictly: any failure -- on any composite-aggregation
+    page -- raises instead of silently returning an incomplete or empty list
+    (`scan_document_uids_composite(strict=True)`), so this activity's Temporal
+    retry policy actually retries a transient failure instead of the workflow
+    mistaking it for "0 vectors".
+
+    Proves only that *at least one* chunk exists for the document_uid. There is
+    no reliable "expected chunk count" to compare against (Kea's original chunk
+    counts were never transported), so this can never prove every chunk of a
+    multi-chunk document survived the manual OpenSearch restore -- only that the
+    document is not entirely empty. That is a deliberate, documented limitation
+    of this urgent repair (#2234), not an oversight: see
+    `RepairVectorMetadataResult`'s docstring, which callers (the report, the
+    frontend) must not contradict by implying full completeness was verified.
+
+    Deliberately never constructs an `OpenSearchVectorStoreAdapter`: its
+    `__init__` unconditionally calls `ensure_ready()`, which calls the
+    embedder (`_get_embedding_dimension`) and can create or update the index,
+    its mapping, or the hybrid-search ingest pipeline -- every one of those is
+    forbidden for a metadata-only repair. This activity calls neither
+    `get_embedder()` nor `get_create_vector_store()`: it uses only
+    `ApplicationContext.get_opensearch_client()` (a plain, already-configured
+    `OpenSearch` client the embedder never touches) plus the configured index
+    name, and the pure `scan_document_uids_composite` helper --
+    `OpenSearchVectorStoreAdapter.list_document_uids` itself delegates to the
+    same helper, so there is exactly one paging implementation and no
+    vector-store instance is ever built here.
+    """
+    from knowledge_flow_backend.application_context import ApplicationContext
+    from knowledge_flow_backend.common.structures import OpenSearchVectorIndexConfig
+    from knowledge_flow_backend.core.stores.vector.opensearch_vector_store import scan_document_uids_composite
+
+    context = ApplicationContext.get_instance()
+    store_config = context.get_config().storage.vector_store
+    if not isinstance(store_config, OpenSearchVectorIndexConfig):
+        raise RuntimeError(f"repair-vector-metadata requires the OpenSearch vector store backend, got {type(store_config).__name__}")
+    client = context.get_opensearch_client()
+    # Blocking, synchronous OpenSearch call -- same thread-offload reasoning as
+    # get_chunk_count/delete_vectors elsewhere in this feature.
+    return await asyncio.to_thread(scan_document_uids_composite, client, store_config.index, strict=True)
+
+
+@activity.defn
+async def list_strict_content_document_uids() -> list[str]:
+    """
+    Return every document_uid with at least one object in the content store,
+    scanned strictly: any listing failure raises instead of silently returning
+    an empty list (see `BaseContentStore.list_document_uids(strict=True)`).
+
+    Proves only that *at least one* object exists under the document_uid's
+    prefix -- not that every expected object (all pages/attachments) survived
+    the restore. Same documented limitation as `list_strict_vector_document_uids`
+    above; see `RepairVectorMetadataResult`'s docstring.
+    """
+    from knowledge_flow_backend.application_context import ApplicationContext
+
+    content_store = ApplicationContext.get_instance().get_content_store()
+    return await asyncio.to_thread(content_store.list_document_uids, strict=True)
+
+
+@activity.defn
+async def bulk_repair_vector_metadata(source_tag: str, document_uids: list[str]) -> list[str]:
+    """
+    The only write this action performs: atomically set
+    `processing.stages.vector = done` and clear `processing.errors.vector` for
+    exactly the given document_uids, scoped to `source_tag`
+    (`PostgresDocumentMetadataStore.bulk_mark_vector_done`) -- one Postgres
+    transaction, no other JSON field touched.
+
+    `source_tag` re-scopes the `WHERE` clause at write time (not just at the
+    earlier scan time): if a document's `source_tag` changed between the scan
+    and this write, it is excluded rather than silently repaired outside the
+    scope the operator actually authorized.
+
+    Re-running with the same arguments converges to the same end state
+    (semantically idempotent) -- not a guaranteed physical no-op, since
+    PostgreSQL may still rewrite the row even when the JSON value it computes
+    is unchanged.
+    """
+    from knowledge_flow_backend.application_context import ApplicationContext
+
+    metadata_store = ApplicationContext.get_instance().get_metadata_store()
+    if not hasattr(metadata_store, "bulk_mark_vector_done"):
+        raise RuntimeError(f"repair-vector-metadata requires a metadata store with bulk_mark_vector_done, got {type(metadata_store).__name__}")
+    updated = await metadata_store.bulk_mark_vector_done(source_tag, document_uids)  # type: ignore[attr-defined]
+    activity.logger.info("[SCHEDULER][ACTIVITY][REPAIR_VECTOR_METADATA] repaired %d document(s) for source_tag=%s", len(updated), source_tag)
+    return updated
+
+
+@activity.defn
+async def emit_repair_vector_metadata_task_event(task_id: str, state: str, error: str | None, result: dict | None) -> None:
+    """
+    Emit a TaskEvent for a repair-vector-metadata task run (kind stays
+    "ingestion" -- this is a knowledge-flow task, changing it to "migration"
+    would misroute its SSE subscription to control-plane).
+
+    On the terminal event, `result` carries the structured
+    `RepairVectorMetadataResult` report (#2234) so the operator sees real
+    counts directly on the task -- on `/admin/tasks` -- never folded into the
+    generic `error` string of a `succeeded` task.
+    """
+    from fred_core.tasks.models import IngestionDetail, IngestionTaskEvent, RepairVectorMetadataResult, TaskState
+
+    from knowledge_flow_backend.application_context import ApplicationContext
+
+    report = RepairVectorMetadataResult(**result) if result is not None else None
+    detail = IngestionDetail(
+        processed=report.repaired if report else 0,
+        total=report.metadata_documents if report else 0,
+        failed=report.errors if report else 0,
+        preview=0,
+        vectorized=report.repaired if report else 0,
+        sql_indexed=0,
+        result=report,
+    )
+    event = IngestionTaskEvent(
+        task_id=task_id,
+        state=TaskState(state),
+        seq=0,  # auto-incremented by TaskStore.record_event
+        timestamp=datetime.now(tz=timezone.utc),
+        step="done",
+        progress=1.0 if report else None,
+        error=error,
+        detail=detail,
+        target=None,  # initial target/label was already set at task creation
+    )
+    task_service = ApplicationContext.get_instance().get_task_service()
+    await task_service.record(event)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_activities.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_activities.py
@@ -60,7 +60,17 @@ async def list_repair_candidates_for_source_tag(source_tag: str) -> list[dict]:
     blobs, keeping the Temporal payload small at repair scale (~10k docs):
     `document_uid`, whether the document is tabular (CSV/XLSX -- excluded from
     this vector-only repair and reported separately, `sql` reconciliation is
-    out of scope here), and whether `vector` already reads `done`.
+    out of scope here), whether `vector` already reads `done`, and whether
+    *any* processing stage reads `failed` or `in_progress`.
+
+    That last flag exists because a stale `not_started` and a real failure/stuck
+    stage look identical if you only check `vector != done`: on the real Kea
+    corpus, some documents already have real vectors in OpenSearch despite a
+    `failed`/`in_progress` stage elsewhere (e.g. a `preview` failure on a
+    document whose `vector` never started). Without this flag, the workflow
+    would silently mark such a document `done` and clear its error the same as
+    any clean `not_started` case -- erasing a real, worth-investigating failure
+    signal. See `_wf_repair_categorize`'s precedence for how this is used.
     """
     from knowledge_flow_backend.application_context import ApplicationContext
 
@@ -70,11 +80,13 @@ async def list_repair_candidates_for_source_tag(source_tag: str) -> list[dict]:
     for doc in docs:
         file_type = doc.file.file_type.value if doc.file and doc.file.file_type else None
         vector_done = doc.processing.stages.get(ProcessingStage.VECTORIZED) == ProcessingStatus.DONE
+        failed_or_running = any(status in (ProcessingStatus.FAILED, ProcessingStatus.IN_PROGRESS) for status in doc.processing.stages.values())
         records.append(
             {
                 "document_uid": doc.document_uid,
                 "is_tabular": file_type in _TABULAR_FILE_TYPES,
                 "vector_done": vector_done,
+                "failed_or_running": failed_or_running,
             }
         )
     activity.logger.info(

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_workflow.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_workflow.py
@@ -1,0 +1,228 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Temporal workflow (sandboxed) for the vector-metadata repair action
+("3a — Réparer uniquement", #2234).
+
+Deliberately NOT built on `RevectorizeCorpusWorkflow`/`RevectorizeDocument`
+(`features/scheduler/workflow.py`): that shape is one child workflow per
+document, sized for a real re-vectorization pipeline. A metadata-only status
+repair needs none of that -- one parent workflow, a handful of bulk
+activities (each internally paginated/batched, never one Temporal call per
+document), no children. History stays a few dozen events even at ~10,000
+documents; `continue_as_new` is never needed.
+
+Same plain-data sandbox convention as `workflow.py` (see its module
+docstring): only stdlib + temporalio here, payloads read via `_wf_get`.
+
+Fail-closed by construction: `list_strict_vector_document_uids` and
+`list_strict_content_document_uids` raise on any scan failure (see their
+docstrings) instead of returning an incomplete/empty list, and both scans
+happen before the one write (`bulk_repair_vector_metadata`). Any exception
+raised while scanning or writing is caught once, reported as a `failed`
+terminal task event with the real error text, and re-raised -- so a scan
+failure can never read as "0 vectors found" or a silent empty success.
+
+Business outcome vs. reporting outcome are kept separate: the *scans and the
+bulk write* are what can put a document in the wrong state, so only their
+failure aborts the batch and reports `failed`. Publishing a task event
+(initial "running" ping, or the terminal event) is best-effort on top of that
+-- a bounded number of retries, then a logged warning, never a re-raise --
+because a reporting hiccup after a successful bulk write must never read as
+"the repair did not happen" when it did.
+
+Neither scan proves *complete* recovery, only *some* recovery: "has a vector"
+means at least one chunk was found, and "has content" means at least one
+object was found under the document's prefix -- there is no reliable expected
+count to compare against. See `RepairVectorMetadataResult`'s docstring.
+"""
+
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from knowledge_flow_backend.features.scheduler.workflow import _wf_get
+
+
+def _wf_repair_categorize(candidates: list[Any], vector_uids: list[str], content_uids: list[str]) -> dict:
+    """
+    Pure, deterministic intersection over the three scans -- no I/O, so it runs
+    directly in workflow code rather than as its own activity.
+
+    Precedence (mutually exclusive buckets):
+      1. tabular (CSV/XLSX) -> `tabular_excluded`, regardless of its vector stage
+         -- this repair is vector-only; `sql` reconciliation for tabular docs is
+         a separate, out-of-scope gap (#2234 remediation notes).
+      2. already `vector: done` -> `already_done`, left untouched.
+      3. has both real vectors and real content -> eligible for repair.
+      4. no real vectors -> `missing_vectors`, left untouched.
+      5. has vectors but no real content -> `missing_content`, left untouched.
+
+    "has real vectors"/"has real content" means the document_uid appeared at
+    least once in the corresponding strict scan -- not that every expected
+    chunk/object was found (see `list_strict_vector_document_uids`'s docstring).
+    """
+    vector_set = set(vector_uids)
+    content_set = set(content_uids)
+
+    tabular_excluded = 0
+    already_done = 0
+    eligible: list[str] = []
+    missing_vectors = 0
+    missing_content = 0
+
+    for candidate in candidates:
+        document_uid = _wf_get(candidate, "document_uid")
+        if _wf_get(candidate, "is_tabular", False):
+            tabular_excluded += 1
+            continue
+        if _wf_get(candidate, "vector_done", False):
+            already_done += 1
+            continue
+        if document_uid not in vector_set:
+            missing_vectors += 1
+        elif document_uid not in content_set:
+            missing_content += 1
+        else:
+            eligible.append(document_uid)
+
+    return {
+        "tabular_excluded": tabular_excluded,
+        "already_done": already_done,
+        "eligible": eligible,
+        "missing_vectors": missing_vectors,
+        "missing_content": missing_content,
+    }
+
+
+@workflow.defn
+class RepairVectorMetadataWorkflow:
+    @workflow.run
+    async def run(self, payload: Any) -> dict:
+        """
+        payload: {"source_tag": str, "task_id": str | None}
+
+        Phase 1 (read-only): list metadata candidates for `source_tag` (1 SQL
+        query), the real vector document_uids (1 strict, internally-paginated
+        OpenSearch scan), the real content document_uids (1 strict content-store
+        listing). Any failure here raises before phase 2 ever runs.
+
+        Phase 2 (the only write): one bulk Postgres update for exactly the
+        eligible document_uids.
+
+        Always ends with one terminal task event carrying the structured
+        `RepairVectorMetadataResult` report -- unless publishing that event
+        itself fails after a successful repair, in which case the failure is
+        logged, not raised (see module docstring: reporting failure must never
+        masquerade as business failure).
+        """
+        source_tag = _wf_get(payload, "source_tag")
+        task_id = _wf_get(payload, "task_id", None)
+
+        # Best-effort progress ping: bounded retries, then give up quietly. A
+        # failure here must never abort a repair that hasn't touched anything yet.
+        if task_id:
+            try:
+                await workflow.execute_activity(
+                    "emit_ingestion_task_event",
+                    args=[task_id, "running", "scanning", None, None, 0, 1, 0, None, None],
+                    schedule_to_close_timeout=timedelta(hours=1),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            except Exception:
+                workflow.logger.warning("repair-vector-metadata: failed to publish the initial running event for task_id=%s", task_id)
+
+        try:
+            candidates = await workflow.execute_activity(
+                "list_repair_candidates_for_source_tag",
+                args=[source_tag],
+                schedule_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            vector_uids = await workflow.execute_activity(
+                "list_strict_vector_document_uids",
+                args=[],
+                schedule_to_close_timeout=timedelta(minutes=30),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            content_uids = await workflow.execute_activity(
+                "list_strict_content_document_uids",
+                args=[],
+                schedule_to_close_timeout=timedelta(minutes=30),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+
+            buckets = _wf_repair_categorize(candidates, vector_uids, content_uids)
+            eligible = buckets["eligible"]
+
+            repaired_uids = (
+                await workflow.execute_activity(
+                    "bulk_repair_vector_metadata",
+                    args=[source_tag, eligible],
+                    schedule_to_close_timeout=timedelta(minutes=30),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+                if eligible
+                else []
+            )
+
+            report = {
+                "source_tag": source_tag,
+                "metadata_documents": len(candidates),
+                "already_done": buckets["already_done"],
+                "eligible_with_vectors_and_content": len(eligible),
+                "repaired": len(repaired_uids),
+                "missing_vectors": buckets["missing_vectors"],
+                "missing_content": buckets["missing_content"],
+                "tabular_excluded": buckets["tabular_excluded"],
+                "errors": 0,
+            }
+        except Exception as exc:
+            # A failure at or before the bulk write -- the real business failure
+            # this workflow reports for. Reporting it is itself best-effort: if
+            # publishing the failed event also fails, log and still raise the
+            # ORIGINAL exception, never mask it with the reporting error.
+            if task_id:
+                error_str = str(exc).strip() or "Vector-metadata repair failed"
+                try:
+                    await workflow.execute_activity(
+                        "emit_repair_vector_metadata_task_event",
+                        args=[task_id, "failed", error_str, None],
+                        schedule_to_close_timeout=timedelta(hours=1),
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                    )
+                except Exception:
+                    workflow.logger.warning("repair-vector-metadata: failed to publish the failed task event for task_id=%s (original error: %s)", task_id, error_str)
+            raise
+
+        # The bulk write (if any) already committed by this point -- everything
+        # below is reporting only, and must never turn a successful repair into
+        # an apparent failure.
+        if task_id:
+            try:
+                await workflow.execute_activity(
+                    "emit_repair_vector_metadata_task_event",
+                    args=[task_id, "succeeded", None, report],
+                    schedule_to_close_timeout=timedelta(hours=1),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            except Exception:
+                workflow.logger.warning(
+                    "repair-vector-metadata: repair succeeded (repaired=%d) but failed to publish the terminal task event for task_id=%s",
+                    report["repaired"],
+                    task_id,
+                )
+        return report

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_workflow.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/repair_vector_metadata_workflow.py
@@ -67,9 +67,14 @@ def _wf_repair_categorize(candidates: list[Any], vector_uids: list[str], content
          -- this repair is vector-only; `sql` reconciliation for tabular docs is
          a separate, out-of-scope gap (#2234 remediation notes).
       2. already `vector: done` -> `already_done`, left untouched.
-      3. has both real vectors and real content -> eligible for repair.
-      4. no real vectors -> `missing_vectors`, left untouched.
-      5. has vectors but no real content -> `missing_content`, left untouched.
+      3. any processing stage reads `failed` or `in_progress` -> `failed_or_running_excluded`,
+         left untouched. A stale `not_started` flag and a real failure/stuck stage are not
+         the same problem: this repair must never silently mark such a document `done`
+         (clearing its error) just because it happens to already have vectors/content --
+         that would erase a real failure signal instead of surfacing it for investigation.
+      4. has both real vectors and real content -> eligible for repair.
+      5. no real vectors -> `missing_vectors`, left untouched.
+      6. has vectors but no real content -> `missing_content`, left untouched.
 
     "has real vectors"/"has real content" means the document_uid appeared at
     least once in the corresponding strict scan -- not that every expected
@@ -80,6 +85,7 @@ def _wf_repair_categorize(candidates: list[Any], vector_uids: list[str], content
 
     tabular_excluded = 0
     already_done = 0
+    failed_or_running_excluded = 0
     eligible: list[str] = []
     missing_vectors = 0
     missing_content = 0
@@ -92,6 +98,9 @@ def _wf_repair_categorize(candidates: list[Any], vector_uids: list[str], content
         if _wf_get(candidate, "vector_done", False):
             already_done += 1
             continue
+        if _wf_get(candidate, "failed_or_running", False):
+            failed_or_running_excluded += 1
+            continue
         if document_uid not in vector_set:
             missing_vectors += 1
         elif document_uid not in content_set:
@@ -102,6 +111,7 @@ def _wf_repair_categorize(candidates: list[Any], vector_uids: list[str], content
     return {
         "tabular_excluded": tabular_excluded,
         "already_done": already_done,
+        "failed_or_running_excluded": failed_or_running_excluded,
         "eligible": eligible,
         "missing_vectors": missing_vectors,
         "missing_content": missing_content,
@@ -188,6 +198,7 @@ class RepairVectorMetadataWorkflow:
                 "missing_vectors": buckets["missing_vectors"],
                 "missing_content": buckets["missing_content"],
                 "tabular_excluded": buckets["tabular_excluded"],
+                "failed_or_running_excluded": buckets["failed_or_running_excluded"],
                 "errors": 0,
             }
         except Exception as exc:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/scheduler_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/scheduler_service.py
@@ -171,6 +171,20 @@ class IngestionTaskService:
         }
         return await self._scheduler.start_revectorize(payload=payload, task_id=task_id)
 
+    async def start_repair_vector_metadata(self, *, source_tag: str, task_id: str) -> WorkflowHandle:
+        """
+        Start the vector-metadata repair job ("3a — Réparer uniquement", #2234).
+
+        Deliberately not `start_revectorize`: this never touches vectors, content,
+        or the embedder — see `RepairVectorMetadataWorkflow`'s module docstring.
+        Only the Temporal backend supports it today, same constraint as revectorize.
+        """
+        if not isinstance(self._scheduler, TemporalScheduler):
+            raise NotImplementedError("Vector-metadata repair requires the Temporal scheduler backend.")
+
+        payload = {"source_tag": source_tag, "task_id": task_id}
+        return await self._scheduler.start_repair_vector_metadata(payload=payload, task_id=task_id)
+
     async def store_fast_vectors(self, *, payload: dict) -> dict:
         """
         Store fast-ingest vectors using the configured scheduler backend.

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/temporal_scheduler.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/temporal_scheduler.py
@@ -27,8 +27,8 @@ from temporalio.client import Client, WorkflowExecutionStatus
 from knowledge_flow_backend.common.structures import SchedulerConfig
 from knowledge_flow_backend.features.metadata.service import MetadataService
 from knowledge_flow_backend.features.scheduler.base_scheduler import BaseScheduler, WorkflowHandle
-from knowledge_flow_backend.features.scheduler.scheduler_structures import PipelineDefinition
 from knowledge_flow_backend.features.scheduler.repair_vector_metadata_workflow import RepairVectorMetadataWorkflow
+from knowledge_flow_backend.features.scheduler.scheduler_structures import PipelineDefinition
 from knowledge_flow_backend.features.scheduler.workflow import FastDeleteVectors, FastStoreVectors, ProcessPull, ProcessPush, RevectorizeCorpusWorkflow
 
 logger = logging.getLogger(__name__)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/temporal_scheduler.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/temporal_scheduler.py
@@ -28,6 +28,7 @@ from knowledge_flow_backend.common.structures import SchedulerConfig
 from knowledge_flow_backend.features.metadata.service import MetadataService
 from knowledge_flow_backend.features.scheduler.base_scheduler import BaseScheduler, WorkflowHandle
 from knowledge_flow_backend.features.scheduler.scheduler_structures import PipelineDefinition
+from knowledge_flow_backend.features.scheduler.repair_vector_metadata_workflow import RepairVectorMetadataWorkflow
 from knowledge_flow_backend.features.scheduler.workflow import FastDeleteVectors, FastStoreVectors, ProcessPull, ProcessPush, RevectorizeCorpusWorkflow
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,23 @@ class TemporalScheduler(BaseScheduler):
             rpc_timeout=_rpc_timeout(self._scheduler_config.temporal.rpc_timeout_seconds),
         )
         logger.info("🛠️ started temporal revectorize workflow=%s", workflow_handle.id)
+        return WorkflowHandle(workflow_id=workflow_handle.id, run_id=workflow_handle.first_execution_run_id)
+
+    async def start_repair_vector_metadata(self, *, payload: dict, task_id: str) -> WorkflowHandle:
+        """
+        Start a `RepairVectorMetadataWorkflow` ("3a — Réparer uniquement", #2234).
+        `payload` is just `{source_tag, task_id}` plain data -- scope resolution and
+        the vector/content scans all happen inside the workflow's own activities.
+        """
+        client: Client = await self._client_provider.get_client()
+        workflow_handle = await client.start_workflow(
+            RepairVectorMetadataWorkflow.run,
+            payload,
+            id=f"repair-vector-metadata-{task_id}",
+            task_queue=self._scheduler_config.temporal.task_queue,
+            rpc_timeout=_rpc_timeout(self._scheduler_config.temporal.rpc_timeout_seconds),
+        )
+        logger.info("🛠️ started temporal repair-vector-metadata workflow=%s", workflow_handle.id)
         return WorkflowHandle(workflow_id=workflow_handle.id, run_id=workflow_handle.first_execution_run_id)
 
     async def get_workflow_execution_status(self, workflow_id: str) -> Optional[WorkflowExecutionStatus]:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/worker.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/worker.py
@@ -48,6 +48,14 @@ from knowledge_flow_backend.features.scheduler.push_files_activities import (
     get_push_file_metadata,
     push_input_process,
 )
+from knowledge_flow_backend.features.scheduler.repair_vector_metadata_activities import (
+    bulk_repair_vector_metadata,
+    emit_repair_vector_metadata_task_event,
+    list_repair_candidates_for_source_tag,
+    list_strict_content_document_uids,
+    list_strict_vector_document_uids,
+)
+from knowledge_flow_backend.features.scheduler.repair_vector_metadata_workflow import RepairVectorMetadataWorkflow
 from knowledge_flow_backend.features.scheduler.workflow import (
     CreatePullFileMetadata,
     FastDeleteVectors,
@@ -120,6 +128,7 @@ async def run_worker(
             FastDeleteVectors,
             RevectorizeCorpusWorkflow,
             RevectorizeDocument,
+            RepairVectorMetadataWorkflow,
         ],
         activities=[
             create_pull_file_metadata,
@@ -136,6 +145,11 @@ async def run_worker(
             delete_vectors,
             prepare_revectorize_file,
             mark_document_vectorized,
+            list_repair_candidates_for_source_tag,
+            list_strict_vector_document_uids,
+            list_strict_content_document_uids,
+            bulk_repair_vector_metadata,
+            emit_repair_vector_metadata_task_event,
         ],
         activity_executor=executor,
         max_concurrent_workflow_tasks=workflow_task_concurrency,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/workflow.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/workflow.py
@@ -196,6 +196,23 @@ def _wf_should_skip_revectorize(*, mode: Any, force: bool, chunk_count: int) -> 
     return mode == "incremental" and not force and chunk_count > 0
 
 
+def _wf_scope_resolution_failed_event_args(exc: BaseException, task_id: str) -> list[Any]:
+    """Build the `emit_ingestion_task_event` args for a hard failure while resolving
+    `payload.scope` to document_uids in `RevectorizeCorpusWorkflow.run` -- the one
+    call made before any task event exists yet.
+
+    Without this, a `list_documents_in_scope` failure (e.g. Postgres retries
+    exhausted) leaves the workflow to die with no operator-visible signal until the
+    generic stale-task reconcile sweeper eventually marks it failed with a bare
+    "Execution failed" and no detail (`fred_core.tasks.service.TaskService.
+    _reconciled_terminal`, on a multi-minute sweep interval). Emitting this
+    immediately, with the real exception text, gives the same fast, specific signal
+    a per-document failure already gets from `RevectorizeDocument`.
+    """
+    error_str = str(exc).strip() or "Failed to resolve revectorize scope"
+    return [task_id, "failed", "listed", None, error_str, 0, 0, 0, None, None]
+
+
 def _wf_final_revectorize_state(*, failed: int, total: int) -> tuple[str, str | None]:
     """
     Decide `RevectorizeCorpusWorkflow`'s terminal task state from its
@@ -731,6 +748,13 @@ class RevectorizeCorpusWorkflow:
         children (same bounded-parallelism shape as `_wf_run_parent_pipeline`), and
         emit one running/succeeded overall event carrying processed/total/failed
         counts. Never raises for per-document failures — see `RevectorizeDocument`.
+
+        Scope resolution itself (the `list_documents_in_scope` call, before any
+        child workflow exists) is the one failure this workflow does still raise
+        for — after emitting an immediate, specific `failed` task event
+        (`_wf_scope_resolution_failed_event_args`) so the operator doesn't have to
+        wait for the generic stale-task reconcile sweeper's multi-minute, detail-free
+        fallback.
         """
         scope = _wf_get(payload, "scope", {}) or {}
         options = _wf_get(payload, "options", {}) or {}
@@ -738,12 +762,22 @@ class RevectorizeCorpusWorkflow:
         task_id = _wf_get(payload, "task_id", None)
         max_parallelism = max(1, int(_wf_get(payload, "max_parallelism", 1) or 1))
 
-        document_uids = await workflow.execute_activity(
-            "list_documents_in_scope",
-            args=[scope],
-            schedule_to_close_timeout=timedelta(minutes=10),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
+        try:
+            document_uids = await workflow.execute_activity(
+                "list_documents_in_scope",
+                args=[scope],
+                schedule_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+        except Exception as exc:
+            if task_id:
+                await workflow.execute_activity(
+                    "emit_ingestion_task_event",
+                    args=_wf_scope_resolution_failed_event_args(exc, task_id),
+                    schedule_to_close_timeout=timedelta(hours=1),
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+            raise
         total = len(document_uids)
 
         if task_id:

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/kea_reconcile_scan.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/kea_reconcile_scan.py
@@ -1,0 +1,225 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Read-only reconciliation scan for the Kea->Swift "stuck pending" gap (GitHub #2234).
+
+Documents restored by the manual OpenSearch/S3 copy have their Postgres
+`processing.stages` reset by the importer (`importer.py::_reset_transported_stages`),
+so `stages["vector"]`/`stages["sql"]` read `not_started` even when the real
+content already exists. `/corpus/revectorize` (mode=incremental, force=false)
+is the safe repair path, but running it blind at ~10k documents across an
+unknown number of `source_tag` values is not "extra sure": it silently falls
+back to a real, costly re-embed whenever `get_document_chunk_count` errors or
+returns 0 (index misconfiguration, or a genuinely never-restored document),
+and it never repairs the `sql` stage for tabular (CSV/XLSX) documents at all.
+
+This script makes NO writes anywhere (Postgres, OpenSearch, object store). It
+loads every document's metadata and, for each one not already marked done,
+checks the *real* backing store directly -- the same calls the production
+workflow (`RevectorizeDocument`, `features/scheduler/workflow.py`) makes --
+and buckets the result so an operator can see, with real numbers instead of
+guesses, which repairs are free and which are not, per `source_tag`, before
+anything is run for real.
+
+Buckets:
+  already_ready          -- stage already DONE, nothing to do.
+  safe_repair             -- vector chunks exist; /corpus/revectorize will only
+                              flip the Postgres flag, no re-embed.
+  needs_real_reembed      -- 0 vector chunks found; /corpus/revectorize would
+                              trigger a genuine (LLM-cost) re-embed. Review by
+                              hand before running.
+  tabular_ok_flag_only    -- Parquet artifact exists in the content store but
+                              `sql` stage isn't marked done; NOT fixed by
+                              /corpus/revectorize today (metadata-only repair
+                              is vector-only) -- needs a small backend addition
+                              or a manual flag flip.
+  tabular_needs_reprocess -- no Parquet artifact found; a real re-process is
+                              required, not just a flag repair.
+  count_error              -- the real-store check itself failed (e.g. index
+                              name/config mismatch). Fix and re-run the scan
+                              before touching anything else -- do NOT treat
+                              these as "needs_real_reembed", the check itself
+                              is unreliable for them.
+
+Usage (against the target environment's own config, same as the API/worker):
+
+  CONFIG_FILE=/path/to/target-configuration.yaml \
+    uv run python -m knowledge_flow_backend.scripts.kea_reconcile_scan \
+    [--out report.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+
+from fred_core.documents.document_structures import (
+    DocumentMetadata,
+    ProcessingStage,
+    ProcessingStatus,
+)
+
+from knowledge_flow_backend.application_context import ApplicationContext
+from knowledge_flow_backend.common.config_loader import load_configuration
+from knowledge_flow_backend.core.stores.content.base_content_store import BaseContentStore
+from knowledge_flow_backend.core.stores.vector.base_vector_store import BaseVectorStore
+from knowledge_flow_backend.features.tabular.artifacts import (
+    TABULAR_EXTENSION_KEY,
+    TABULAR_MULTI_EXTENSION_KEY,
+)
+
+logger = logging.getLogger("kea_reconcile_scan")
+
+_TABULAR_FILE_TYPES = {"csv", "xlsx"}
+
+
+@dataclass
+class DocVerdict:
+    document_uid: str
+    document_name: str
+    source_tag: str | None
+    file_type: str
+    bucket: str
+    detail: str = ""
+
+
+def _tabular_object_key(metadata: DocumentMetadata) -> str | None:
+    extensions = metadata.extensions or {}
+    single = extensions.get(TABULAR_EXTENSION_KEY)
+    if isinstance(single, dict) and single.get("object_key"):
+        return str(single["object_key"])
+    multi = extensions.get(TABULAR_MULTI_EXTENSION_KEY)
+    if isinstance(multi, dict):
+        tables = multi.get("tables")
+        if isinstance(tables, list) and tables and isinstance(tables[0], dict):
+            return str(tables[0].get("object_key")) if tables[0].get("object_key") else None
+    return None
+
+
+async def _scan_one(
+    metadata: DocumentMetadata,
+    vector_store: BaseVectorStore,
+    content_store: BaseContentStore,
+) -> DocVerdict:
+    uid = metadata.identity.document_uid
+    name = metadata.identity.document_name
+    source_tag = metadata.source.source_tag
+    file_type = metadata.file.file_type.value if metadata.file else "other"
+    stages = metadata.processing.stages
+
+    if file_type in _TABULAR_FILE_TYPES:
+        if stages.get(ProcessingStage.SQL_INDEXED) == ProcessingStatus.DONE:
+            return DocVerdict(uid, name, source_tag, file_type, "already_ready")
+        object_key = _tabular_object_key(metadata)
+        if not object_key:
+            return DocVerdict(uid, name, source_tag, file_type, "tabular_needs_reprocess", "no tabular_v1/tabular_multi_v1 extension recorded")
+        try:
+            await asyncio.to_thread(content_store.stat_object, object_key)
+            return DocVerdict(
+                uid,
+                name,
+                source_tag,
+                file_type,
+                "tabular_ok_flag_only",
+                f"parquet present at {object_key}; sql stage needs a metadata-only repair not yet wired up",
+            )
+        except FileNotFoundError:
+            return DocVerdict(uid, name, source_tag, file_type, "tabular_needs_reprocess", f"parquet missing at {object_key}")
+        except Exception as exc:  # noqa: BLE001 -- deliberately broad: any store failure must surface as count_error, never as a silent 0
+            return DocVerdict(uid, name, source_tag, file_type, "count_error", f"stat_object({object_key}) failed: {exc}")
+
+    if stages.get(ProcessingStage.VECTORIZED) == ProcessingStatus.DONE:
+        return DocVerdict(uid, name, source_tag, file_type, "already_ready")
+
+    if not hasattr(vector_store, "get_document_chunk_count"):
+        return DocVerdict(uid, name, source_tag, file_type, "count_error", f"{type(vector_store).__name__} has no get_document_chunk_count")
+
+    try:
+        count = await asyncio.to_thread(vector_store.get_document_chunk_count, document_uid=uid)  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001 -- same reasoning: never fold a real error into "0 chunks"
+        return DocVerdict(uid, name, source_tag, file_type, "count_error", str(exc))
+
+    if count > 0:
+        return DocVerdict(uid, name, source_tag, file_type, "safe_repair", f"{count} chunks already indexed")
+    return DocVerdict(uid, name, source_tag, file_type, "needs_real_reembed", "0 chunks found in the vector store")
+
+
+async def run(out_path: str | None) -> None:
+    configuration = load_configuration()
+    ApplicationContext(configuration)
+    app_context = ApplicationContext.get_instance()
+
+    metadata_store = app_context.get_metadata_store()
+    content_store = app_context.get_content_store()
+    vector_store = app_context.get_create_vector_store(app_context.get_embedder())
+
+    docs = await metadata_store.get_all_metadata({})
+    logger.info("Loaded %d document metadata row(s)", len(docs))
+
+    verdicts = [await _scan_one(d, vector_store, content_store) for d in docs]
+
+    by_tag: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for v in verdicts:
+        by_tag[v.source_tag or "<no source_tag>"][v.bucket] += 1
+
+    print("\n=== Kea reconciliation scan -- per source_tag ===")
+    grand_total: dict[str, int] = defaultdict(int)
+    for tag, counts in sorted(by_tag.items()):
+        print(f"\nsource_tag={tag}  (total={sum(counts.values())})")
+        for bucket, n in sorted(counts.items()):
+            print(f"  {bucket:26s} {n}")
+            grand_total[bucket] += n
+
+    print(f"\n=== TOTAL ({len(verdicts)} documents) ===")
+    for bucket, n in sorted(grand_total.items()):
+        print(f"  {bucket:26s} {n}")
+
+    if grand_total.get("count_error"):
+        print(
+            f"\n/!\\ {grand_total['count_error']} document(s) errored checking the real store -- "
+            "fix this (likely an index/config mismatch) BEFORE running /corpus/revectorize. "
+            "Run with --out and inspect their `detail` field."
+        )
+    if grand_total.get("needs_real_reembed"):
+        print(f"/!\\ {grand_total['needs_real_reembed']} document(s) have 0 real vector chunks -- /corpus/revectorize would trigger a genuine, costly re-embed for these. Review by hand.")
+    if grand_total.get("tabular_needs_reprocess"):
+        print(f"/!\\ {grand_total['tabular_needs_reprocess']} tabular document(s) have no Parquet artifact -- these need a real re-process, not a flag repair.")
+    if grand_total.get("tabular_ok_flag_only"):
+        print(
+            f"/!\\ {grand_total['tabular_ok_flag_only']} tabular document(s) have their Parquet artifact but "
+            "no repair path exists yet for the `sql` stage -- /corpus/revectorize's metadata-only skip only "
+            "marks `vector`, never `sql`."
+        )
+
+    if out_path:
+        with open(out_path, "w") as f:
+            json.dump([asdict(v) for v in verdicts], f, indent=2)
+        print(f"\nFull per-document report written to {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out", default=None, help="Optional path to write the full per-document JSON report")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+    asyncio.run(run(args.out))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
@@ -1,0 +1,429 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Seed a large synthetic corpus (fake libraries + documents + vectors) for local
+load-testing of repair/audit tooling (e.g. metadata/vector reconciliation scans,
+`/corpus/revectorize`, `MetadataService.audit_stores`).
+
+This writes directly to the same Postgres tag/metadata stores, OpenSearch
+vector index, ReBAC engine (OpenFGA), and content store (Minio/S3) the
+running backend uses -- it does NOT go through the ingestion pipeline, so no
+LLM/embedding cost is incurred for the documents themselves. The only real
+network call is a single dummy embedding to learn the configured vector
+dimension (needed so fake vectors match the real mapping); everything else
+is synthetic. Pass --skip-content to skip writing content objects
+(Postgres+OpenSearch+ReBAC only, faster, but every document is flagged
+`missing_content` by audit tooling).
+
+`--team-id` must be the team's *real* internal id, not its display name --
+they are different strings (see `teammetadata` table). A document's ReBAC
+visibility (schema.fga: `tag.read = ... team_member from owner`, then
+`document.read = read from parent`) depends on BOTH the tag->team ownership
+tuple AND a document->tag parent tuple per document; this script writes both,
+but a wrong --team-id makes every seeded library invisible with no error.
+
+Intended for a LOCAL docker-compose stack only. Never point CONFIG_FILE at a
+shared/staging/prod configuration when running this.
+
+Usage (against your local stack's own config, same as the API/worker):
+
+  CONFIG_FILE=/path/to/local-configuration.yaml \
+    uv run python -m knowledge_flow_backend.scripts.seed_synthetic_corpus \
+    --team-id fredlab --libraries 100 --documents 20000
+
+  # Remove everything this script previously created (matched by source_tag),
+  # before re-seeding a fresh run:
+  CONFIG_FILE=/path/to/local-configuration.yaml \
+    uv run python -m knowledge_flow_backend.scripts.seed_synthetic_corpus --purge
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import logging
+import random
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Iterator
+
+import numpy as np
+from fred_core import Relation, RebacReference, RelationType, Resource
+from minio.deleteobjects import DeleteObject
+from fred_core.documents.document_structures import (
+    AccessInfo,
+    DocumentMetadata,
+    FileInfo,
+    FileType,
+    Identity,
+    ProcessingStage,
+    SourceInfo,
+    SourceType,
+    Tagging,
+)
+from opensearchpy.helpers import bulk
+
+from knowledge_flow_backend.application_context import ApplicationContext
+from knowledge_flow_backend.common.config_loader import load_configuration
+from knowledge_flow_backend.features.tag.structure import Tag, TagType
+
+logger = logging.getLogger("seed_synthetic_corpus")
+
+SEED_SOURCE_TAG = "seed-synthetic-corpus"
+SEED_CHUNK_SUFFIX = "::seed-chunk-0"
+
+
+def _build_tag(team_id: str, index: int) -> Tag:
+    now = datetime.now(timezone.utc)
+    return Tag(
+        id=str(uuid.uuid4()),
+        created_at=now,
+        updated_at=now,
+        owner_id=team_id,
+        name=f"seed-library-{index:03d}",
+        description="Synthetic seed library for local load-testing (seed_synthetic_corpus.py)",
+        type=TagType.DOCUMENT,
+    )
+
+
+def _build_document(tag: Tag, index: int) -> DocumentMetadata:
+    now = datetime.now(timezone.utc)
+    name = f"seed-doc-{index:06d}.txt"
+    doc = DocumentMetadata(
+        identity=Identity(
+            document_name=name,
+            document_uid=str(uuid.uuid4()),
+            title=name,
+            created=now,
+            modified=now,
+            uploaded_by="seed-synthetic-corpus",
+        ),
+        source=SourceInfo(
+            source_type=SourceType.PUSH,
+            source_tag=SEED_SOURCE_TAG,
+            retrievable=True,
+            date_added_to_kb=now,
+        ),
+        file=FileInfo(
+            file_type=FileType.TXT,
+            mime_type="text/plain",
+            file_size_bytes=random.randint(2_000, 200_000),
+            page_count=1,
+        ),
+        tags=Tagging(tag_ids=[tag.id], tag_names=[tag.name]),
+        access=AccessInfo(),
+    )
+    doc.mark_stage_done(ProcessingStage.RAW_AVAILABLE)
+    doc.mark_stage_done(ProcessingStage.PREVIEW_READY)
+    doc.mark_stage_done(ProcessingStage.VECTORIZED)
+    return doc
+
+
+async def _seed_tags(tag_store, rebac, team_id: str, n_tags: int, concurrency: int) -> list[Tag]:
+    tags = [_build_tag(team_id, i) for i in range(n_tags)]
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _one(tag: Tag) -> None:
+        async with sem:
+            await tag_store.create_tag(tag)
+            # Team ownership tuple, mirrors TagService.create_tag_for_user -- without
+            # this, a ReBAC-enabled stack won't show the library under the team space.
+            await rebac.add_relation(
+                Relation(
+                    subject=RebacReference(type=Resource.TEAM, id=team_id),
+                    relation=RelationType.OWNER,
+                    resource=RebacReference(type=Resource.TAGS, id=tag.id),
+                )
+            )
+
+    await asyncio.gather(*(_one(t) for t in tags))
+    return tags
+
+
+async def _seed_documents(metadata_store, tags: list[Tag], n_docs: int, concurrency: int) -> list[DocumentMetadata]:
+    docs: list[DocumentMetadata] = []
+    sem = asyncio.Semaphore(concurrency)
+    done = 0
+
+    async def _one(i: int) -> None:
+        nonlocal done
+        doc = _build_document(tags[i % len(tags)], i)
+        async with sem:
+            await metadata_store.save_metadata(doc)
+        docs.append(doc)
+        done += 1
+        if done % 2000 == 0:
+            logger.info("  ... %d/%d documents saved", done, n_docs)
+
+    await asyncio.gather(*(_one(i) for i in range(n_docs)))
+    return docs
+
+
+def _document_parent_relation(doc: DocumentMetadata) -> Relation:
+    # schema.fga: `document.read = read from parent`, `parent: [tag]`. Without this
+    # tuple a document is invisible in any ReBAC-filtered listing (e.g. the
+    # "Ressources d'equipe" folder view, MetadataService.get_document_metadata_in_tag)
+    # even though the tag/folder itself is visible and the Postgres row carries the
+    # right tag_id -- the tag being visible does not imply its documents are.
+    return Relation(
+        subject=RebacReference(type=Resource.TAGS, id=doc.tags.tag_ids[0]),
+        relation=RelationType.PARENT,
+        resource=RebacReference(type=Resource.DOCUMENTS, id=doc.document_uid),
+    )
+
+
+async def _seed_document_parent_relations(rebac, docs: list[DocumentMetadata], concurrency: int) -> None:
+    sem = asyncio.Semaphore(concurrency)
+    done = 0
+
+    async def _one(doc: DocumentMetadata) -> None:
+        nonlocal done
+        async with sem:
+            await rebac.add_relation(_document_parent_relation(doc))
+        done += 1
+        if done % 2000 == 0:
+            logger.info("  ... %d/%d document ReBAC parent tuple(s) written", done, len(docs))
+
+    await asyncio.gather(*(_one(d) for d in docs))
+
+
+def _content_object_key(doc: DocumentMetadata) -> str:
+    # `input/` matters: MinioStorageBackend.get_content() looks for the primary
+    # object under exactly this prefix, so this also makes preview/download work,
+    # not just the content-store presence check `audit_stores` relies on.
+    return f"{doc.document_uid}/input/{doc.document_name}"
+
+
+def _fake_content_bytes(doc: DocumentMetadata) -> bytes:
+    return (
+        f"Synthetic seed content for {doc.document_name} (document_uid={doc.document_uid}).\nGenerated by seed_synthetic_corpus.py for local audit/repair load-testing -- not a real file.\n"
+    ).encode("utf-8")
+
+
+async def _seed_content(content_store, docs: list[DocumentMetadata], concurrency: int) -> None:
+    sem = asyncio.Semaphore(concurrency)
+    done = 0
+
+    def _put_one(doc: DocumentMetadata) -> None:
+        data = _fake_content_bytes(doc)
+        content_store.client.put_object(
+            content_store.document_bucket,
+            _content_object_key(doc),
+            io.BytesIO(data),
+            length=len(data),
+            content_type="text/plain",
+        )
+
+    async def _one(doc: DocumentMetadata) -> None:
+        nonlocal done
+        async with sem:
+            await asyncio.to_thread(_put_one, doc)
+        done += 1
+        if done % 2000 == 0:
+            logger.info("  ... %d/%d fake content object(s) written", done, len(docs))
+
+    await asyncio.gather(*(_one(d) for d in docs))
+
+
+def _vector_actions(docs: list[DocumentMetadata], index_name: str, dim: int, rng: np.random.Generator) -> Iterator[dict]:
+    for doc in docs:
+        chunk_uid = f"{doc.document_uid}{SEED_CHUNK_SUFFIX}"
+        yield {
+            "_op_type": "index",
+            "_index": index_name,
+            "_id": chunk_uid,
+            "_source": {
+                "text": "Synthetic seed content for local audit/repair load-testing.",
+                "vector_field": rng.uniform(-1.0, 1.0, dim).tolist(),
+                "metadata": {
+                    "document_uid": doc.document_uid,
+                    "document_name": doc.document_name,
+                    "chunk_uid": chunk_uid,
+                    "chunk_index": 0,
+                    "tag_ids": list(doc.tags.tag_ids),
+                    "retrievable": True,
+                    "type": doc.file.file_type.value,
+                    "mime_type": doc.file.mime_type,
+                    "file_size_bytes": doc.file.file_size_bytes,
+                },
+            },
+        }
+
+
+async def _purge_document_parent_relations(rebac, docs: list[DocumentMetadata], concurrency: int) -> None:
+    sem = asyncio.Semaphore(concurrency)
+    done = 0
+
+    async def _one(doc: DocumentMetadata) -> None:
+        nonlocal done
+        try:
+            async with sem:
+                await rebac.delete_relation(_document_parent_relation(doc))
+        except Exception as exc:  # noqa: BLE001 -- tuple may already be gone (partial prior run); never block metadata cleanup
+            logger.debug("Could not delete ReBAC parent tuple for document=%s (may already be absent): %s", doc.document_uid, exc)
+        done += 1
+        if done % 2000 == 0:
+            logger.info("  ... %d/%d document ReBAC parent tuple(s) purged", done, len(docs))
+
+    await asyncio.gather(*(_one(d) for d in docs))
+
+
+async def _purge(app_context: ApplicationContext, concurrency: int) -> None:
+    metadata_store = app_context.get_metadata_store()
+    tag_store = app_context.get_tag_store()
+    rebac = app_context.get_rebac_engine()
+    vector_store = app_context.get_create_vector_store(app_context.get_embedder())
+
+    docs = await metadata_store.list_by_source_tag(SEED_SOURCE_TAG)
+    logger.info("Purging %d previously seeded document(s) (ReBAC parent tuple + Postgres row) ...", len(docs))
+    if docs:
+        await _purge_document_parent_relations(rebac, docs, concurrency)
+    tag_ids: set[str] = set()
+    doc_uids: list[str] = []
+    for doc in docs:
+        tag_ids.update(doc.tags.tag_ids or [])
+        doc_uids.append(doc.document_uid)
+        await metadata_store.delete_metadata(doc.document_uid)
+
+    if docs:
+        # Content objects carry no "seed" marker of their own -- they're only
+        # findable through the Postgres rows just deleted above, via the exact
+        # key this script writes them under (`_content_object_key`). A content
+        # object orphaned by an earlier run that died between these two steps
+        # would not be caught here; that's a known gap, not a bug in this pass.
+        content_store = app_context.get_content_store()
+        logger.info("Purging %d fake content object(s) from bucket=%s ...", len(docs), content_store.document_bucket)
+        delete_list = [DeleteObject(_content_object_key(doc)) for doc in docs]
+        errors = list(content_store.client.remove_objects(content_store.document_bucket, delete_list))
+        if errors:
+            logger.warning("Some content object(s) failed to delete: %s", errors[:5])
+
+    all_tags = await tag_store.list_all_tags()
+    seed_tags = [t for t in all_tags if t.id in tag_ids or t.name.startswith("seed-library-")]
+    logger.info("Purging %d previously seeded library/tag(s) (Postgres row + ReBAC ownership tuple) ...", len(seed_tags))
+    for tag in seed_tags:
+        try:
+            await rebac.delete_relation(
+                Relation(
+                    subject=RebacReference(type=Resource.TEAM, id=tag.owner_id),
+                    relation=RelationType.OWNER,
+                    resource=RebacReference(type=Resource.TAGS, id=tag.id),
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 -- tuple may already be gone (partial prior run); never block the Postgres cleanup below on it
+            logger.warning("Could not delete ReBAC ownership tuple for tag=%s (may already be absent): %s", tag.id, exc)
+        await tag_store.delete_tag_by_id(tag.id)
+
+    # Match on *both* document_uid (docs found via source_tag above) and tag_ids
+    # (covers a prior interrupted run that deleted the Postgres row but not the
+    # vector chunk, or vice versa) -- either signal alone can miss a partial run.
+    seed_tag_id_list = [t.id for t in seed_tags]
+    should_clauses: list[dict] = []
+    if doc_uids:
+        should_clauses.append({"terms": {"metadata.document_uid": doc_uids}})
+    if seed_tag_id_list:
+        should_clauses.append({"terms": {"metadata.tag_ids": seed_tag_id_list}})
+
+    if should_clauses:
+        logger.info("Purging fake vector chunks from OpenSearch index=%s ...", vector_store.index_name)
+        resp = vector_store.client.delete_by_query(
+            index=vector_store.index_name,
+            body={"query": {"bool": {"should": should_clauses, "minimum_should_match": 1}}},
+        )
+        vector_store.client.indices.refresh(index=vector_store.index_name)
+        logger.info("Deleted %d vector chunk(s).", resp.get("deleted", 0))
+    else:
+        logger.info("No seeded document_uid/tag_ids found -- nothing to purge from OpenSearch.")
+
+
+async def run(args: argparse.Namespace) -> None:
+    configuration = load_configuration()
+    ApplicationContext(configuration)
+    app_context = ApplicationContext.get_instance()
+
+    if args.purge:
+        await _purge(app_context, args.concurrency)
+        return
+
+    tag_store = app_context.get_tag_store()
+    metadata_store = app_context.get_metadata_store()
+    rebac = app_context.get_rebac_engine()
+
+    logger.info("Creating %d synthetic librar(y/ies) under team_id=%r ...", args.libraries, args.team_id)
+    tags = await _seed_tags(tag_store, rebac, args.team_id, args.libraries, args.concurrency)
+
+    logger.info("Creating %d synthetic document(s) across %d librar(y/ies) ...", args.documents, len(tags))
+    t0 = time.monotonic()
+    docs = await _seed_documents(metadata_store, tags, args.documents, args.concurrency)
+    logger.info("Postgres metadata seeded in %.1fs", time.monotonic() - t0)
+
+    logger.info("Writing %d document ReBAC parent tuple(s) (tag -> document) ...", len(docs))
+    t0 = time.monotonic()
+    await _seed_document_parent_relations(rebac, docs, args.concurrency)
+    logger.info("ReBAC parent tuples written in %.1fs", time.monotonic() - t0)
+
+    if not args.skip_content:
+        content_store = app_context.get_content_store()
+        logger.info("Writing %d small fake content object(s) to bucket=%s ...", len(docs), content_store.document_bucket)
+        t0 = time.monotonic()
+        await _seed_content(content_store, docs, args.concurrency)
+        logger.info("Fake content written in %.1fs", time.monotonic() - t0)
+
+    logger.info("Resolving the real embedder once to learn the configured vector dimension (one real API call) ...")
+    vector_store = app_context.get_create_vector_store(app_context.get_embedder())
+    mapping = vector_store.client.indices.get_mapping(index=vector_store.index_name)
+    dim = mapping[vector_store.index_name]["mappings"]["properties"]["vector_field"]["dimension"]
+    logger.info("Vector index=%s dimension=%d -- indexing %d fake vector chunk(s) ...", vector_store.index_name, dim, len(docs))
+
+    t0 = time.monotonic()
+    rng = np.random.default_rng(args.seed)
+    success, errors = bulk(
+        vector_store.client,
+        _vector_actions(docs, vector_store.index_name, dim, rng),
+        chunk_size=1000,
+        request_timeout=120,
+        raise_on_error=False,
+    )
+    vector_store.client.indices.refresh(index=vector_store.index_name)
+    logger.info(
+        "Indexed %d fake vector chunk(s) in %.1fs (errors=%d)",
+        success,
+        time.monotonic() - t0,
+        len(errors) if isinstance(errors, list) else 0,
+    )
+    if errors:
+        logger.warning("First few bulk errors: %s", errors[:3])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--team-id", default="fredlab", help="Team space that will own the synthetic libraries.")
+    parser.add_argument("--libraries", type=int, default=100, help="Number of synthetic libraries (tags) to create.")
+    parser.add_argument("--documents", type=int, default=20000, help="Number of synthetic documents to create, spread round-robin across libraries.")
+    parser.add_argument("--concurrency", type=int, default=20, help="Max concurrent Postgres writes.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for fake vectors/sizes (reproducible runs).")
+    parser.add_argument("--skip-content", action="store_true", help="Skip writing small fake content objects to the content store (Minio/S3) -- Postgres+OpenSearch only, faster.")
+    parser.add_argument(
+        "--purge", action="store_true", help="Delete everything a previous run of this script created (matched by source_tag/embedding_model), then exit. Run again without --purge to re-seed."
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
@@ -129,7 +129,7 @@ def _build_document(tag: Tag, index: int) -> DocumentMetadata:
         file=FileInfo(
             file_type=FileType.TXT,
             mime_type="text/plain",
-            file_size_bytes=random.randint(2_000, 200_000),
+            file_size_bytes=random.randint(2_000, 200_000),  # nosec B311: synthetic fixture size, not security-sensitive
             page_count=1,
         ),
         tags=Tagging(tag_ids=[tag.id], tag_names=[tag.name]),
@@ -380,7 +380,7 @@ async def _mark_stuck_pending(metadata_store, n: int, seed: int, concurrency: in
     logger.info("Synthetic pool=%d, eligible (currently vector=done)=%d", len(pool), len(eligible))
     if n > len(eligible):
         logger.warning("Requested %d but only %d eligible -- marking all of them.", n, len(eligible))
-    rng = random.Random(seed)
+    rng = random.Random(seed)  # nosec B311: deterministic sampling for test-corpus reproducibility, not security-sensitive
     chosen = rng.sample(eligible, min(n, len(eligible)))
 
     sem = asyncio.Semaphore(concurrency)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
@@ -81,6 +81,8 @@ from opensearchpy.helpers import bulk
 
 from knowledge_flow_backend.application_context import ApplicationContext
 from knowledge_flow_backend.common.config_loader import load_configuration
+from knowledge_flow_backend.core.stores.content.minio_content_store import MinioStorageBackend
+from knowledge_flow_backend.core.stores.vector.opensearch_vector_store import OpenSearchVectorStoreAdapter
 from knowledge_flow_backend.features.tag.structure import Tag, TagType
 
 logger = logging.getLogger("seed_synthetic_corpus")
@@ -114,7 +116,7 @@ def _build_document(tag: Tag, index: int) -> DocumentMetadata:
             modified=now,
             uploaded_by=SEED_UPLOADED_BY,
         ),
-        source=SourceInfo(
+        source=SourceInfo(  # type: ignore[reportCallIssue]  # basedpyright doesn't recognize Field(None, ...) positional defaults (only Field(default=...)) as satisfying SourceInfo's synthesized __init__; pull_location genuinely defaults to None (document_structures.py) -- same false positive on every SourceInfo(...) call omitting it, e.g. test_repair_vector_metadata_activities.py:75
             source_type=SourceType.PUSH,
             # "fred" (not a seed-specific marker) on purpose: it's the same source_tag
             # every real manual upload gets (IngestionInput.source_tag default,
@@ -295,6 +297,16 @@ async def _purge(app_context: ApplicationContext, concurrency: int) -> None:
     tag_store = app_context.get_tag_store()
     rebac = app_context.get_rebac_engine()
     vector_store = app_context.get_create_vector_store(app_context.get_embedder())
+    # This script is explicitly OpenSearch/Minio-only (see module docstring): it writes
+    # fake vector chunks and content objects straight to those backends' low-level
+    # clients for bulk-seeding/purging performance, bypassing the abstract
+    # BaseVectorStore/BaseContentStore interface on purpose. Narrowing with isinstance
+    # (instead of a blanket type:ignore on every attribute access below) gives real type
+    # safety and a clear failure if this is ever run against a differently configured
+    # local stack (e.g. Chroma or filesystem content storage) instead of a cryptic
+    # AttributeError mid-purge.
+    if not isinstance(vector_store, OpenSearchVectorStoreAdapter):
+        raise RuntimeError(f"seed_synthetic_corpus.py only supports the OpenSearch-backed vector store; configured backend is {type(vector_store).__name__}.")
 
     # Matched on identity.uploaded_by, not source_tag: seeded documents deliberately
     # carry source_tag="fred" (the same value every real upload gets) so repair
@@ -318,6 +330,8 @@ async def _purge(app_context: ApplicationContext, concurrency: int) -> None:
         # object orphaned by an earlier run that died between these two steps
         # would not be caught here; that's a known gap, not a bug in this pass.
         content_store = app_context.get_content_store()
+        if not isinstance(content_store, MinioStorageBackend):
+            raise RuntimeError(f"seed_synthetic_corpus.py only supports the MinIO/S3-backed content store; configured backend is {type(content_store).__name__}.")
         logger.info("Purging %d fake content object(s) from bucket=%s ...", len(docs), content_store.document_bucket)
         delete_list = [DeleteObject(_content_object_key(doc)) for doc in docs]
         errors = list(content_store.client.remove_objects(content_store.document_bucket, delete_list))
@@ -456,6 +470,8 @@ async def run(args: argparse.Namespace) -> None:
 
     if not args.skip_content:
         content_store = app_context.get_content_store()
+        if not isinstance(content_store, MinioStorageBackend):
+            raise RuntimeError(f"seed_synthetic_corpus.py only supports the MinIO/S3-backed content store; configured backend is {type(content_store).__name__}.")
         logger.info("Writing %d small fake content object(s) to bucket=%s ...", len(docs), content_store.document_bucket)
         t0 = time.monotonic()
         await _seed_content(content_store, docs, args.concurrency)
@@ -463,20 +479,25 @@ async def run(args: argparse.Namespace) -> None:
 
     logger.info("Resolving the real embedder once to learn the configured vector dimension (one real API call) ...")
     vector_store = app_context.get_create_vector_store(app_context.get_embedder())
-    mapping = vector_store.client.indices.get_mapping(index=vector_store.index_name)
-    dim = mapping[vector_store.index_name]["mappings"]["properties"]["vector_field"]["dimension"]
-    logger.info("Vector index=%s dimension=%d -- indexing %d fake vector chunk(s) ...", vector_store.index_name, dim, len(docs))
+    if not isinstance(vector_store, OpenSearchVectorStoreAdapter):
+        raise RuntimeError(f"seed_synthetic_corpus.py only supports the OpenSearch-backed vector store; configured backend is {type(vector_store).__name__}.")
+    index_name = vector_store.index_name
+    if index_name is None:
+        raise RuntimeError("OpenSearch vector store has no configured index_name.")
+    mapping = vector_store.client.indices.get_mapping(index=index_name)
+    dim = mapping[index_name]["mappings"]["properties"]["vector_field"]["dimension"]
+    logger.info("Vector index=%s dimension=%d -- indexing %d fake vector chunk(s) ...", index_name, dim, len(docs))
 
     t0 = time.monotonic()
     rng = np.random.default_rng(args.seed)
     success, errors = bulk(
         vector_store.client,
-        _vector_actions(docs, vector_store.index_name, dim, rng),
+        _vector_actions(docs, index_name, dim, rng),
         chunk_size=1000,
         request_timeout=120,
         raise_on_error=False,
     )
-    vector_store.client.indices.refresh(index=vector_store.index_name)
+    vector_store.client.indices.refresh(index=index_name)
     logger.info(
         "Indexed %d fake vector chunk(s) in %.1fs (errors=%d)",
         success,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
@@ -43,8 +43,9 @@ Usage (against your local stack's own config, same as the API/worker):
     uv run python -m knowledge_flow_backend.scripts.seed_synthetic_corpus \
     --team-id fredlab --libraries 100 --documents 20000
 
-  # Remove everything this script previously created (matched by source_tag),
-  # before re-seeding a fresh run:
+  # Remove everything this script previously created (matched by identity.uploaded_by,
+  # never by source_tag -- see the note on source_tag="fred" below), before
+  # re-seeding a fresh run:
   CONFIG_FILE=/path/to/local-configuration.yaml \
     uv run python -m knowledge_flow_backend.scripts.seed_synthetic_corpus --purge
 """
@@ -62,8 +63,7 @@ from datetime import datetime, timezone
 from typing import Iterator
 
 import numpy as np
-from fred_core import Relation, RebacReference, RelationType, Resource
-from minio.deleteobjects import DeleteObject
+from fred_core import RebacReference, Relation, RelationType, Resource
 from fred_core.documents.document_structures import (
     AccessInfo,
     DocumentMetadata,
@@ -75,6 +75,7 @@ from fred_core.documents.document_structures import (
     SourceType,
     Tagging,
 )
+from minio.deleteobjects import DeleteObject
 from opensearchpy.helpers import bulk
 
 from knowledge_flow_backend.application_context import ApplicationContext
@@ -83,7 +84,7 @@ from knowledge_flow_backend.features.tag.structure import Tag, TagType
 
 logger = logging.getLogger("seed_synthetic_corpus")
 
-SEED_SOURCE_TAG = "seed-synthetic-corpus"
+SEED_UPLOADED_BY = "seed-synthetic-corpus"
 SEED_CHUNK_SUFFIX = "::seed-chunk-0"
 
 
@@ -110,11 +111,17 @@ def _build_document(tag: Tag, index: int) -> DocumentMetadata:
             title=name,
             created=now,
             modified=now,
-            uploaded_by="seed-synthetic-corpus",
+            uploaded_by=SEED_UPLOADED_BY,
         ),
         source=SourceInfo(
             source_type=SourceType.PUSH,
-            source_tag=SEED_SOURCE_TAG,
+            # "fred" (not a seed-specific marker) on purpose: it's the same source_tag
+            # every real manual upload gets (IngestionInput.source_tag default,
+            # ingestion_controller.py) -- repair tooling like 3a filters candidates by
+            # source_tag, so a synthetic-only marker here would make seeded documents
+            # invisible to exactly the workflows this corpus exists to load-test.
+            # `identity.uploaded_by` above is the safe marker `_purge` matches on instead.
+            source_tag="fred",
             retrievable=True,
             date_added_to_kb=now,
         ),
@@ -288,7 +295,11 @@ async def _purge(app_context: ApplicationContext, concurrency: int) -> None:
     rebac = app_context.get_rebac_engine()
     vector_store = app_context.get_create_vector_store(app_context.get_embedder())
 
-    docs = await metadata_store.list_by_source_tag(SEED_SOURCE_TAG)
+    # Matched on identity.uploaded_by, not source_tag: seeded documents deliberately
+    # carry source_tag="fred" (the same value every real upload gets) so repair
+    # tooling that filters by source_tag actually sees them -- uploaded_by is the
+    # marker no real document shares, so this is still exact and safe.
+    docs = await metadata_store.get_all_metadata({"identity": {"uploaded_by": SEED_UPLOADED_BY}})
     logger.info("Purging %d previously seeded document(s) (ReBAC parent tuple + Postgres row) ...", len(docs))
     if docs:
         await _purge_document_parent_relations(rebac, docs, concurrency)
@@ -328,7 +339,7 @@ async def _purge(app_context: ApplicationContext, concurrency: int) -> None:
             logger.warning("Could not delete ReBAC ownership tuple for tag=%s (may already be absent): %s", tag.id, exc)
         await tag_store.delete_tag_by_id(tag.id)
 
-    # Match on *both* document_uid (docs found via source_tag above) and tag_ids
+    # Match on *both* document_uid (docs found via uploaded_by above) and tag_ids
     # (covers a prior interrupted run that deleted the Postgres row but not the
     # vector chunk, or vice versa) -- either signal alone can miss a partial run.
     seed_tag_id_list = [t.id for t in seed_tags]
@@ -418,7 +429,9 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=42, help="Random seed for fake vectors/sizes (reproducible runs).")
     parser.add_argument("--skip-content", action="store_true", help="Skip writing small fake content objects to the content store (Minio/S3) -- Postgres+OpenSearch only, faster.")
     parser.add_argument(
-        "--purge", action="store_true", help="Delete everything a previous run of this script created (matched by source_tag/embedding_model), then exit. Run again without --purge to re-seed."
+        "--purge",
+        action="store_true",
+        help="Delete everything a previous run of this script created (matched by identity.uploaded_by / seed-library-* tag names), then exit. Run again without --purge to re-seed.",
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/scripts/seed_synthetic_corpus.py
@@ -71,6 +71,7 @@ from fred_core.documents.document_structures import (
     FileType,
     Identity,
     ProcessingStage,
+    ProcessingStatus,
     SourceInfo,
     SourceType,
     Tagging,
@@ -361,6 +362,64 @@ async def _purge(app_context: ApplicationContext, concurrency: int) -> None:
         logger.info("No seeded document_uid/tag_ids found -- nothing to purge from OpenSearch.")
 
 
+async def _synthetic_pool(metadata_store) -> list[DocumentMetadata]:
+    return await metadata_store.get_all_metadata({"identity": {"uploaded_by": SEED_UPLOADED_BY}})
+
+
+async def _mark_stuck_pending(metadata_store, n: int, seed: int, concurrency: int) -> None:
+    """
+    The #2234 "stuck pending" shape, at scale: flip VECTORIZED back to
+    NOT_STARTED in Postgres for `n` synthetic documents while leaving their
+    OpenSearch chunks and S3 content completely untouched -- Postgres lies
+    that the work was never done, even though it demonstrably was. Never
+    touches the 18(ish) real documents: the candidate pool is scoped to
+    identity.uploaded_by, same as `_purge`.
+    """
+    pool = await _synthetic_pool(metadata_store)
+    eligible = [d for d in pool if d.processing.stages.get(ProcessingStage.VECTORIZED) == ProcessingStatus.DONE]
+    logger.info("Synthetic pool=%d, eligible (currently vector=done)=%d", len(pool), len(eligible))
+    if n > len(eligible):
+        logger.warning("Requested %d but only %d eligible -- marking all of them.", n, len(eligible))
+    rng = random.Random(seed)
+    chosen = rng.sample(eligible, min(n, len(eligible)))
+
+    sem = asyncio.Semaphore(concurrency)
+    done = 0
+
+    async def _one(doc: DocumentMetadata) -> None:
+        nonlocal done
+        doc.set_stage_status(ProcessingStage.VECTORIZED, ProcessingStatus.NOT_STARTED)
+        async with sem:
+            await metadata_store.save_metadata(doc)
+        done += 1
+
+    await asyncio.gather(*(_one(d) for d in chosen))
+    logger.info("Marked %d synthetic document(s) as stuck-pending (vector=not_started; OpenSearch/S3 untouched).", done)
+
+
+async def _restore_stuck_pending(metadata_store, concurrency: int) -> None:
+    """Reverse _mark_stuck_pending: set vector back to DONE for every synthetic
+    document currently marked not_started. Safe because nothing else in this
+    pool ever sets that stage to not_started -- there's nothing else to confuse
+    it with."""
+    pool = await _synthetic_pool(metadata_store)
+    stuck = [d for d in pool if d.processing.stages.get(ProcessingStage.VECTORIZED) == ProcessingStatus.NOT_STARTED]
+    logger.info("Restoring %d stuck-pending synthetic document(s) back to vector=done ...", len(stuck))
+
+    sem = asyncio.Semaphore(concurrency)
+    done = 0
+
+    async def _one(doc: DocumentMetadata) -> None:
+        nonlocal done
+        doc.set_stage_status(ProcessingStage.VECTORIZED, ProcessingStatus.DONE)
+        async with sem:
+            await metadata_store.save_metadata(doc)
+        done += 1
+
+    await asyncio.gather(*(_one(d) for d in stuck))
+    logger.info("Restored %d document(s).", done)
+
+
 async def run(args: argparse.Namespace) -> None:
     configuration = load_configuration()
     ApplicationContext(configuration)
@@ -368,6 +427,14 @@ async def run(args: argparse.Namespace) -> None:
 
     if args.purge:
         await _purge(app_context, args.concurrency)
+        return
+
+    if args.mark_stuck_pending is not None:
+        await _mark_stuck_pending(app_context.get_metadata_store(), args.mark_stuck_pending, args.seed, args.concurrency)
+        return
+
+    if args.restore_stuck_pending:
+        await _restore_stuck_pending(app_context.get_metadata_store(), args.concurrency)
         return
 
     tag_store = app_context.get_tag_store()
@@ -432,6 +499,18 @@ def main() -> None:
         "--purge",
         action="store_true",
         help="Delete everything a previous run of this script created (matched by identity.uploaded_by / seed-library-* tag names), then exit. Run again without --purge to re-seed.",
+    )
+    parser.add_argument(
+        "--mark-stuck-pending",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Standalone action: flip N already-seeded synthetic documents' vector stage back to not_started in Postgres, leaving their OpenSearch chunks and S3 content untouched (the #2234 'stuck pending' shape, at scale). Never touches real documents. Exits after running.",
+    )
+    parser.add_argument(
+        "--restore-stuck-pending",
+        action="store_true",
+        help="Standalone action: reverse --mark-stuck-pending -- set vector back to done for every synthetic document currently marked not_started. Exits after running.",
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")

--- a/apps/knowledge-flow-backend/tests/features/corpus_manager/test_corpus_manager_authz.py
+++ b/apps/knowledge-flow-backend/tests/features/corpus_manager/test_corpus_manager_authz.py
@@ -56,11 +56,19 @@ async def _fake_revectorize_corpus(self, req, user) -> StartTaskResponse:
     return StartTaskResponse(task_id="fake-task-id")
 
 
+async def _fake_repair_vector_metadata(self, req, user) -> StartTaskResponse:
+    """Stub for CorpusManagerService.repair_vector_metadata (#2234, 3a): same
+    reasoning as `_fake_revectorize_corpus` -- these tests exercise
+    `_authorize_repair_vector_metadata`, not the real Temporal wiring."""
+    return StartTaskResponse(task_id="fake-repair-task-id")
+
+
 @pytest.fixture
 def corpus_client(monkeypatch):
     fake_rebac = _FakeRebac()
     monkeypatch.setattr(corpus_module, "get_rebac_engine", lambda: fake_rebac)
     monkeypatch.setattr(CorpusManagerService, "revectorize_corpus", _fake_revectorize_corpus)
+    monkeypatch.setattr(CorpusManagerService, "repair_vector_metadata", _fake_repair_vector_metadata)
 
     app = FastAPI()
     router = APIRouter(prefix="/knowledge-flow/v1")
@@ -337,3 +345,121 @@ def test_build_toc_source_tag_only_scope_also_requires_platform_admin(corpus_cli
         (TeamPermission.CAN_READ_MEMEBERS, "team-a"),
         (OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID),
     ]
+
+
+# ── #2234 (3a): repair-vector-metadata authorization + input validation ──────
+# Always a bare source_tag scope (no tag_ids/document_uids variant exists on
+# RepairVectorMetadataRequestV1) -- so, unlike revectorize, it always requires
+# BOTH real membership on the filing team AND platform-admin, every time
+# (`_authorize_repair_vector_metadata`), never just the narrower tag/document
+# check revectorize falls back to for a non-source_tag scope.
+
+
+def test_repair_vector_metadata_checks_team_and_platform_admin_permission(corpus_client) -> None:
+    client, fake_rebac = corpus_client
+
+    response = client.post(
+        "/knowledge-flow/v1/corpus/repair-vector-metadata",
+        json={"team_id": "team-a", "source_tag": "kea-import"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"task_id": "fake-repair-task-id"}
+    assert fake_rebac.calls == [
+        (TeamPermission.CAN_READ_MEMEBERS, "team-a"),
+        (OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID),
+    ]
+
+
+def test_repair_vector_metadata_rejects_non_platform_admin(monkeypatch) -> None:
+    """A team member without CAN_MANAGE_PLATFORM must be denied -- this action
+    always spans arbitrary teams, so team membership alone is never enough."""
+
+    class _DenyingPlatformAdminRebac(_FakeRebac):
+        async def check_user_permission_or_raise(self, user, permission, resource_id, **_kw) -> None:
+            self.calls.append((permission, resource_id))
+            if permission == OrganizationPermission.CAN_MANAGE_PLATFORM:
+                raise HTTPException(403, "not a platform admin")
+
+    fake_rebac = _DenyingPlatformAdminRebac()
+    monkeypatch.setattr(corpus_module, "get_rebac_engine", lambda: fake_rebac)
+    monkeypatch.setattr(CorpusManagerService, "repair_vector_metadata", _fake_repair_vector_metadata)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/knowledge-flow/v1")
+    CorpusManagerController(router)
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: KeycloakUser(uid="alice", username="alice", email=None, roles=[])
+    with TestClient(app) as client:
+        response = client.post(
+            "/knowledge-flow/v1/corpus/repair-vector-metadata",
+            json={"team_id": "team-a", "source_tag": "kea-import"},
+        )
+
+    assert response.status_code == 403
+    assert fake_rebac.calls == [
+        (TeamPermission.CAN_READ_MEMEBERS, "team-a"),
+        (OrganizationPermission.CAN_MANAGE_PLATFORM, ORGANIZATION_ID),
+    ]
+
+
+def test_repair_vector_metadata_rejects_empty_source_tag(corpus_client) -> None:
+    client, fake_rebac = corpus_client
+
+    response = client.post(
+        "/knowledge-flow/v1/corpus/repair-vector-metadata",
+        json={"team_id": "team-a", "source_tag": ""},
+    )
+
+    assert response.status_code == 422
+    assert fake_rebac.calls == []
+
+
+def test_repair_vector_metadata_rejects_whitespace_only_source_tag(corpus_client) -> None:
+    client, fake_rebac = corpus_client
+
+    response = client.post(
+        "/knowledge-flow/v1/corpus/repair-vector-metadata",
+        json={"team_id": "team-a", "source_tag": "   "},
+    )
+
+    assert response.status_code == 422
+    assert fake_rebac.calls == []
+
+
+def test_repair_vector_metadata_rejects_whitespace_only_team_id(corpus_client) -> None:
+    client, fake_rebac = corpus_client
+
+    response = client.post(
+        "/knowledge-flow/v1/corpus/repair-vector-metadata",
+        json={"team_id": "   ", "source_tag": "kea-import"},
+    )
+
+    assert response.status_code == 422
+    assert fake_rebac.calls == []
+
+
+def test_repair_vector_metadata_strips_surrounding_whitespace() -> None:
+    """A valid but padded source_tag/team_id must be usable, not rejected --
+    only the pure-whitespace/empty case is invalid."""
+    from knowledge_flow_backend.features.corpus_manager.corpus_manager_service import RepairVectorMetadataRequestV1
+
+    req = RepairVectorMetadataRequestV1(source_tag="  kea-import  ", team_id=" team-a ")
+
+    assert req.source_tag == "kea-import"
+    assert req.team_id == "team-a"
+
+
+def test_repair_vector_metadata_rejects_unknown_fields(corpus_client) -> None:
+    """`extra="forbid"` must still hold after adding the strip/non-empty
+    validator -- e.g. a stray `options`/`scope` field on the payload must 422,
+    not be silently ignored."""
+    client, fake_rebac = corpus_client
+
+    response = client.post(
+        "/knowledge-flow/v1/corpus/repair-vector-metadata",
+        json={"team_id": "team-a", "source_tag": "kea-import", "options": {"force": True}},
+    )
+
+    assert response.status_code == 422
+    assert fake_rebac.calls == []

--- a/apps/knowledge-flow-backend/tests/features/corpus_manager/test_repair_vector_metadata_service.py
+++ b/apps/knowledge-flow-backend/tests/features/corpus_manager/test_repair_vector_metadata_service.py
@@ -1,0 +1,137 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`CorpusManagerService.repair_vector_metadata` (#2234, 3a) error handling:
+a `task_run` row is created (state `pending`) *before* the Temporal workflow is
+started. If starting the workflow itself fails, that row must never be left
+pending with no execution behind it -- `fail_task` must be called with the
+real error, and the original exception must still propagate to the caller
+(not be masked by a `fail_task`-only success). This exercises the real
+`repair_vector_metadata` method directly, not through FastAPI/TestClient --
+`test_corpus_manager_authz.py` covers the HTTP/authz layer with this method
+stubbed out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_flow_backend.features.corpus_manager import corpus_manager_service as corpus_service_module
+from knowledge_flow_backend.features.corpus_manager.corpus_manager_service import (
+    CorpusManagerService,
+    RepairVectorMetadataRequestV1,
+)
+
+
+class _FakeUser:
+    uid = "alice"
+
+
+class _FakeTaskService:
+    def __init__(self) -> None:
+        self.started: list[tuple] = []
+        self.failed: list[tuple[str, str]] = []
+        self.bound: list[tuple[str, str]] = []
+
+    async def start(self, start_req, *, created_by, team_id, target):
+        self.started.append((created_by, team_id, target))
+        return type("Resp", (), {"task_id": "task-1"})()
+
+    async def fail_task(self, task_id: str, message: str) -> bool:
+        self.failed.append((task_id, message))
+        return True
+
+    async def bind_execution(self, task_id: str, *, execution_id: str) -> None:
+        self.bound.append((task_id, execution_id))
+
+
+class _FakeAppContext:
+    def __init__(self, task_service: _FakeTaskService) -> None:
+        self._task_service = task_service
+
+    def get_task_service(self):
+        return self._task_service
+
+
+class _RaisingIngestionTaskService:
+    """`start_repair_vector_metadata` fails as if the Temporal frontend were
+    unreachable -- the scenario `fail_task` exists for."""
+
+    async def start_repair_vector_metadata(self, *, source_tag: str, task_id: str):
+        raise RuntimeError("Temporal frontend unreachable")
+
+
+class _SucceedingIngestionTaskService:
+    async def start_repair_vector_metadata(self, *, source_tag: str, task_id: str):
+        return type("Handle", (), {"workflow_id": "wf-1"})()
+
+
+def _patch_app_context(monkeypatch, task_service: _FakeTaskService) -> None:
+    fake_ctx = _FakeAppContext(task_service)
+    monkeypatch.setattr(
+        corpus_service_module.ApplicationContext,
+        "get_instance",
+        staticmethod(lambda: fake_ctx),
+    )
+
+
+@pytest.mark.asyncio
+async def test_repair_vector_metadata_fails_the_task_when_temporal_submission_raises(monkeypatch) -> None:
+    task_service = _FakeTaskService()
+    _patch_app_context(monkeypatch, task_service)
+    service = CorpusManagerService(ingestion_task_service=_RaisingIngestionTaskService())
+    req = RepairVectorMetadataRequestV1(source_tag="fred", team_id="team-a")
+
+    with pytest.raises(RuntimeError, match="Temporal frontend unreachable"):
+        await service.repair_vector_metadata(req, _FakeUser())
+
+    # The task_run row created by task_svc.start() must be driven to `failed`
+    # with a bounded, explicit message -- never left pending with no workflow.
+    assert task_service.failed == [("task-1", "Temporal frontend unreachable")]
+    # bind_execution must never be attempted -- there is no workflow to bind to.
+    assert task_service.bound == []
+
+
+@pytest.mark.asyncio
+async def test_repair_vector_metadata_truncates_an_unbounded_error_message(monkeypatch) -> None:
+    task_service = _FakeTaskService()
+    _patch_app_context(monkeypatch, task_service)
+
+    class _RaisingWithHugeMessage:
+        async def start_repair_vector_metadata(self, *, source_tag: str, task_id: str):
+            raise RuntimeError("x" * 10_000)
+
+    service = CorpusManagerService(ingestion_task_service=_RaisingWithHugeMessage())
+    req = RepairVectorMetadataRequestV1(source_tag="fred", team_id="team-a")
+
+    with pytest.raises(RuntimeError):
+        await service.repair_vector_metadata(req, _FakeUser())
+
+    assert len(task_service.failed) == 1
+    _, message = task_service.failed[0]
+    assert len(message) <= 500
+
+
+@pytest.mark.asyncio
+async def test_repair_vector_metadata_binds_execution_on_success_and_never_fails_the_task(monkeypatch) -> None:
+    task_service = _FakeTaskService()
+    _patch_app_context(monkeypatch, task_service)
+    service = CorpusManagerService(ingestion_task_service=_SucceedingIngestionTaskService())
+    req = RepairVectorMetadataRequestV1(source_tag="fred", team_id="team-a")
+
+    resp = await service.repair_vector_metadata(req, _FakeUser())
+
+    assert resp.task_id == "task-1"
+    assert task_service.bound == [("task-1", "wf-1")]
+    assert task_service.failed == []

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_activities.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_activities.py
@@ -1,0 +1,285 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the vector-metadata repair activities (#2234, 3a).
+
+Mirrors `test_revectorize_activities.py`'s pattern: call the `@activity.defn`
+function directly (it's a plain async function) and patch
+`ApplicationContext.get_instance`.
+
+The most important tests in this file are the structural safety-guarantee
+ones (`TestNeverTouchesTheEmbedderOrVectorStoreAdapter`): the whole point of
+`list_strict_vector_document_uids` is that it can list real vector
+document_uids WITHOUT ever calling `get_embedder()`/`get_create_vector_store()`
+or constructing an `OpenSearchVectorStoreAdapter` (whose `__init__` calls
+`ensure_ready()`, which calls the embedder and can create/update the index,
+its mapping, or the hybrid-search pipeline -- every one of those is forbidden
+for a metadata-only repair).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fred_core.documents.document_structures import (
+    DocumentMetadata,
+    FileInfo,
+    FileType,
+    Identity,
+    ProcessingStage,
+    SourceInfo,
+    SourceType,
+)
+
+from knowledge_flow_backend.common.structures import ChromaVectorStorageConfig, OpenSearchVectorIndexConfig
+from knowledge_flow_backend.core.stores.vector.opensearch_vector_store import OpenSearchVectorStoreAdapter
+from knowledge_flow_backend.features.scheduler.repair_vector_metadata_activities import (
+    bulk_repair_vector_metadata,
+    emit_repair_vector_metadata_task_event,
+    list_repair_candidates_for_source_tag,
+    list_strict_content_document_uids,
+    list_strict_vector_document_uids,
+)
+
+_PATCH_CTX = "knowledge_flow_backend.application_context.ApplicationContext.get_instance"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_metadata(document_uid: str, *, file_type: FileType = FileType.PDF, vector_done: bool = False, source_tag: str = "fred") -> DocumentMetadata:
+    md = DocumentMetadata(
+        identity=Identity(document_name=f"{document_uid}.pdf", document_uid=document_uid, title=document_uid),
+        source=SourceInfo(source_type=SourceType.PUSH, source_tag=source_tag),
+        file=FileInfo(file_type=file_type),
+    )
+    if vector_done:
+        md.processing.mark_done(ProcessingStage.VECTORIZED)
+    return md
+
+
+def _fake_search_client(pages: list[dict]) -> MagicMock:
+    """A bare mock standing in for `ApplicationContext.get_opensearch_client()`'s
+    return value -- only `.search()` is ever expected to be called; `.indices`/
+    `.ingest` are left as ordinary auto-created mocks so a test can assert they
+    were never *called* (see `TestNeverTouchesTheEmbedderOrVectorStoreAdapter`)."""
+    client = MagicMock()
+    client.search = MagicMock(side_effect=pages)
+    return client
+
+
+def _one_empty_page() -> dict:
+    return {"aggregations": {"by_doc": {"buckets": []}}}
+
+
+class TestListRepairCandidatesForSourceTag:
+    def test_resolves_via_list_by_source_tag_and_flags_tabular_and_vector_done(self):
+        docs = [
+            _make_metadata("doc-1"),
+            _make_metadata("doc-2", vector_done=True),
+            _make_metadata("doc-3", file_type=FileType.CSV),
+            _make_metadata("doc-4", file_type=FileType.XLSX),
+        ]
+        metadata_store = MagicMock()
+        metadata_store.list_by_source_tag = AsyncMock(return_value=docs)
+        app_ctx = MagicMock()
+        app_ctx.get_metadata_store.return_value = metadata_store
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            result = _run(list_repair_candidates_for_source_tag("fred"))
+
+        metadata_store.list_by_source_tag.assert_awaited_once_with("fred")
+        assert result == [
+            {"document_uid": "doc-1", "is_tabular": False, "vector_done": False},
+            {"document_uid": "doc-2", "is_tabular": False, "vector_done": True},
+            {"document_uid": "doc-3", "is_tabular": True, "vector_done": False},
+            {"document_uid": "doc-4", "is_tabular": True, "vector_done": False},
+        ]
+
+
+class TestNeverTouchesTheEmbedderOrVectorStoreAdapter:
+    """The structural safety guarantee for `list_strict_vector_document_uids`."""
+
+    def test_never_calls_get_embedder_or_get_create_vector_store(self, monkeypatch):
+        app_ctx = MagicMock()
+        app_ctx.get_config.return_value.storage.vector_store = OpenSearchVectorIndexConfig(type="opensearch", index="fred-vectors")
+        app_ctx.get_opensearch_client.return_value = _fake_search_client([_one_empty_page()])
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            result = _run(list_strict_vector_document_uids())
+
+        assert result == []
+        app_ctx.get_embedder.assert_not_called()
+        app_ctx.get_create_vector_store.assert_not_called()
+
+    def test_never_constructs_an_opensearch_vector_store_adapter(self, monkeypatch):
+        def _forbidden_init(self, *args, **kwargs):
+            raise AssertionError("OpenSearchVectorStoreAdapter must never be constructed by the 3a repair path")
+
+        monkeypatch.setattr(OpenSearchVectorStoreAdapter, "__init__", _forbidden_init)
+
+        app_ctx = MagicMock()
+        app_ctx.get_config.return_value.storage.vector_store = OpenSearchVectorIndexConfig(type="opensearch", index="fred-vectors")
+        app_ctx.get_opensearch_client.return_value = _fake_search_client([_one_empty_page()])
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            # Would raise AssertionError above if the forbidden constructor ran.
+            result = _run(list_strict_vector_document_uids())
+
+        assert result == []
+
+    def test_never_touches_indices_or_ingest_pipeline_management(self):
+        """No `indices.create`/`indices.put_mapping`/pipeline `put` call -- the
+        only client method this activity may call is `search`."""
+        app_ctx = MagicMock()
+        app_ctx.get_config.return_value.storage.vector_store = OpenSearchVectorIndexConfig(type="opensearch", index="fred-vectors")
+        client = _fake_search_client([_one_empty_page()])
+        app_ctx.get_opensearch_client.return_value = client
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            _run(list_strict_vector_document_uids())
+
+        client.indices.create.assert_not_called()
+        client.indices.put_mapping.assert_not_called()
+        client.indices.exists.assert_not_called()
+        client.ingest.put_pipeline.assert_not_called()
+
+    def test_uses_the_configured_index_name_and_the_raw_opensearch_client(self):
+        app_ctx = MagicMock()
+        app_ctx.get_config.return_value.storage.vector_store = OpenSearchVectorIndexConfig(type="opensearch", index="fred-vectors-prod")
+        client = _fake_search_client([_one_empty_page()])
+        app_ctx.get_opensearch_client.return_value = client
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            _run(list_strict_vector_document_uids())
+
+        app_ctx.get_opensearch_client.assert_called_once()
+        called_kwargs = client.search.call_args.kwargs
+        assert called_kwargs["index"] == "fred-vectors-prod"
+
+    def test_raises_a_clear_error_when_the_configured_backend_is_not_opensearch(self):
+        app_ctx = MagicMock()
+        app_ctx.get_config.return_value.storage.vector_store = ChromaVectorStorageConfig(type="chroma", local_path="/tmp/chroma", collection_name="c")
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            with pytest.raises(RuntimeError, match="OpenSearch"):
+                _run(list_strict_vector_document_uids())
+
+        app_ctx.get_embedder.assert_not_called()
+        app_ctx.get_create_vector_store.assert_not_called()
+        app_ctx.get_opensearch_client.assert_not_called()
+
+    def test_strict_scan_failure_propagates_instead_of_returning_an_incomplete_list(self):
+        app_ctx = MagicMock()
+        app_ctx.get_config.return_value.storage.vector_store = OpenSearchVectorIndexConfig(type="opensearch", index="fred-vectors")
+        client = MagicMock()
+        client.search = MagicMock(side_effect=RuntimeError("opensearch timeout"))
+        app_ctx.get_opensearch_client.return_value = client
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            with pytest.raises(RuntimeError, match="opensearch timeout"):
+                _run(list_strict_vector_document_uids())
+
+
+class TestListStrictContentDocumentUids:
+    def test_calls_content_store_list_document_uids_strict(self):
+        content_store = MagicMock()
+        content_store.list_document_uids = MagicMock(return_value=["doc-1", "doc-2"])
+        app_ctx = MagicMock()
+        app_ctx.get_content_store.return_value = content_store
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            result = _run(list_strict_content_document_uids())
+
+        assert result == ["doc-1", "doc-2"]
+        content_store.list_document_uids.assert_called_once_with(strict=True)
+
+    def test_a_content_store_failure_propagates(self):
+        content_store = MagicMock()
+        content_store.list_document_uids = MagicMock(side_effect=RuntimeError("minio unreachable"))
+        app_ctx = MagicMock()
+        app_ctx.get_content_store.return_value = content_store
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            with pytest.raises(RuntimeError, match="minio unreachable"):
+                _run(list_strict_content_document_uids())
+
+
+class TestBulkRepairVectorMetadata:
+    def test_passes_source_tag_and_document_uids_through_to_the_store(self):
+        metadata_store = MagicMock()
+        metadata_store.bulk_mark_vector_done = AsyncMock(return_value=["doc-1", "doc-2"])
+        app_ctx = MagicMock()
+        app_ctx.get_metadata_store.return_value = metadata_store
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            result = _run(bulk_repair_vector_metadata("fred", ["doc-1", "doc-2"]))
+
+        assert result == ["doc-1", "doc-2"]
+        metadata_store.bulk_mark_vector_done.assert_awaited_once_with("fred", ["doc-1", "doc-2"])
+
+    def test_raises_clearly_when_the_metadata_store_lacks_bulk_mark_vector_done(self):
+        app_ctx = MagicMock(spec=["get_metadata_store"])
+        metadata_store = MagicMock(spec=[])  # no bulk_mark_vector_done attribute at all
+        app_ctx.get_metadata_store.return_value = metadata_store
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            with pytest.raises(RuntimeError, match="bulk_mark_vector_done"):
+                _run(bulk_repair_vector_metadata("fred", ["doc-1"]))
+
+
+class TestEmitRepairVectorMetadataTaskEvent:
+    def test_succeeded_event_carries_the_structured_report(self):
+        task_service = MagicMock()
+        task_service.record = AsyncMock()
+        app_ctx = MagicMock()
+        app_ctx.get_task_service.return_value = task_service
+        report = {
+            "source_tag": "fred",
+            "metadata_documents": 10,
+            "already_done": 1,
+            "eligible_with_vectors_and_content": 8,
+            "repaired": 8,
+            "missing_vectors": 1,
+            "missing_content": 0,
+            "tabular_excluded": 0,
+            "errors": 0,
+        }
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            _run(emit_repair_vector_metadata_task_event("task-1", "succeeded", None, report))
+
+        task_service.record.assert_awaited_once()
+        (event,) = task_service.record.await_args.args
+        assert event.state.value == "succeeded"
+        assert event.detail.result.source_tag == "fred"
+        assert event.detail.result.repaired == 8
+        assert event.detail.processed == 8
+
+    def test_failed_event_carries_the_error_and_no_result(self):
+        task_service = MagicMock()
+        task_service.record = AsyncMock()
+        app_ctx = MagicMock()
+        app_ctx.get_task_service.return_value = task_service
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            _run(emit_repair_vector_metadata_task_event("task-1", "failed", "OpenSearch scan failed", None))
+
+        (event,) = task_service.record.await_args.args
+        assert event.state.value == "failed"
+        assert event.error == "OpenSearch scan failed"
+        assert event.detail.result is None

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_activities.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_activities.py
@@ -40,6 +40,7 @@ from fred_core.documents.document_structures import (
     FileType,
     Identity,
     ProcessingStage,
+    ProcessingStatus,
     SourceInfo,
     SourceType,
 )
@@ -61,7 +62,14 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def _make_metadata(document_uid: str, *, file_type: FileType = FileType.PDF, vector_done: bool = False, source_tag: str = "fred") -> DocumentMetadata:
+def _make_metadata(
+    document_uid: str,
+    *,
+    file_type: FileType = FileType.PDF,
+    vector_done: bool = False,
+    source_tag: str = "fred",
+    stage_status: tuple[ProcessingStage, ProcessingStatus] | None = None,
+) -> DocumentMetadata:
     md = DocumentMetadata(
         identity=Identity(document_name=f"{document_uid}.pdf", document_uid=document_uid, title=document_uid),
         source=SourceInfo(source_type=SourceType.PUSH, source_tag=source_tag),
@@ -69,6 +77,9 @@ def _make_metadata(document_uid: str, *, file_type: FileType = FileType.PDF, vec
     )
     if vector_done:
         md.processing.mark_done(ProcessingStage.VECTORIZED)
+    if stage_status is not None:
+        stage, status = stage_status
+        md.processing.set_status(stage, status)
     return md
 
 
@@ -104,11 +115,38 @@ class TestListRepairCandidatesForSourceTag:
 
         metadata_store.list_by_source_tag.assert_awaited_once_with("fred")
         assert result == [
-            {"document_uid": "doc-1", "is_tabular": False, "vector_done": False},
-            {"document_uid": "doc-2", "is_tabular": False, "vector_done": True},
-            {"document_uid": "doc-3", "is_tabular": True, "vector_done": False},
-            {"document_uid": "doc-4", "is_tabular": True, "vector_done": False},
+            {"document_uid": "doc-1", "is_tabular": False, "vector_done": False, "failed_or_running": False},
+            {"document_uid": "doc-2", "is_tabular": False, "vector_done": True, "failed_or_running": False},
+            {"document_uid": "doc-3", "is_tabular": True, "vector_done": False, "failed_or_running": False},
+            {"document_uid": "doc-4", "is_tabular": True, "vector_done": False, "failed_or_running": False},
         ]
+
+    def test_flags_failed_or_running_when_any_stage_is_failed_or_in_progress(self):
+        """Real Kea-corpus shape (#2234 hardening): a document whose `vector`
+        never started but whose `preview` stage reads `failed`, and one whose
+        `vector` stage itself reads `failed` -- both must be flagged, not
+        silently treated the same as a clean `not_started` document."""
+        docs = [
+            _make_metadata("doc-failed-preview", stage_status=(ProcessingStage.PREVIEW_READY, ProcessingStatus.FAILED)),
+            _make_metadata("doc-failed-vector", stage_status=(ProcessingStage.VECTORIZED, ProcessingStatus.FAILED)),
+            _make_metadata("doc-in-progress", stage_status=(ProcessingStage.PREVIEW_READY, ProcessingStatus.IN_PROGRESS)),
+            _make_metadata("doc-clean"),
+        ]
+        metadata_store = MagicMock()
+        metadata_store.list_by_source_tag = AsyncMock(return_value=docs)
+        app_ctx = MagicMock()
+        app_ctx.get_metadata_store.return_value = metadata_store
+
+        with patch(_PATCH_CTX, return_value=app_ctx):
+            result = _run(list_repair_candidates_for_source_tag("fred"))
+
+        by_uid = {r["document_uid"]: r["failed_or_running"] for r in result}
+        assert by_uid == {
+            "doc-failed-preview": True,
+            "doc-failed-vector": True,
+            "doc-in-progress": True,
+            "doc-clean": False,
+        }
 
 
 class TestNeverTouchesTheEmbedderOrVectorStoreAdapter:

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_workflow.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_workflow.py
@@ -1,0 +1,266 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `RepairVectorMetadataWorkflow` (#2234, 3a).
+
+Two kinds of test here, deliberately:
+
+1. Pure-function tests of `_wf_repair_categorize` -- the same "no Temporal
+   context needed" strategy `test_workflow.py` already uses for
+   `RevectorizeCorpusWorkflow`'s decision helpers (see that file's module
+   docstring: `@workflow.defn` classes need a live Temporal test environment
+   to execute, which this repo's test suite does not otherwise use).
+
+2. Static source-inspection tests proving the structural safety guarantees
+   that can't be expressed as a call assertion: no per-document child
+   workflow, no forbidden symbol (delete/ingest/embed) anywhere in the 3a
+   call graph, and a constant (not per-document) Temporal activity surface.
+   These are deliberately textual/structural rather than executed-workflow
+   tests -- see the close-out notes for why, and what a follow-up
+   `WorkflowEnvironment`-based test would add.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from knowledge_flow_backend.features.scheduler import repair_vector_metadata_activities as activities_module
+from knowledge_flow_backend.features.scheduler import repair_vector_metadata_workflow as workflow_module
+from knowledge_flow_backend.features.scheduler import worker as worker_module
+from knowledge_flow_backend.features.scheduler.repair_vector_metadata_workflow import _wf_repair_categorize
+
+
+def _candidate(document_uid: str, *, is_tabular: bool = False, vector_done: bool = False) -> dict:
+    return {"document_uid": document_uid, "is_tabular": is_tabular, "vector_done": vector_done}
+
+
+class TestRepairCategorize:
+    def test_distinguishes_all_five_buckets(self) -> None:
+        candidates = [
+            _candidate("already-done", vector_done=True),
+            _candidate("eligible-1"),
+            _candidate("eligible-2"),
+            _candidate("no-vector"),
+            _candidate("no-content"),
+            _candidate("tabular-1", is_tabular=True),
+        ]
+        vector_uids = ["eligible-1", "eligible-2", "no-content"]
+        content_uids = ["eligible-1", "eligible-2", "no-vector"]
+
+        buckets = _wf_repair_categorize(candidates, vector_uids, content_uids)
+
+        assert buckets["already_done"] == 1
+        assert sorted(buckets["eligible"]) == ["eligible-1", "eligible-2"]
+        assert buckets["missing_vectors"] == 1  # "no-vector"
+        assert buckets["missing_content"] == 1  # "no-content"
+        assert buckets["tabular_excluded"] == 1
+
+    def test_tabular_takes_precedence_over_already_done(self) -> None:
+        """A tabular document must always land in `tabular_excluded`, even if it
+        somehow already reads `vector: done` -- never double-counted, never
+        silently reclassified as a normal already-done document."""
+        candidates = [_candidate("csv-1", is_tabular=True, vector_done=True)]
+
+        buckets = _wf_repair_categorize(candidates, vector_uids=["csv-1"], content_uids=["csv-1"])
+
+        assert buckets["tabular_excluded"] == 1
+        assert buckets["already_done"] == 0
+        assert buckets["eligible"] == []
+
+    def test_missing_vectors_takes_precedence_over_missing_content(self) -> None:
+        """A document missing both is reported once, under missing_vectors --
+        never double-counted across both buckets."""
+        candidates = [_candidate("doc-1")]
+
+        buckets = _wf_repair_categorize(candidates, vector_uids=[], content_uids=[])
+
+        assert buckets["missing_vectors"] == 1
+        assert buckets["missing_content"] == 0
+
+    def test_empty_candidate_list_yields_all_zero_buckets(self) -> None:
+        buckets = _wf_repair_categorize([], vector_uids=["doc-1"], content_uids=["doc-1"])
+
+        assert buckets == {
+            "tabular_excluded": 0,
+            "already_done": 0,
+            "eligible": [],
+            "missing_vectors": 0,
+            "missing_content": 0,
+        }
+
+    def test_accepts_object_candidates_not_just_dicts(self) -> None:
+        """`_wf_get` reads either a dict or a plain object -- payloads cross the
+        Temporal boundary untyped (see `workflow.py`'s module docstring)."""
+
+        class _Candidate:
+            document_uid = "doc-1"
+            is_tabular = False
+            vector_done = False
+
+        buckets = _wf_repair_categorize([_Candidate()], vector_uids=["doc-1"], content_uids=["doc-1"])
+
+        assert buckets["eligible"] == ["doc-1"]
+
+
+# ── Structural / static call-graph proof ──────────────────────────────────────
+# The forbidden symbols: anything capable of deleting vectors, reading/writing
+# document content, re-running ingestion, or calling an embedding provider.
+#
+# Checked via each function's *bytecode* `co_names` (the globals/attributes its
+# compiled code actually references), NOT a raw source-text search: this module
+# and `repair_vector_metadata_activities.py` deliberately document, in prose,
+# every one of these forbidden symbols (to explain *why* they must never be
+# called) -- a plain substring/regex search over `inspect.getsource(...)` would
+# false-positive on that prose. `co_names` only contains names the compiled
+# code actually loads/calls; a docstring is stored as a string constant
+# (`co_consts`), never turned into a `LOAD_GLOBAL`/`LOAD_METHOD` name.
+_FORBIDDEN_NAMES = {
+    "delete_vectors",
+    "prepare_revectorize_file",
+    "output_process",
+    "output_process_trusted",
+    "get_embedder",
+    "get_create_vector_store",
+    "OpenSearchVectorStoreAdapter",
+    "ensure_ready",
+    "embed_query",
+    "embed_documents",
+    "start_child_workflow",
+    "execute_child_workflow",
+}
+
+
+def _module_source(module) -> str:
+    return inspect.getsource(module)
+
+
+def _referenced_names(func) -> set[str]:
+    """Every global/attribute name `func`'s compiled bytecode references,
+    recursing into any nested code objects (inner functions/comprehensions)."""
+    code = func.__code__
+    names: set[str] = set(code.co_names)
+    for const in code.co_consts:
+        if hasattr(const, "co_names"):  # a nested code object
+            names |= _referenced_names_from_code(const)
+    return names
+
+
+def _referenced_names_from_code(code) -> set[str]:
+    names: set[str] = set(code.co_names)
+    for const in code.co_consts:
+        if hasattr(const, "co_names"):
+            names |= _referenced_names_from_code(const)
+    return names
+
+
+_ACTIVITY_FUNCS = [
+    activities_module.list_repair_candidates_for_source_tag,
+    activities_module.list_strict_vector_document_uids,
+    activities_module.list_strict_content_document_uids,
+    activities_module.bulk_repair_vector_metadata,
+    activities_module.emit_repair_vector_metadata_task_event,
+]
+_WORKFLOW_FUNCS = [
+    workflow_module.RepairVectorMetadataWorkflow.run,
+    workflow_module._wf_repair_categorize,
+]
+
+
+class TestNoForbiddenSymbolsInThe3aCallGraph:
+    def test_activities_never_reference_a_forbidden_symbol(self) -> None:
+        for func in _ACTIVITY_FUNCS:
+            hit = _referenced_names(func) & _FORBIDDEN_NAMES
+            assert not hit, f"{func.__qualname__} references forbidden symbol(s): {hit}"
+
+    def test_workflow_never_references_a_forbidden_symbol(self) -> None:
+        for func in _WORKFLOW_FUNCS:
+            hit = _referenced_names(func) & _FORBIDDEN_NAMES
+            assert not hit, f"{func.__qualname__} references forbidden symbol(s): {hit}"
+
+    def test_workflow_never_starts_a_child_workflow(self) -> None:
+        """Belt-and-suspenders source-text check specifically for
+        `start_child_workflow`/`execute_child_workflow`: these are read off
+        `workflow.<name>` as an attribute access, which the `co_names`-based
+        check above already covers via `_FORBIDDEN_NAMES`, but the whole point
+        of this workflow's shape (one parent, a handful of bulk activities,
+        versus `RevectorizeCorpusWorkflow`'s one child per document) is
+        important enough to also assert directly against the raw source."""
+        source = _module_source(workflow_module)
+        assert "start_child_workflow" not in source
+        assert "execute_child_workflow" not in source
+
+
+class TestConstantActivitySurface:
+    """`bulk_repair_vector_metadata` etc. are each called exactly once per
+    `run()`, regardless of how many document_uids are involved -- the count of
+    *distinct* activity names this workflow can invoke is a small constant,
+    never O(documents). Cross-checked against `worker.py`'s registration list
+    so the two can't silently drift apart."""
+
+    _EXPECTED_ACTIVITY_NAMES = {
+        "emit_ingestion_task_event",  # reused for the initial "running" ping
+        "list_repair_candidates_for_source_tag",
+        "list_strict_vector_document_uids",
+        "list_strict_content_document_uids",
+        "bulk_repair_vector_metadata",
+        "emit_repair_vector_metadata_task_event",
+    }
+
+    def test_workflow_source_only_ever_names_the_expected_constant_activity_set(self) -> None:
+        source = _module_source(workflow_module)
+        named_activities = set(re.findall(r'execute_activity\(\s*"([a-zA-Z0-9_]+)"', source))
+        assert named_activities == self._EXPECTED_ACTIVITY_NAMES
+
+    def test_worker_registers_exactly_the_repair_activities_module_functions(self) -> None:
+        """`worker.py`'s activity list for this feature must be the module's own
+        `@activity.defn` functions -- not a per-document list built at runtime."""
+        worker_source = inspect.getsource(worker_module)
+        for name in ("list_repair_candidates_for_source_tag", "list_strict_vector_document_uids", "list_strict_content_document_uids", "bulk_repair_vector_metadata", "emit_repair_vector_metadata_task_event"):
+            assert name in worker_source, f"{name} must be registered in worker.py"
+        assert "RepairVectorMetadataWorkflow" in worker_source
+
+
+class TestBulkOnlyCalledAfterAllThreeScans:
+    """Structural proof, by source order, that `bulk_repair_vector_metadata` is
+    textually positioned after all three read-only scans inside the same `try`
+    block -- combined with Python's own control flow (an activity exception
+    propagates immediately, so a raised scan never reaches the lines below it),
+    this is what guarantees the bulk write never runs after a failed scan."""
+
+    def test_bulk_call_is_textually_after_all_three_scan_calls(self) -> None:
+        source = _module_source(workflow_module)
+        bulk_pos = source.index('"bulk_repair_vector_metadata"')
+        for scan_activity in (
+            "list_repair_candidates_for_source_tag",
+            "list_strict_vector_document_uids",
+            "list_strict_content_document_uids",
+        ):
+            scan_pos = source.index(f'"{scan_activity}"')
+            assert scan_pos < bulk_pos, f"{scan_activity} must be scanned before the bulk write"
+
+    def test_bulk_call_and_all_three_scans_share_the_same_try_block(self) -> None:
+        """From the main (8-space-indented) `try:` up to the bulk call, there must
+        be no `except` -- i.e. nothing lets a scan failure be caught and
+        swallowed before reaching the bulk write undetected. (The unrelated,
+        separately-indented `try/except` around the best-effort initial "running"
+        event, earlier in the function, is deliberately not this one -- see
+        `main_try_marker`'s exact indentation.)"""
+        source = _module_source(workflow_module)
+        bulk_pos = source.index('"bulk_repair_vector_metadata"')
+        main_try_marker = "\n        try:\n"
+        try_pos = source.index(main_try_marker)
+        assert try_pos < bulk_pos
+        between = source[try_pos:bulk_pos]
+        assert "except" not in between

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_workflow.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_workflow.py
@@ -227,7 +227,13 @@ class TestConstantActivitySurface:
         """`worker.py`'s activity list for this feature must be the module's own
         `@activity.defn` functions -- not a per-document list built at runtime."""
         worker_source = inspect.getsource(worker_module)
-        for name in ("list_repair_candidates_for_source_tag", "list_strict_vector_document_uids", "list_strict_content_document_uids", "bulk_repair_vector_metadata", "emit_repair_vector_metadata_task_event"):
+        for name in (
+            "list_repair_candidates_for_source_tag",
+            "list_strict_vector_document_uids",
+            "list_strict_content_document_uids",
+            "bulk_repair_vector_metadata",
+            "emit_repair_vector_metadata_task_event",
+        ):
             assert name in worker_source, f"{name} must be registered in worker.py"
         assert "RepairVectorMetadataWorkflow" in worker_source
 

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_workflow.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_repair_vector_metadata_workflow.py
@@ -42,12 +42,12 @@ from knowledge_flow_backend.features.scheduler import worker as worker_module
 from knowledge_flow_backend.features.scheduler.repair_vector_metadata_workflow import _wf_repair_categorize
 
 
-def _candidate(document_uid: str, *, is_tabular: bool = False, vector_done: bool = False) -> dict:
-    return {"document_uid": document_uid, "is_tabular": is_tabular, "vector_done": vector_done}
+def _candidate(document_uid: str, *, is_tabular: bool = False, vector_done: bool = False, failed_or_running: bool = False) -> dict:
+    return {"document_uid": document_uid, "is_tabular": is_tabular, "vector_done": vector_done, "failed_or_running": failed_or_running}
 
 
 class TestRepairCategorize:
-    def test_distinguishes_all_five_buckets(self) -> None:
+    def test_distinguishes_all_six_buckets(self) -> None:
         candidates = [
             _candidate("already-done", vector_done=True),
             _candidate("eligible-1"),
@@ -55,9 +55,10 @@ class TestRepairCategorize:
             _candidate("no-vector"),
             _candidate("no-content"),
             _candidate("tabular-1", is_tabular=True),
+            _candidate("broken-1", failed_or_running=True),
         ]
-        vector_uids = ["eligible-1", "eligible-2", "no-content"]
-        content_uids = ["eligible-1", "eligible-2", "no-vector"]
+        vector_uids = ["eligible-1", "eligible-2", "no-content", "broken-1"]
+        content_uids = ["eligible-1", "eligible-2", "no-vector", "broken-1"]
 
         buckets = _wf_repair_categorize(candidates, vector_uids, content_uids)
 
@@ -66,6 +67,7 @@ class TestRepairCategorize:
         assert buckets["missing_vectors"] == 1  # "no-vector"
         assert buckets["missing_content"] == 1  # "no-content"
         assert buckets["tabular_excluded"] == 1
+        assert buckets["failed_or_running_excluded"] == 1  # "broken-1"
 
     def test_tabular_takes_precedence_over_already_done(self) -> None:
         """A tabular document must always land in `tabular_excluded`, even if it
@@ -78,6 +80,33 @@ class TestRepairCategorize:
         assert buckets["tabular_excluded"] == 1
         assert buckets["already_done"] == 0
         assert buckets["eligible"] == []
+
+    def test_failed_or_running_takes_precedence_over_eligible(self) -> None:
+        """A document with a `failed`/`in_progress` stage elsewhere must never be
+        silently marked `done` just because it already has real vectors and
+        content -- that would erase a real failure signal instead of surfacing
+        it. This is the #2234 hardening gap found against the real Kea corpus
+        (e.g. `vector: failed` or `preview: failed` docs that already have
+        vectors in OpenSearch)."""
+        candidates = [_candidate("broken-1", failed_or_running=True)]
+
+        buckets = _wf_repair_categorize(candidates, vector_uids=["broken-1"], content_uids=["broken-1"])
+
+        assert buckets["failed_or_running_excluded"] == 1
+        assert buckets["eligible"] == []
+        assert buckets["missing_vectors"] == 0
+        assert buckets["missing_content"] == 0
+
+    def test_failed_or_running_takes_precedence_over_already_done(self) -> None:
+        """`vector_done` is checked first (bucket 2), so a document already
+        reading `vector: done` stays `already_done` even if another stage is
+        failed/running -- only a non-done `vector` stage needs this exclusion."""
+        candidates = [_candidate("doc-1", vector_done=True, failed_or_running=True)]
+
+        buckets = _wf_repair_categorize(candidates, vector_uids=["doc-1"], content_uids=["doc-1"])
+
+        assert buckets["already_done"] == 1
+        assert buckets["failed_or_running_excluded"] == 0
 
     def test_missing_vectors_takes_precedence_over_missing_content(self) -> None:
         """A document missing both is reported once, under missing_vectors --
@@ -95,6 +124,7 @@ class TestRepairCategorize:
         assert buckets == {
             "tabular_excluded": 0,
             "already_done": 0,
+            "failed_or_running_excluded": 0,
             "eligible": [],
             "missing_vectors": 0,
             "missing_content": 0,
@@ -108,6 +138,7 @@ class TestRepairCategorize:
             document_uid = "doc-1"
             is_tabular = False
             vector_done = False
+            failed_or_running = False
 
         buckets = _wf_repair_categorize([_Candidate()], vector_uids=["doc-1"], content_uids=["doc-1"])
 

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_revectorize_activities.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_revectorize_activities.py
@@ -149,16 +149,20 @@ def test_get_chunk_count_returns_zero_when_store_lacks_the_method():
     assert result == 0
 
 
-def test_get_chunk_count_returns_zero_when_store_raises():
+def test_get_chunk_count_propagates_when_store_raises():
+    """A store failure (timeout, index/auth misconfiguration) must never be folded
+    into "0 chunks" -- that used to make an unrelated check failure look like a
+    genuinely empty document and trigger an unnecessary real re-embed (#2234).
+    Letting it propagate lets the activity's own retry policy retry it, and lets
+    `RevectorizeDocument` report a real failure instead."""
     vector_store = MagicMock()
     vector_store.get_document_chunk_count.side_effect = RuntimeError("boom")
     app_ctx = MagicMock()
     app_ctx.get_create_vector_store.return_value = vector_store
 
     with patch(_PATCH_CTX, return_value=app_ctx):
-        result = _run(get_chunk_count("doc-1"))
-
-    assert result == 0
+        with pytest.raises(RuntimeError, match="boom"):
+            _run(get_chunk_count("doc-1"))
 
 
 def test_get_chunk_count_runs_the_blocking_opensearch_call_in_a_thread():

--- a/apps/knowledge-flow-backend/tests/features/scheduler/test_workflow.py
+++ b/apps/knowledge-flow-backend/tests/features/scheduler/test_workflow.py
@@ -27,6 +27,7 @@ import pytest
 
 from knowledge_flow_backend.features.scheduler.workflow import (
     _wf_final_revectorize_state,
+    _wf_scope_resolution_failed_event_args,
     _wf_should_skip_revectorize,
 )
 
@@ -68,3 +69,16 @@ def test_final_revectorize_state_failed_even_when_every_document_failed() -> Non
     state, error = _wf_final_revectorize_state(failed=5, total=5)
     assert state == "failed"
     assert error == "5 of 5 document(s) failed to re-vectorize"
+
+
+def test_scope_resolution_failed_event_args_carries_the_real_exception_text() -> None:
+    """`RevectorizeCorpusWorkflow.run` emits this immediately, with the real error,
+    instead of waiting on the generic stale-task reconcile sweeper's detail-free
+    "Execution failed" (fred_core.tasks.service.TaskService._reconciled_terminal)."""
+    args = _wf_scope_resolution_failed_event_args(RuntimeError("Postgres unavailable"), "task-1")
+    assert args == ["task-1", "failed", "listed", None, "Postgres unavailable", 0, 0, 0, None, None]
+
+
+def test_scope_resolution_failed_event_args_falls_back_when_exception_has_no_message() -> None:
+    args = _wf_scope_resolution_failed_event_args(RuntimeError(), "task-1")
+    assert args[4] == "Failed to resolve revectorize scope"

--- a/apps/knowledge-flow-backend/tests/features/test_metadata_rename.py
+++ b/apps/knowledge-flow-backend/tests/features/test_metadata_rename.py
@@ -50,6 +50,10 @@ class _FakeRebac:
         del user, permission
         return RebacDisabledResult()
 
+    async def has_user_permission(self, user, permission, document_uid):
+        del user, permission, document_uid
+        return True
+
 
 class _FakeMetadataStore:
     def __init__(self, doc: DocumentMetadata | None, siblings: list[DocumentMetadata] | None = None) -> None:

--- a/apps/knowledge-flow-backend/tests/features/test_metadata_rename.py
+++ b/apps/knowledge-flow-backend/tests/features/test_metadata_rename.py
@@ -50,10 +50,6 @@ class _FakeRebac:
         del user, permission
         return RebacDisabledResult()
 
-    async def has_user_permission(self, user, permission, document_uid):
-        del user, permission, document_uid
-        return True
-
 
 class _FakeMetadataStore:
     def __init__(self, doc: DocumentMetadata | None, siblings: list[DocumentMetadata] | None = None) -> None:

--- a/apps/knowledge-flow-backend/tests/stores/test_opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/test_opensearch_vector_store.py
@@ -98,6 +98,9 @@ class FakeOpenSearchClient:
         self.search_pipeline = FakeSearchPipeline(exists=pipeline_exists)
         self.update_by_query_calls: list[tuple[str, dict]] = []
         self.update_by_query_response: dict = {"updated": 1}
+        self.search_calls: list[dict] = []
+        self.search_responses: list[dict] = []
+        self.search_request_timeouts: list[int | None] = []
 
     def close(self) -> None:
         return None
@@ -105,6 +108,13 @@ class FakeOpenSearchClient:
     def update_by_query(self, *, index: str, body: dict, params: dict | None = None) -> dict:
         self.update_by_query_calls.append((index, deepcopy(body)))
         return self.update_by_query_response
+
+    def search(self, *, index: str, body: dict, request_timeout: int | None = None) -> dict:
+        self.search_calls.append(deepcopy(body))
+        self.search_request_timeouts.append(request_timeout)
+        if self.search_responses:
+            return self.search_responses.pop(0)
+        return {"aggregations": {}}
 
 
 def test_opensearch_vector_store_creates_missing_index(monkeypatch):
@@ -538,3 +548,153 @@ def test_opensearch_vector_store_retries_transient_embedding_failure_without_spl
         (4, ["cid-0", "cid-1", "cid-2", "cid-3"]),
     ]
     assert sleep_calls == [ovs.EMBEDDING_RETRY_BASE_DELAY_SECONDS]
+
+
+def test_list_document_uids_pages_past_a_single_page_via_composite_aggregation(monkeypatch):
+    """A one-shot `terms` agg silently truncates once an index holds more distinct
+    document_uids than its `size`. This must page through `after_key` until
+    exhausted instead, or a real deployment's own audit tool (`MetadataService.
+    audit_stores`) would eventually treat correctly-vectorized documents that fell
+    off the truncated list as `missing_vectors` and reset them (#2234)."""
+    mapping = ovs.build_vector_index_mapping(4)
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors", index_body=mapping)
+    fake_client.search_responses = [
+        {
+            "aggregations": {
+                "by_doc": {
+                    "after_key": {"doc_uid": "doc-2"},
+                    "buckets": [
+                        {"key": {"doc_uid": "doc-1"}, "doc_count": 5},
+                        {"key": {"doc_uid": "doc-2"}, "doc_count": 3},
+                    ],
+                }
+            }
+        },
+        {
+            "aggregations": {
+                "by_doc": {
+                    "after_key": {"doc_uid": "doc-3"},
+                    "buckets": [{"key": {"doc_uid": "doc-3"}, "doc_count": 1}],
+                }
+            }
+        },
+        {"aggregations": {"by_doc": {"buckets": []}}},
+    ]
+    store = _make_store_for_existing_index(monkeypatch, fake_client)
+
+    result = store.list_document_uids(page_size=2)
+
+    assert result == ["doc-1", "doc-2", "doc-3"]
+    assert len(fake_client.search_calls) == 3
+    assert fake_client.search_calls[0]["aggs"]["by_doc"]["composite"]["size"] == 2
+    assert "after" not in fake_client.search_calls[0]["aggs"]["by_doc"]["composite"]
+    assert fake_client.search_calls[1]["aggs"]["by_doc"]["composite"]["after"] == {"doc_uid": "doc-2"}
+    assert fake_client.search_calls[2]["aggs"]["by_doc"]["composite"]["after"] == {"doc_uid": "doc-3"}
+
+
+def test_list_document_uids_returns_empty_list_when_store_raises(monkeypatch):
+    mapping = ovs.build_vector_index_mapping(4)
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors", index_body=mapping)
+
+    def _raise(*, index: str, body: dict, request_timeout: int | None = None) -> dict:
+        raise RuntimeError("boom")
+
+    fake_client.search = _raise  # type: ignore[method-assign]
+    store = _make_store_for_existing_index(monkeypatch, fake_client)
+
+    assert store.list_document_uids() == []
+
+
+# ── scan_document_uids_composite (module-level, pure) -- #2234 3a repair path ─
+# Extracted so the repair action's `list_strict_vector_document_uids` activity
+# can page through document_uids using only a raw, already-configured
+# `OpenSearch` client (`ApplicationContext.get_opensearch_client()`) -- never an
+# `OpenSearchVectorStoreAdapter` instance, whose `__init__` calls `ensure_ready()`
+# (embedder call, possible index/pipeline creation). These tests exercise the
+# helper directly, the same way the activity does, independent of the adapter.
+
+
+def test_scan_document_uids_composite_pages_multiple_times_via_after_key():
+    mapping = ovs.build_vector_index_mapping(4)
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors", index_body=mapping)
+    fake_client.search_responses = [
+        {
+            "aggregations": {
+                "by_doc": {
+                    "after_key": {"doc_uid": "doc-2"},
+                    "buckets": [
+                        {"key": {"doc_uid": "doc-1"}, "doc_count": 5},
+                        {"key": {"doc_uid": "doc-2"}, "doc_count": 3},
+                    ],
+                }
+            }
+        },
+        {
+            "aggregations": {
+                "by_doc": {
+                    "after_key": {"doc_uid": "doc-3"},
+                    "buckets": [{"key": {"doc_uid": "doc-3"}, "doc_count": 1}],
+                }
+            }
+        },
+        {"aggregations": {"by_doc": {"buckets": []}}},
+    ]
+
+    result = ovs.scan_document_uids_composite(fake_client, "fred-vectors", page_size=2, strict=True)
+
+    assert result == ["doc-1", "doc-2", "doc-3"]
+    assert len(fake_client.search_calls) == 3
+
+
+def test_scan_document_uids_composite_passes_a_bounded_request_timeout():
+    mapping = ovs.build_vector_index_mapping(4)
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors", index_body=mapping)
+    fake_client.search_responses = [{"aggregations": {"by_doc": {"buckets": []}}}]
+
+    ovs.scan_document_uids_composite(fake_client, "fred-vectors", request_timeout=7)
+
+    assert fake_client.search_request_timeouts == [7]
+
+
+def test_scan_document_uids_composite_strict_raises_when_an_intermediate_page_fails():
+    """The failure happens on page 2, *after* page 1 already returned real
+    document_uids -- strict mode must still raise (never return the partial
+    list collected so far), so a caller that must never treat "scan failed" as
+    "these N document_uids are the complete answer" gets a hard error."""
+    mapping = ovs.build_vector_index_mapping(4)
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors", index_body=mapping)
+    call_count = {"n": 0}
+    first_page = {
+        "aggregations": {
+            "by_doc": {
+                "after_key": {"doc_uid": "doc-1"},
+                "buckets": [{"key": {"doc_uid": "doc-1"}, "doc_count": 5}],
+            }
+        }
+    }
+
+    def _search(*, index: str, body: dict, request_timeout: int | None = None) -> dict:
+        call_count["n"] += 1
+        fake_client.search_calls.append(deepcopy(body))
+        if call_count["n"] == 1:
+            return first_page
+        raise RuntimeError("boom on page 2")
+
+    fake_client.search = _search  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="boom on page 2"):
+        ovs.scan_document_uids_composite(fake_client, "fred-vectors", page_size=1, strict=True)
+
+    assert call_count["n"] == 2
+
+
+def test_scan_document_uids_composite_non_strict_swallows_and_returns_empty_on_first_page_failure():
+    mapping = ovs.build_vector_index_mapping(4)
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors", index_body=mapping)
+
+    def _raise(*, index: str, body: dict, request_timeout: int | None = None) -> dict:
+        raise RuntimeError("boom")
+
+    fake_client.search = _raise  # type: ignore[method-assign]
+
+    assert ovs.scan_document_uids_composite(fake_client, "fred-vectors", strict=False) == []

--- a/docs/swift/platform/authz-endpoint-matrix.yaml
+++ b/docs/swift/platform/authz-endpoint-matrix.yaml
@@ -577,6 +577,11 @@ operations:
     required_permission: pending_review
   - service: knowledge-flow
     method: POST
+    path: /knowledge-flow/v1/corpus/repair-vector-metadata
+    review_status: pending_review
+    required_permission: pending_review
+  - service: knowledge-flow
+    method: POST
     path: /knowledge-flow/v1/corpus/revectorize
     review_status: pending_review
     required_permission: pending_review

--- a/libs/fred-core/fred_core/documents/postgres_document_store.py
+++ b/libs/fred-core/fred_core/documents/postgres_document_store.py
@@ -28,7 +28,11 @@ from fred_core.documents.document_store import (
     BaseDocumentMetadataStore,
     DocumentMetadataDeserializationError,
 )
-from fred_core.documents.document_structures import DocumentMetadata, ProcessingStage, ProcessingStatus
+from fred_core.documents.document_structures import (
+    DocumentMetadata,
+    ProcessingStage,
+    ProcessingStatus,
+)
 from fred_core.documents.tag_models import TagRow
 from fred_core.sql.async_session import make_session_factory, use_session
 
@@ -295,7 +299,10 @@ class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
             row.doc = self._to_dict(metadata)
 
     async def bulk_mark_vector_done(
-        self, source_tag: str, document_uids: list[str], session: AsyncSession | None = None
+        self,
+        source_tag: str,
+        document_uids: list[str],
+        session: AsyncSession | None = None,
     ) -> list[str]:
         """Atomically set `processing.stages.vector = done` and clear any
         `processing.errors.vector` for exactly these document_uids -- nothing else
@@ -363,7 +370,9 @@ class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
                 updated: list[str] = []
                 for i in range(0, len(unique_uids), _BULK_UPDATE_CHUNK_SIZE):
                     chunk = unique_uids[i : i + _BULK_UPDATE_CHUNK_SIZE]
-                    result = await s.execute(update_stmt, {"source_tag": source_tag, "uids": chunk})
+                    result = await s.execute(
+                        update_stmt, {"source_tag": source_tag, "uids": chunk}
+                    )
                     updated.extend(row[0] for row in result.fetchall())
 
                 missing = set(unique_uids) - set(updated)
@@ -432,7 +441,10 @@ class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
             not_verified = [
                 document_uid
                 for document_uid in updated
-                if found_by_uid[document_uid].doc.get("processing", {}).get("stages", {}).get(ProcessingStage.VECTORIZED.value)
+                if found_by_uid[document_uid]
+                .doc.get("processing", {})
+                .get("stages", {})
+                .get(ProcessingStage.VECTORIZED.value)
                 != ProcessingStatus.DONE.value
             ]
             if not_verified:

--- a/libs/fred-core/fred_core/documents/postgres_document_store.py
+++ b/libs/fred-core/fred_core/documents/postgres_document_store.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any, List, Optional, cast
 
 from pydantic import ValidationError
-from sqlalchemy import BigInteger, CursorResult, delete, func, select
+from sqlalchemy import BigInteger, CursorResult, bindparam, delete, func, select, text
 from sqlalchemy import cast as sql_cast
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
@@ -28,11 +28,16 @@ from fred_core.documents.document_store import (
     BaseDocumentMetadataStore,
     DocumentMetadataDeserializationError,
 )
-from fred_core.documents.document_structures import DocumentMetadata
+from fred_core.documents.document_structures import DocumentMetadata, ProcessingStage, ProcessingStatus
 from fred_core.documents.tag_models import TagRow
 from fred_core.sql.async_session import make_session_factory, use_session
 
 logger = logging.getLogger(__name__)
+
+# Chunk size for `bulk_mark_vector_done`'s `WHERE document_uid IN (...)` batches --
+# bounds each statement's parameter count for very large repairs (e.g. ~10,000
+# document_uids) while the whole call still runs inside one transaction.
+_BULK_UPDATE_CHUNK_SIZE = 2000
 
 
 class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
@@ -288,6 +293,156 @@ class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
             row.date_added_to_kb = metadata.source.date_added_to_kb
             row.tag_ids = list(metadata.tags.tag_ids or [])
             row.doc = self._to_dict(metadata)
+
+    async def bulk_mark_vector_done(
+        self, source_tag: str, document_uids: list[str], session: AsyncSession | None = None
+    ) -> list[str]:
+        """Atomically set `processing.stages.vector = done` and clear any
+        `processing.errors.vector` for exactly these document_uids -- nothing else
+        in `doc` (identity, source, tags, ACL, other stages/errors, extensions,
+        business timestamps) is touched. `processing`/`processing.stages` are
+        created if the document's JSON doesn't have them yet (`jsonb_set(...,
+        create_missing=true)` alone does NOT create missing *intermediate* parent
+        objects in PostgreSQL -- only the final path element -- so this builds the
+        `processing` object explicitly via `COALESCE(...) || jsonb_build_object(...)`
+        instead of relying on that).
+
+        `source_tag` re-scopes the `WHERE` clause at write time, not just at the
+        caller's earlier scan time (`WHERE source_tag = :source_tag AND
+        document_uid IN (...)`): a document whose `source_tag` changed between the
+        scan and this write is out of scope and must not be silently repaired.
+
+        One transaction for the whole call, chunked into bounded
+        `WHERE ... IN (...)` statements (`_BULK_UPDATE_CHUNK_SIZE`) so a single call
+        stays well clear of practical statement-parameter limits even at ~10,000
+        uids: if any chunk's UPDATE fails, or either postcondition below fails, the
+        whole call raises before returning -- the caller's transaction (this
+        method's own, when `session` is None; see `use_session`) rolls back
+        entirely, so a partially-applied repair can never be observed.
+
+        Postconditions checked before returning (both required, both raise on
+        failure so the caller rolls back):
+          1. every requested document_uid was actually found under `source_tag` --
+             an absent uid, or one whose `source_tag` no longer matches, fails the
+             whole batch rather than being silently skipped.
+          2. every updated document_uid reads back `processing.stages.vector ==
+             "done"` -- a defensive read-back check, independent of the UPDATE
+             statement's own correctness.
+
+        Semantically idempotent: re-running with the same `source_tag` and uids
+        converges to the same end state. This is not a guaranteed physical no-op --
+        PostgreSQL may still rewrite a row even when the JSON value it computes is
+        unchanged -- only that the observable result is identical.
+        """
+        unique_uids = list(dict.fromkeys(document_uids))
+        if not unique_uids:
+            return []
+
+        async with use_session(self._sessions, session) as s:
+            if self._is_postgres:
+                update_stmt = text(
+                    """
+                    UPDATE metadata
+                    SET doc = doc || jsonb_build_object(
+                        'processing',
+                        COALESCE(doc->'processing', '{}'::jsonb)
+                        || jsonb_build_object(
+                            'stages',
+                            COALESCE(doc->'processing'->'stages', '{}'::jsonb) || jsonb_build_object('vector', 'done')
+                        )
+                        || jsonb_build_object(
+                            'errors',
+                            COALESCE(doc->'processing'->'errors', '{}'::jsonb) - 'vector'
+                        )
+                    )
+                    WHERE source_tag = :source_tag
+                      AND document_uid IN :uids
+                    RETURNING document_uid
+                    """
+                ).bindparams(bindparam("uids", expanding=True))
+                updated: list[str] = []
+                for i in range(0, len(unique_uids), _BULK_UPDATE_CHUNK_SIZE):
+                    chunk = unique_uids[i : i + _BULK_UPDATE_CHUNK_SIZE]
+                    result = await s.execute(update_stmt, {"source_tag": source_tag, "uids": chunk})
+                    updated.extend(row[0] for row in result.fetchall())
+
+                missing = set(unique_uids) - set(updated)
+                if missing:
+                    raise RuntimeError(
+                        f"bulk_mark_vector_done: {len(missing)} document_uid(s) not found under "
+                        f"source_tag={source_tag!r} (absent, or its source_tag changed since the "
+                        "scan) -- rolling back the whole repair batch instead of applying a partial one."
+                    )
+
+                verify_stmt = text(
+                    """
+                    SELECT document_uid
+                    FROM metadata
+                    WHERE document_uid IN :uids
+                      AND doc #>> '{processing,stages,vector}' = 'done'
+                    """
+                ).bindparams(bindparam("uids", expanding=True))
+                verified: set[str] = set()
+                for i in range(0, len(updated), _BULK_UPDATE_CHUNK_SIZE):
+                    chunk = updated[i : i + _BULK_UPDATE_CHUNK_SIZE]
+                    result = await s.execute(verify_stmt, {"uids": chunk})
+                    verified.update(row[0] for row in result.fetchall())
+                not_verified = set(updated) - verified
+                if not_verified:
+                    raise RuntimeError(
+                        f"bulk_mark_vector_done: {len(not_verified)} document_uid(s) did not read back "
+                        "processing.stages.vector == 'done' after the update -- rolling back the whole "
+                        "repair batch."
+                    )
+
+                return updated
+
+            # SQLite (tests): no jsonb `||`/`#>>` operators used above -- per-row
+            # read/modify/write in the same transaction, applying the identical
+            # source_tag scoping and postcondition checks the Postgres path
+            # enforces directly in SQL.
+            rows = (
+                (
+                    await s.execute(
+                        select(DocumentMetadataRow).where(
+                            DocumentMetadataRow.document_uid.in_(unique_uids),
+                            DocumentMetadataRow.source_tag == source_tag,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            found_by_uid = {row.document_uid: row for row in rows}
+            missing = set(unique_uids) - set(found_by_uid)
+            if missing:
+                raise RuntimeError(
+                    f"bulk_mark_vector_done: {len(missing)} document_uid(s) not found under "
+                    f"source_tag={source_tag!r} (absent, or its source_tag changed since the "
+                    "scan) -- rolling back the whole repair batch instead of applying a partial one."
+                )
+
+            updated = []
+            for document_uid, row in found_by_uid.items():
+                metadata = self._from_row(row)
+                metadata.processing.mark_done(ProcessingStage.VECTORIZED)
+                row.doc = self._to_dict(metadata)
+                updated.append(document_uid)
+
+            not_verified = [
+                document_uid
+                for document_uid in updated
+                if found_by_uid[document_uid].doc.get("processing", {}).get("stages", {}).get(ProcessingStage.VECTORIZED.value)
+                != ProcessingStatus.DONE.value
+            ]
+            if not_verified:
+                raise RuntimeError(
+                    f"bulk_mark_vector_done: {len(not_verified)} document_uid(s) did not read back "
+                    "processing.stages.vector == 'done' after the update -- rolling back the whole "
+                    "repair batch."
+                )
+
+            return updated
 
     async def delete_metadata(
         self, document_uid: str, session: AsyncSession | None = None

--- a/libs/fred-core/fred_core/documents/postgres_document_store.py
+++ b/libs/fred-core/fred_core/documents/postgres_document_store.py
@@ -441,8 +441,8 @@ class PostgresDocumentMetadataStore(BaseDocumentMetadataStore):
             not_verified = [
                 document_uid
                 for document_uid in updated
-                if found_by_uid[document_uid]
-                .doc.get("processing", {})
+                if (found_by_uid[document_uid].doc or {})
+                .get("processing", {})
                 .get("stages", {})
                 .get(ProcessingStage.VECTORIZED.value)
                 != ProcessingStatus.DONE.value

--- a/libs/fred-core/fred_core/tasks/models.py
+++ b/libs/fred-core/fred_core/tasks/models.py
@@ -43,6 +43,33 @@ class IngestionProcessingProfile(StrEnum):
 # ── per-kind detail models ────────────────────────────────────────────────────
 
 
+class RepairVectorMetadataResult(BaseModel):
+    """Structured outcome of the vector-metadata repair action (#2234, 3a).
+
+    Populated only on the terminal `succeeded`/`failed` event of
+    `RepairVectorMetadataWorkflow`, same convention as `MigrationResult` below --
+    a typed report an operator reads directly off the task, not just a pass/fail.
+
+    IMPORTANT scope limitation, by design (an urgent repair, not a full audit):
+    `eligible_with_vectors_and_content`/`repaired` mean the document_uid had *at
+    least one* real vector chunk in OpenSearch and *at least one* real object in
+    the content store -- there is no reliable expected chunk/object count to
+    compare against (it was never transported by the Kea restore), so this can
+    never prove *every* chunk or object of a document survived. Never present
+    this report, in UI text or logs, as having verified full completeness.
+    """
+
+    source_tag: str
+    metadata_documents: int = 0
+    already_done: int = 0
+    eligible_with_vectors_and_content: int = 0
+    repaired: int = 0
+    missing_vectors: int = 0
+    missing_content: int = 0
+    tabular_excluded: int = 0
+    errors: int = 0
+
+
 class IngestionDetail(BaseModel):
     processed: int
     total: int
@@ -50,6 +77,9 @@ class IngestionDetail(BaseModel):
     preview: int
     vectorized: int
     sql_indexed: int
+    # Populated only on the terminal event of the vector-metadata repair action
+    # (#2234, 3a) -- every other ingestion-kind task leaves this None.
+    result: RepairVectorMetadataResult | None = None
 
 
 class TaskLogDetail(BaseModel):

--- a/libs/fred-core/fred_core/tasks/models.py
+++ b/libs/fred-core/fred_core/tasks/models.py
@@ -57,6 +57,12 @@ class RepairVectorMetadataResult(BaseModel):
     compare against (it was never transported by the Kea restore), so this can
     never prove *every* chunk or object of a document survived. Never present
     this report, in UI text or logs, as having verified full completeness.
+
+    `failed_or_running_excluded` counts documents left untouched because some
+    processing stage reads `failed` or `in_progress` -- a stale `not_started`
+    flag and a real failure/stuck stage are not the same problem, and this
+    repair must never silently mark one `done` (clearing its error) just
+    because it happens to already have vectors/content present.
     """
 
     source_tag: str
@@ -67,6 +73,7 @@ class RepairVectorMetadataResult(BaseModel):
     missing_vectors: int = 0
     missing_content: int = 0
     tabular_excluded: int = 0
+    failed_or_running_excluded: int = 0
     errors: int = 0
 
 

--- a/libs/fred-core/fred_core/tests/documents/test_postgres_document_store_bulk_mark_vector_done.py
+++ b/libs/fred-core/fred_core/tests/documents/test_postgres_document_store_bulk_mark_vector_done.py
@@ -104,6 +104,7 @@ async def test_bulk_mark_vector_done_sets_vector_done_and_clears_the_vector_erro
 
     assert updated == ["doc-1"]
     result = await store.get_metadata_by_uid("doc-1")
+    assert result is not None
     assert _vector_stage(result) == ProcessingStatus.DONE
     assert ProcessingStage.VECTORIZED not in result.processing.errors
 
@@ -126,6 +127,7 @@ async def test_bulk_mark_vector_done_touches_only_the_two_allowed_json_paths(
     await store.bulk_mark_vector_done("fred", ["doc-1"])
 
     after = await store.get_metadata_by_uid("doc-1")
+    assert after is not None
     assert after.identity == before.identity
     assert after.source == before.source
     assert after.tags.tag_ids == ["tag-a", "tag-b"]
@@ -173,6 +175,7 @@ async def test_bulk_mark_vector_done_works_when_processing_is_entirely_absent(
 
     assert updated == ["doc-1"]
     result = await store.get_metadata_by_uid("doc-1")
+    assert result is not None
     assert _vector_stage(result) == ProcessingStatus.DONE
 
 
@@ -200,6 +203,7 @@ async def test_bulk_mark_vector_done_works_when_stages_is_absent_but_processing_
 
     assert updated == ["doc-1"]
     result = await store.get_metadata_by_uid("doc-1")
+    assert result is not None
     assert _vector_stage(result) == ProcessingStatus.DONE
 
 
@@ -227,6 +231,7 @@ async def test_bulk_mark_vector_done_works_when_errors_is_absent(
 
     assert updated == ["doc-1"]
     result = await store.get_metadata_by_uid("doc-1")
+    assert result is not None
     assert _vector_stage(result) == ProcessingStatus.DONE
     assert (
         result.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
@@ -250,6 +255,7 @@ async def test_bulk_mark_vector_done_rolls_back_everything_when_one_uid_is_absen
 
     # doc-1 would have matched on its own -- it must still be untouched.
     result = await store.get_metadata_by_uid("doc-1")
+    assert result is not None
     assert _vector_stage(result) != ProcessingStatus.DONE
 
 
@@ -270,6 +276,7 @@ async def test_bulk_mark_vector_done_rolls_back_everything_when_a_uid_source_tag
         await store.bulk_mark_vector_done("fred", ["doc-1", "doc-2"])
 
     result = await store.get_metadata_by_uid("doc-1")
+    assert result is not None
     assert _vector_stage(result) != ProcessingStatus.DONE
 
 
@@ -283,9 +290,11 @@ async def test_bulk_mark_vector_done_retry_converges_to_the_same_final_state(
 
     first = await store.bulk_mark_vector_done("fred", ["doc-1"])
     after_first = await store.get_metadata_by_uid("doc-1")
+    assert after_first is not None
 
     second = await store.bulk_mark_vector_done("fred", ["doc-1"])
     after_second = await store.get_metadata_by_uid("doc-1")
+    assert after_second is not None
 
     assert first == second == ["doc-1"]
     assert after_first.model_dump(mode="json") == after_second.model_dump(mode="json")
@@ -304,6 +313,7 @@ async def test_bulk_mark_vector_done_returns_empty_list_and_touches_nothing_for_
 
     assert result == []
     after = await store.get_metadata_by_uid("doc-1")
+    assert after is not None
     assert _vector_stage(after) != ProcessingStatus.DONE
 
 

--- a/libs/fred-core/fred_core/tests/documents/test_postgres_document_store_bulk_mark_vector_done.py
+++ b/libs/fred-core/fred_core/tests/documents/test_postgres_document_store_bulk_mark_vector_done.py
@@ -60,11 +60,15 @@ async def _make_sqlite_engine(tmp_path: Path, filename: str) -> AsyncEngine:
 def _doc(uid: str, source_tag: str = "fred") -> DocumentMetadata:
     return DocumentMetadata(
         identity=Identity(document_name=f"{uid}.pdf", document_uid=uid, title=uid),
-        source=SourceInfo(source_type=SourceType.PUSH, source_tag=source_tag, pull_location=None),
+        source=SourceInfo(
+            source_type=SourceType.PUSH, source_tag=source_tag, pull_location=None
+        ),
     )
 
 
-async def _insert_raw_row(sessions: async_sessionmaker, *, document_uid: str, source_tag: str, doc: dict) -> None:
+async def _insert_raw_row(
+    sessions: async_sessionmaker, *, document_uid: str, source_tag: str, doc: dict
+) -> None:
     """Insert a row with a hand-crafted `doc` JSON blob, bypassing
     `DocumentMetadata`/`save_metadata` entirely -- the only way to construct a
     row whose `processing`/`stages`/`errors` keys are genuinely absent (going
@@ -72,7 +76,14 @@ async def _insert_raw_row(sessions: async_sessionmaker, *, document_uid: str, so
     `default_factory`)."""
     async with sessions() as s:
         async with s.begin():
-            s.add(DocumentMetadataRow(document_uid=document_uid, source_tag=source_tag, tag_ids=[], doc=doc))
+            s.add(
+                DocumentMetadataRow(
+                    document_uid=document_uid,
+                    source_tag=source_tag,
+                    tag_ids=[],
+                    doc=doc,
+                )
+            )
 
 
 def _vector_stage(md: DocumentMetadata) -> ProcessingStatus | None:
@@ -80,7 +91,9 @@ def _vector_stage(md: DocumentMetadata) -> ProcessingStatus | None:
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_sets_vector_done_and_clears_the_vector_error(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_sets_vector_done_and_clears_the_vector_error(
+    tmp_path: Path,
+) -> None:
     engine = await _make_sqlite_engine(tmp_path, "bulk_basic.sqlite3")
     store = PostgresDocumentMetadataStore(engine)
     md = _doc("doc-1")
@@ -96,7 +109,9 @@ async def test_bulk_mark_vector_done_sets_vector_done_and_clears_the_vector_erro
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_touches_only_the_two_allowed_json_paths(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_touches_only_the_two_allowed_json_paths(
+    tmp_path: Path,
+) -> None:
     """Everything else on the document -- identity, source, tags, other
     processing stages, other processing errors -- must survive byte-for-byte."""
     engine = await _make_sqlite_engine(tmp_path, "bulk_scope.sqlite3")
@@ -114,14 +129,24 @@ async def test_bulk_mark_vector_done_touches_only_the_two_allowed_json_paths(tmp
     assert after.identity == before.identity
     assert after.source == before.source
     assert after.tags.tag_ids == ["tag-a", "tag-b"]
-    assert after.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
-    assert after.processing.stages[ProcessingStage.PREVIEW_READY] == ProcessingStatus.IN_PROGRESS
-    assert after.processing.errors[ProcessingStage.SQL_INDEXED] == "unrelated tabular failure"
+    assert (
+        after.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
+    )
+    assert (
+        after.processing.stages[ProcessingStage.PREVIEW_READY]
+        == ProcessingStatus.IN_PROGRESS
+    )
+    assert (
+        after.processing.errors[ProcessingStage.SQL_INDEXED]
+        == "unrelated tabular failure"
+    )
     assert _vector_stage(after) == ProcessingStatus.DONE
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_works_when_processing_is_entirely_absent(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_works_when_processing_is_entirely_absent(
+    tmp_path: Path,
+) -> None:
     """A row whose `doc` JSON has no `processing` key at all (e.g. a very old or
     hand-restored row) must not crash, and must end up with exactly
     `processing.stages.vector = done` -- proving `processing`/`stages` are
@@ -132,11 +157,17 @@ async def test_bulk_mark_vector_done_works_when_processing_is_entirely_absent(tm
     sessions = make_session_factory(engine)
     store = PostgresDocumentMetadataStore(engine)
     raw_doc = {
-        "identity": {"document_name": "doc-1.pdf", "document_uid": "doc-1", "title": "doc-1"},
+        "identity": {
+            "document_name": "doc-1.pdf",
+            "document_uid": "doc-1",
+            "title": "doc-1",
+        },
         "source": {"source_type": "push", "source_tag": "fred"},
         # no "processing" key at all
     }
-    await _insert_raw_row(sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc)
+    await _insert_raw_row(
+        sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc
+    )
 
     updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
 
@@ -146,16 +177,24 @@ async def test_bulk_mark_vector_done_works_when_processing_is_entirely_absent(tm
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_works_when_stages_is_absent_but_processing_is_present(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_works_when_stages_is_absent_but_processing_is_present(
+    tmp_path: Path,
+) -> None:
     engine = await _make_sqlite_engine(tmp_path, "bulk_no_stages.sqlite3")
     sessions = make_session_factory(engine)
     store = PostgresDocumentMetadataStore(engine)
     raw_doc = {
-        "identity": {"document_name": "doc-1.pdf", "document_uid": "doc-1", "title": "doc-1"},
+        "identity": {
+            "document_name": "doc-1.pdf",
+            "document_uid": "doc-1",
+            "title": "doc-1",
+        },
         "source": {"source_type": "push", "source_tag": "fred"},
         "processing": {},  # present, but no "stages"/"errors" keys
     }
-    await _insert_raw_row(sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc)
+    await _insert_raw_row(
+        sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc
+    )
 
     updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
 
@@ -165,27 +204,39 @@ async def test_bulk_mark_vector_done_works_when_stages_is_absent_but_processing_
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_works_when_errors_is_absent(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_works_when_errors_is_absent(
+    tmp_path: Path,
+) -> None:
     engine = await _make_sqlite_engine(tmp_path, "bulk_no_errors.sqlite3")
     sessions = make_session_factory(engine)
     store = PostgresDocumentMetadataStore(engine)
     raw_doc = {
-        "identity": {"document_name": "doc-1.pdf", "document_uid": "doc-1", "title": "doc-1"},
+        "identity": {
+            "document_name": "doc-1.pdf",
+            "document_uid": "doc-1",
+            "title": "doc-1",
+        },
         "source": {"source_type": "push", "source_tag": "fred"},
         "processing": {"stages": {"raw": "done"}},  # no "errors" key
     }
-    await _insert_raw_row(sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc)
+    await _insert_raw_row(
+        sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc
+    )
 
     updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
 
     assert updated == ["doc-1"]
     result = await store.get_metadata_by_uid("doc-1")
     assert _vector_stage(result) == ProcessingStatus.DONE
-    assert result.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
+    assert (
+        result.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
+    )
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_rolls_back_everything_when_one_uid_is_absent(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_rolls_back_everything_when_one_uid_is_absent(
+    tmp_path: Path,
+) -> None:
     """A document_uid absent from the table entirely (never existed, or a typo
     in the caller's scan result) must fail the WHOLE batch -- including the
     other, genuinely valid uids in the same call -- rather than silently
@@ -203,7 +254,9 @@ async def test_bulk_mark_vector_done_rolls_back_everything_when_one_uid_is_absen
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_rolls_back_everything_when_a_uid_source_tag_no_longer_matches(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_rolls_back_everything_when_a_uid_source_tag_no_longer_matches(
+    tmp_path: Path,
+) -> None:
     """A document whose `source_tag` changed between the caller's earlier scan
     and this write (e.g. re-tagged mid-repair) is out of scope -- and, same as
     the absent-uid case, must fail the whole batch rather than silently
@@ -221,7 +274,9 @@ async def test_bulk_mark_vector_done_rolls_back_everything_when_a_uid_source_tag
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_retry_converges_to_the_same_final_state(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_retry_converges_to_the_same_final_state(
+    tmp_path: Path,
+) -> None:
     engine = await _make_sqlite_engine(tmp_path, "bulk_retry.sqlite3")
     store = PostgresDocumentMetadataStore(engine)
     await store.save_metadata(_doc("doc-1"))
@@ -238,7 +293,9 @@ async def test_bulk_mark_vector_done_retry_converges_to_the_same_final_state(tmp
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_returns_empty_list_and_touches_nothing_for_empty_input(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_returns_empty_list_and_touches_nothing_for_empty_input(
+    tmp_path: Path,
+) -> None:
     engine = await _make_sqlite_engine(tmp_path, "bulk_empty.sqlite3")
     store = PostgresDocumentMetadataStore(engine)
     await store.save_metadata(_doc("doc-1"))
@@ -251,7 +308,9 @@ async def test_bulk_mark_vector_done_returns_empty_list_and_touches_nothing_for_
 
 
 @pytest.mark.asyncio
-async def test_bulk_mark_vector_done_deduplicates_repeated_uids_in_the_input(tmp_path: Path) -> None:
+async def test_bulk_mark_vector_done_deduplicates_repeated_uids_in_the_input(
+    tmp_path: Path,
+) -> None:
     engine = await _make_sqlite_engine(tmp_path, "bulk_dedup.sqlite3")
     store = PostgresDocumentMetadataStore(engine)
     await store.save_metadata(_doc("doc-1"))

--- a/libs/fred-core/fred_core/tests/documents/test_postgres_document_store_bulk_mark_vector_done.py
+++ b/libs/fred-core/fred_core/tests/documents/test_postgres_document_store_bulk_mark_vector_done.py
@@ -1,0 +1,261 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`PostgresDocumentMetadataStore.bulk_mark_vector_done` -- the only write the
+vector-metadata repair action (#2234, 3a) performs.
+
+Runs against SQLite, which takes the store's Python-fallback branch (no
+`jsonb`/`||`/`#>>` operators) -- the same branch every other JSON-manipulating
+method in this store already falls back to for tests (see
+`test_postgres_document_store_count_by_team.py`). IMPORTANT LIMITATION: this
+means the actual PostgreSQL `jsonb_build_object`/`COALESCE`/`#>>` SQL text
+(the part of the #2234 fix that specifically handles a document whose
+`processing`/`stages` JSON key is missing) is exercised here only via its
+Python-fallback *equivalent*, not the raw SQL itself -- there is no PostgreSQL
+available in this environment to test that text directly. The SQL was
+reviewed carefully (see the method's docstring) but is not executed by any
+test in this repository; recommend verifying it directly against a real
+PostgreSQL instance during manual testing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fred_core.documents.document_models import DocumentMetadataRow
+from fred_core.documents.document_structures import (
+    DocumentMetadata,
+    Identity,
+    ProcessingStage,
+    ProcessingStatus,
+    SourceInfo,
+    SourceType,
+)
+from fred_core.documents.postgres_document_store import PostgresDocumentMetadataStore
+from fred_core.models.base import Base
+from fred_core.sql.async_session import make_session_factory
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+
+async def _make_sqlite_engine(tmp_path: Path, filename: str) -> AsyncEngine:
+    db_path = tmp_path / filename
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine
+
+
+def _doc(uid: str, source_tag: str = "fred") -> DocumentMetadata:
+    return DocumentMetadata(
+        identity=Identity(document_name=f"{uid}.pdf", document_uid=uid, title=uid),
+        source=SourceInfo(source_type=SourceType.PUSH, source_tag=source_tag, pull_location=None),
+    )
+
+
+async def _insert_raw_row(sessions: async_sessionmaker, *, document_uid: str, source_tag: str, doc: dict) -> None:
+    """Insert a row with a hand-crafted `doc` JSON blob, bypassing
+    `DocumentMetadata`/`save_metadata` entirely -- the only way to construct a
+    row whose `processing`/`stages`/`errors` keys are genuinely absent (going
+    through the pydantic model always populates them via `Processing`'s
+    `default_factory`)."""
+    async with sessions() as s:
+        async with s.begin():
+            s.add(DocumentMetadataRow(document_uid=document_uid, source_tag=source_tag, tag_ids=[], doc=doc))
+
+
+def _vector_stage(md: DocumentMetadata) -> ProcessingStatus | None:
+    return md.processing.stages.get(ProcessingStage.VECTORIZED)
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_sets_vector_done_and_clears_the_vector_error(tmp_path: Path) -> None:
+    engine = await _make_sqlite_engine(tmp_path, "bulk_basic.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    md = _doc("doc-1")
+    md.processing.errors[ProcessingStage.VECTORIZED] = "index mismatch"
+    await store.save_metadata(md)
+
+    updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
+
+    assert updated == ["doc-1"]
+    result = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(result) == ProcessingStatus.DONE
+    assert ProcessingStage.VECTORIZED not in result.processing.errors
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_touches_only_the_two_allowed_json_paths(tmp_path: Path) -> None:
+    """Everything else on the document -- identity, source, tags, other
+    processing stages, other processing errors -- must survive byte-for-byte."""
+    engine = await _make_sqlite_engine(tmp_path, "bulk_scope.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    md = _doc("doc-1")
+    md.processing.stages[ProcessingStage.RAW_AVAILABLE] = ProcessingStatus.DONE
+    md.processing.stages[ProcessingStage.PREVIEW_READY] = ProcessingStatus.IN_PROGRESS
+    md.processing.errors[ProcessingStage.SQL_INDEXED] = "unrelated tabular failure"
+    md.tags.tag_ids = ["tag-a", "tag-b"]
+    before = await store.save_metadata(md) or md
+
+    await store.bulk_mark_vector_done("fred", ["doc-1"])
+
+    after = await store.get_metadata_by_uid("doc-1")
+    assert after.identity == before.identity
+    assert after.source == before.source
+    assert after.tags.tag_ids == ["tag-a", "tag-b"]
+    assert after.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
+    assert after.processing.stages[ProcessingStage.PREVIEW_READY] == ProcessingStatus.IN_PROGRESS
+    assert after.processing.errors[ProcessingStage.SQL_INDEXED] == "unrelated tabular failure"
+    assert _vector_stage(after) == ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_works_when_processing_is_entirely_absent(tmp_path: Path) -> None:
+    """A row whose `doc` JSON has no `processing` key at all (e.g. a very old or
+    hand-restored row) must not crash, and must end up with exactly
+    `processing.stages.vector = done` -- proving `processing`/`stages` are
+    created, not assumed present (the exact PostgreSQL `jsonb_set(...,
+    create_missing=true)` pitfall this fix addresses -- see module docstring
+    for the SQLite-vs-PostgreSQL coverage caveat)."""
+    engine = await _make_sqlite_engine(tmp_path, "bulk_no_processing.sqlite3")
+    sessions = make_session_factory(engine)
+    store = PostgresDocumentMetadataStore(engine)
+    raw_doc = {
+        "identity": {"document_name": "doc-1.pdf", "document_uid": "doc-1", "title": "doc-1"},
+        "source": {"source_type": "push", "source_tag": "fred"},
+        # no "processing" key at all
+    }
+    await _insert_raw_row(sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc)
+
+    updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
+
+    assert updated == ["doc-1"]
+    result = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(result) == ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_works_when_stages_is_absent_but_processing_is_present(tmp_path: Path) -> None:
+    engine = await _make_sqlite_engine(tmp_path, "bulk_no_stages.sqlite3")
+    sessions = make_session_factory(engine)
+    store = PostgresDocumentMetadataStore(engine)
+    raw_doc = {
+        "identity": {"document_name": "doc-1.pdf", "document_uid": "doc-1", "title": "doc-1"},
+        "source": {"source_type": "push", "source_tag": "fred"},
+        "processing": {},  # present, but no "stages"/"errors" keys
+    }
+    await _insert_raw_row(sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc)
+
+    updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
+
+    assert updated == ["doc-1"]
+    result = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(result) == ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_works_when_errors_is_absent(tmp_path: Path) -> None:
+    engine = await _make_sqlite_engine(tmp_path, "bulk_no_errors.sqlite3")
+    sessions = make_session_factory(engine)
+    store = PostgresDocumentMetadataStore(engine)
+    raw_doc = {
+        "identity": {"document_name": "doc-1.pdf", "document_uid": "doc-1", "title": "doc-1"},
+        "source": {"source_type": "push", "source_tag": "fred"},
+        "processing": {"stages": {"raw": "done"}},  # no "errors" key
+    }
+    await _insert_raw_row(sessions, document_uid="doc-1", source_tag="fred", doc=raw_doc)
+
+    updated = await store.bulk_mark_vector_done("fred", ["doc-1"])
+
+    assert updated == ["doc-1"]
+    result = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(result) == ProcessingStatus.DONE
+    assert result.processing.stages[ProcessingStage.RAW_AVAILABLE] == ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_rolls_back_everything_when_one_uid_is_absent(tmp_path: Path) -> None:
+    """A document_uid absent from the table entirely (never existed, or a typo
+    in the caller's scan result) must fail the WHOLE batch -- including the
+    other, genuinely valid uids in the same call -- rather than silently
+    repairing a partial set."""
+    engine = await _make_sqlite_engine(tmp_path, "bulk_missing_uid.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    await store.save_metadata(_doc("doc-1"))
+
+    with pytest.raises(RuntimeError, match="not found under source_tag"):
+        await store.bulk_mark_vector_done("fred", ["doc-1", "doc-does-not-exist"])
+
+    # doc-1 would have matched on its own -- it must still be untouched.
+    result = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(result) != ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_rolls_back_everything_when_a_uid_source_tag_no_longer_matches(tmp_path: Path) -> None:
+    """A document whose `source_tag` changed between the caller's earlier scan
+    and this write (e.g. re-tagged mid-repair) is out of scope -- and, same as
+    the absent-uid case, must fail the whole batch rather than silently
+    excluding just that one uid."""
+    engine = await _make_sqlite_engine(tmp_path, "bulk_retagged.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    await store.save_metadata(_doc("doc-1", source_tag="fred"))
+    await store.save_metadata(_doc("doc-2", source_tag="some-other-tag"))
+
+    with pytest.raises(RuntimeError, match="not found under source_tag"):
+        await store.bulk_mark_vector_done("fred", ["doc-1", "doc-2"])
+
+    result = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(result) != ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_retry_converges_to_the_same_final_state(tmp_path: Path) -> None:
+    engine = await _make_sqlite_engine(tmp_path, "bulk_retry.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    await store.save_metadata(_doc("doc-1"))
+
+    first = await store.bulk_mark_vector_done("fred", ["doc-1"])
+    after_first = await store.get_metadata_by_uid("doc-1")
+
+    second = await store.bulk_mark_vector_done("fred", ["doc-1"])
+    after_second = await store.get_metadata_by_uid("doc-1")
+
+    assert first == second == ["doc-1"]
+    assert after_first.model_dump(mode="json") == after_second.model_dump(mode="json")
+    assert _vector_stage(after_second) == ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_returns_empty_list_and_touches_nothing_for_empty_input(tmp_path: Path) -> None:
+    engine = await _make_sqlite_engine(tmp_path, "bulk_empty.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    await store.save_metadata(_doc("doc-1"))
+
+    result = await store.bulk_mark_vector_done("fred", [])
+
+    assert result == []
+    after = await store.get_metadata_by_uid("doc-1")
+    assert _vector_stage(after) != ProcessingStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_bulk_mark_vector_done_deduplicates_repeated_uids_in_the_input(tmp_path: Path) -> None:
+    engine = await _make_sqlite_engine(tmp_path, "bulk_dedup.sqlite3")
+    store = PostgresDocumentMetadataStore(engine)
+    await store.save_metadata(_doc("doc-1"))
+
+    updated = await store.bulk_mark_vector_done("fred", ["doc-1", "doc-1", "doc-1"])
+
+    assert updated == ["doc-1"]


### PR DESCRIPTION
## Summary

Fixes #2234 — migrated documents stay "En attente" although their vectors/content already exist.

- New dedicated backend action ("3a — Réparer uniquement"): one Temporal parent workflow, a
  constant handful of bulk activities (never one per document, never a child workflow), fail-closed
  scans (source_tag → Postgres, strict OpenSearch composite scan, strict content-store scan) before
  the single bulk Postgres write. Structurally never touches the embedder, never constructs an
  `OpenSearchVectorStoreAdapter`, never deletes/re-embeds vectors or content.
- `POST /knowledge-flow/v1/corpus/repair-vector-metadata`, gated on `CAN_MANAGE_PLATFORM` +
  team membership, input validated (strip/reject empty `source_tag`/`team_id`).
- `bulk_mark_vector_done` (fred-core): atomic, source_tag-scoped, postcondition-checked update of
  exactly `processing.stages.vector`/`processing.errors.vector`.
- Frontend: 3a wired to the new endpoint (never calls `/corpus/revectorize`), structured repair
  report surfaced on `/admin/tasks`, plus a fix for API errors rendering as literal `"[object
  Object]"` on this page.
- 3b (real re-vectorization) and normal ingestion are unchanged.
- Companion read-only diagnostics: `kea_reconcile_scan.py` and the `seed-synthetic-corpus` skill,
  for testing this against a local synthetic corpus without touching real data.

## Test plan

- [ ] Manual test against a local synthetic corpus (seed → reset `vector` stage → run 3a → verify
      report on `/admin/tasks` → re-run, confirm idempotent)
- [ ] `make code-quality` / `make test` (knowledge-flow-backend, fred-core, frontend)
- [ ] Review with Simon before merge