### PR TITLE
fix(knowledge-flow): drop unpaired UTF-16 surrogates from PDF extraction (#2261)

### DIFF
--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/lightweight_markdown_processor/lite2_pdf_to_md_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/lightweight_markdown_processor/lite2_pdf_to_md_processor.py
@@ -32,6 +32,7 @@ from knowledge_flow_backend.core.processors.input.lightweight_markdown_processor
     collapse_whitespace,
     enforce_max_chars,
     normalize_repeated_chars,
+    strip_surrogates,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,7 @@ class LitePdfToMdExtractor(BaseLiteMdProcessor):
         converted = self._md.convert(str(file_path))
         # Pylance sometimes flags `.text`; guard with getattr for static peace of mind.
         md = converted.markdown
+        md = strip_surrogates(md)
         md = self._normalize_whitespace(md, opts)
 
         md, truncated = enforce_max_chars(md, opts.max_chars)
@@ -116,8 +118,11 @@ class LitePdfToMdExtractor(BaseLiteMdProcessor):
                 text = ""
                 page_no = -1
 
-            # Apply your normalization pipeline
-            md_text = self._normalize_repeated_chars(text, opts)
+            # Apply your normalization pipeline. strip_surrogates runs first and is not
+            # opt-gated: unpaired surrogates from a malformed ToUnicode CMap are not a
+            # style choice, they make the page impossible to encode as UTF-8 downstream.
+            md_text = strip_surrogates(text)
+            md_text = self._normalize_repeated_chars(md_text, opts)
             md_text = self._remove_additional_tags(md_text, opts)
             md_text = self._normalize_whitespace(md_text, opts)
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/lightweight_markdown_processor/lite_markdown_structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/lightweight_markdown_processor/lite_markdown_structures.py
@@ -95,3 +95,37 @@ def collapse_whitespace(text: str) -> str:
 def normalize_repeated_chars(text):
     # Replace "." character repeated three or more times with exactly three occurrences of that character
     return re.sub(r"(\.)\1{2,}", r"\1\1\1", text)
+
+
+_SURROGATE_RE = re.compile("[\ud800-\udfff]")
+
+
+def strip_surrogates(text: str) -> str:
+    """Make extracted text UTF-8 encodable by removing unpaired UTF-16 surrogates.
+
+    Fred rationale:
+    PyMuPDF builds text from a PDF's `ToUnicode` CMap, which is UTF-16BE. A malformed
+    CMap leaks unpaired surrogates (U+D800–U+DFFF) into the Python `str`. A `str` may
+    legally hold one, but UTF-8 cannot encode it — so ingestion dies at the first encode
+    boundary (writing `output.md`, JSON-serializing chunks for OpenSearch, or the
+    embedding HTTP call) with `UnicodeEncodeError`, and fails every Temporal retry
+    because the input is deterministic. Sanitizing here rather than at the file write
+    keeps the poisoned text out of the index and the embeddings too.
+
+    Two steps, in order:
+    1. A UTF-16 `surrogatepass` round-trip re-pairs surrogates the extractor failed to
+       combine, recovering the real character (emoji, CJK-ext glyph) instead of losing it.
+    2. Whatever is still a surrogate afterwards is genuinely unpaired and carries no
+       character to preserve, so it is dropped.
+
+    Cheap on the common path: the scan short-circuits before any allocation when the text
+    holds no surrogate at all, which is every well-formed document.
+    """
+    if not text or not _SURROGATE_RE.search(text):
+        return text
+    try:
+        text = text.encode("utf-16", "surrogatepass").decode("utf-16", "surrogatepass")
+    except UnicodeError:
+        # Malformed beyond re-pairing; the unconditional strip below still makes it safe.
+        pass
+    return _SURROGATE_RE.sub("", text)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pdf_markdown_processor/pymupdf_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/pdf_markdown_processor/pymupdf_processor.py
@@ -22,6 +22,7 @@ import pymupdf4llm
 from knowledge_flow_backend.core.processors.input.lightweight_markdown_processor.lite_markdown_structures import (
     collapse_whitespace,
     normalize_repeated_chars,
+    strip_surrogates,
 )
 from knowledge_flow_backend.core.processors.input.pdf_markdown_processor.base_pdf_extractor import BasePdfExtractor
 from knowledge_flow_backend.core.processors.input.pdf_markdown_processor.utils.image_transcription import ImageTranscription
@@ -58,7 +59,10 @@ class PyMuPdfExtractor(BasePdfExtractor):
             else:
                 text = ""
 
-            md_text = normalize_repeated_chars(text)
+            # Same PyMuPDF source as the lite path, so the same unpaired-surrogate hazard:
+            # strip before anything can try to encode this page as UTF-8.
+            md_text = strip_surrogates(text)
+            md_text = normalize_repeated_chars(md_text)
             md_text = collapse_whitespace(md_text)
             cleaned_pages.append(md_text)
 

--- a/apps/knowledge-flow-backend/tests/processors/input/lightweight_markdown_processor/test_lite2_pdf_to_md_processor.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/lightweight_markdown_processor/test_lite2_pdf_to_md_processor.py
@@ -23,6 +23,7 @@ that accumulates across ingestion batches until the worker pod OOMs.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -73,3 +74,55 @@ def test_processor_extract_file_metadata_closes_the_document(fitz_open_spy: Fitz
     assert metadata["page_count"] >= 1
     assert len(fitz_open_spy.opened) == 1
     assert fitz_open_spy.opened[0].is_closed
+
+
+# --- unpaired-surrogate regression (issue #2261) ------------------------------
+#
+# A malformed ToUnicode CMap makes PyMuPDF hand back text holding unpaired UTF-16
+# surrogates. Writing output.md then raised UnicodeEncodeError, and since the input
+# is deterministic the document failed all three Temporal attempts.
+
+LONE_SURROGATE = chr(0xDBFF)  # the code point reported in the issue
+
+
+def test_extract_pymupdf4llm_drops_unpaired_surrogates(sample_pdf_file: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.lightweight_markdown_processor.lite2_pdf_to_md_processor.pymupdf4llm.to_markdown",
+        lambda *a, **k: [{"text": f"AERS Sensor{LONE_SURROGATE} ICD", "metadata": {"page_number": 1}}],
+    )
+
+    result = LitePdfToMdExtractor().extract(sample_pdf_file)
+
+    assert result.markdown == "AERS Sensor ICD"
+    result.markdown.encode("utf-8")  # would raise before the fix
+
+
+def test_extract_with_markitdown_drops_unpaired_surrogates(sample_pdf_file: Path, monkeypatch: pytest.MonkeyPatch):
+    # Force the primary engine to fail so the markitdown fallback is exercised.
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.lightweight_markdown_processor.lite2_pdf_to_md_processor.pymupdf4llm.to_markdown",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    extractor = LitePdfToMdExtractor()
+    monkeypatch.setattr(
+        extractor._md,
+        "convert",
+        lambda *a, **k: SimpleNamespace(markdown=f"AERS Sensor{LONE_SURROGATE} ICD"),
+    )
+
+    result = extractor.extract(sample_pdf_file)
+
+    assert result.extras == {"engine": "markitdown"}
+    assert result.markdown == "AERS Sensor ICD"
+
+
+def test_convert_file_to_markdown_writes_output_for_surrogate_tainted_pdf(sample_pdf_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """End-to-end guard: this is the exact call that raised in production."""
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.lightweight_markdown_processor.lite2_pdf_to_md_processor.pymupdf4llm.to_markdown",
+        lambda *a, **k: [{"text": f"page one{LONE_SURROGATE}", "metadata": {"page_number": 1}}],
+    )
+
+    result = LitePdfMarkdownProcessor().convert_file_to_markdown(sample_pdf_file, tmp_path, "uid-2261")
+
+    assert Path(result["md_file"]).read_text(encoding="utf-8") == "page one"

--- a/apps/knowledge-flow-backend/tests/processors/input/lightweight_markdown_processor/test_lite_markdown_structures.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/lightweight_markdown_processor/test_lite_markdown_structures.py
@@ -1,0 +1,58 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for strip_surrogates (issue #2261).
+
+PyMuPDF reads text through a PDF's ToUnicode CMap, which is UTF-16BE. A malformed
+CMap leaks unpaired surrogates into the extracted str; a str may hold one, UTF-8
+cannot encode one, so ingestion used to die with UnicodeEncodeError on the first
+encode — and, the input being deterministic, on all three Temporal retries too.
+"""
+
+from knowledge_flow_backend.core.processors.input.lightweight_markdown_processor.lite_markdown_structures import (
+    strip_surrogates,
+)
+
+HIGH = chr(0xD83D)  # high surrogate of U+1F600 GRINNING FACE
+LOW = chr(0xDE00)  # low surrogate of U+1F600
+LONE = chr(0xDBFF)  # the exact code point reported in issue #2261
+
+
+def test_clean_text_is_returned_unchanged():
+    text = "# Title\n\nPlain ASCII, accents (éàü) and CJK (日本語) are all untouched."
+    assert strip_surrogates(text) is text
+
+
+def test_empty_text_is_returned_unchanged():
+    assert strip_surrogates("") == ""
+
+
+def test_lone_surrogate_is_dropped():
+    assert strip_surrogates(f"AERS Sensor{LONE} ICD") == "AERS Sensor ICD"
+
+
+def test_leaked_surrogate_pair_is_recombined_not_lost():
+    # The extractor failed to combine the pair; the real character is recoverable,
+    # so it must survive rather than be silently deleted with the broken ones.
+    assert strip_surrogates(f"emoji {HIGH}{LOW} here") == "emoji \U0001f600 here"
+
+
+def test_mixed_pair_and_lone_surrogates():
+    assert strip_surrogates(f"a{HIGH}{LOW}b{LONE}c") == "a\U0001f600bc"
+
+
+def test_result_is_always_utf8_encodable():
+    for raw in (f"x{LONE}y", f"{LOW}{HIGH}", HIGH, LOW, f"{HIGH}{LOW}{LONE}"):
+        # The assertion is that this does not raise UnicodeEncodeError.
+        strip_surrogates(raw).encode("utf-8")

--- a/apps/knowledge-flow-backend/tests/processors/input/pdf_markdown_processor/test_pymupdf_processor.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/pdf_markdown_processor/test_pymupdf_processor.py
@@ -69,3 +69,21 @@ def test_extract_closes_the_document_even_on_failure(fitz_open_spy: list, sample
 
     assert len(fitz_open_spy) == 1
     assert fitz_open_spy[0].is_closed
+
+
+def test_extract_drops_unpaired_surrogates(sample_pdf_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Regression for issue #2261.
+
+    A malformed ToUnicode CMap makes PyMuPDF return text holding unpaired UTF-16
+    surrogates, which UTF-8 cannot encode — the medium/rich profile writes the same
+    output.md as the lite path, so it carries the same hazard.
+    """
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.pdf_markdown_processor.pymupdf_processor.pymupdf4llm.to_markdown",
+        lambda *a, **k: [{"text": "AERS Sensor" + chr(0xDBFF) + " ICD", "metadata": {"page_number": 1}}],
+    )
+
+    md_text, _images = PyMuPdfExtractor().extract(sample_pdf_file, str(tmp_path))
+
+    assert md_text == "AERS Sensor ICD"
+    md_text.encode("utf-8")  # would raise before the fix


### PR DESCRIPTION
Closes #2261.

## Problem

Ingesting `AERS Sensor Software Integration ICD v1.0 REV- D.pdf` failed on all three
Temporal attempts:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udbff' in position 45507: surrogates not allowed
  File ".../lite2_pdf_to_md_processor.py", in convert_file_to_markdown
    output_markdown_path.write_text(markdown, encoding="utf-8")
```

PyMuPDF reads text through the PDF's `ToUnicode` CMap, which is UTF-16BE. When that CMap
is malformed, unpaired surrogates (`U+D800`–`U+DFFF`) leak into the extracted `str`. A
`str` may legally hold one; UTF-8 **cannot encode one**. So it blew up at the first encode
boundary, and since the input is deterministic, every retry failed identically.

## Fix

New shared `strip_surrogates()` in `lite_markdown_structures.py` — already the common
normalization module for both PDF paths:

1. A UTF-16 `surrogatepass` round-trip **re-pairs** surrogates the extractor failed to
   combine, so a genuine astral character (emoji, CJK-ext glyph) is recovered rather than
   silently deleted.
2. Whatever is still a surrogate afterwards is truly unpaired and carries no character, so
   it is dropped.

Applied at **extraction**, not at the file write, and deliberately not opt-gated. Fixing
only `write_text` would leave the same poisoned text to break JSON serialization for
OpenSearch and the embedding HTTP call further down the pipeline.

Both PyMuPDF-backed paths carry the identical hazard, so both are covered:

| Path | Profile | Status |
| --- | --- | --- |
| `LitePdfToMdExtractor` (`lite2_pdf_to_md_processor.py`) | `fast` | fixed (the reported traceback) |
| `PyMuPdfExtractor` (`pymupdf_processor.py`) | `medium` / `rich` | fixed (same latent bug) |

The markitdown fallback inside the lite path is sanitized too.

## Performance

The scan short-circuits before any allocation when the text holds no surrogate — i.e. on
every well-formed document, the added cost is one `re.search` per page, against a page
that PyMuPDF has just parsed. No behaviour change on clean input.

## Tests

`tests/.../test_lite_markdown_structures.py` (new) covers the helper: clean text returned
unchanged (identity), lone surrogate dropped, leaked pair recombined into the real
character, and the result always UTF-8 encodable.

End-to-end regressions added to both processor test files, including one that drives the
exact call that raised in production (`convert_file_to_markdown` → `output.md`).

Verified these are genuine regression tests: with the source fix reverted, all four fail
and reproduce the original error verbatim —
`InputConversionError: ... 'utf-8' codec can't encode character '\udbff'`.

- `make code-quality` (monorepo root): all modules pass
- `make test` (knowledge-flow-backend): 821 passed
