### PR TITLE
fix(FRONT): admin Capabilities toggle freezes the UI (Chromium forced-blur scroll)

### DIFF
--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -32,6 +32,30 @@ import "@fontsource/inter/400.css";
 import "@fontsource/inter/500.css";
 import "@fontsource/inter/600.css";
 
+// <html> is deliberately `overflow: hidden` (styles/index.css) — every real
+// scroll in this app happens inside a purpose-built internal container, so
+// the document itself scrolling is always a browser quirk, never a user
+// action. The recurring case: Chromium force-blurs a still-focused control
+// when it's disabled or removed from the DOM (a mutation's `isLoading`
+// disabling a switch mid-toggle, a dialog/drawer closing under a focused
+// button) and silently scrollIntoView()s the nearest scrollable ancestor —
+// which, absent a normal scrolling body, is <html>. The page then looks
+// frozen: no visible scrollbar, no wheel response, top content scrolled out
+// of reach, recoverable only by a reload (admin Capabilities page, reported
+// repeatedly — #2275). Patching every trigger site is whack-a-mole; this
+// snaps the illegitimate scroll back the instant it happens, regardless of
+// which future interaction causes it.
+window.addEventListener(
+  "scroll",
+  () => {
+    const html = document.documentElement;
+    if (html.scrollTop !== 0 || html.scrollLeft !== 0) {
+      html.scrollTo(0, 0);
+    }
+  },
+  { passive: true },
+);
+
 const startApp = async () => {
   console.info("Starting Fred UI...");
   try {

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
@@ -104,6 +104,12 @@ export default function CapabilitiesPage() {
   // reintroducing the exact Chromium forced-blur bug the exclusion above
   // was written to prevent.
   const inFlightDefaultOnIdRef = useRef<string | null>(null);
+  // Same guard pair, same reason, for the Modèles-tab reasoning Switch: it
+  // shares `Switch`, `isTogglingReasoning` spans every row like
+  // `isTogglingDefault` did, and `<html>` is still `overflow: hidden` — an
+  // undisabled just-clicked row here would blur+scrollIntoView identically.
+  const [togglingReasoningId, setTogglingReasoningId] = useState<string | null>(null);
+  const inFlightReasoningIdRef = useRef<string | null>(null);
 
   const allCapabilities = data?.items ?? [];
   // `kind` is optional on the generated type (added to the enablement item
@@ -155,6 +161,11 @@ export default function CapabilitiesPage() {
   };
 
   const applyReasoning = async (capability: CapabilityEnablementItem, nextValue: boolean) => {
+    if (inFlightReasoningIdRef.current === capability.id) {
+      return;
+    }
+    inFlightReasoningIdRef.current = capability.id;
+    setTogglingReasoningId(capability.id);
     try {
       await setModelReasoning({
         capabilityId: capability.id,
@@ -167,6 +178,9 @@ export default function CapabilitiesPage() {
       });
     } catch {
       showError({ summary: t("rework.admin.capabilities.reasoningToggleError") });
+    } finally {
+      inFlightReasoningIdRef.current = null;
+      setTogglingReasoningId(null);
     }
   };
 
@@ -294,7 +308,7 @@ export default function CapabilitiesPage() {
                   <Tooltip text={t("rework.admin.capabilities.reasoningHint")}>
                     <Switch
                       checked={cap.reasoning_enabled ?? false}
-                      disabled={isTogglingReasoning}
+                      disabled={isTogglingReasoning && togglingReasoningId !== cap.id}
                       onChange={() => void applyReasoning(cap, !(cap.reasoning_enabled ?? false))}
                       aria-label={t("rework.admin.capabilities.col.reasoning")}
                     />


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**Issue:** #2275

**Problem in one sentence:** Toggling a switch (or confirming the default-off dialog) on `/admin/capabilities` can silently freeze the whole app — no scrollbar, no wheel response, top of the page scrolled out of reach — recoverable only by a full reload, reported repeatedly by multiple users over several weeks.

**Backlog ref:** none — live bug triage, not backlog-tracked work.

---

## 2. Before you wrote a single line of code

**RFC written?** Not required — bug fix, no design/schema/endpoint change.

**Plan presented to the team before implementation?** Yes — diagnosed live with Dimitri in-session: found and explained the root cause (Chromium force-blurring a still-focused control that gets `disabled`/removed from the DOM, then `scrollIntoView()`-ing the nearest scrollable ancestor, which is `<html>` here since it's kept `overflow: hidden` app-wide), proposed the fix approach, and got explicit go-ahead before each step (component guard, then the global fix after the bug reproduced a third time at a new site).

**Confirmation received?** Yes — Dimitri confirmed "seems good" after live-testing both the reasoning toggle and the default-off confirmation dialog on his own machine before this push.

---

## 3. What you built

Two commits, same root cause, escalating scope once the first two component-level fixes proved insufficient:

1. `46e77ecd` — guarded the Modèles-tab reasoning `Switch` in `CapabilitiesPage.tsx` the same way the platform default-on toggle already was (`a2d947e0`, #2185): exclude the just-toggled row's own id from the `disabled` check via a new `togglingReasoningId` state + `inFlightReasoningIdRef` ref guard, so the clicked switch never gets disabled while it still holds focus.
2. `4118a9e9` — reproduced the identical freeze immediately after, this time via the default-off **confirmation dialog's** Confirm button (which has no focus management at all) — proving the bug is systemic, not limited to `Switch`. Added a global `scroll` listener in `index.tsx` that snaps `document.documentElement`'s scroll position back to `(0, 0)` the instant it moves, since `<html>` is never legitimately supposed to scroll in this app (every real scroll happens in a purpose-built internal container). This neutralizes the whole bug class regardless of which future component triggers Chromium's quirk, instead of patching every trigger site individually.

---

## 4. Proof of quality

**Tests added or updated:** None. The sibling pattern this mirrors (`defaultOn` toggle guard, `a2d947e0`) has no test either; the global scroll-guard is a browser-quirk workaround with no meaningful unit-test surface (verified live in-browser instead, per team convention for this kind of fix).

| Test | File | What it covers |
| ---- | ---- | -------------- |
| n/a  | n/a  | n/a             |

**`make code-quality` output:**

```
npx tsc --noEmit
npx prettier . --check
Checking formatting...
All matched files use Prettier code style!
npx eslint "src/**/*.{ts,tsx}"
All frontend code quality checks completed
```

**Raw `basedpyright` output:** n/a — frontend-only change, no Python package touched.

**`make test` output:** n/a — no backend/testable-unit change; verified via live manual retest in the browser (see close-out).

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — not backlog-tracked |
| New behaviour, API field, or contract change                      | n/a — no contract change |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a |
| UX component implemented or visual status changed                 | n/a — bug fix restores intended behavior, no visual change |
| Phase progress row exists for this area                           | n/a |
| WORKPLAN sprint item finished                                     | n/a — WORKPLAN is frozen |
| Code and a design doc now diverge                                 | n/a |

---

## 6. Close-out statement

```
## Task close-out
- Code: guarded the Modèles reasoning toggle (CapabilitiesPage.tsx) against the same forced-blur freeze already fixed for the default-on toggle, then added a global <html> scroll-snap guard (index.tsx) after the bug reproduced a third time via the default-off confirmation dialog, proving it's systemic rather than per-component.
- Tests: make code-quality passes (tsc, prettier, eslint); no unit test added — mirrors the untested sibling fix and the browser-quirk nature of the global guard; verified live in-browser by Dimitri.
- Docs updated: none — mechanical/behavioral fix, no contract or UX change.
- Backlog: none — not backlog-tracked; tracked via GitHub issue #2275 instead.
- Skipped steps: Step 1 (RFC) — not applicable, no design decision; issue #2275 was opened during triage rather than before the first fix, since this started as a live bug report, not planned work.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** Worst case for the reasoning-toggle guard: a double-click race reappears (same class of bug the ref-guard prevents, already proven safe for the sibling `defaultOn` case). Worst case for the global scroll guard: if some future feature legitimately needs `<html>` to scroll, this listener would fight it — unlikely given the app's layout is built entirely on internal scroll containers by design, but worth remembering if that assumption ever changes.

**How do we roll back?** Revert either commit independently — they're unrelated in mechanism (one is a per-component guard, the other a global listener) and don't depend on each other.