### PR TITLE
fix(PROMPT-10): stop rejecting unknown {tokens} in prompt templates

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -37,7 +37,6 @@ from fred_sdk.contracts.capability import (
     StoredCapabilityConfig,
 )
 from fred_sdk.contracts.models import TeamScopePolicy
-from fred_sdk.contracts.prompt_utils import validate_prompt_template
 from pydantic import ValidationError
 
 from control_plane_backend.agent_instances.store import AgentInstanceRecord
@@ -1077,13 +1076,9 @@ def _validate_tuning_field_values(
                 _fail(key, f"expected a string for type {field.type!r}")
             if field.pattern is not None and re.fullmatch(field.pattern, value) is None:
                 _fail(key, f"value does not match pattern {field.pattern!r}")
-            if field.type == "prompt":
-                prompt_errors = validate_prompt_template(value)
-                if prompt_errors:
-                    details = "; ".join(
-                        f"'{e.pattern}': {e.reason}" for e in prompt_errors
-                    )
-                    _fail(key, f"invalid template syntax — {details}")
+            # `prompt` fields carry no token validation (#2277): the runtime
+            # renderer substitutes only PROMPT_SAFE_TOKENS and leaves every other
+            # `{…}` verbatim, so an unknown token is harmless rather than invalid.
         elif field.type == "select":
             if not isinstance(value, str):
                 _fail(key, "expected a string for type 'select'")
@@ -3262,37 +3257,6 @@ async def get_runtime_binding_for_team(
 # ---------------------------------------------------------------------------
 
 
-def _validate_prompt_library_text(
-    *,
-    text: str,
-    context_label: str,
-) -> None:
-    """
-    Validate one saved prompt-library text payload before persistence.
-
-    Why this function exists:
-    - managed-agent tuning validation already protects inline `prompts.*`
-      values, but the prompt library needs the same persistence-time safety at
-      its own CRUD boundary
-
-    How to use it:
-    - call before creating or updating one `Prompt` record
-    - invalid template syntax raises `PromptRequestError(http_status=422)`
-
-    Example:
-    - `_validate_prompt_library_text(text=request.text, context_label="prompt create")`
-    """
-
-    prompt_errors = validate_prompt_template(text)
-    if not prompt_errors:
-        return
-    details = "; ".join(f"'{error.pattern}': {error.reason}" for error in prompt_errors)
-    raise PromptRequestError(
-        f"Invalid prompt template during {context_label}: {details}.",
-        http_status=422,
-    )
-
-
 def _prompt_record_to_summary(record: PromptRecord) -> PromptSummary:
     """Project one stored prompt record into the list/command summary shape.
 
@@ -3386,17 +3350,12 @@ async def create_prompt(
 
     How to use it:
     - call from the prompt-library POST route after team membership is checked
-    - invalid template syntax raises `PromptRequestError(422)`
     - duplicate prompt names inside the same team raise `PromptRequestError(409)`
 
     Example:
     - `summary = await create_prompt(user=user, team_id=team_id, request=body, deps=deps)`
     """
 
-    _validate_prompt_library_text(
-        text=request.text,
-        context_label=f"prompt create for team {team_id!r}",
-    )
     record = PromptRecord(
         prompt_id=str(uuid4()),
         team_id=team_id,
@@ -3510,17 +3469,12 @@ async def update_prompt(
     How to use it:
     - call from the prompt PUT route after team membership is checked
     - returns `None` when the prompt does not belong to `team_id`
-    - invalid template syntax raises `PromptRequestError(422)`
     - duplicate names raise `PromptRequestError(409)`
 
     Example:
     - `summary = await update_prompt(team_id, prompt_id, request, deps)`
     """
 
-    _validate_prompt_library_text(
-        text=request.text,
-        context_label=f"prompt update for team {team_id!r}",
-    )
     try:
         updated = await deps.get_prompt_store().update(
             prompt_id,

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -7613,10 +7613,10 @@ async def test_get_prompt_detail_includes_category_id_emoji_and_tags(
 
 
 @pytest.mark.asyncio
-async def test_prompt_library_rejects_invalid_prompt_template_before_write(
+async def test_prompt_library_accepts_unknown_prompt_template_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prompt CRUD validates template text before any prompt row is written."""
+    """Prompt CRUD stores unknown {tokens} verbatim rather than rejecting (#2277)."""
 
     monkeypatch.setattr(
         "control_plane_backend.product.api.require_team_access",
@@ -7632,15 +7632,15 @@ async def test_prompt_library_rejects_invalid_prompt_template_before_write(
         resp = await client.post(
             "/control-plane/v1/teams/personal/prompts",
             json={
-                "name": "Bad prompt",
+                "name": "Unknown token prompt",
                 "description": None,
                 "text": "Hello {unknown_token}.",
             },
         )
 
-    assert resp.status_code == 422
-    assert "{unknown_token}" in resp.json()["detail"]
-    assert store._records == []
+    assert resp.status_code == 201
+    assert len(store._records) == 1
+    assert store._records[0].text == "Hello {unknown_token}."
 
 
 # ---------------------------------------------------------------------------
@@ -7774,15 +7774,15 @@ async def test_delete_prompt_category_blocked_while_in_use(
 
 
 # ---------------------------------------------------------------------------
-# Prompt template validation — enroll (create-then-reject)
+# Prompt template tokens — enroll (unknown tokens are accepted, #2277)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_enroll_agent_instance_rejects_unknown_prompt_token(
+async def test_enroll_agent_instance_accepts_unknown_prompt_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unknown {token} in prompts.system → 422 before any DB write."""
+    """Unknown {token} in prompts.system → 201; the renderer leaves it verbatim."""
     monkeypatch.setattr(
         "control_plane_backend.product.api.require_team_access",
         _fake_require_team_access,
@@ -7817,17 +7817,20 @@ async def test_enroll_agent_instance_rejects_unknown_prompt_token(
             json={
                 "usage_statement": "Test usage statement covering purpose, users, data, and error impact.",
                 "template_id": "runtime-a:rags.sample.validated",
-                "display_name": "Bad Prompt Agent",
+                "display_name": "Unknown Token Agent",
                 "tuning_field_values": {
                     "prompts.system": "Hello {name}, today is {today}.",
                 },
             },
         )
 
-    assert resp.status_code == 422
-    assert "{name}" in resp.json()["detail"]
-    # Agent must not have been written to the store
-    assert store._records == []
+    assert resp.status_code == 201
+    assert len(store._records) == 1
+    # Text is stored verbatim — {name} survives to be rendered as a literal
+    assert (
+        store._records[0].tuning.values["prompts.system"]
+        == "Hello {name}, today is {today}."
+    )
 
 
 @pytest.mark.asyncio
@@ -7936,10 +7939,10 @@ async def test_enroll_agent_instance_accepts_prompt_with_code_braces(
 
 
 @pytest.mark.asyncio
-async def test_patch_agent_instance_rejects_unknown_prompt_token(
+async def test_patch_agent_instance_accepts_unknown_prompt_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Updating prompts.system with an unknown {token} → 422, record unchanged."""
+    """Updating prompts.system with an unknown {token} → 200, value persisted."""
     monkeypatch.setattr(
         "control_plane_backend.product.api.require_team_access",
         _fake_require_team_access,
@@ -7972,10 +7975,11 @@ async def test_patch_agent_instance_rejects_unknown_prompt_token(
             },
         )
 
-    assert resp.status_code == 422
-    assert "{unknown_var}" in resp.json()["detail"]
-    # Stored record must be unchanged
-    assert store._records[0].tuning.values.get("prompts.system") is None
+    assert resp.status_code == 200
+    assert (
+        store._records[0].tuning.values["prompts.system"]
+        == "Hi {unknown_var}, today is {today}."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/swift/design/PROMPTS.md
+++ b/docs/swift/design/PROMPTS.md
@@ -40,19 +40,26 @@ Supported user-authored tokens are:
 | `{user_id}` | Authenticated user identifier |
 | `{agent_id}` | Agent definition identifier |
 
-Persistence-time validation rejects unknown simple tokens such as `{name}` with
-HTTP 422 before writing the agent or prompt-library record. Non-simple brace
-patterns such as `{}`, `{0}`, `{object.attr}`, and code blocks containing braces
-are preserved as literals by the renderer and are not rejected by the current
-validator.
+Any `{…}` the renderer does not recognize is left exactly as written. That covers
+unknown simple tokens such as `{name}`, and equally non-simple patterns such as
+`{}`, `{0}`, `{object.attr}`, JSON, and code blocks containing braces. The
+renderer never raises: substitution falls back to the matched text.
 
-Validation applies to:
+**There is no persistence-time validation of prompt tokens** (#2277). Prompt text
+is stored verbatim on managed-agent create/update (`type == "prompt"` field specs)
+and on prompt-library create/update.
 
-- managed-agent create/update for field specs with `type == "prompt"`
-- prompt-library create/update
+Rejecting unknown tokens with HTTP 422 was removed because it was a false
+positive — the renderer already handled those prompts correctly, so the check only
+blocked authors from writing legitimate text such as `Hello {name}`, with no
+in-product documentation or UI hint to explain the rule. The accepted trade-off is
+that a typo (`{todya}` for `{today}`) now reaches the prompt as literal text
+instead of being caught on write; that failure is visible to the author in the
+agent's output.
 
-Atomic agent creation follows from that validation: a bad prompt tuning value is
-rejected before the agent instance row is created.
+`PROMPT_SAFE_TOKENS` remains the single source of truth for the renderer, and is
+the intended source for a prompt-editor UI hint that would make the feature
+discoverable.
 
 ## 3. Prompt Library
 

--- a/libs/fred-runtime/fred_runtime/react/react_prompting.py
+++ b/libs/fred-runtime/fred_runtime/react/react_prompting.py
@@ -278,10 +278,11 @@ def build_context_prompt_suffix(binding: BoundRuntimeContext, *, agent_id: str) 
       reached the agent binding but was never appended to the system prompt, so a
       selected prompt such as "speak Spanish" had no effect on the model (#1915).
     - user-authored context prompts may legitimately use the same safe tokens as
-      agent templates (e.g. ``{response_language}``, ``{today}``), which are
-      persistence-validated against ``PROMPT_SAFE_TOKENS``. They are therefore
-      rendered through the same safe renderer rather than appended verbatim, so a
-      token in a library prompt substitutes exactly as it would in an agent prompt.
+      agent templates (e.g. ``{response_language}``, ``{today}``). They are
+      therefore rendered through the same safe renderer rather than appended
+      verbatim, so a token in a library prompt substitutes exactly as it would in
+      an agent prompt — and any unrecognized ``{…}`` is preserved as written,
+      since prompt text is stored without token validation (#2277).
 
     How to use:
     - call while assembling the final system prompt for one runtime turn; returns

--- a/libs/fred-sdk/fred_sdk/contracts/__init__.py
+++ b/libs/fred-sdk/fred_sdk/contracts/__init__.py
@@ -63,11 +63,7 @@ from .openai_compat import (
     OpenAIToolCall,
     OpenAIToolCallFunction,
 )
-from .prompt_utils import (
-    PROMPT_SAFE_TOKENS,
-    PromptTemplateError,
-    validate_prompt_template,
-)
+from .prompt_utils import PROMPT_SAFE_TOKENS
 from .runtime import RuntimeErrorEvent, TurnPersistedEvent
 from .ui_part_union import (
     BASE_UI_PARTS,
@@ -120,8 +116,6 @@ __all__ = [
     "OpenAIModelList",
     "OpenAIToolCall",
     "OpenAIToolCallFunction",
-    # Prompt template token registry and validation
+    # Prompt template token registry
     "PROMPT_SAFE_TOKENS",
-    "PromptTemplateError",
-    "validate_prompt_template",
 ]

--- a/libs/fred-sdk/fred_sdk/contracts/prompt_utils.py
+++ b/libs/fred-sdk/fred_sdk/contracts/prompt_utils.py
@@ -13,40 +13,39 @@
 # limitations under the License.
 
 """
-Canonical prompt-template token registry and validation utilities.
+Canonical prompt-template token registry.
 
 Why this module exists:
-- define the single source of truth for which {tokens} are supported in
+- define the single source of truth for which {tokens} are substituted in
   user-authored system prompts
-- provide a validator that control-plane can call before persisting any
-  prompt field value, so broken templates are rejected at save time rather
-  than crashing the agent at execution time
-- let the renderer in fred-runtime import the same token set so the two
-  surfaces stay in sync automatically
+- let the renderer in fred-runtime import that token set, so the registry and
+  the substitution stay in sync automatically
+
+Why there is no validator here (#2277):
+- the renderer substitutes a token only when it is present in this registry and
+  otherwise leaves the matched text verbatim, so an unrecognized `{token}` is
+  already harmless — it renders as itself and cannot crash the agent
+- rejecting unknown tokens at save time was therefore a false positive: it
+  blocked prompts such as `Hello {name}` that would have rendered correctly,
+  with no in-product documentation or UI hint to warn the author
+- the accepted trade-off is that a typo (`{todya}`) now reaches the prompt as
+  literal text instead of being caught on write; that failure is visible to the
+  author in the agent's output
 
 How to use:
 - import PROMPT_SAFE_TOKENS to get the canonical {token} → description map
-- call validate_prompt_template(text) before persisting a prompt field;
-  an empty return list means the template is safe to store
 """
 
 from __future__ import annotations
 
-import re
 from typing import Final
-
-from pydantic import BaseModel
-
-# Matches only {simple_identifier} — no dots, no digits, no spaces, not empty.
-# This is the only pattern that can ever be a valid template token.
-_SIMPLE_TOKEN_RE: Final = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 # Canonical set of runtime tokens available in user-authored system prompts.
 # Key   = token name (used inside {…} in the prompt text).
-# Value = human-readable description forwarded to the frontend in error messages.
+# Value = human-readable description, intended for a prompt-editor UI hint.
 #
-# To add a new supported token: add one entry here. The renderer and validator
-# pick it up automatically — no other site needs to change.
+# To add a new supported token: add one entry here plus its runtime value in
+# `safe_prompt_token_map` (fred-runtime) — no other site needs to change.
 PROMPT_SAFE_TOKENS: Final[dict[str, str]] = {
     "today": "ISO-8601 date at execution time (e.g. 2026-05-07)",
     "response_language": "Human-readable response language (e.g. English, français)",
@@ -54,59 +53,3 @@ PROMPT_SAFE_TOKENS: Final[dict[str, str]] = {
     "user_id": "Authenticated user identifier",
     "agent_id": "Agent definition identifier",
 }
-
-# Pre-built hint string included in error messages so users see the full list.
-_SUPPORTED_HINT: Final[str] = ", ".join(f"{{{k}}}" for k in PROMPT_SAFE_TOKENS)
-
-
-class PromptTemplateError(BaseModel):
-    """One validation error found in a prompt template."""
-
-    pattern: str
-    reason: str
-
-
-def validate_prompt_template(text: str) -> list[PromptTemplateError]:
-    """
-    Validate a user-authored prompt template text against PROMPT_SAFE_TOKENS.
-
-    Why this exists:
-    - prompt fields submitted via the control-plane API are stored before the
-      agent ever executes; without up-front validation a bad template silently
-      breaks the agent on the first chat message
-
-    How to use:
-    - call before persisting any field whose FieldSpec.type == "prompt"
-    - an empty return list means the template is safe to store
-    - a non-empty list means the create/update should be rejected with 422
-
-    Validation rule:
-    - any {simple_identifier} not in PROMPT_SAFE_TOKENS is an error
-    - non-simple brace patterns ({}, {0}, {toto.toto}, { x }) are not matched
-      and are silently preserved as literals by the renderer — no error raised,
-      because they cannot be confused with template tokens (they will never be
-      substituted and they no longer crash the renderer)
-
-    Example:
-    - validate_prompt_template("Today is {today}.")  →  []
-    - validate_prompt_template("Hello {name}!")      →  [PromptTemplateError(...)]
-    """
-    errors: list[PromptTemplateError] = []
-    seen: set[str] = set()
-
-    for match in _SIMPLE_TOKEN_RE.finditer(text):
-        token = match.group(1)
-        raw = match.group(0)
-        if token not in PROMPT_SAFE_TOKENS and raw not in seen:
-            seen.add(raw)
-            errors.append(
-                PromptTemplateError(
-                    pattern=raw,
-                    reason=(
-                        f"Unknown template token. "
-                        f"Supported tokens are: {_SUPPORTED_HINT}."
-                    ),
-                )
-            )
-
-    return errors

--- a/libs/fred-sdk/tests/test_prompt_utils.py
+++ b/libs/fred-sdk/tests/test_prompt_utils.py
@@ -24,8 +24,10 @@ with `safe_prompt_token_map` in fred-runtime, and adding a key here without
 adding the matching runtime value would render that token as empty text.
 """
 
+import fred_sdk.contracts.prompt_utils as prompt_utils
 from fred_sdk.contracts import PROMPT_SAFE_TOKENS as PROMPT_SAFE_TOKENS_REEXPORT
-from fred_sdk.contracts.prompt_utils import PROMPT_SAFE_TOKENS
+
+PROMPT_SAFE_TOKENS = prompt_utils.PROMPT_SAFE_TOKENS
 
 # ---------------------------------------------------------------------------
 # PROMPT_SAFE_TOKENS registry
@@ -74,7 +76,5 @@ def test_validator_surface_is_gone() -> None:
     Re-adding save-time rejection would once again block prompts such as
     `Hello {name}` that the renderer handles correctly.
     """
-    import fred_sdk.contracts.prompt_utils as prompt_utils
-
     assert not hasattr(prompt_utils, "validate_prompt_template")
     assert not hasattr(prompt_utils, "PromptTemplateError")

--- a/libs/fred-sdk/tests/test_prompt_utils.py
+++ b/libs/fred-sdk/tests/test_prompt_utils.py
@@ -15,16 +15,17 @@
 """
 Tests for fred_sdk.contracts.prompt_utils.
 
-Ref: docs/backlog/BACKLOG.md §3d.9 (P1) — PROMPT_SAFE_TOKENS registry,
-     validate_prompt_template (unknown tokens → error, non-simple braces preserved),
-     crash-proof rendering for code braces and dotted-notation patterns.
+The module is now a pure registry: save-time validation of unknown {tokens}
+was removed in #2277 because the fred-runtime renderer already preserves any
+token outside PROMPT_SAFE_TOKENS verbatim, making rejection a false positive.
+
+These tests pin the registry itself — its exact key set is a contract shared
+with `safe_prompt_token_map` in fred-runtime, and adding a key here without
+adding the matching runtime value would render that token as empty text.
 """
 
-import pytest
-from fred_sdk.contracts.prompt_utils import (
-    PROMPT_SAFE_TOKENS,
-    validate_prompt_template,
-)
+from fred_sdk.contracts import PROMPT_SAFE_TOKENS as PROMPT_SAFE_TOKENS_REEXPORT
+from fred_sdk.contracts.prompt_utils import PROMPT_SAFE_TOKENS
 
 # ---------------------------------------------------------------------------
 # PROMPT_SAFE_TOKENS registry
@@ -46,122 +47,34 @@ def test_safe_tokens_all_have_non_empty_descriptions() -> None:
         assert desc, f"Token '{key}' has an empty description"
 
 
-# ---------------------------------------------------------------------------
-# Clean templates — no errors expected
-# ---------------------------------------------------------------------------
+def test_safe_tokens_are_simple_identifiers() -> None:
+    """
+    Every registry key must be a bare identifier.
+
+    The renderer matches `\\{([a-zA-Z_][a-zA-Z0-9_]*)\\}`; a key that does not
+    fit that shape could never be substituted and would silently do nothing.
+    """
+    for key in PROMPT_SAFE_TOKENS:
+        assert key.isidentifier(), f"Token '{key}' is not a simple identifier"
 
 
-@pytest.mark.parametrize(
-    "text",
-    [
-        "You are a helpful assistant.",
-        "Today is {today}.",
-        "Respond in {response_language}.",
-        "Session: {session_id}, User: {user_id}, Agent: {agent_id}.",
-        "All tokens: {today} {response_language} {session_id} {user_id} {agent_id}.",
-        # Code braces are not simple identifiers — preserved as literals, no error
-        "function main(workbook: ExcelScript.Workbook) { doSomething(); }",
-        # Dotted notation is not a simple identifier — left as literal, no error
-        "{toto.toto} should not be flagged",
-        # Empty brace not a simple identifier
-        "Use {} carefully",
-        # Positional placeholder not a simple identifier
-        "Value: {0}",
-        # Whitespace inside braces not a simple identifier
-        "{ not a token }",
-    ],
-)
-def test_clean_templates(text: str) -> None:
-    assert validate_prompt_template(text) == []
+def test_registry_is_re_exported_from_contracts_package() -> None:
+    assert PROMPT_SAFE_TOKENS_REEXPORT is PROMPT_SAFE_TOKENS
 
 
 # ---------------------------------------------------------------------------
-# Invalid templates — errors expected
+# Removed surface (#2277)
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_simple_token_single() -> None:
-    errors = validate_prompt_template("Hello {name}!")
-    assert len(errors) == 1
-    assert errors[0].pattern == "{name}"
-    assert "Unknown template token" in errors[0].reason
-    # Error message must list the supported tokens
-    for token in PROMPT_SAFE_TOKENS:
-        assert token in errors[0].reason
+def test_validator_surface_is_gone() -> None:
+    """
+    The validator must not come back without a deliberate decision.
 
+    Re-adding save-time rejection would once again block prompts such as
+    `Hello {name}` that the renderer handles correctly.
+    """
+    import fred_sdk.contracts.prompt_utils as prompt_utils
 
-def test_unknown_simple_token_multiple_distinct() -> None:
-    errors = validate_prompt_template("{foo} and {bar} are unknown")
-    patterns = {e.pattern for e in errors}
-    assert patterns == {"{foo}", "{bar}"}
-
-
-def test_unknown_simple_token_repeated_deduplicated() -> None:
-    errors = validate_prompt_template("{foo} again {foo}")
-    assert len(errors) == 1
-    assert errors[0].pattern == "{foo}"
-
-
-def test_mix_valid_and_invalid_tokens() -> None:
-    errors = validate_prompt_template("Today is {today} and {bad_token} here.")
-    assert len(errors) == 1
-    assert errors[0].pattern == "{bad_token}"
-
-
-def test_all_valid_tokens_produce_no_errors() -> None:
-    text = " ".join(f"{{{k}}}" for k in PROMPT_SAFE_TOKENS)
-    assert validate_prompt_template(text) == []
-
-
-# ---------------------------------------------------------------------------
-# Non-simple brace patterns are NOT flagged (renderer preserves them safely)
-# ---------------------------------------------------------------------------
-
-
-def test_dotted_notation_not_flagged() -> None:
-    assert validate_prompt_template("{object.attr}") == []
-
-
-def test_empty_braces_not_flagged() -> None:
-    assert validate_prompt_template("{}") == []
-
-
-def test_positional_placeholder_not_flagged() -> None:
-    assert validate_prompt_template("{0}") == []
-
-
-def test_whitespace_brace_not_flagged() -> None:
-    assert validate_prompt_template("{ spaces }") == []
-
-
-def test_code_block_not_flagged() -> None:
-    prompt = (
-        "You help users write Excel scripts. Example:\n"
-        "function main(workbook: ExcelScript.Workbook) {\n"
-        "    workbook.getActiveWorksheet().getCell(0, 0).setValue('Hello');\n"
-        "}"
-    )
-    assert validate_prompt_template(prompt) == []
-
-
-# ---------------------------------------------------------------------------
-# Edge cases
-# ---------------------------------------------------------------------------
-
-
-def test_empty_string_is_valid() -> None:
-    assert validate_prompt_template("") == []
-
-
-def test_no_braces_is_valid() -> None:
-    assert validate_prompt_template("Plain text without any braces.") == []
-
-
-def test_token_adjacent_to_punctuation() -> None:
-    errors = validate_prompt_template("Hi, {unknown}!")
-    assert len(errors) == 1
-    assert errors[0].pattern == "{unknown}"
-
-
-def test_known_token_at_start_and_end() -> None:
-    assert validate_prompt_template("{today} is a great day, {user_id}.") == []
+    assert not hasattr(prompt_utils, "validate_prompt_template")
+    assert not hasattr(prompt_utils, "PromptTemplateError")


### PR DESCRIPTION
Closes #2277

## Problem

Writing a prompt containing something as ordinary as `Hello {name}` was refused at save time with HTTP 422. The templating syntax is documented nowhere in the product and there is no UI hint (no frontend consumer of `PROMPT_SAFE_TOKENS` exists), so authors had no way to anticipate the rule — they just hit a wall on text that would have worked.

## Why the check was wrong

It was a false positive. The runtime renderer substitutes via `tokens.get(name, matched_text)` ([`react_prompting.py`](https://github.com/ThalesGroup/fred/blob/swift/libs/fred-runtime/fred_runtime/react/react_prompting.py)) — an unrecognized token falls back to the matched text unchanged. No crash, no `KeyError`, no degraded output:

```
"Hello {name}, today is {today}."   →  "Hello {name}, today is 2026-08-07."
"if (x > 0) { return x; }"          →  unchanged
"JSON: {\"name\": \"x\"} and {toto.toto} and {} and {0}"  →  unchanged
```

`{today}` substitutes; `{name}` survives verbatim. The validator was rejecting prompts the renderer already handled correctly.

## Change

Delete the save-time validation. **Runtime behaviour is identical before and after** — only the accept/reject decision at the API boundary moves, which is what makes this a low-risk deletion rather than a behaviour change.

- removed `validate_prompt_template` + `PromptTemplateError` from `fred_sdk/contracts/prompt_utils.py` and the `contracts/__init__.py` exports
- removed both call sites in `product/service.py`: the `type == "prompt"` tuning branch and `_validate_prompt_library_text` (prompt-library create/update)
- `PROMPT_SAFE_TOKENS` kept — it is the renderer registry and the source for a future UI hint

Net −184 lines.

## Accepted trade-off

A genuine typo (`{todya}` for `{today}`) now ships as literal text instead of being caught on write. That was the original justification for the check, but catching it cost every legitimate `{name}`, and the failure is visible to the author in the agent output.

This does make the deferred UI hint more valuable than before: it is now the *only* place the token syntax could be discovered. Worth a follow-up issue.

## Tests

- 717 passed (control-plane), 239 (fred-sdk), 783 (fred-runtime); `make code-quality` exit 0
- four tests inverted from 422 to 201/200 — two agent-instance (enroll + patch), one prompt-library, plus the code-braces case that already asserted 201
- `test_prompt_utils.py` rewritten around the registry, with a guard that the validator surface does not silently return and a check that every key is a valid identifier (a key not matching the renderer regex would be dead weight)

## Docs

- `docs/swift/design/PROMPTS.md` §2 rewritten — it documented the opposite rule
- fixed a docstring in `react_prompting.py` claiming context prompts are "persistence-validated against `PROMPT_SAFE_TOKENS`", which was the stated reason for routing them through the renderer and would have become misleading

🤖 Generated with [Claude Code](https://claude.com/claude-code)