### PR TITLE
fix(frontend): reword reasoning capability hint in the agent form (#2262)

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2035,7 +2035,7 @@
           },
           "reasoning": {
             "label": "Reasoning",
-            "hint": "Give this agent's users a chat-composer button to turn the model's reasoning on, question by question. Requires a model that supports reasoning."
+            "hint": "Give this agent's users a chat-composer button to turn the model's reasoning on for the conversation. Requires a model that supports reasoning."
           },
           "reasoningDefaultOn": {
             "label": "Reasoning on by default",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2035,7 +2035,7 @@
           },
           "reasoning": {
             "label": "Reasoning",
-            "hint": "Let users turn the model's reasoning on for a single question, from the chat composer. Only appears when the model supports it and an administrator has enabled it."
+            "hint": "Give this agent's users a chat-composer button to turn the model's reasoning on, question by question. Requires a model that supports reasoning."
           },
           "reasoningDefaultOn": {
             "label": "Reasoning on by default",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2035,7 +2035,7 @@
           },
           "reasoning": {
             "label": "Raisonnement",
-            "hint": "Permet aux utilisateurs d'activer le raisonnement du modèle pour une seule question, depuis le composeur de chat. N'apparaît que si le modèle le supporte et qu'un administrateur l'a activé."
+            "hint": "Offre aux utilisateurs de cet agent un bouton dans le composeur de chat pour activer le raisonnement du modèle, question par question. Nécessite un modèle prenant en charge le raisonnement."
           },
           "reasoningDefaultOn": {
             "label": "Raisonnement activé par défaut",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2035,7 +2035,7 @@
           },
           "reasoning": {
             "label": "Raisonnement",
-            "hint": "Offre aux utilisateurs de cet agent un bouton dans le composeur de chat pour activer le raisonnement du modèle, question par question. Nécessite un modèle prenant en charge le raisonnement."
+            "hint": "Offre aux utilisateurs de cet agent un bouton dans le composeur de chat pour activer le raisonnement du modèle dans la conversation. Nécessite un modèle prenant en charge le raisonnement."
           },
           "reasoningDefaultOn": {
             "label": "Raisonnement activé par défaut",


### PR DESCRIPTION
Fixes #2262.

The Raisonnement capability hint in the agent create/edit form was written from the chat-composer viewpoint (« N'apparaît que si le modèle le supporte et qu'un administrateur l'a activé ») — confusing in the capability-selection context, where it reads as if it described the card's own visibility, and the admin clause is not actionable for the agent owner.

New wording (FR + EN), agent-creation perspective — the toggle is conversation-scoped (per-session composer setting in `useComposerSettings`), not per-question:

- FR : « Offre aux utilisateurs de cet agent un bouton dans le composeur de chat pour activer le raisonnement du modèle dans la conversation. Nécessite un modèle prenant en charge le raisonnement. »
- EN: "Give this agent's users a chat-composer button to turn the model's reasoning on for the conversation. Requires a model that supports reasoning."

Value-only i18n change (`rework.teams.formAgent.fields.reasoning.hint`, used solely by `AgentFormBody.tsx`); no key structure touched. Prettier clean.