### PR TITLE
Minor UI fixes + capability pack options

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -147,8 +147,8 @@
           "description": "Show a document library selector in the chat interface."
         },
         "bind_libraries": {
-          "title": "Bind to specific libraries",
-          "description": "Restrict this agent to a fixed set of document libraries chosen at configuration time."
+          "title": "Restrict to specific folders",
+          "description": "Restrict the agent's knowledge and search to specific folders."
         },
         "library_tag_ids": {
           "title": "Bound document libraries",
@@ -248,6 +248,7 @@
         "templateInvalid": "Fix the template errors below before saving.",
         "analyzing": "Analyzing the template…",
         "analyzeFailed": "The template could not be analyzed. Check the file and try again.",
+        "uploadSuccessToast": "PowerPoint template validated.",
         "schemaTitle": "Fields the agent will fill",
         "learnMore": "How does this work? What should I upload?",
         "slide": "Slide {{number}}",
@@ -1402,6 +1403,11 @@
     "marketplace": {
       "teams": {
         "otherTeams": "Discover other teams",
+        "search": {
+          "ariaLabel": "Search for a team",
+          "clearAriaLabel": "Clear search",
+          "placeholder": "Search for a team"
+        },
         "title": "Community teams",
         "yourTeams": "Your teams"
       }

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -147,8 +147,8 @@
           "description": "Afficher un sélecteur de bibliothèque de documents dans l'interface de discussion."
         },
         "bind_libraries": {
-          "title": "Lier à des bibliothèques spécifiques",
-          "description": "Restreindre cet agent à un ensemble fixe de bibliothèques de documents choisies lors de la configuration."
+          "title": "Restreindre à des dossiers spécifiques",
+          "description": "Restreindre la connaissance et la recherche de l'agent à certains dossiers."
         },
         "library_tag_ids": {
           "title": "Bibliothèques de documents liées",
@@ -248,6 +248,7 @@
         "templateInvalid": "Corrigez les erreurs du modèle ci-dessous avant d'enregistrer.",
         "analyzing": "Analyse du modèle…",
         "analyzeFailed": "Le modèle n'a pas pu être analysé. Vérifiez le fichier et réessayez.",
+        "uploadSuccessToast": "Modèle PowerPoint validé.",
         "schemaTitle": "Champs que l'agent remplira",
         "learnMore": "Comment ça marche ? Que dois-je uploader ?",
         "slide": "Diapositive {{number}}",
@@ -1402,6 +1403,11 @@
     "marketplace": {
       "teams": {
         "otherTeams": "Découvrez d'autres équipes",
+        "search": {
+          "ariaLabel": "Rechercher une équipe",
+          "clearAriaLabel": "Effacer la recherche",
+          "placeholder": "Rechercher une équipe"
+        },
         "title": "Équipes de la communauté",
         "yourTeams": "Vos équipes"
       }

--- a/apps/frontend/src/rework/components/pages/PromptsPage/PromptViewDialog/PromptViewDialog.module.scss
+++ b/apps/frontend/src/rework/components/pages/PromptsPage/PromptViewDialog/PromptViewDialog.module.scss
@@ -3,11 +3,18 @@
   position: relative;
   flex-direction: column;
   gap: var(--spacing-m);
-  margin: 2rem auto;
+  /* Auto margins on both axes centre the card in FullPageModal's flex column
+   * (overriding its default align-items/justify-content, per the flexbox auto-
+   * margin rule) and — combined with max-height below — collapse to exactly
+   * 2rem (32px) top/bottom once the card is as tall as it's allowed to get. */
+  margin: auto;
   border-radius: var(--radius-l);
   background: var(--surface-container-high);
   padding: var(--spacing-l);
   width: min(48rem, calc(100vw - 2rem));
+  min-height: 500px;
+  /* Never closer than 2rem (32px) to the scrim's top/bottom edge. */
+  max-height: calc(100vh - 4rem);
 }
 
 .closeButton {
@@ -56,8 +63,13 @@
 
 .textSection {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: var(--spacing-2xs);
+  /* Lets this section shrink below its content's natural height once the
+   * card hits max-height — without it, a flex item's default automatic
+   * min-height would keep forcing the card taller than its cap. */
+  min-height: 0;
 }
 
 .textHeader {
@@ -73,12 +85,17 @@
 }
 
 .textarea {
+  /* Sized to its own content by default (no forced height — a short prompt
+   * keeps a short box); once .textSection runs out of room under the card's
+   * max-height, this is the only part of the dialog that shrinks and scrolls
+   * — see .textSection's min-height: 0 for why that's possible. */
+  flex: 1;
   cursor: default;
   border: 1px solid var(--outline-retreat);
   border-radius: var(--spacing-xs);
   background-color: var(--surface-container-lowest);
   padding: var(--spacing-s);
-  height: 24rem;
+  min-height: 0;
   overflow-y: auto;
   color: var(--on-surface);
   font: var(--font-body-large);

--- a/apps/frontend/src/rework/components/pages/PromptsPage/PromptsPage.module.scss
+++ b/apps/frontend/src/rework/components/pages/PromptsPage/PromptsPage.module.scss
@@ -7,13 +7,11 @@
 
 .pageTitle {
   display: flex;
-  justify-content: center;
   align-items: center;
   gap: var(--spacing-m);
   padding: var(--spacing-xl) var(--spacing-l) var(--spacing-s);
   color: var(--on-surface);
   font: var(--font-title-large);
-  text-align: center;
 }
 
 /* ── Search + tag filter bar ────────────────────────────────────────────────── */

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -33,6 +33,9 @@ import { CapabilitiesInfoBanner } from "./CapabilitiesInfoBanner/CapabilitiesInf
 import { CapabilityCard, CapabilityConfigForm } from "./CapabilityCard/CapabilityCard.tsx";
 import { SimpleCapabilitiesView } from "./SimpleCapabilitiesView/SimpleCapabilitiesView.tsx";
 import type { CapabilitySelectionState } from "./toolPackLogic.ts";
+import { CAP_DOCUMENT_ACCESS, CAP_PPT_FILLER, type ToolPack } from "./toolPacks.ts";
+import { PptFillerPackOptions } from "../../../../features/capabilities/ppt_filler/PptFillerPackOptions.tsx";
+import { DocumentAccessPackOptions } from "./DocumentAccessPackOptions/DocumentAccessPackOptions.tsx";
 import { SwitchRow } from "../AgentCreateEditModal/SwitchRow/SwitchRow.tsx";
 import styles from "./AgentFormBody.module.css";
 
@@ -250,6 +253,40 @@ export function AgentFormBody({
       />
     ));
 
+  // Per-pack options for the Simple capabilities view — each wired to the same
+  // capability config/asset state the Advanced view writes, so the two stay in
+  // sync. Only offered when the team can actually use the backing capability.
+  const renderPackOptions = (pack: ToolPack) => {
+    // Team resources → document_access folder scoping: the "restrict to specific
+    // folders" switch + the folder tree, same labels as Advanced but a leaner
+    // visual (see DocumentAccessPackOptions). The corpus intent uniquely
+    // identifies the team-resources pack.
+    if (pack.documentAccessIntent === "corpus" && availableCapabilityIds.has(CAP_DOCUMENT_ACCESS)) {
+      return (
+        <DocumentAccessPackOptions
+          configValues={capabilityConfigValues[CAP_DOCUMENT_ACCESS] ?? {}}
+          onConfigChange={(key, value) => onCapabilityConfigChange(CAP_DOCUMENT_ACCESS, key, value)}
+          teamId={teamId}
+        />
+      );
+    }
+    // PowerPoint → the same mandatory-template upload as the Advanced ppt_filler
+    // card, wired to the same config/asset/blocking-error state so Save is gated
+    // identically.
+    if (pack.enablesCapabilityIds.includes(CAP_PPT_FILLER) && availableCapabilityIds.has(CAP_PPT_FILLER)) {
+      return (
+        <PptFillerPackOptions
+          disabled={isSubmitting}
+          configValues={capabilityConfigValues[CAP_PPT_FILLER] ?? {}}
+          assetFiles={capabilityAssetFiles[CAP_PPT_FILLER] ?? {}}
+          onAssetFileChange={(slotKey, file) => onCapabilityAssetFileChange(CAP_PPT_FILLER, slotKey, file)}
+          onBlockingErrorChange={(message) => onCapabilityBlockingErrorChange(CAP_PPT_FILLER, message)}
+        />
+      );
+    }
+    return undefined;
+  };
+
   return (
     <div className={styles.body}>
       {/* Absorbs Chrome's username+password credential heuristic away from real form fields */}
@@ -355,10 +392,11 @@ export function AgentFormBody({
                 </div>
                 {capabilityView === "simple" ? (
                   <SimpleCapabilitiesView
-                    availableIds={new Set(capabilities.map((c) => c.id))}
+                    availableIds={availableCapabilityIds}
                     selection={{ selectedCapabilityIds, capabilityConfigValues, reasoningEnabled }}
                     disabled={isSubmitting}
                     onSelectionChange={onCapabilitySelectionReplace}
+                    renderPackOptions={renderPackOptions}
                   />
                 ) : (
                   <ul className={styles.toolsList}>

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.module.css
@@ -1,0 +1,17 @@
+/* Copyright Thales 2026 — Apache-2.0 (see repository license header convention). */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+/* The folder tree, alone, on its own tinted surface — the "simple mode" visual:
+   no field label, no hint (the switch above already explains it), just the
+   picker. 12px radius is an explicit per-design value off the 8/16/24 token
+   scale; padding is --spacing-xs (8px). */
+.treeCard {
+  border-radius: 12px;
+  background: var(--surface-container-low);
+  padding: var(--spacing-xs);
+}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.test.tsx
@@ -1,0 +1,51 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The folder tree mirrors the Advanced `visible_when: bind_libraries` rule — it
+// shows only while the "restrict to specific folders" switch is on, so an agent
+// that isn't restricted never renders (nor fetches) the picker.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx", () => ({
+  DocumentLibraryScopePicker: () => <div data-testid="folder-tree" />,
+}));
+
+vi.mock("../../AgentCreateEditModal/SwitchRow/SwitchRow.tsx", () => ({
+  SwitchRow: ({ label }: { label: string }) => <div data-testid="bind-switch">{label}</div>,
+}));
+
+import { DocumentAccessPackOptions } from "./DocumentAccessPackOptions";
+
+function render(configValues: Record<string, unknown>): string {
+  return renderToStaticMarkup(
+    <DocumentAccessPackOptions configValues={configValues} onConfigChange={() => {}} teamId="team-1" />,
+  );
+}
+
+describe("DocumentAccessPackOptions", () => {
+  it("always shows the restrict switch", () => {
+    expect(render({})).toContain("bind-switch");
+  });
+
+  it("hides the folder tree until libraries are bound", () => {
+    expect(render({ bind_libraries: false })).not.toContain("folder-tree");
+    expect(render({ bind_libraries: true })).toContain("folder-tree");
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.tsx
@@ -51,6 +51,7 @@ export function DocumentAccessPackOptions({ configValues, onConfigChange, teamId
             teamId={teamId}
             selectedTagIds={selectedTagIds}
             onChange={(tagIds) => onConfigChange("library_tag_ids", tagIds)}
+            foldersOnly
           />
         </div>
       )}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/DocumentAccessPackOptions/DocumentAccessPackOptions.tsx
@@ -1,0 +1,59 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "team resources" pack options (Simple capabilities view): a leaner take on
+// the Advanced document_access folder-scoping. It reuses the same two config
+// keys — `bind_libraries` (the "restrict to specific folders" switch) and
+// `library_tag_ids` (the picked folders) — and the SAME labels as the Advanced
+// card, but strips the field label and hint around the tree and drops the folder
+// picker onto its own tinted card, for a simpler look suited to Simple mode.
+
+import { DocumentLibraryScopePicker } from "@shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx";
+import { useTranslation } from "react-i18next";
+import { SwitchRow } from "../../AgentCreateEditModal/SwitchRow/SwitchRow.tsx";
+import styles from "./DocumentAccessPackOptions.module.css";
+
+interface DocumentAccessPackOptionsProps {
+  /** document_access's current config values (`bind_libraries`, `library_tag_ids`). */
+  configValues: Record<string, unknown>;
+  /** Patch one document_access config value (writes back into the pack selection). */
+  onConfigChange: (key: string, value: unknown) => void;
+  teamId?: string;
+}
+
+export function DocumentAccessPackOptions({ configValues, onConfigChange, teamId }: DocumentAccessPackOptionsProps) {
+  const { t } = useTranslation();
+  const bindLibraries = Boolean(configValues.bind_libraries);
+  const selectedTagIds = Array.isArray(configValues.library_tag_ids) ? (configValues.library_tag_ids as string[]) : [];
+
+  return (
+    <div className={styles.root}>
+      <SwitchRow
+        label={t("capability.document_access.fields.bind_libraries.title")}
+        description={t("capability.document_access.fields.bind_libraries.description")}
+        checked={bindLibraries}
+        onChange={(checked) => onConfigChange("bind_libraries", checked)}
+      />
+      {bindLibraries && (
+        <div className={styles.treeCard}>
+          <DocumentLibraryScopePicker
+            teamId={teamId}
+            selectedTagIds={selectedTagIds}
+            onChange={(tagIds) => onConfigChange("library_tag_ids", tagIds)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/SimpleCapabilitiesView/SimpleCapabilitiesView.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/SimpleCapabilitiesView/SimpleCapabilitiesView.tsx
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { ToolPackCard } from "../ToolPackCard/ToolPackCard.tsx";
 import { applyPackToggle, derivePackChecked, type CapabilitySelectionState } from "../toolPackLogic.ts";
-import { TOOL_PACK_SECTIONS } from "../toolPacks.ts";
+import { TOOL_PACK_SECTIONS, type ToolPack } from "../toolPacks.ts";
 import styles from "./SimpleCapabilitiesView.module.css";
 
 interface SimpleCapabilitiesViewProps {
@@ -24,6 +25,10 @@ interface SimpleCapabilitiesViewProps {
   selection: CapabilitySelectionState;
   disabled: boolean;
   onSelectionChange: (next: CapabilitySelectionState) => void;
+  /** Optional per-pack options UI (e.g. the PowerPoint template upload), shown
+   *  inside the card while the pack is active. Returns `undefined` for packs
+   *  with nothing to configure. */
+  renderPackOptions?: (pack: ToolPack) => ReactNode;
 }
 
 /**
@@ -38,6 +43,7 @@ export function SimpleCapabilitiesView({
   selection,
   disabled,
   onSelectionChange,
+  renderPackOptions,
 }: SimpleCapabilitiesViewProps) {
   const { t } = useTranslation();
   const activeIds = new Set(selection.selectedCapabilityIds);
@@ -60,6 +66,7 @@ export function SimpleCapabilitiesView({
                   availableIds={availableIds}
                   activeIds={activeIds}
                   onToggle={(nextOn) => onSelectionChange(applyPackToggle(pack, nextOn, selection, availableIds))}
+                  options={renderPackOptions?.(pack)}
                 />
               ))}
             </ul>

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/ToolPackCard/ToolPackCard.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/ToolPackCard/ToolPackCard.module.css
@@ -69,6 +69,28 @@
   flex-shrink: 0;
 }
 
+/* Options reveal: per-pack configuration UI shown between the header and the
+   expander while the pack is active. Height-animated on open (the design
+   system's max-height technique — grid-rows was tested and dropped); the cap is
+   lifted to `none` after the transition (inline style) so async-growing content
+   is never clipped. */
+.optionsReveal {
+  transition: max-height var(--duration-medium-4) var(--easing-emphasized-decelerate);
+  max-height: 0;
+  overflow: hidden;
+}
+
+.optionsRevealOpen {
+  /* Generous cap comfortably above the real content — only governs the open
+     animation, then removed. */
+  max-height: 480px;
+}
+
+.optionsInner {
+  border-top: 1px solid var(--outline-muted);
+  padding: var(--spacing-m);
+}
+
 /* Expander row: reveals the included-capabilities list. Full-width, left-aligned
    label + chevron, separated from the header by a thin divider. */
 .expander {

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/ToolPackCard/ToolPackCard.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/ToolPackCard/ToolPackCard.test.tsx
@@ -1,0 +1,60 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The `options` slot is the per-pack config surface (e.g. the PowerPoint
+// template upload): it must render only while the pack is active, so an
+// inactive pack never mounts its options (whose effects would otherwise, for
+// ppt_filler, register a Save-blocking "template required" error for a pack the
+// user hasn't even turned on).
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolPack } from "../toolPacks";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ToolPackCard } from "./ToolPackCard";
+
+const pack: ToolPack = {
+  id: "powerpoint_document",
+  kind: "capabilities",
+  icon: "slideshow",
+  titleKey: "pack.title",
+  descriptionKey: "pack.description",
+  includes: [],
+  enablesCapabilityIds: ["ppt_filler"],
+};
+
+function render(checked: boolean): string {
+  return renderToStaticMarkup(
+    <ToolPackCard
+      pack={pack}
+      checked={checked}
+      disabled={false}
+      availableIds={new Set(["ppt_filler"])}
+      activeIds={new Set(checked ? ["ppt_filler"] : [])}
+      onToggle={() => {}}
+      options={<div data-testid="pack-options">options</div>}
+    />,
+  );
+}
+
+describe("ToolPackCard options slot", () => {
+  it("renders the options only when the pack is active", () => {
+    expect(render(false)).not.toContain("pack-options");
+    expect(render(true)).toContain("pack-options");
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/ToolPackCard/ToolPackCard.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/ToolPackCard/ToolPackCard.tsx
@@ -16,7 +16,7 @@ import Icon from "@shared/atoms/Icon/Icon.tsx";
 import Switch from "@shared/atoms/Switch/Switch.tsx";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
 import type { IconType } from "@shared/utils/Type.ts";
-import { useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { includedCapabilityStatus, type IncludedCapabilityStatus } from "../toolPackLogic.ts";
 import type { ToolPack } from "../toolPacks.ts";
@@ -33,6 +33,39 @@ interface ToolPackCardProps {
   /** Capability ids currently active on the agent (drives active vs. inactive). */
   activeIds: ReadonlySet<string>;
   onToggle: (nextOn: boolean) => void;
+  /** Optional per-pack configuration UI (e.g. the PowerPoint template upload),
+   *  revealed with a smooth open animation while the pack is active. Only some
+   *  packs supply one; omit for packs with nothing to configure. */
+  options?: ReactNode;
+}
+
+/**
+ * Height-animated reveal for a pack's options, mounted only while the pack is
+ * active — so the entrance animates once (max-height, the design-system's
+ * chosen technique over grid-rows). The cap is lifted to `none` after the
+ * open transition so async-growing content (the template's per-slide error
+ * list) is never clipped.
+ */
+function PackOptionsReveal({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [capLifted, setCapLifted] = useState(false);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setOpen(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  return (
+    <div
+      className={`${styles.optionsReveal} ${open ? styles.optionsRevealOpen : ""}`}
+      style={capLifted ? { maxHeight: "none" } : undefined}
+      onTransitionEnd={(e) => {
+        if (e.propertyName === "max-height" && open) setCapLifted(true);
+      }}
+    >
+      <div className={styles.optionsInner}>{children}</div>
+    </div>
+  );
 }
 
 const STATUS_ICON: Record<IncludedCapabilityStatus, IconType> = {
@@ -54,7 +87,15 @@ const STATUS_TOOLTIP_KEY: Record<IncludedCapabilityStatus, string> = {
  * the platform admin enabled it for the team. Shape mirrors the app's other
  * organism cards (AgentCard/CapabilityCard) so the form reads as one system.
  */
-export function ToolPackCard({ pack, checked, disabled, availableIds, activeIds, onToggle }: ToolPackCardProps) {
+export function ToolPackCard({
+  pack,
+  checked,
+  disabled,
+  availableIds,
+  activeIds,
+  onToggle,
+  options,
+}: ToolPackCardProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const hasIncluded = pack.includes.length > 0;
@@ -87,6 +128,8 @@ export function ToolPackCard({ pack, checked, disabled, availableIds, activeIds,
           />
         </span>
       </label>
+
+      {checked && options && <PackOptionsReveal>{options}</PackOptionsReveal>}
 
       {hasIncluded && (
         <>

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -7,13 +7,11 @@
 
 .title {
   display: flex;
-  justify-content: center;
   align-items: center;
   gap: var(--spacing-m);
   padding: var(--spacing-xl) var(--spacing-l) var(--spacing-l);
   color: var(--on-surface);
   font: var(--font-title-large);
-  text-align: center;
 }
 
 .bannerNotice {
@@ -29,7 +27,6 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, 320px);
   grid-auto-rows: minmax(210px, auto);
-  justify-content: center;
   gap: var(--spacing-m);
   padding: 0 var(--spacing-l) var(--spacing-l);
   overflow: auto;

--- a/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.module.scss
+++ b/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.module.scss
@@ -17,6 +17,15 @@
   font: var(--font-title-large-emphasized);
 }
 
+// No `width` here on purpose — the header is a flex row with
+// justify-content: space-between, so a shrink-to-fit box capped by
+// max-width keeps the field right-aligned and compact instead of growing
+// to fill the row (which is what SearchInput's own wrapper: width: 100%
+// would otherwise force).
+.marketplaceTeamsSearch {
+  max-width: 260px;
+}
+
 .marketplaceTeamsContent {
   padding-bottom: var(--spacing-s);
 }
@@ -33,6 +42,16 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  align-items: stretch;
   gap: var(--spacing-m);
   padding-bottom: var(--spacing-m);
+}
+
+// Wraps a card only when it's navigable (member teams) — must stay a flex
+// container itself so the stretched row height reaches TeamCard's
+// height: 100%, and must not restyle the link (no underline/color change).
+.marketplaceTeamsCardLink {
+  display: flex;
+  color: inherit;
+  text-decoration: none;
 }

--- a/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.test.tsx
+++ b/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.test.tsx
@@ -20,6 +20,7 @@
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import type { Team, TeamWithPermissions } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 
 const h = vi.hoisted(() => ({
@@ -35,6 +36,19 @@ const h = vi.hoisted(() => ({
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// `renderToStaticMarkup` has no router context, so a real `Link`/`Navigate`
+// throws (`useContext(...) is null`) the moment a member card wraps itself
+// in one — stand in with plain markup, same as other page tests that don't
+// need actual routing behaviour asserted.
+vi.mock("react-router-dom", () => ({
+  Link: ({ to, children, className }: { to: string; children: ReactNode; className?: string }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
 }));
 
 vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
@@ -89,5 +103,53 @@ describe("MarketplaceTeams personal-space exclusion", () => {
     const html = render();
     expect(html).not.toContain("team-card-personal-other-user");
     expect(html).toContain("team-card-fredlab");
+  });
+});
+
+describe("MarketplaceTeams card navigability", () => {
+  beforeEach(() => {
+    h.bootstrap = {
+      activeTeam: { id: "personal-me" } as TeamWithPermissions,
+      availableTeams: [{ id: "personal-me" }, { id: "fredlab" }] as Team[],
+      bootstrap: undefined,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  it("only wraps member-team cards in a navigation link, regardless of platform-admin status", () => {
+    h.teams = {
+      data: [
+        { id: "fredlab", name: "fredlab", is_member: true } as Team,
+        { id: "acme", name: "acme", is_member: false } as Team,
+      ],
+    };
+    const html = render();
+    expect(html).toContain(`<a href="/team/fredlab/agents"`);
+    expect(html).not.toContain('href="/team/acme/agents"');
+  });
+});
+
+describe("MarketplaceTeams search", () => {
+  beforeEach(() => {
+    h.bootstrap = {
+      activeTeam: { id: "personal-me" } as TeamWithPermissions,
+      availableTeams: [{ id: "personal-me" }, { id: "fredlab" }] as Team[],
+      bootstrap: undefined,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    h.teams = {
+      data: [
+        { id: "fredlab", name: "Fred Lab", is_member: true } as Team,
+        { id: "acme", name: "Acme", is_member: false } as Team,
+      ],
+    };
+  });
+
+  it("renders every team when no search query is set", () => {
+    const html = render();
+    expect(html).toContain("team-card-fredlab");
+    expect(html).toContain("team-card-acme");
   });
 });

--- a/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.tsx
+++ b/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.tsx
@@ -15,11 +15,34 @@
 import styles from "./MarketplaceTeams.module.scss";
 import { useTranslation } from "react-i18next";
 import TeamCard from "@shared/organisms/TeamCard/TeamCard.tsx";
+import SearchInput from "@shared/molecules/SearchInput/SearchInput.tsx";
 import { useListTeamsQuery } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import { Team } from "../../../../../slices/controlPlane/controlPlaneOpenApi.ts";
 import { Link, Navigate } from "react-router-dom";
 import { useFrontendBootstrap } from "../../../../../hooks/useFrontendBootstrap";
 import { isPersonalTeamId } from "@shared/utils/teamId";
+import { useMemo, useState } from "react";
+
+// Free-text query matched against name and description — a team must match
+// every whitespace-separated token in at least one of those two fields.
+// Same tokenized-match approach as TeamSettingsMembersTable. Applied
+// client-side: both team lists are already fetched in full by useListTeamsQuery.
+const MIN_SEARCH_LENGTH = 2;
+
+function matchesSearch(team: Team, tokens: string[]): boolean {
+  const haystacks = [team.name, team.description]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => value.toLowerCase());
+  return tokens.every((token) => haystacks.some((haystack) => haystack.includes(token)));
+}
+
+function filterTeams(teams: Team[] | undefined, search: string): Team[] {
+  if (!teams) return [];
+  const trimmed = search.trim().toLowerCase();
+  if (trimmed.length < MIN_SEARCH_LENGTH) return teams;
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  return teams.filter((team) => matchesSearch(team, tokens));
+}
 
 /**
  * Render the collaborative team marketplace only when collaborative teams exist.
@@ -37,10 +60,8 @@ import { isPersonalTeamId } from "@shared/utils/teamId";
  */
 export default function MarketplaceTeams() {
   const { t } = useTranslation();
-  const { activeTeam, availableTeams, bootstrap, isLoading, refetch } = useFrontendBootstrap();
-  // AUTHZ-05 review item 4: platform-admin gating is OpenFGA-derived
-  // (`PermissionSummary.is_platform_admin`), not a raw Keycloak role check.
-  const isAdmin = bootstrap?.permissions?.is_platform_admin ?? false;
+  const { activeTeam, availableTeams, isLoading, refetch } = useFrontendBootstrap();
+  const [search, setSearch] = useState("");
   const personalTeamId = activeTeam?.id ?? "personal";
   const collaborativeTeams = availableTeams.filter((team) => team.id !== personalTeamId);
   const { data: teams } = useListTeamsQuery(undefined, {
@@ -52,6 +73,9 @@ export default function MarketplaceTeams() {
   // list one, including the caller's own — see #2068.
   const yourTeams = teams && teams.filter((t) => t.is_member && !isPersonalTeamId(t.id));
   const otherTeams = teams && teams.filter((t) => !t.is_member && !isPersonalTeamId(t.id));
+
+  const filteredYourTeams = useMemo(() => filterTeams(yourTeams, search), [yourTeams, search]);
+  const filteredOtherTeams = useMemo(() => filterTeams(otherTeams, search), [otherTeams, search]);
 
   // Wait for bootstrap before redirecting away: redirecting on the first,
   // pre-bootstrap render sends the user to the bare "personal" alias, then a
@@ -69,10 +93,12 @@ export default function MarketplaceTeams() {
     // ControlPlaneTeam:LIST tag invalidation baked into useJoinTeamMutation —
     // bootstrap's own team list (the navbar/team switcher) is a separate
     // cache, so it needs its own refetch.
-    if (isAdmin)
+    // Only a team the caller is a member of is navigable — non-member cards
+    // (the "discover" section) offer join/invite-only affordances, not entry.
+    if (team.is_member)
       return (
-        <Link to={`/team/${team.id}/agents`}>
-          <TeamCard key={team.id} team={team} withDescription={withDescription} onJoined={refetch} />
+        <Link key={team.id} className={styles.marketplaceTeamsCardLink} to={`/team/${team.id}/agents`}>
+          <TeamCard team={team} withDescription={withDescription} onJoined={refetch} />
         </Link>
       );
     return <TeamCard key={team.id} team={team} withDescription={withDescription} onJoined={refetch} />;
@@ -82,16 +108,22 @@ export default function MarketplaceTeams() {
     <div className={styles.marketplaceTeamsContainer}>
       <div className={styles.marketplaceTeamsHeader}>
         <h1 className={styles.marketplaceTeamsTitle}>{t("rework.marketplace.teams.title")}</h1>
+        <div className={styles.marketplaceTeamsSearch}>
+          <SearchInput
+            value={search}
+            onChange={setSearch}
+            placeholder={t("rework.marketplace.teams.search.placeholder")}
+            ariaLabel={t("rework.marketplace.teams.search.ariaLabel")}
+            clearAriaLabel={t("rework.marketplace.teams.search.clearAriaLabel")}
+            size="small"
+          />
+        </div>
       </div>
       <div className={styles.marketplaceTeamsContent}>
         <div className={styles.marketplaceTeamsListSubtitle}>{t("rework.marketplace.teams.yourTeams")}</div>
-        <div className={styles.marketplaceTeamsList}>
-          {yourTeams && yourTeams.map((team) => renderCard(team, false))}
-        </div>
+        <div className={styles.marketplaceTeamsList}>{filteredYourTeams.map((team) => renderCard(team, false))}</div>
         <div className={styles.marketplaceTeamsListSubtitle}>{t("rework.marketplace.teams.otherTeams")}</div>
-        <div className={styles.marketplaceTeamsList}>
-          {otherTeams && otherTeams.map((team) => renderCard(team, true))}
-        </div>
+        <div className={styles.marketplaceTeamsList}>{filteredOtherTeams.map((team) => renderCard(team, true))}</div>
       </div>
     </div>
   );

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
@@ -18,6 +18,7 @@
   position: relative;
   align-items: center;
   gap: var(--spacing-xs);
+  border: 1px solid var(--outline-muted);
   border-radius: var(--radius-s);
   background: var(--surface-main);
   padding: var(--spacing-xs) var(--spacing-s);
@@ -72,9 +73,12 @@
   accent-color: var(--primary);
 }
 
+/* Color comes from the shared fileIconSpec (inline style), matching the
+   Resources table; only the glyph size is fixed here. */
 .folderIcon,
 .documentIcon {
-  color: var(--on-surface-retreat);
+  display: inline-flex;
+  align-items: center;
   font-size: 18px;
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
@@ -68,6 +68,12 @@
   font-size: 18px;
 }
 
+/* Non-expandable folder (folders-only mode): keep the chevron's box for
+   alignment but hide the glyph. */
+.expandIconHidden {
+  visibility: hidden;
+}
+
 .checkbox {
   margin: 0;
   accent-color: var(--primary);

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
@@ -33,6 +33,11 @@ interface DocumentLibraryScopePickerProps {
   selectedDocumentUids?: string[];
   onDocumentsChange?: (documentUids: string[]) => void;
   disableLibrarySelection?: boolean;
+  /** Folders-only mode: hide (and never fetch) the documents inside folders, and
+   *  only make a folder expandable when it has sub-folders. Used by the Simple
+   *  capabilities view, where the tree is for a quick folder overview, not
+   *  per-document scoping. */
+  foldersOnly?: boolean;
 }
 
 function findPrimaryTagId(node: TagNode): string | null {
@@ -70,6 +75,7 @@ export function DocumentLibraryScopePicker({
   selectedDocumentUids,
   onDocumentsChange,
   disableLibrarySelection = false,
+  foldersOnly = false,
 }: DocumentLibraryScopePickerProps) {
   const { t } = useTranslation();
   const { activeTeam } = useFrontendBootstrap();
@@ -120,6 +126,7 @@ export function DocumentLibraryScopePicker({
   );
 
   useEffect(() => {
+    if (foldersOnly) return;
     expanded.forEach((path) => {
       const node = path
         .split("/")
@@ -128,7 +135,7 @@ export function DocumentLibraryScopePicker({
       const tagId = node ? findPrimaryTagId(node) : null;
       if (tagId) void loadDocumentsForTag(tagId);
     });
-  }, [expanded, loadDocumentsForTag, tree]);
+  }, [expanded, loadDocumentsForTag, tree, foldersOnly]);
 
   const toggleExpand = (path: string) => {
     setExpanded((prev) => (prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]));
@@ -169,6 +176,10 @@ export function DocumentLibraryScopePicker({
         const tagId = findPrimaryTagId(child);
         const docs = tagId ? (documentsByTagId[tagId] ?? []) : [];
         const isLoadingDocs = tagId ? Boolean(loadingTagIds[tagId]) : false;
+        // Folders-only: a folder is expandable only when it holds sub-folders
+        // (documents are never shown here), so leaf folders don't offer an
+        // expand affordance that would open onto nothing.
+        const expandable = !foldersOnly || child.children.size > 0;
 
         return (
           <li key={child.full} className={styles.node}>
@@ -177,14 +188,21 @@ export function DocumentLibraryScopePicker({
                   (padding included) so a click anywhere on the tile expands,
                   and doubles as the hover state-layer. The checkbox and any
                   other real controls sit above it and keep their own clicks. */}
-              <button
-                type="button"
-                className={styles.nodeTrigger}
-                onClick={() => toggleExpand(child.full)}
-                aria-label={isExpanded ? t("rework.collapse") : t("rework.expand")}
-                aria-expanded={isExpanded}
-              />
-              <span className={`${styles.expandIcon} material-symbols-outlined`} aria-hidden>
+              {expandable && (
+                <button
+                  type="button"
+                  className={styles.nodeTrigger}
+                  onClick={() => toggleExpand(child.full)}
+                  aria-label={isExpanded ? t("rework.collapse") : t("rework.expand")}
+                  aria-expanded={isExpanded}
+                />
+              )}
+              {/* Kept in the layout even when not expandable (visibility:hidden)
+                  so every folder row's checkbox/icon stay aligned. */}
+              <span
+                className={`${styles.expandIcon} material-symbols-outlined ${expandable ? "" : styles.expandIconHidden}`}
+                aria-hidden
+              >
                 {isExpanded ? "expand_more" : "chevron_right"}
               </span>
               <input
@@ -213,7 +231,7 @@ export function DocumentLibraryScopePicker({
 
             {isExpanded && (
               <div className={styles.nodeChildren}>
-                {docs.length > 0 && (
+                {!foldersOnly && docs.length > 0 && (
                   <ul className={styles.documentList}>
                     {docs.map((doc) => {
                       const documentUid = doc.identity.document_uid;

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
@@ -14,6 +14,8 @@
 
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import Icon from "@shared/atoms/Icon/Icon.tsx";
+import { FOLDER_ICON, fileIconSpec } from "../../../../utils/fileIconSpec.ts";
 import { useFrontendBootstrap } from "../../../../../hooks/useFrontendBootstrap";
 import { buildTree, type TagNode } from "../../../../../shared/utils/tagTree";
 import type { DocumentMetadata } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
@@ -195,8 +197,11 @@ export function DocumentLibraryScopePicker({
                 }}
                 onChange={() => toggleNodeSelection(child)}
               />
-              <span className={`${styles.folderIcon} material-symbols-outlined`} aria-hidden>
-                {isExpanded ? "folder_open" : "folder"}
+              {/* Same folder icon/color as the Resources table (shared
+                  fileIconSpec) — the chevron already carries the expand state,
+                  so no folder_open swap here. */}
+              <span className={styles.folderIcon} style={{ color: FOLDER_ICON.color }} aria-hidden>
+                <Icon category="outlined" type={FOLDER_ICON.type} filled={FOLDER_ICON.filled} />
               </span>
               <div className={styles.nodeMeta}>
                 <span className={styles.nodeLabel}>{child.name}</span>
@@ -213,6 +218,14 @@ export function DocumentLibraryScopePicker({
                     {docs.map((doc) => {
                       const documentUid = doc.identity.document_uid;
                       const checked = selectedDocumentUids?.includes(documentUid) ?? false;
+                      // Same file-type icon/color as the Resources table (shared
+                      // fileIconSpec), so a given extension reads identically here.
+                      const docSpec = fileIconSpec(doc.file?.file_type);
+                      const docIcon = (
+                        <span className={styles.documentIcon} style={{ color: docSpec.color }} aria-hidden>
+                          <Icon category="outlined" type={docSpec.type} filled={docSpec.filled} />
+                        </span>
+                      );
                       return (
                         <li key={documentUid} className={styles.documentItem}>
                           {documentSelectionEnabled ? (
@@ -223,16 +236,12 @@ export function DocumentLibraryScopePicker({
                                 checked={checked}
                                 onChange={(event) => toggleDocumentSelection(documentUid, event.target.checked)}
                               />
-                              <span className={`${styles.documentIcon} material-symbols-outlined`} aria-hidden>
-                                description
-                              </span>
+                              {docIcon}
                               <span className={styles.documentName}>{doc.identity.document_name}</span>
                             </label>
                           ) : (
                             <>
-                              <span className={`${styles.documentIcon} material-symbols-outlined`} aria-hidden>
-                                description
-                              </span>
+                              {docIcon}
                               <span className={styles.documentName}>{doc.identity.document_name}</span>
                             </>
                           )}

--- a/apps/frontend/src/rework/components/shared/molecules/SearchInput/SearchInput.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/SearchInput/SearchInput.module.scss
@@ -1,6 +1,5 @@
 .wrapper {
   position: relative;
-  width: 100%;
 }
 
 .clear {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -5,6 +5,11 @@
   border-radius: var(--radius-m);
   background-color: var(--surface-container);
   width: 290px;
+  /* Fills whatever height the row gives it (flex `align-items: stretch` on
+   * the parent list, and — when wrapped for navigation — the flex Link
+   * wrapper), so cards in the same row line up on their footer regardless of
+   * description length. */
+  height: 100%;
   /* No overflow: hidden here — an admin-avatar tooltip in the footer must be
    * able to escape the card bounds. The banner below clips its own square
    * corners to match the card's rounded top instead. */

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptFillerConfigForm.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptFillerConfigForm.tsx
@@ -19,40 +19,14 @@
 // travels with the atomic save (multipart with-assets endpoints) — this
 // preview never stores anything; the backend re-parses the real bytes on save.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import Button from "@shared/atoms/Button/Button";
 import Icon from "@shared/atoms/Icon/Icon";
 import type { CapabilityConfigWidgetProps } from "../types";
-import {
-  useAnalyzeAnalyzePostMutation,
-  type BodyAnalyzeAnalyzePost,
-  type ParseResult,
-  type SlideSchema,
-  type TemplateError,
-} from "./api/pptFillerCapabilityOpenApi";
+import { usePptTemplateAnalysis } from "./usePptTemplateAnalysis";
 import styles from "./PptFillerConfigForm.module.css";
-
-/** The manifest's one upload slot key (AssetSlot.key on the backend). */
-const TEMPLATE_SLOT = "template";
-
-/**
- * i18n an error by its stable code (the RFC contract: `code` is the machine
- * key, `message` the English fallback). Unknown codes fall back to the
- * backend-provided message so a new code never renders blank.
- */
-function useTemplateErrorText() {
-  const { t } = useTranslation();
-  return (error: TemplateError): string =>
-    t(`capability.ppt_filler.errors.${error.code}`, {
-      defaultValue: error.message,
-      slide: error.slide,
-      // The literal `{{key}}` placeholder is prebuilt here — braces inside an
-      // i18next template would be parsed as interpolation markers.
-      placeholder: `{{${error.key}}}`,
-    });
-}
 
 export function PptFillerConfigForm({
   disabled,
@@ -62,56 +36,22 @@ export function PptFillerConfigForm({
   onBlockingErrorChange,
 }: CapabilityConfigWidgetProps) {
   const { t } = useTranslation();
-  const errorText = useTemplateErrorText();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [analyze, { isLoading: isAnalyzing }] = useAnalyzeAnalyzePostMutation();
-  const [analysis, setAnalysis] = useState<ParseResult | null>(null);
-  const [analyzeFailed, setAnalyzeFailed] = useState(false);
-
-  const stagedFile = assetFiles[TEMPLATE_SLOT];
-  const persistedSchema = (configValues.schema_slides as SlideSchema[] | undefined) ?? [];
-  const hasPersistedTemplate = persistedSchema.length > 0;
-
-  // What the preview shows: the staged file's live analysis when one is
-  // picked, else the persisted schema (source of truth: the saved template).
-  const previewSlides = stagedFile ? (analysis?.schema ?? []) : persistedSchema;
-  const previewErrors = stagedFile ? (analysis?.errors ?? []) : [];
-
-  const blockingError = useMemo(() => {
-    if (!stagedFile && !hasPersistedTemplate) return t("capability.ppt_filler.form.templateRequired");
-    if (stagedFile && previewErrors.length > 0) return t("capability.ppt_filler.form.templateInvalid");
-    return null;
-  }, [stagedFile, hasPersistedTemplate, previewErrors.length, t]);
-
-  useEffect(() => {
-    onBlockingErrorChange(blockingError);
-    // Clearing on unmount keeps a deselected capability from blocking Save.
-    return () => onBlockingErrorChange(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockingError]);
-
-  const handlePick = async (file: File) => {
-    onAssetFileChange(TEMPLATE_SLOT, file);
-    setAnalysis(null);
-    setAnalyzeFailed(false);
-    try {
-      // The generated client cannot express multipart; the FormData body cast
-      // is the sanctioned narrow exception (types still come from the client).
-      const formData = new FormData();
-      formData.append("file", file, file.name);
-      const result = await analyze({
-        bodyAnalyzeAnalyzePost: formData as unknown as BodyAnalyzeAnalyzePost,
-      }).unwrap();
-      setAnalysis(result);
-    } catch {
-      setAnalyzeFailed(true);
-    }
-  };
+  const {
+    stagedFile,
+    hasPersistedTemplate,
+    isAnalyzing,
+    analyzeFailed,
+    previewSlides,
+    previewErrors,
+    blockingError,
+    handlePick,
+    handleClear: clearAnalysis,
+    errorText,
+  } = usePptTemplateAnalysis({ configValues, assetFiles, onAssetFileChange, onBlockingErrorChange });
 
   const handleClear = () => {
-    onAssetFileChange(TEMPLATE_SLOT, null);
-    setAnalysis(null);
-    setAnalyzeFailed(false);
+    clearAnalysis();
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptFillerPackOptions.module.css
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptFillerPackOptions.module.css
@@ -1,0 +1,55 @@
+/* Copyright Thales 2026 — Apache-2.0 (see repository license header convention). */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+/* Upload button + staged-file chip on one wrapping row. */
+.uploadRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.fileInput {
+  display: none;
+}
+
+/* Spinner sits where the button icon would, inheriting the button's text color. */
+.buttonSpinner {
+  display: inline-flex;
+  align-items: center;
+}
+
+.learnMoreLink {
+  align-self: flex-start;
+  color: var(--primary);
+  font: var(--font-body-small);
+  text-decoration: none;
+}
+
+.learnMoreLink:hover {
+  text-decoration: underline;
+}
+
+.blocking {
+  margin: 0;
+  color: var(--error);
+  font: var(--font-body-small);
+}
+
+.errorList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3xs);
+  margin: 0;
+  padding-left: var(--spacing-m);
+}
+
+.error {
+  color: var(--error);
+  font: var(--font-body-small);
+}

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptFillerPackOptions.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptFillerPackOptions.tsx
@@ -1,0 +1,152 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The ppt_filler options shown INSIDE the "PowerPoint document" capability pack
+// (Simple capabilities view, #2220 follow-up): the same mandatory-template upload
+// as the Advanced-view widget, but trimmed to the pack's lighter surface — an
+// upload button (spinner while analyzing), a removable file chip, the "how it
+// works" link, the Save-gating template label and per-slide validation errors,
+// plus a success toast once a freshly picked template analyzes cleanly. The
+// upload/analyze/blocking logic is shared with PptFillerConfigForm via
+// usePptTemplateAnalysis; the slide-schema preview is intentionally NOT shown here.
+
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import Button from "@shared/atoms/Button/Button";
+import Chip from "@shared/atoms/Chip/Chip.tsx";
+import Icon from "@shared/atoms/Icon/Icon";
+import { Spinner } from "@shared/atoms/Spinner/Spinner.tsx";
+import { useToast } from "@shared/molecules/Toast/ToastProvider";
+import { usePptTemplateAnalysis } from "./usePptTemplateAnalysis";
+import styles from "./PptFillerPackOptions.module.css";
+
+interface PptFillerPackOptionsProps {
+  disabled: boolean;
+  configValues: Record<string, unknown>;
+  assetFiles: Record<string, File | undefined>;
+  onAssetFileChange: (slotKey: string, file: File | null) => void;
+  onBlockingErrorChange: (message: string | null) => void;
+}
+
+export function PptFillerPackOptions({
+  disabled,
+  configValues,
+  assetFiles,
+  onAssetFileChange,
+  onBlockingErrorChange,
+}: PptFillerPackOptionsProps) {
+  const { t } = useTranslation();
+  const { showSuccess } = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const {
+    stagedFile,
+    hasPersistedTemplate,
+    isAnalyzing,
+    analyzeFailed,
+    previewErrors,
+    blockingError,
+    stagedAnalyzedClean,
+    handlePick,
+    handleClear: clearAnalysis,
+    errorText,
+  } = usePptTemplateAnalysis({ configValues, assetFiles, onAssetFileChange, onBlockingErrorChange });
+
+  // One "upload succeeded" toast each time a freshly staged template analyzes
+  // cleanly. `stagedAnalyzedClean` flips back to false on the next pick (analysis
+  // is reset before re-analyzing), so a second good upload toasts again.
+  useEffect(() => {
+    if (stagedAnalyzedClean) {
+      showSuccess({ summary: t("capability.ppt_filler.form.uploadSuccessToast") });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stagedAnalyzedClean]);
+
+  const handleClear = () => {
+    clearAnalysis();
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const showReplaceLabel = hasPersistedTemplate || Boolean(stagedFile);
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.uploadRow}>
+        <input
+          ref={fileInputRef}
+          className={styles.fileInput}
+          type="file"
+          accept=".pptx"
+          disabled={disabled}
+          aria-label={t("capability.ppt_filler.form.uploadAria")}
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) void handlePick(file);
+          }}
+        />
+        <Button
+          color="primary"
+          variant="outlined"
+          size="small"
+          disabled={disabled || isAnalyzing}
+          icon={isAnalyzing ? undefined : { category: "outlined", type: "upload" }}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {isAnalyzing ? (
+            <span className={styles.buttonSpinner}>
+              <Spinner size={16} />
+            </span>
+          ) : showReplaceLabel ? (
+            t("capability.ppt_filler.form.replaceTemplate")
+          ) : (
+            t("capability.ppt_filler.form.uploadTemplate")
+          )}
+        </Button>
+
+        {stagedFile ? (
+          <Chip
+            label={stagedFile.name}
+            leading={<Icon category="outlined" type="slideshow" />}
+            onRemove={handleClear}
+            removeAriaLabel={t("capability.ppt_filler.form.clearAria")}
+          />
+        ) : (
+          hasPersistedTemplate && (
+            <Chip
+              label={t("capability.ppt_filler.form.currentTemplate")}
+              leading={<Icon category="outlined" type="check_circle" />}
+            />
+          )
+        )}
+      </div>
+
+      <Link className={styles.learnMoreLink} to="/ppt-filler-help" target="_blank" rel="noopener noreferrer">
+        {t("capability.ppt_filler.form.learnMore")}
+      </Link>
+
+      {blockingError && <p className={styles.blocking}>{blockingError}</p>}
+      {analyzeFailed && <p className={styles.error}>{t("capability.ppt_filler.form.analyzeFailed")}</p>}
+
+      {previewErrors.length > 0 && (
+        <ul className={styles.errorList}>
+          {previewErrors.map((error, index) => (
+            <li key={`${error.slide}-${error.key}-${error.code}-${index}`} className={styles.error}>
+              {errorText(error)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/usePptTemplateAnalysis.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/usePptTemplateAnalysis.ts
@@ -1,0 +1,156 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared ppt_filler template-upload orchestration (#1903), consumed by BOTH the
+// Advanced-view config widget (PptFillerConfigForm) and the Simple-view capability
+// pack options (PptFillerPackOptions). Kept as one hook so the analyze call, the
+// Save-gating blocking error, and the per-slide error i18n never drift between the
+// two surfaces — presentation stays in each component, this owns the logic only.
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  useAnalyzeAnalyzePostMutation,
+  type BodyAnalyzeAnalyzePost,
+  type ParseResult,
+  type SlideSchema,
+  type TemplateError,
+} from "./api/pptFillerCapabilityOpenApi";
+
+/** The manifest's one upload slot key (AssetSlot.key on the backend). */
+export const TEMPLATE_SLOT = "template";
+
+/**
+ * i18n an error by its stable code (the RFC contract: `code` is the machine
+ * key, `message` the English fallback). Unknown codes fall back to the
+ * backend-provided message so a new code never renders blank.
+ */
+export function useTemplateErrorText() {
+  const { t } = useTranslation();
+  return (error: TemplateError): string =>
+    t(`capability.ppt_filler.errors.${error.code}`, {
+      defaultValue: error.message,
+      slide: error.slide,
+      // The literal `{{key}}` placeholder is prebuilt here — braces inside an
+      // i18next template would be parsed as interpolation markers.
+      placeholder: `{{${error.key}}}`,
+    });
+}
+
+interface UsePptTemplateAnalysisArgs {
+  configValues: Record<string, unknown>;
+  assetFiles: Record<string, File | undefined>;
+  onAssetFileChange: (slotKey: string, file: File | null) => void;
+  onBlockingErrorChange: (message: string | null) => void;
+}
+
+export interface PptTemplateAnalysis {
+  stagedFile: File | undefined;
+  hasPersistedTemplate: boolean;
+  isAnalyzing: boolean;
+  analyzeFailed: boolean;
+  /** Slide schema of the current preview source (staged analysis, else persisted). */
+  previewSlides: SlideSchema[];
+  /** Validation errors for the staged file (empty for a clean or persisted template). */
+  previewErrors: TemplateError[];
+  /** Save-gating message (template missing / invalid), or null when the config is valid. */
+  blockingError: string | null;
+  /** True once a freshly staged file has analyzed cleanly (no errors). */
+  stagedAnalyzedClean: boolean;
+  handlePick: (file: File) => Promise<void>;
+  handleClear: () => void;
+  errorText: (error: TemplateError) => string;
+}
+
+/**
+ * Owns the upload → stateless `/analyze` → preview/validation lifecycle for the
+ * ppt_filler template slot. The uploaded file itself travels with the atomic
+ * save (multipart with-assets endpoints); this analysis never persists anything.
+ */
+export function usePptTemplateAnalysis({
+  configValues,
+  assetFiles,
+  onAssetFileChange,
+  onBlockingErrorChange,
+}: UsePptTemplateAnalysisArgs): PptTemplateAnalysis {
+  const { t } = useTranslation();
+  const errorText = useTemplateErrorText();
+  const [analyze, { isLoading: isAnalyzing }] = useAnalyzeAnalyzePostMutation();
+  const [analysis, setAnalysis] = useState<ParseResult | null>(null);
+  const [analyzeFailed, setAnalyzeFailed] = useState(false);
+
+  const stagedFile = assetFiles[TEMPLATE_SLOT];
+  const persistedSchema = (configValues.schema_slides as SlideSchema[] | undefined) ?? [];
+  const hasPersistedTemplate = persistedSchema.length > 0;
+
+  // What the preview shows: the staged file's live analysis when one is
+  // picked, else the persisted schema (source of truth: the saved template).
+  const previewSlides = stagedFile ? (analysis?.schema ?? []) : persistedSchema;
+  const previewErrors = stagedFile ? (analysis?.errors ?? []) : [];
+
+  const blockingError = useMemo(() => {
+    if (!stagedFile && !hasPersistedTemplate) return t("capability.ppt_filler.form.templateRequired");
+    if (stagedFile && previewErrors.length > 0) return t("capability.ppt_filler.form.templateInvalid");
+    return null;
+  }, [stagedFile, hasPersistedTemplate, previewErrors.length, t]);
+
+  useEffect(() => {
+    onBlockingErrorChange(blockingError);
+    // Clearing on unmount keeps a deselected capability from blocking Save.
+    return () => onBlockingErrorChange(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [blockingError]);
+
+  // Only true right after a staged file analyzes with no errors — lets a caller
+  // (the pack options) fire a one-shot "upload succeeded" toast.
+  const stagedAnalyzedClean = Boolean(stagedFile) && analysis !== null && (analysis?.errors ?? []).length === 0;
+
+  const handlePick = async (file: File) => {
+    onAssetFileChange(TEMPLATE_SLOT, file);
+    setAnalysis(null);
+    setAnalyzeFailed(false);
+    try {
+      // The generated client cannot express multipart; the FormData body cast
+      // is the sanctioned narrow exception (types still come from the client).
+      const formData = new FormData();
+      formData.append("file", file, file.name);
+      const result = await analyze({
+        bodyAnalyzeAnalyzePost: formData as unknown as BodyAnalyzeAnalyzePost,
+      }).unwrap();
+      setAnalysis(result);
+    } catch {
+      setAnalyzeFailed(true);
+    }
+  };
+
+  const handleClear = () => {
+    onAssetFileChange(TEMPLATE_SLOT, null);
+    setAnalysis(null);
+    setAnalyzeFailed(false);
+  };
+
+  return {
+    stagedFile,
+    hasPersistedTemplate,
+    isAnalyzing,
+    analyzeFailed,
+    previewSlides,
+    previewErrors,
+    blockingError,
+    stagedAnalyzedClean,
+    handlePick,
+    handleClear,
+    errorText,
+  };
+}

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
@@ -135,8 +135,17 @@ class VectorSearchService:
         self.vector_store = ctx.get_create_vector_store(self.embedder)
         self.tag_service = TagService()
         self.metadata_service = MetadataService()
-        self.crossencoder_model = ctx.get_crossencoder_model()
         self.kpi: BaseKPIWriter = ctx.get_kpi_writer()
+        self._crossencoder_model: Optional[Any] = None
+
+    @property
+    def crossencoder_model(self) -> Any:
+        # Loaded on first actual rerank, not at service construction: constructing this
+        # service (e.g. FastAPI route registration, OpenAPI generation) must not require
+        # a working HF model client — see cross-encoder CI 429s on generate-openapi.
+        if self._crossencoder_model is None:
+            self._crossencoder_model = ApplicationContext.get_instance().get_crossencoder_model()
+        return self._crossencoder_model
 
     def _kpi_search_dims(self, *, policy: str) -> dict[str, Optional[str]]:
         index_name = getattr(self.vector_store, "index_name", None) or getattr(self.vector_store, "index", None)


### PR DESCRIPTION
Bundle of minor UI fixes and two new Simple-view capability pack options.

## Team marketplace
- Gate whole-card navigation on team membership (`is_member`) instead of platform-admin status — non-member cards are no longer clickable.
- Cards stretch to equal height per row.
- Header search field (reusing `SearchInput`) filtering both team lists.

## Prompt view dialog
- Vertically centered, height capped at `100vh - 4rem` (never closer than 32px to the scrim), `min-height: 500px`; only the textarea scrolls internally.

## Prompts & Agents pages
- Left-align page headers and the Agents card grid.

## Capability packs (Simple view, #2220)
- New per-pack options section between card header and expander, with a smooth open animation.
- **PowerPoint pack**: mandatory `.pptx` template upload (spinner while analyzing, removable file chip, learn-more link, Save-gating template label + per-slide errors, success toast). Shares the analyze/blocking logic with the Advanced widget via a new `usePptTemplateAnalysis` hook.
- **Team resources pack**: `document_access` folder scoping — the "restrict to specific folders" switch + folder tree, same labels as Advanced with a leaner visual. The tree runs in a new `foldersOnly` mode (documents hidden and never fetched; folders expandable only when they have sub-folders).

## Shared library tree
- File/folder icons and colors now come from the shared `fileIconSpec`/`FOLDER_ICON`, matching the Resources table; folder tiles get an `outline-muted` border.

## Advanced view
- Rename `document_access` `bind_libraries` label/description to "Restrict to specific folders".

## Verification
- `make code-quality` (tsc + prettier + eslint) green.
- Unit tests updated/added (marketplace navigability + search, ToolPackCard options slot, DocumentAccessPackOptions folder-tree gating); touched suites pass.
- Visual review in-app still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)