### PR TITLE
feat(migration): persistent, non-dismissable, full-width banner on every page

### DIFF
--- a/agentic-backend/agentic_backend/common/structures.py
+++ b/agentic-backend/agentic_backend/common/structures.py
@@ -385,7 +385,7 @@ class UploadWarning(BaseModel):
     )
 
 
-class MigrationBannerLink(BaseModel):
+class InfoBannerLink(BaseModel):
     url: str = Field(description="Link target URL.")
     labels: Dict[str, str] = Field(
         default_factory=dict,
@@ -393,7 +393,7 @@ class MigrationBannerLink(BaseModel):
     )
 
 
-class MigrationBanner(BaseModel):
+class InfoBanner(BaseModel):
     color: str = Field(
         default="#00BBDD",
         description="Banner background CSS color.",
@@ -406,7 +406,7 @@ class MigrationBanner(BaseModel):
         default_factory=dict,
         description='Locale → message map (e.g. {"en": "...", "fr": "..."}).',
     )
-    links: List[MigrationBannerLink] = Field(
+    links: List[InfoBannerLink] = Field(
         default_factory=list,
         description="Links rendered on the right side of the banner.",
     )
@@ -449,9 +449,9 @@ class Properties(BaseModel):
         default=None,
         description="Optional alert shown in the document upload drawer. Omit to show nothing.",
     )
-    migrationBanner: Optional[MigrationBanner] = Field(
+    infoBanner: Optional[InfoBanner] = Field(
         default=None,
-        description="Optional new-version banner overlaid on the page content. Omit to show nothing.",
+        description="Optional informative banner shown above the app content. Omit to show nothing.",
     )
 
 

--- a/agentic-backend/config/configuration.yaml
+++ b/agentic-backend/config/configuration.yaml
@@ -60,23 +60,19 @@ frontend_settings:
   properties:
     logoName: "fred"
     siteDisplayName: "Fred"
-    migrationBanner:
-      color: "#00BBDD"
-      titles:
-        en: "New version available"
-        fr: "Nouvelle version disponible"
-      messages:
-        en: "Fred has a new home."
-        fr: "Fred a une nouvelle adresse."
-      links:
-        - url: "https://fred.example.com"
-          labels:
-            en: "Go to new Fred"
-            fr: "Accéder au nouveau Fred"
-        - url: "https://fredk8.dev"
-          labels:
-            en: "Go to new Fred"
-            fr: "Accéder au nouveau Fred"
+    # infoBanner:
+    #   color: "#00BBDD"
+    #   titles:
+    #     en: "New version available"
+    #     fr: "Nouvelle version disponible"
+    #   messages:
+    #     en: "Access the Fred documentation & blog"
+    #     fr: "Accédez à la documentation et au blog de Fred."
+    #   links:
+    #     - url: "https://fredk8.dev"
+    #       labels:
+    #         en: "Go to the Fred blog"
+    #         fr: "Accéder au blog de Fred"
 ai:
   # In production  activate the configuration persistence mechanism
   # that allow users to create/update agents at runtime and change

--- a/agentic-backend/config/configuration.yaml
+++ b/agentic-backend/config/configuration.yaml
@@ -60,6 +60,23 @@ frontend_settings:
   properties:
     logoName: "fred"
     siteDisplayName: "Fred"
+    migrationBanner:
+      color: "#00BBDD"
+      titles:
+        en: "New version available"
+        fr: "Nouvelle version disponible"
+      messages:
+        en: "Fred has a new home."
+        fr: "Fred a une nouvelle adresse."
+      links:
+        - url: "https://fred.example.com"
+          labels:
+            en: "Go to new Fred"
+            fr: "Accéder au nouveau Fred"
+        - url: "https://fredk8.dev"
+          labels:
+            en: "Go to new Fred"
+            fr: "Accéder au nouveau Fred"
 ai:
   # In production  activate the configuration persistence mechanism
   # that allow users to create/update agents at runtime and change

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -26,6 +26,7 @@ import { AuthProvider } from "../security/AuthContext";
 import { createDarkTheme, createLightTheme } from "../styles/theme";
 import { ApplicationContext, ApplicationContextProvider } from "./ApplicationContextProvider";
 import GcuGuard from "@core/guards/GcuGuard.tsx";
+import MigrationBanner from "../migration/MigrationBanner.tsx"; // KEA-MIGRATION (throwaway)
 
 const pulse = keyframes`
   0% { transform: scale(1); opacity: 0.9; }
@@ -164,16 +165,21 @@ function FredUiContent() {
       }
     >
       <AuthProvider>
-        <GcuGuard>
-          {/* Following providers (dialog, toast, drawer...) needs to be inside the ThemeProvider */}
-          <ConfirmationDialogProvider>
-            <ToastProvider>
-              <DrawerProvider>
-                <RouterProvider router={router} />
-              </DrawerProvider>
-            </ToastProvider>
-          </ConfirmationDialogProvider>
-        </GcuGuard>
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100vh", width: "100vw" }}>
+          <MigrationBanner /> {/* KEA-MIGRATION (throwaway) */}
+          <Box sx={{ flex: 1, minHeight: 0 }}>
+            <GcuGuard>
+              {/* Following providers (dialog, toast, drawer...) needs to be inside the ThemeProvider */}
+              <ConfirmationDialogProvider>
+                <ToastProvider>
+                  <DrawerProvider>
+                    <RouterProvider router={router} />
+                  </DrawerProvider>
+                </ToastProvider>
+              </ConfirmationDialogProvider>
+            </GcuGuard>
+          </Box>
+        </Box>
       </AuthProvider>
     </React.Suspense>
   );

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -26,7 +26,7 @@ import { AuthProvider } from "../security/AuthContext";
 import { createDarkTheme, createLightTheme } from "../styles/theme";
 import { ApplicationContext, ApplicationContextProvider } from "./ApplicationContextProvider";
 import GcuGuard from "@core/guards/GcuGuard.tsx";
-import MigrationBanner from "../migration/MigrationBanner.tsx"; // KEA-MIGRATION (throwaway)
+import InfoBanner from "../banner/InfoBanner.tsx";
 
 const pulse = keyframes`
   0% { transform: scale(1); opacity: 0.9; }
@@ -166,7 +166,7 @@ function FredUiContent() {
     >
       <AuthProvider>
         <Box sx={{ display: "flex", flexDirection: "column", height: "100vh", width: "100vw" }}>
-          <MigrationBanner /> {/* KEA-MIGRATION (throwaway) */}
+          <InfoBanner />
           <Box sx={{ flex: 1, minHeight: 0 }}>
             <GcuGuard>
               {/* Following providers (dialog, toast, drawer...) needs to be inside the ThemeProvider */}

--- a/frontend/src/banner/InfoBanner.module.css
+++ b/frontend/src/banner/InfoBanner.module.css
@@ -1,4 +1,4 @@
-/* KEA MIGRATION (throwaway) — top banner, see MigrationBanner.tsx */
+/* Generic informative top banner, see InfoBanner.tsx */
 
 /* Background color comes from configuration (inline style); the fixed dark
    text assumes the configured color stays light, like the default #00BBDD. */

--- a/frontend/src/banner/InfoBanner.tsx
+++ b/frontend/src/banner/InfoBanner.tsx
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 // ---------------------------------------------------------------------------
-// KEA MIGRATION (one-shot, throwaway-on-kea).
-// Announces, persistently and without a dismiss action, that the new version
-// is available. Color, texts and links come from the platform-managed
-// frontend_settings.properties.migrationBanner; without it, nothing renders.
+// Generic informative top banner (not tied to any one announcement).
+// Announces, persistently and without a dismiss action, whatever platform
+// operators configure. Color, texts and links come from the platform-managed
+// frontend_settings.properties.infoBanner; without it, nothing renders.
 // Rendered once at the app root (see App.tsx), above the routed content, so
 // it shows on every page and pushes the rest of the app down instead of
 // covering it.
@@ -25,30 +25,30 @@
 import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
 import { useFrontendProperties } from "../hooks/useFrontendProperties";
-import styles from "./MigrationBanner.module.css";
+import styles from "./InfoBanner.module.css";
 
 const resolveLocalized = (map: { [key: string]: string } | undefined | null, lang: string): string | null =>
   map ? (map[lang] ?? map["en"] ?? null) : null;
 
-export default function MigrationBanner() {
+export default function InfoBanner() {
   const { i18n } = useTranslation();
-  const { migrationBanner } = useFrontendProperties();
+  const { infoBanner: banner } = useFrontendProperties();
 
   const lang = i18n.language?.split("-")[0] ?? "en";
-  const title = resolveLocalized(migrationBanner?.titles, lang);
-  const message = resolveLocalized(migrationBanner?.messages, lang);
+  const title = resolveLocalized(banner?.titles, lang);
+  const message = resolveLocalized(banner?.messages, lang);
 
-  if (!migrationBanner || (!title && !message)) return null;
+  if (!banner || (!title && !message)) return null;
 
   return (
-    <div className={styles.banner} style={{ backgroundColor: migrationBanner.color }} role="status" aria-live="polite">
+    <div className={styles.banner} style={{ backgroundColor: banner.color }} role="status" aria-live="polite">
       <p className={styles.message}>
         {title && <strong>{title}</strong>}
         {title && message ? " " : null}
         {message}
       </p>
       <div className={styles.actions}>
-        {(migrationBanner.links ?? []).map((link, index) => (
+        {(banner.links ?? []).map((link, index) => (
           <Fragment key={link.url}>
             {index > 0 && (
               <span className={styles.separator} aria-hidden="true">

--- a/frontend/src/components/chatbot/ConversationOptionsController.tsx
+++ b/frontend/src/components/chatbot/ConversationOptionsController.tsx
@@ -939,7 +939,7 @@ export function ConversationOptionsPanel({
     <>
       <Box
         sx={{
-          position: "fixed",
+          position: "absolute",
           top: { xs: 8, md: 12 },
           right: { xs: 8, md: 16 + rightOffsetPx },
           // Match the pane's width animation so the rail travels with the pane

--- a/frontend/src/migration/MigrationBanner.module.css
+++ b/frontend/src/migration/MigrationBanner.module.css
@@ -1,4 +1,4 @@
-/* KEA MIGRATION (throwaway) — overlay banner, see MigrationBanner.tsx */
+/* KEA MIGRATION (throwaway) — top banner, see MigrationBanner.tsx */
 
 /* Background color comes from configuration (inline style); the fixed dark
    text assumes the configured color stays light, like the default #00BBDD. */
@@ -7,20 +7,12 @@
   --banner-text: #00222c;
 
   display: flex;
-  position: absolute;
-  top: var(--spacing-m);
-  right: var(--spacing-xl);
-  left: var(--spacing-xl);
+  flex-shrink: 0;
   justify-content: space-between;
   align-items: center;
   gap: var(--spacing-s);
-  z-index: 1100;
   animation: slide-in 200ms ease-out;
-  margin: 0 auto;
-  box-shadow: var(--shadow-s);
-  border-radius: var(--radius-s);
-  padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) var(--spacing-m);
-  max-width: 1100px;
+  padding: var(--spacing-m) var(--spacing-xl);
 }
 
 .message {
@@ -49,14 +41,6 @@
 
 .separator {
   color: var(--banner-text);
-}
-
-/* IconButton sets --main-color on the button itself via [data-color], so the
-   override has to target the button too — inheriting from .banner would lose. */
-.banner button {
-  --main-color: var(--banner-text);
-  --state-on-surface-hover: rgb(0 0 0 / 10%);
-  --state-on-surface-pressed: rgb(0 0 0 / 20%);
 }
 
 @keyframes slide-in {

--- a/frontend/src/migration/MigrationBanner.tsx
+++ b/frontend/src/migration/MigrationBanner.tsx
@@ -14,64 +14,31 @@
 
 // ---------------------------------------------------------------------------
 // KEA MIGRATION (one-shot, throwaway-on-kea).
-// Announces, once per session (i.e. once per login), that the new version is
-// available. Color, texts and links come from the platform-managed
+// Announces, persistently and without a dismiss action, that the new version
+// is available. Color, texts and links come from the platform-managed
 // frontend_settings.properties.migrationBanner; without it, nothing renders.
-// Rendered as an overlay over the page content only — never over the sidebar.
+// Rendered once at the app root (see App.tsx), above the routed content, so
+// it shows on every page and pushes the rest of the app down instead of
+// covering it.
 // ---------------------------------------------------------------------------
 
-import { Fragment, useEffect, useState } from "react";
+import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
-import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import { useFrontendProperties } from "../hooks/useFrontendProperties";
 import styles from "./MigrationBanner.module.css";
-
-const DISMISSED_KEY = "kea-migration-banner-dismissed";
-const AUTO_HIDE_MS = 30_000;
-
-const wasDismissed = () => {
-  try {
-    return sessionStorage.getItem(DISMISSED_KEY) === "true";
-  } catch {
-    return false; // private mode / storage disabled: show the banner anyway
-  }
-};
-
-const markDismissed = () => {
-  try {
-    sessionStorage.setItem(DISMISSED_KEY, "true");
-  } catch {
-    /* storage unavailable — the banner simply reappears on reload */
-  }
-};
 
 const resolveLocalized = (map: { [key: string]: string } | undefined | null, lang: string): string | null =>
   map ? (map[lang] ?? map["en"] ?? null) : null;
 
 export default function MigrationBanner() {
-  const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
   const { migrationBanner } = useFrontendProperties();
-  const [open, setOpen] = useState(() => !wasDismissed());
-
-  useEffect(() => {
-    if (!open) return;
-    const timer = window.setTimeout(() => {
-      markDismissed();
-      setOpen(false);
-    }, AUTO_HIDE_MS);
-    return () => window.clearTimeout(timer);
-  }, [open]);
 
   const lang = i18n.language?.split("-")[0] ?? "en";
   const title = resolveLocalized(migrationBanner?.titles, lang);
   const message = resolveLocalized(migrationBanner?.messages, lang);
 
-  if (!open || !migrationBanner || (!title && !message)) return null;
-
-  const close = () => {
-    markDismissed();
-    setOpen(false);
-  };
+  if (!migrationBanner || (!title && !message)) return null;
 
   return (
     <div className={styles.banner} style={{ backgroundColor: migrationBanner.color }} role="status" aria-live="polite">
@@ -93,14 +60,6 @@ export default function MigrationBanner() {
             </a>
           </Fragment>
         ))}
-        <IconButton
-          color="on-surface"
-          variant="icon"
-          size="xs"
-          icon={{ category: "outlined", type: "close" }}
-          onClick={close}
-          aria-label={t("common.close")}
-        />
       </div>
     </div>
   );

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -84,7 +84,7 @@ export default function Chat() {
 
   if (flowsLoading) {
     return (
-      <Box sx={{ p: 3, display: "grid", placeItems: "center", height: "100vh" }}>
+      <Box sx={{ p: 3, display: "grid", placeItems: "center", height: "100%" }}>
         <CircularProgress />
       </Box>
     );

--- a/frontend/src/pages/ComingSoon.tsx
+++ b/frontend/src/pages/ComingSoon.tsx
@@ -23,8 +23,8 @@ export function ComingSoon() {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          height: "100vh",
-          width: "100vw",
+          height: "100%",
+          width: "100%",
         }}
       >
         <EmptyState

--- a/frontend/src/rework/components/pages/GcuPage/GcuPage.module.css
+++ b/frontend/src/rework/components/pages/GcuPage/GcuPage.module.css
@@ -5,7 +5,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-xs) 0 var(--spacing-m) 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/frontend/src/rework/components/pages/GdprPage/GdprPage.module.css
+++ b/frontend/src/rework/components/pages/GdprPage/GdprPage.module.css
@@ -5,7 +5,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-xs) 0 var(--spacing-m) 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/frontend/src/rework/components/pages/PptFillerHelpPage/PptFillerHelpPage.module.css
+++ b/frontend/src/rework/components/pages/PptFillerHelpPage/PptFillerHelpPage.module.css
@@ -4,7 +4,7 @@
   align-items: flex-start;
   background-color: var(--surface-main);
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow-y: auto;
   color: var(--on-surface);
 }

--- a/frontend/src/rework/components/pages/ReleaseNotesPage/ReleaseNotesPage.module.css
+++ b/frontend/src/rework/components/pages/ReleaseNotesPage/ReleaseNotesPage.module.css
@@ -4,7 +4,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-m);
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/frontend/src/rework/components/pages/UserSettingsPage/UserSettingsPage.module.css
+++ b/frontend/src/rework/components/pages/UserSettingsPage/UserSettingsPage.module.css
@@ -4,8 +4,8 @@
   align-items: flex-start;
   box-sizing: border-box;
   padding: var(--spacing-xl) var(--spacing-m);
-  width: 100vw;
-  min-height: 100vh;
+  width: 100%;
+  min-height: 100%;
 }
 
 .userSettingsPage {

--- a/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.module.css
+++ b/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.module.css
@@ -1,7 +1,7 @@
 .mainLayout {
   display: flex;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
 }
 
 .sidebar {
@@ -9,11 +9,8 @@
   overflow: visible;
 }
 
-/* Positioning context for overlays (e.g. the migration banner) so they cover
-   the page content only, never the sidebar. */
 .contentArea {
   display: flex;
-  position: relative;
   flex: 1;
   min-width: 0;
   height: 100%;

--- a/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.tsx
+++ b/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from "react-router-dom";
 import Sidebar from "@shared/organisms/Sidebar/Sidebar.tsx";
 import { CssBaseline } from "@mui/material";
-import MigrationBanner from "src/migration/MigrationBanner.tsx"; // KEA-MIGRATION (throwaway)
 import styles from "./MainLayout.module.css";
 
 export default function MainLayout() {
@@ -13,7 +12,6 @@ export default function MainLayout() {
           <Sidebar />
         </nav>
         <div className={styles.contentArea}>
-          <MigrationBanner /> {/* KEA-MIGRATION (throwaway) */}
           <main className={styles.content}>
             <Outlet />
           </main>

--- a/frontend/src/slices/agentic/agenticOpenApi.ts
+++ b/frontend/src/slices/agentic/agenticOpenApi.ts
@@ -1379,7 +1379,7 @@ export type UploadWarning = {
     [key: string]: string;
   };
 };
-export type MigrationBannerLink = {
+export type InfoBannerLink = {
   /** Link target URL. */
   url: string;
   /** Locale → label map (e.g. {"en": "...", "fr": "..."}). */
@@ -1387,7 +1387,7 @@ export type MigrationBannerLink = {
     [key: string]: string;
   };
 };
-export type MigrationBanner = {
+export type InfoBanner = {
   /** Banner background CSS color. */
   color?: string;
   /** Locale → emphasized lead sentence map, rendered in bold before the message. */
@@ -1399,7 +1399,7 @@ export type MigrationBanner = {
     [key: string]: string;
   };
   /** Links rendered on the right side of the banner. */
-  links?: MigrationBannerLink[];
+  links?: InfoBannerLink[];
 };
 export type Properties = {
   logoName?: string;
@@ -1429,8 +1429,8 @@ export type Properties = {
   gcuVersion?: string | null;
   /** Optional alert shown in the document upload drawer. Omit to show nothing. */
   uploadWarning?: UploadWarning | null;
-  /** Optional new-version banner overlaid on the page content. Omit to show nothing. */
-  migrationBanner?: MigrationBanner | null;
+  /** Optional informative banner shown above the app content. Omit to show nothing. */
+  infoBanner?: InfoBanner | null;
 };
 export type FrontendSettings = {
   feature_flags: FrontendFlags;


### PR DESCRIPTION
## Summary
- Removes the 30s auto-hide and the close/dismiss action on the KEA migration banner — it now stays visible for the whole session.
- Mounts the banner once at the app root (`App.tsx`) instead of inside `MainLayout`, so it shows on every route, including standalone pages (`/gcu`, `/gdpr`, `/settings`, `/release-notes`, `/ppt-filler-help`, `coming-soon`).
- Switches it from an absolutely-positioned overlay to normal document flow, full width, pushing the rest of the app down instead of covering it.
- Every page that hardcoded `100vh` (assuming it always occupies the full viewport) is switched to `100%` so it fills the space actually left under the banner, avoiding clipped/hidden content at the bottom.
- Fixes the chat "options rail" (chevron + widget icons), which was `position: fixed` relative to the viewport and ended up overlapping the banner — switched to `position: absolute` relative to its already-`position: relative` chat container.
- Adds a short example `migrationBanner` config block to `agentic-backend/config/configuration.yaml` for local dev.

Closes #2268

## Test plan
- [x] `make code-quality` in `agentic-backend`
- [x] `npx tsc --noEmit` in `frontend` (no type errors)
- [ ] Manual check in browser: banner shows on a `MainLayout` route and on a standalone route (e.g. `/gcu`), cannot be dismissed, and no content is hidden/clipped underneath it