### PR TITLE
fix: folder tag id summarized as a document (403) + one failed parallel tool call no longer discards the final answer (#2244)

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -349,8 +349,11 @@ export default function ManagedChatPage() {
             </div>
           )}
           {/* Session title bar — full-width surface; the inner row is capped to
-              the composer field width so title and composer stay aligned. */}
-          <div className={styles.topBar}>
+              the composer field width so title and composer stay aligned.
+              data-picker-top-boundary: the composer's anchored pickers
+              (usePickerMenuMaxHeight) stop just below this bar instead of
+              sliding under it. */}
+          <div className={styles.topBar} data-picker-top-boundary>
             <div className={styles.topBarInner}>
               <div className={styles.topBarTitle}>
                 {chat.sessionId && chat.sessionTitle != null && (

--- a/apps/frontend/src/rework/components/shared/molecules/MenuPopover/usePickerMenuMaxHeight.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/MenuPopover/usePickerMenuMaxHeight.ts
@@ -18,8 +18,15 @@
 // `pickerMenu` at `bottom: 0` that grows upward, so a tall list would overflow
 // past the top of the viewport without this clamp. Shared so every anchored
 // "dialog" row (capability-driven or not) gets the same behavior.
+//
+// A page can lower the top limit below the viewport edge by marking one element
+// with `data-picker-top-boundary` (e.g. the chat session title bar): the picker
+// then stops just below that element instead of sliding under it. Without a
+// marked element the viewport top stays the limit.
 
 import { type CSSProperties, type RefObject, useEffect, useState } from "react";
+
+export const PICKER_TOP_BOUNDARY_SELECTOR = "[data-picker-top-boundary]";
 
 const PICKER_VIEWPORT_MARGIN_PX = 16;
 const PICKER_MOBILE_MAX_HEIGHT_PX = 480;
@@ -39,14 +46,22 @@ export function usePickerMenuMaxHeight(
       const rect = wrapRef.current?.getBoundingClientRect();
       if (!rect) return;
 
+      const boundary = document.querySelector(PICKER_TOP_BOUNDARY_SELECTOR);
+      const topLimit = boundary ? Math.max(0, boundary.getBoundingClientRect().bottom) : 0;
       const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
       const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
       const heightCap = viewportWidth <= 720 ? PICKER_MOBILE_MAX_HEIGHT_PX : desktopMaxHeightPx;
-      const availableHeight = Math.floor(Math.min(rect.bottom, viewportHeight) - PICKER_VIEWPORT_MARGIN_PX);
+      const availableHeight = Math.floor(Math.min(rect.bottom, viewportHeight) - topLimit - PICKER_VIEWPORT_MARGIN_PX);
       setMaxHeight(Math.min(heightCap, Math.max(PICKER_MIN_HEIGHT_PX, availableHeight)));
     };
 
     update();
+
+    // The boundary's height can change while the picker is open (the session
+    // title appears once the first answer names the conversation).
+    const boundary = document.querySelector(PICKER_TOP_BOUNDARY_SELECTOR);
+    const boundaryObserver = boundary ? new ResizeObserver(update) : null;
+    if (boundary && boundaryObserver) boundaryObserver.observe(boundary);
 
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);
@@ -54,6 +69,7 @@ export function usePickerMenuMaxHeight(
     window.visualViewport?.addEventListener("scroll", update);
 
     return () => {
+      boundaryObserver?.disconnect();
       window.removeEventListener("resize", update);
       window.removeEventListener("scroll", update, true);
       window.visualViewport?.removeEventListener("resize", update);

--- a/apps/frontend/src/rework/utils/traceUtils.test.ts
+++ b/apps/frontend/src/rework/utils/traceUtils.test.ts
@@ -721,6 +721,13 @@ describe("stripDocumentUids", () => {
   it("leaves text with no bracketed uid unchanged", () => {
     expect(stripDocumentUids("Sales\n  HR")).toBe("Sales\n  HR");
   });
+
+  it("strips folder tag ids rendered as [folder:tag-id] (issue #2244)", () => {
+    const tree = ["docs [folder:8e0927eb-3650-4696-a21c-47e78d48f54f]/", "  report.pdf [doc-1] (2026-01-01)"].join(
+      "\n",
+    );
+    expect(stripDocumentUids(tree)).toBe(["docs/", "  report.pdf (2026-01-01)"].join("\n"));
+  });
 });
 
 describe("toolCopyText", () => {

--- a/apps/frontend/src/rework/utils/traceUtils.ts
+++ b/apps/frontend/src/rework/utils/traceUtils.ts
@@ -312,11 +312,12 @@ export function isDocumentTreeTool(name: string): boolean {
   return name === "list_document_tree";
 }
 
-/** Strips list_document_tree's bracketed internal document uids before display —
+/** Strips list_document_tree's bracketed internal ids before display — document
+ *  uids on leaves and `[folder:tag-id]` ids on folder lines (issue #2244) —
  *  same "never show this id to the user" rule the tool's docstring imposes on the
  *  model's own answers (identifier hygiene, shared with summarize_document). */
 export function stripDocumentUids(tree: string): string {
-  return tree.replace(/\s*\[[\w-]+\]/g, "");
+  return tree.replace(/\s*\[[\w:-]+\]/g, "");
 }
 
 /** Curated {action, status, latency} payload for tool results with no recognized richer shape. */

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/tree/tree_builder.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/tree/tree_builder.py
@@ -29,7 +29,10 @@ Fred rationale:
 - The bracketed ids in the rendering (tag ids on folders, document uids on
   leaves) are internal working identifiers for the agent's own tool calls
   (e.g. summarize by uid). They are agent-facing only — agents are instructed
-  never to repeat them to the end user.
+  never to repeat them to the end user. Folder ids carry a ``folder:`` prefix
+  so a model cannot mistake them for document uids (issue #2244); leaf uids
+  stay bare because they are the value passed verbatim to summarize/search
+  tools.
 """
 
 from __future__ import annotations
@@ -123,10 +126,16 @@ def _format_leaf(doc: DocLeaf) -> str:
 
 
 def _format_folder(node: TreeNode) -> str:
-    """Folder line: ``name/`` for synthetic grouping nodes, ``name [tag_id]/``
-    for real tags -- the id is what a caller passes back as a tag filter."""
+    """Folder line: ``name/`` for synthetic grouping nodes, ``name [folder:tag_id]/``
+    for real tags -- the id is what a caller passes back as a tag filter.
+
+    The ``folder:`` prefix is load-bearing: without it, folder lines look
+    exactly like document leaves (``name [uid] (uploaded ...)``) and models
+    pass the folder's tag id to ``summarize_document`` as a ``document_uid``,
+    which 403s (observed live, issue #2244). The prefix keeps the id available
+    for tag filters while making it unmistakably not-a-document-uid."""
     if node.tag_id:
-        return f"{node.name} [{node.tag_id}]/"
+        return f"{node.name} [folder:{node.tag_id}]/"
     return f"{node.name}/"
 
 

--- a/apps/knowledge-flow-backend/tests/features/test_tree_builder.py
+++ b/apps/knowledge-flow-backend/tests/features/test_tree_builder.py
@@ -49,15 +49,21 @@ def test_leaf_includes_document_uid_so_callers_can_target_other_tools():
 
 def test_folder_renders_its_tag_id_so_callers_can_filter_on_it():
     """The folder line must expose the tag id -- it's what an agent passes back as
-    a document_library_tags_ids / tag_ids filter to scope a search to that folder."""
+    a document_library_tags_ids / tag_ids filter to scope a search to that folder.
+    The 'folder:' prefix keeps it distinguishable from a document uid: without it,
+    models pass the folder id to summarize_document and 403 (issue #2244)."""
     folders = [("Sales", ["doc-1"], "tag-sales"), ("Sales/HR", ["doc-2"], "tag-hr")]
     leaves = {"doc-1": ("Overview.pdf", None), "doc-2": ("Onboarding.pdf", None)}
 
     root = build_tree(folders=folders, leaves_by_uid=leaves)
     text, _ = render_tree(root, max_chars=10_000)
 
-    assert "Sales [tag-sales]/" in text
-    assert "HR [tag-hr]/" in text
+    assert "Sales [folder:tag-sales]/" in text
+    assert "HR [folder:tag-hr]/" in text
+    # The bare-bracket form is exactly the ambiguity that made a model
+    # summarize a folder -- it must not come back.
+    assert "[tag-sales]" not in text
+    assert "[tag-hr]" not in text
 
 
 def test_synthetic_parent_folder_has_no_tag_id():
@@ -71,7 +77,7 @@ def test_synthetic_parent_folder_has_no_tag_id():
 
     assert "Sales/" in text
     assert "Sales [" not in text
-    assert "HR [tag-hr]/" in text
+    assert "HR [folder:tag-hr]/" in text
 
 
 def test_folders_without_tag_id_stay_backward_compatible():

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -2462,6 +2462,45 @@ persisted before this fix.
 
 ---
 
+### 8.42 ✅ Tool error claims the final response only when the whole round failed (issue #2244, 2026-08-05)
+
+**Refines §8.27's runtime half.** Since the v2 loop shipped, any
+`is_error=True` tool result made the ReAct stream surface that error text
+verbatim as the `FinalRuntimeEvent` content and discard the LLM's own
+synthesis ("the LLM is NOT trusted to relay it", `react_runtime.py`).
+Observed live (mistral-small, 2026-08-05): a "summarize all my docs" turn
+made six parallel `summarize_document` calls — five succeeded, one 403'd
+(the model had passed a folder's tag id from `list_document_tree` as a
+`document_uid`) — and the user got only the raw 403 text while five good
+summaries were thrown away. This also actively contradicted §8.27's
+tool-failure-recovery prompt suffix, which instructs the model to answer
+from what succeeded: the model complied, and the runtime then discarded
+that answer.
+
+**New policy** (`react_runtime.py`, `round_had_tool_success`): an error
+claims the final response only while no tool call of the same round (the
+batch requested by one tool-calling `AIMessage`) has succeeded. Any
+success — a parallel sibling arriving before or after the error, or a
+later round's recovery retry — revokes the claim and restores the LLM's
+synthesis as the final response; the failed call itself still reports
+`is_error=True` in the trace. A wholly-failed round keeps the pre-existing
+guarantee: the error text is the final response and assistant deltas stay
+suppressed. A success in an *earlier* round does not shield a later
+wholly-failed round — each round is judged on its own results.
+
+**Companion fixes in the same change (issue #2244):** Knowledge Flow's
+tree rendering now prefixes folder tag ids (`name [folder:tag-id]/`,
+`tree_builder.py`) so they are no longer visually identical to document
+uids; `list_document_tree`'s docstring warns folder ids are never
+`document_uid`s; `summarize_document`'s 403/404 recovery hint covers the
+folder-id cause; the frontend's `stripDocumentUids` redaction also strips
+the `folder:` form. Regression tests:
+`test_react_tool_error_final_2244.py` (all four round shapes),
+`test_tree_builder.py`, `test_capability_document_summarize.py`,
+`traceUtils.test.ts`.
+
+---
+
 ## 8. Developer CLI — `fred-agents-cli`
 
 > **Platform convention:** every Fred backend exposes `make cli`.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -186,6 +186,13 @@ sibling. Uses the profile-menu token set (`--surface-container-*`, `--on-surface
   `groups` entry; a `pickerSurface` className adds internal scroll for tall content. Applied to
   `ComposerControlSlot` (prompt library) and `DocumentScopeControl` (document/library picker).
 
+- **Pickers stop below the session top bar (2026-08-05, #2245)** — `usePickerMenuMaxHeight`
+  clamped the upward-growing pickers against the viewport top, so once the session top bar
+  landed (#2214/#2218) an expanded document tree slid under it and got clipped. The hook now
+  honors an optional boundary element marked `data-picker-top-boundary` (measured from its
+  bottom edge, tracked with a `ResizeObserver` while open); `ManagedChatPage` marks its
+  `.topBar`. Pages without a marked boundary keep the viewport-top clamp.
+
 ---
 
 ### `SearchConfig`

--- a/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
@@ -661,7 +661,11 @@ class DocumentAccessCapability(
 
             Documents are rendered as "name [document_uid] (uploaded date)" —
             use that uid as the `document_uid` argument to summarize_document.
-            The bracketed identifiers are internal working ids for YOUR tool
+            Folder lines end with "/" and are rendered as "name [folder:id]/":
+            a folder id is NOT a document_uid — never pass it to
+            summarize_document (the call will fail). To summarize a folder's
+            content, summarize each document leaf under it instead. The
+            bracketed identifiers are internal working ids for YOUR tool
             calls only: NEVER repeat them in your answer to the user — always
             refer to documents by their display name.
 

--- a/libs/fred-runtime/fred_runtime/capabilities/document_summarize/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_summarize/capability.py
@@ -286,19 +286,27 @@ class DocumentSummarizeCapability(
                     elapsed_s=time.monotonic() - started,
                     document_uid=document_uid,
                 )
-                # 403/404 almost always means the model passed a file NAME (or
-                # a stale/foreign uid) — the backend fails closed on unknown
-                # resources. Tell the model how to recover instead of letting
-                # it give up and echo the error.
+                # 403/404 almost always means the model passed something that
+                # is not a document uid — a file NAME, a stale/foreign uid, or
+                # a FOLDER's tag id from a list_document_tree folder line
+                # (observed live, issue #2244) — the backend fails closed on
+                # unknown resources. Tell the model how to recover instead of
+                # letting it give up and echo the error.
                 if getattr(exc, "status_code", None) in (403, 404):
                     message += (
-                        " If you passed a file name, that is the likely cause: "
-                        "document_uid must be the opaque uid. Find it in the "
-                        "conversation's attached-files list (the bracketed "
-                        "value after the file name), in a search hit's 'uid' "
-                        "field, or via list_document_tree — then call "
-                        "summarize_document again with that uid. Do not "
-                        "repeat the uid to the user."
+                        " Likely cause: document_uid was not a document's "
+                        "opaque uid. If you passed a file name, resolve the "
+                        "uid first: it is in the conversation's attached-files "
+                        "list (the bracketed value after the file name), in a "
+                        "search hit's 'uid' field, or on a DOCUMENT line of "
+                        "list_document_tree. If you took the id from a FOLDER "
+                        "line (it ends with '/', id shown as [folder:...]), "
+                        "that is a folder id, not a document — summarize each "
+                        "document listed under that folder instead. Then call "
+                        "summarize_document again with a real document uid; "
+                        "if other documents already summarized fine, continue "
+                        "with those results. Do not repeat the uid to the "
+                        "user."
                     )
                     # CAPAB-02: `_document_tool_failure` already baked the
                     # (shorter) pre-hint message into `artifact.blocks`; the

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -346,11 +346,25 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         # last-write-wins variable silently undercounted any multi-call turn).
         total_token_usage: dict[str, int] | None = None
         last_finish_reason: str | None = None
-        # When any tool returns is_error=True, the error is surfaced directly as
-        # the final response.  The LLM is NOT trusted to relay it: its subsequent
-        # turn is consumed but discarded, and its streaming deltas are suppressed.
+        # When a whole round of tool calls fails (every call errored, no
+        # success anywhere in the batch), the error is surfaced directly as the
+        # final response. The LLM is NOT trusted to relay a bare failure: its
+        # subsequent turn is consumed but discarded, and its streaming deltas
+        # are suppressed. But a PARTIAL failure — some calls of the round
+        # succeeded, or a later call recovered — hands the turn back to the
+        # LLM: it has real results to synthesize, and discarding them for one
+        # failed sibling call threw away 5/6 good summaries live (issue #2244;
+        # also contradicted the §8.27 tool-failure-recovery prompt suffix that
+        # tells the model to answer from what succeeded).
         last_tool_error: str | None = None
         suppress_assistant_deltas: bool = False
+        # Tracks whether the current round (the batch of tool calls requested
+        # by the latest AIMessage) has produced at least one successful result.
+        # Reset on every new tool-calling AIMessage; parallel results within a
+        # round arrive in arbitrary order, so an error only claims the final
+        # response while no sibling has succeeded, and any success revokes a
+        # claim an earlier-arriving error already made.
+        round_had_tool_success: bool = False
         # Maps tool call_id → thought_id so THOUGHT_END can close the block
         # opened by THOUGHT_START before the corresponding TOOL_CALL event.
         active_thought_ids: dict[str, str] = {}
@@ -454,16 +468,31 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                         )
                         is_error = artifact.is_error if artifact is not None else False
                         if is_error:
-                            # Strip the "Tool error:\n" prefix added for the LLM's
-                            # benefit — the user-facing message should be clean.
-                            raw = _stringify_content(message.content)
-                            last_tool_error = raw.removeprefix("Tool error:\n")
-                            suppress_assistant_deltas = True
-                            logger.debug(
-                                "[V2][REACT] tool error intercepted tool=%s — "
-                                "suppressing LLM turn, surfacing error directly",
-                                message.name,
-                            )
+                            if not round_had_tool_success:
+                                # Strip the "Tool error:\n" prefix added for the LLM's
+                                # benefit — the user-facing message should be clean.
+                                raw = _stringify_content(message.content)
+                                last_tool_error = raw.removeprefix("Tool error:\n")
+                                suppress_assistant_deltas = True
+                                logger.debug(
+                                    "[V2][REACT] tool error intercepted tool=%s — "
+                                    "suppressing LLM turn, surfacing error directly",
+                                    message.name,
+                                )
+                        else:
+                            round_had_tool_success = True
+                            if last_tool_error is not None:
+                                # A sibling (or later round's) call succeeded:
+                                # the turn is a partial failure, not a dead
+                                # end — the LLM's synthesis is the final
+                                # answer again, with the error visible to it
+                                # as an ordinary tool result.
+                                last_tool_error = None
+                                suppress_assistant_deltas = False
+                                logger.debug(
+                                    "[V2][REACT] tool success after error — "
+                                    "restoring LLM synthesis as final response",
+                                )
                         thought_id = active_thought_ids.pop(message.tool_call_id, None)
                         thought_started_at = active_thought_started_at.pop(
                             message.tool_call_id, None
@@ -495,6 +524,12 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                         continue
 
                     if isinstance(message, AIMessage) and message.tool_calls:
+                        # A new round of tool calls begins: its outcome is
+                        # judged on its own results. A prior round's error
+                        # stays claimed (sticky) until one of THIS round's
+                        # calls succeeds — success anywhere hands the final
+                        # response back to the LLM's synthesis.
+                        round_had_tool_success = False
                         # The usage of the model call that decided to make these
                         # tool calls — attached per-call to ToolCallRuntimeEvent
                         # (TRACE-01) so the trace UI can show tokens per step,

--- a/libs/fred-runtime/tests/test_capability_document_summarize.py
+++ b/libs/fred-runtime/tests/test_capability_document_summarize.py
@@ -309,6 +309,11 @@ async def test_summarize_403_failure_teaches_uid_recovery() -> None:
     assert message.artifact.is_error is True
     assert "opaque uid" in message.content
     assert "list_document_tree" in message.content
+    # Issue #2244: the other live-observed 403 cause is a FOLDER tag id taken
+    # from a tree folder line — the hint must cover it so the model summarizes
+    # the folder's documents instead of retrying the same bad id.
+    assert "[folder:...]" in message.content
+    assert "summarize each document" in message.content
     # CAPAB-02: the recovery hint is appended to `message` AFTER
     # `_document_tool_failure` already built the artifact — it must also
     # land in `blocks`, or a Graph agent (which keeps only the artifact)

--- a/libs/fred-runtime/tests/test_react_tool_error_final_2244.py
+++ b/libs/fred-runtime/tests/test_react_tool_error_final_2244.py
@@ -1,0 +1,261 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Regression tests for the tool-error final-response policy (issue #2244).
+
+Why this exists:
+- the ReAct stream loop surfaces an `is_error=True` tool result verbatim as
+  the final response and discards the LLM's own synthesis ("the LLM is NOT
+  trusted to relay it"). That is right when the whole round of tool calls
+  failed — but observed live, one 403 out of six parallel summarize calls
+  (a folder tag id mistaken for a document uid) threw away five successful
+  summaries and showed the user only the raw error text.
+- policy under test: an error claims the final response only while no call
+  of the same round has succeeded; any success — a parallel sibling or a
+  later round's recovery — hands the final response back to the LLM's
+  synthesis, with the error still visible to it as an ordinary tool result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from fred_runtime.react.react_runtime import _TransportBackedReActExecutor
+from fred_sdk.contracts.context import (
+    ToolContentBlock,
+    ToolContentKind,
+    ToolInvocationResult,
+)
+from fred_sdk.contracts.react_contract import ReActInput, ReActMessage, ReActMessageRole
+from fred_sdk.contracts.runtime import (
+    ExecutionConfig,
+    FinalRuntimeEvent,
+    ToolResultRuntimeEvent,
+)
+from langchain_core.messages import AIMessage, ToolMessage
+
+
+class _FakePortable:
+    agent_id = "agent-1"
+    session_id = "sess-1"
+    team_id = "personal"
+    baggage: dict[str, object] = {}
+
+
+class _FakeRuntimeContext:
+    pass
+
+
+class _FakeBinding:
+    portable_context = _FakePortable()
+    runtime_context = _FakeRuntimeContext()
+
+
+class _FakeServices:
+    tracer = None
+    metrics = None
+
+
+class _FakeCompiledAgent:
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+
+    async def astream(
+        self,
+        graph_input: object,
+        *,
+        config: object = None,
+        stream_mode: object = None,
+    ) -> AsyncIterator[object]:
+        for event in self._events:
+            yield event
+
+
+async def _run_stream(events: list[object]) -> list[object]:
+    executor = _TransportBackedReActExecutor(
+        compiled_agent=_FakeCompiledAgent(events),  # type: ignore[arg-type]
+        binding=_FakeBinding(),  # type: ignore[arg-type]
+        services=_FakeServices(),  # type: ignore[arg-type]
+    )
+    input_model = ReActInput(
+        messages=(ReActMessage(role=ReActMessageRole.USER, content="hi"),)
+    )
+    collected: list[object] = []
+    async for event in executor.stream(input_model, ExecutionConfig()):
+        collected.append(event)
+    return collected
+
+
+def _tool_calls_message(*call_ids: str) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {"id": call_id, "name": "summarize_document", "args": {}}
+            for call_id in call_ids
+        ],
+    )
+
+
+def _error_result(call_id: str, text: str) -> ToolMessage:
+    return ToolMessage(
+        content=f"Tool error:\n{text}",
+        tool_call_id=call_id,
+        name="summarize_document",
+        artifact=ToolInvocationResult(
+            tool_ref="summarize_document",
+            is_error=True,
+            blocks=(ToolContentBlock(kind=ToolContentKind.TEXT, text=text),),
+        ),
+    )
+
+
+def _ok_result(call_id: str, text: str) -> ToolMessage:
+    return ToolMessage(
+        content=text,
+        tool_call_id=call_id,
+        name="summarize_document",
+        artifact=ToolInvocationResult(
+            tool_ref="summarize_document",
+            blocks=(ToolContentBlock(kind=ToolContentKind.TEXT, text=text),),
+        ),
+    )
+
+
+def _final(collected: list[object]) -> FinalRuntimeEvent:
+    finals = [e for e in collected if isinstance(e, FinalRuntimeEvent)]
+    assert len(finals) == 1
+    return finals[0]
+
+
+@pytest.mark.asyncio
+async def test_partial_round_failure_keeps_llm_synthesis_as_final() -> None:
+    """The live #2244 shape: parallel batch, the error arrives BEFORE the
+    successes — one failure must not discard the successful siblings'
+    synthesis."""
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_calls_message("c1", "c2", "c3")]}}),
+        (
+            "updates",
+            {
+                "tools": {
+                    "messages": [
+                        _error_result("c1", "403 on folder id"),
+                        _ok_result("c2", "summary two"),
+                        _ok_result("c3", "summary three"),
+                    ]
+                }
+            },
+        ),
+        ("updates", {"agent": {"messages": [AIMessage(content="Voici la synthèse.")]}}),
+    ]
+
+    collected = await _run_stream(events)
+
+    assert _final(collected).content == "Voici la synthèse."
+    # The failed call is still reported as failed in the trace — restoring the
+    # synthesis must not repaint the error result as ok.
+    errored = [
+        e
+        for e in collected
+        if isinstance(e, ToolResultRuntimeEvent) and e.call_id == "c1"
+    ]
+    assert errored and errored[0].is_error is True
+
+
+@pytest.mark.asyncio
+async def test_partial_round_failure_error_after_success_keeps_synthesis() -> None:
+    """Parallel results arrive in arbitrary order: an error landing AFTER a
+    successful sibling must not claim the final response either."""
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_calls_message("c1", "c2")]}}),
+        (
+            "updates",
+            {
+                "tools": {
+                    "messages": [
+                        _ok_result("c1", "summary one"),
+                        _error_result("c2", "403 on folder id"),
+                    ]
+                }
+            },
+        ),
+        ("updates", {"agent": {"messages": [AIMessage(content="Voici la synthèse.")]}}),
+    ]
+
+    collected = await _run_stream(events)
+
+    assert _final(collected).content == "Voici la synthèse."
+
+
+@pytest.mark.asyncio
+async def test_wholly_failed_round_still_surfaces_error_as_final() -> None:
+    """The pre-#2244 guarantee stays: when every call of the round failed, the
+    LLM is not trusted to relay the failure — the error text IS the final
+    response (with the LLM-facing "Tool error:" prefix stripped)."""
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_calls_message("c1")]}}),
+        ("updates", {"tools": {"messages": [_error_result("c1", "403 Forbidden")]}}),
+        (
+            "updates",
+            {"agent": {"messages": [AIMessage(content="I could not do it, sorry!")]}},
+        ),
+    ]
+
+    collected = await _run_stream(events)
+
+    assert _final(collected).content == "403 Forbidden"
+
+
+@pytest.mark.asyncio
+async def test_error_then_recovery_in_later_round_restores_synthesis() -> None:
+    """A failed round followed by a successful retry (the recovery path the
+    §8.27 prompt suffix asks for) must end on the LLM's answer, not on the
+    stale first-round error."""
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_calls_message("c1")]}}),
+        ("updates", {"tools": {"messages": [_error_result("c1", "bad uid")]}}),
+        ("updates", {"agent": {"messages": [_tool_calls_message("c2")]}}),
+        ("updates", {"tools": {"messages": [_ok_result("c2", "summary")]}}),
+        (
+            "updates",
+            {"agent": {"messages": [AIMessage(content="Here is the summary.")]}},
+        ),
+    ]
+
+    collected = await _run_stream(events)
+
+    assert _final(collected).content == "Here is the summary."
+
+
+@pytest.mark.asyncio
+async def test_success_then_wholly_failed_round_surfaces_error() -> None:
+    """A success in an EARLIER round must not shield a later wholly-failed
+    round: each round's outcome is judged on its own results."""
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_calls_message("c1")]}}),
+        ("updates", {"tools": {"messages": [_ok_result("c1", "info")]}}),
+        ("updates", {"agent": {"messages": [_tool_calls_message("c2")]}}),
+        ("updates", {"tools": {"messages": [_error_result("c2", "boom")]}}),
+        ("updates", {"agent": {"messages": [AIMessage(content="babble")]}}),
+    ]
+
+    collected = await _run_stream(events)
+
+    assert _final(collected).content == "boom"


### PR DESCRIPTION
Fixes #2244.

## Problem (observed live, mistral-small, 2026-08-05)

« fais moi un gros résumé de mes docs » with 5 documents in one `docs` folder → the agent made **6** `summarize_document` calls (5 documents + the folder's tag id taken from `list_document_tree`'s `docs [8e0927eb-…]/` line). The folder call 403'd, and although the 5 real summaries succeeded, the runtime surfaced the raw 403 text as the final answer and discarded the model's synthesis.

## Fixes (one commit each)

1. **knowledge-flow** — folder lines render as `name [folder:tag-id]/` so a folder id is unmistakably not a document uid. The id stays exposed: the legacy MCP vector-search path accepts `document_library_tags_ids` as an LLM argument.
2. **frontend** — `stripDocumentUids` also redacts the new `[folder:...]` form in the trace drawer.
3. **runtime capabilities** — `list_document_tree`'s docstring warns folder ids are never `document_uid`s; `summarize_document`'s 403/404 recovery hint covers the folder-id cause and tells the model to continue with sibling summaries that succeeded.
4. **ReAct runtime** — a tool error claims the final response **only when the whole round of tool calls failed**. Any success in the round (parallel sibling, either arrival order) or a later round's recovery restores the LLM's synthesis as the final answer; the failed call still shows `is_error` in the trace. A wholly-failed round keeps the pre-existing surface-the-error guarantee. This also removes the contradiction with the §8.27 tool-failure-recovery prompt suffix (the prompt told the model to answer from what succeeded; the runtime then discarded that answer). Documented as §8.42 in `RUNTIME-EXECUTION-CONTRACT.md`.

## Tests

- New `test_react_tool_error_final_2244.py` — 5 tests covering: partial failure error-first, partial failure error-last, wholly-failed round (regression guard), error-then-recovery, success-then-wholly-failed-round.
- Updated `test_tree_builder.py`, `test_capability_document_summarize.py`, `traceUtils.test.ts`.
- Root `make code-quality` passes (all modules). Full suites green: fred-runtime 781, knowledge-flow 765, frontend 1017.
- `fred-performance-reviewer` pass: runtime change is generator-local control flow — no I/O, no new metric, no shared state; only hot-path cost is ~4 docstring lines added to the tool schema per LLM request (negligible).