### PR TITLE
fix(knowledge-flow): remember learned embedding batch cap across bulk slices

### DIFF
--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
@@ -317,6 +317,10 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
         self._secure = secure
         self._verify_certs = verify_certs
         self._bulk_size = bulk_size
+        # Largest batch size the embedding provider has accepted after rejecting a
+        # bigger one (None until a batch-limit error is seen). Only ever lowered, so
+        # later slices skip the provider calls that are known to fail.
+        self._learned_embedding_batch_cap: Optional[int] = None
         self._embedding_model_name = embedding_model_name
         self._kpi = kpi
         self._vs: OpenSearchVectorSearch | None = None
@@ -724,6 +728,23 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
         )
         return prepared_documents, prepared_ids
 
+    def _effective_embedding_batch_size(self) -> int:
+        if self._learned_embedding_batch_cap is None:
+            return self._bulk_size
+        return max(1, min(self._bulk_size, self._learned_embedding_batch_cap))
+
+    def _lower_learned_embedding_batch_cap(self, new_cap: int) -> None:
+        current = self._learned_embedding_batch_cap
+        if current is not None and current <= new_cap:
+            return
+        self._learned_embedding_batch_cap = new_cap
+        logger.info(
+            "[VECTOR][OPENSEARCH] learned embedding batch cap for index=%s lowered to %s (was %s)",
+            self._index,
+            new_cap,
+            current,
+        )
+
     def _add_documents_with_adaptive_batching(
         self,
         documents: List[Document],
@@ -743,9 +764,35 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
             It first tries the batch as-is. If the embedding backend reports a
             structured batch-limit error, the helper splits the batch in half and retries
             recursively until each sub-batch is accepted or only one document remains.
+            The size that triggered the split is remembered on the instance
+            (`_learned_embedding_batch_cap`) so later batches are pre-split without
+            re-attempting a provider call that is known to fail. The cap is only ever
+            lowered; a pathological batch (one giant chunk) can therefore leave it
+            smaller than strictly needed, which costs extra requests but never errors.
             If the backend reports a transient server-side failure, the helper retries the
             same batch with exponential backoff before giving up.
         """
+        cap = self._learned_embedding_batch_cap
+        if cap is not None and len(documents) > cap:
+            split_index = max(1, len(documents) // 2)
+            logger.info(
+                "[VECTOR][OPENSEARCH] batch exceeds learned embedding cap for index=%s batch_size=%s learned_cap=%s; splitting without provider attempt",
+                self._index,
+                len(documents),
+                cap,
+            )
+            left_ids = self._add_documents_with_adaptive_batching(
+                documents=documents[:split_index],
+                ids=ids[:split_index],
+                split_chunk_size=split_chunk_size,
+            )
+            right_ids = self._add_documents_with_adaptive_batching(
+                documents=documents[split_index:],
+                ids=ids[split_index:],
+                split_chunk_size=split_chunk_size,
+            )
+            return left_ids + right_ids
+
         try:
             logger.info(
                 "[VECTOR][OPENSEARCH] add batch attempt index=%s batch_size=%s retry_attempt=%s split_chunk_size=%s ids_sample=%s",
@@ -815,6 +862,7 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
                     )
 
                 split_index = max(1, len(documents) // 2)
+                self._lower_learned_embedding_batch_cap(split_index)
                 logger.warning(
                     "[VECTOR][OPENSEARCH] embedding batch exceeds provider limit for index=%s batch_size=%s; splitting into sub-batches %s and %s",
                     self._index,
@@ -901,15 +949,17 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
             )
 
             assigned_ids: List[str] = []
-            for start in range(0, len(documents), self._bulk_size):
-                end = start + self._bulk_size
+            start = 0
+            while start < len(documents):
+                # Re-read each iteration: an earlier slice may have lowered the cap.
+                end = min(start + self._effective_embedding_batch_size(), len(documents))
                 batch_documents = documents[start:end]
                 batch_ids = ids[start:end]
                 logger.info(
                     "[VECTOR][OPENSEARCH] processing bulk slice index=%s start=%s end=%s batch_size=%s",
                     self._index,
                     start,
-                    min(end, len(documents)),
+                    end,
                     len(batch_documents),
                 )
                 assigned_ids.extend(
@@ -918,6 +968,7 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
                         ids=batch_ids,
                     )
                 )
+                start = end
 
             logger.info(
                 "[VECTOR][OPENSEARCH] add_documents complete index=%s input_documents=%s stored_chunks=%s",

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/vector/opensearch_vector_store.py
@@ -209,6 +209,7 @@ T = TypeVar("T", bound=BaseVectorHit)
 EMBEDDING_RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
 EMBEDDING_RETRY_BASE_DELAY_SECONDS = 0.5
 EMBEDDING_RETRY_MAX_ATTEMPTS = 3
+EMBEDDING_CAP_PROBE_AFTER_SUCCESSES = 10
 
 
 @dataclass(frozen=True)
@@ -318,9 +319,12 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
         self._verify_certs = verify_certs
         self._bulk_size = bulk_size
         # Largest batch size the embedding provider has accepted after rejecting a
-        # bigger one (None until a batch-limit error is seen). Only ever lowered, so
-        # later slices skip the provider calls that are known to fail.
+        # bigger one (None until a batch-limit error is seen). Lowered on rejection;
+        # after EMBEDDING_CAP_PROBE_AFTER_SUCCESSES consecutive successes at the cap,
+        # one batch probes double the size so a dense early batch cannot pin the cap
+        # low for the rest of the corpus.
         self._learned_embedding_batch_cap: Optional[int] = None
+        self._cap_success_streak: int = 0
         self._embedding_model_name = embedding_model_name
         self._kpi = kpi
         self._vs: OpenSearchVectorSearch | None = None
@@ -728,10 +732,25 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
         )
         return prepared_documents, prepared_ids
 
+    def _current_embedding_attempt_limit(self) -> Optional[int]:
+        """
+        Largest batch size worth attempting right now: the learned cap, or — once
+        EMBEDDING_CAP_PROBE_AFTER_SUCCESSES consecutive full-cap batches have
+        succeeded — a one-shot upward probe at double the cap (bounded by
+        bulk_size) so the cap can recover from an unusually dense early batch.
+        """
+        cap = self._learned_embedding_batch_cap
+        if cap is None:
+            return None
+        if self._cap_success_streak >= EMBEDDING_CAP_PROBE_AFTER_SUCCESSES:
+            return min(self._bulk_size, cap * 2)
+        return cap
+
     def _effective_embedding_batch_size(self) -> int:
-        if self._learned_embedding_batch_cap is None:
+        limit = self._current_embedding_attempt_limit()
+        if limit is None:
             return self._bulk_size
-        return max(1, min(self._bulk_size, self._learned_embedding_batch_cap))
+        return max(1, min(self._bulk_size, limit))
 
     def _lower_learned_embedding_batch_cap(self, new_cap: int) -> None:
         current = self._learned_embedding_batch_cap
@@ -766,20 +785,23 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
             recursively until each sub-batch is accepted or only one document remains.
             The size that triggered the split is remembered on the instance
             (`_learned_embedding_batch_cap`) so later batches are pre-split without
-            re-attempting a provider call that is known to fail. The cap is only ever
-            lowered; a pathological batch (one giant chunk) can therefore leave it
-            smaller than strictly needed, which costs extra requests but never errors.
-            If the backend reports a transient server-side failure, the helper retries the
-            same batch with exponential backoff before giving up.
+            re-attempting a provider call that is known to fail. The cap is lowered
+            on rejection; after EMBEDDING_CAP_PROBE_AFTER_SUCCESSES consecutive
+            successes at the cap, one batch probes double the size so the cap
+            converges back up when an early dense batch pushed it lower than the
+            rest of the corpus needs. A failed probe costs a single rejected call
+            and resets the streak. If the backend reports a transient server-side
+            failure, the helper retries the same batch with exponential backoff
+            before giving up.
         """
-        cap = self._learned_embedding_batch_cap
-        if cap is not None and len(documents) > cap:
+        limit = self._current_embedding_attempt_limit()
+        if limit is not None and len(documents) > limit:
             split_index = max(1, len(documents) // 2)
             logger.info(
-                "[VECTOR][OPENSEARCH] batch exceeds learned embedding cap for index=%s batch_size=%s learned_cap=%s; splitting without provider attempt",
+                "[VECTOR][OPENSEARCH] batch exceeds learned embedding cap for index=%s batch_size=%s attempt_limit=%s; splitting without provider attempt",
                 self._index,
                 len(documents),
-                cap,
+                limit,
             )
             left_ids = self._add_documents_with_adaptive_batching(
                 documents=documents[:split_index],
@@ -820,6 +842,20 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
                 retry_attempt,
                 split_chunk_size,
             )
+            cap = self._learned_embedding_batch_cap
+            if cap is not None:
+                if len(documents) > cap:
+                    # Successful upward probe: adopt the bigger size.
+                    self._learned_embedding_batch_cap = len(documents)
+                    self._cap_success_streak = 0
+                    logger.info(
+                        "[VECTOR][OPENSEARCH] learned embedding batch cap for index=%s raised to %s after successful probe (was %s)",
+                        self._index,
+                        len(documents),
+                        cap,
+                    )
+                elif len(documents) == cap:
+                    self._cap_success_streak += 1
             return assigned_ids
         except Exception as error:
             failure = self._get_embedding_request_failure(error)
@@ -862,6 +898,7 @@ class OpenSearchVectorStoreAdapter(BaseVectorStore):
                     )
 
                 split_index = max(1, len(documents) // 2)
+                self._cap_success_streak = 0
                 self._lower_learned_embedding_batch_cap(split_index)
                 logger.warning(
                     "[VECTOR][OPENSEARCH] embedding batch exceeds provider limit for index=%s batch_size=%s; splitting into sub-batches %s and %s",

--- a/apps/knowledge-flow-backend/tests/stores/test_opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/test_opensearch_vector_store.py
@@ -400,13 +400,147 @@ def test_opensearch_vector_store_add_documents_splits_embedding_batches_on_provi
 
     assert assigned_ids == [f"cid-{i}" for i in range(5)]
     assert len(FakeVectorSearch.created) == 1
+    # The failed 5-doc attempt lowers the learned cap to 2, so the 3-doc right
+    # half is pre-split without re-attempting a size known to fail.
     assert FakeVectorSearch.created[0].calls == [
         (5, ["cid-0", "cid-1", "cid-2", "cid-3", "cid-4"]),
         (2, ["cid-0", "cid-1"]),
-        (3, ["cid-2", "cid-3", "cid-4"]),
         (1, ["cid-2"]),
         (2, ["cid-3", "cid-4"]),
     ]
+
+
+def test_opensearch_vector_store_reuses_learned_embedding_batch_size_across_bulk_slices(monkeypatch):
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors")
+    monkeypatch.setattr(ovs, "OpenSearch", lambda *args, **kwargs: fake_client)
+
+    class FakeEmbeddingBatchLimitError(RuntimeError):
+        def __init__(self) -> None:
+            super().__init__("provider rejected embedding batch")
+            self.status_code = 400
+            self.code = "3210"
+            self.type = "invalid_request_prompt"
+            self.body = {
+                "code": "3210",
+                "type": "invalid_request_prompt",
+                "raw_status_code": 400,
+            }
+
+    class FakeVectorSearch:
+        created: list["FakeVectorSearch"] = []
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.calls: list[tuple[int, list[str]]] = []
+            FakeVectorSearch.created.append(self)
+
+        def add_documents(self, documents: list[Document], ids: list[str] | None = None) -> list[str]:
+            assert ids is not None
+            self.calls.append((len(documents), list(ids)))
+            if len(documents) > 2:
+                raise FakeEmbeddingBatchLimitError()
+            return list(ids)
+
+    monkeypatch.setattr(ovs, "OpenSearchVectorSearch", FakeVectorSearch)
+
+    store = ovs.OpenSearchVectorStoreAdapter(
+        embedding_model=DummyEmbeddings(size=8),
+        embedding_model_name="custom-model",
+        kpi=None,
+        host="http://localhost:9200",
+        index="fred-vectors",
+        username="admin",
+        password=TEST_OPENSEARCH_PASSWORD,
+        bulk_size=4,
+    )
+
+    docs = [
+        Document(
+            page_content=f"chunk {i}",
+            metadata={ovs.CHUNK_ID_FIELD: f"cid-{i}", "document_uid": "doc-1"},
+        )
+        for i in range(8)
+    ]
+
+    assigned_ids = store.add_documents(docs)
+
+    assert assigned_ids == [f"cid-{i}" for i in range(8)]
+    # Only the very first slice pays a failed provider call; every later slice
+    # is cut at the learned cap (2) up front.
+    assert FakeVectorSearch.created[0].calls == [
+        (4, ["cid-0", "cid-1", "cid-2", "cid-3"]),
+        (2, ["cid-0", "cid-1"]),
+        (2, ["cid-2", "cid-3"]),
+        (2, ["cid-4", "cid-5"]),
+        (2, ["cid-6", "cid-7"]),
+    ]
+
+
+def test_opensearch_vector_store_does_not_reattempt_a_batch_size_that_just_failed(monkeypatch):
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors")
+    monkeypatch.setattr(ovs, "OpenSearch", lambda *args, **kwargs: fake_client)
+
+    class FakeEmbeddingBatchLimitError(RuntimeError):
+        def __init__(self) -> None:
+            super().__init__("provider rejected embedding batch")
+            self.status_code = 400
+            self.code = "3210"
+            self.type = "invalid_request_prompt"
+            self.body = {
+                "code": "3210",
+                "type": "invalid_request_prompt",
+                "raw_status_code": 400,
+            }
+
+    class FakeVectorSearch:
+        created: list["FakeVectorSearch"] = []
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.calls: list[tuple[int, list[str]]] = []
+            FakeVectorSearch.created.append(self)
+
+        def add_documents(self, documents: list[Document], ids: list[str] | None = None) -> list[str]:
+            assert ids is not None
+            self.calls.append((len(documents), list(ids)))
+            if len(documents) > 2:
+                raise FakeEmbeddingBatchLimitError()
+            return list(ids)
+
+    monkeypatch.setattr(ovs, "OpenSearchVectorSearch", FakeVectorSearch)
+
+    store = ovs.OpenSearchVectorStoreAdapter(
+        embedding_model=DummyEmbeddings(size=8),
+        embedding_model_name="custom-model",
+        kpi=None,
+        host="http://localhost:9200",
+        index="fred-vectors",
+        username="admin",
+        password=TEST_OPENSEARCH_PASSWORD,
+        bulk_size=8,
+    )
+
+    docs = [
+        Document(
+            page_content=f"chunk {i}",
+            metadata={ovs.CHUNK_ID_FIELD: f"cid-{i}", "document_uid": "doc-1"},
+        )
+        for i in range(8)
+    ]
+
+    assigned_ids = store.add_documents(docs)
+
+    assert assigned_ids == [f"cid-{i}" for i in range(8)]
+    # 8 fails -> cap 4; 4 fails -> cap 2. The right 4-doc half is then pre-split
+    # instead of re-attempting size 4, which the left half just saw fail.
+    calls = FakeVectorSearch.created[0].calls
+    assert calls == [
+        (8, [f"cid-{i}" for i in range(8)]),
+        (4, ["cid-0", "cid-1", "cid-2", "cid-3"]),
+        (2, ["cid-0", "cid-1"]),
+        (2, ["cid-2", "cid-3"]),
+        (2, ["cid-4", "cid-5"]),
+        (2, ["cid-6", "cid-7"]),
+    ]
+    assert [size for size, _ in calls].count(4) == 1
 
 
 def test_opensearch_vector_store_retries_single_oversized_document_with_smaller_text_splitter(monkeypatch):

--- a/apps/knowledge-flow-backend/tests/stores/test_opensearch_vector_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/test_opensearch_vector_store.py
@@ -543,6 +543,130 @@ def test_opensearch_vector_store_does_not_reattempt_a_batch_size_that_just_faile
     assert [size for size, _ in calls].count(4) == 1
 
 
+def test_opensearch_vector_store_probes_upward_after_success_streak_and_raises_cap(monkeypatch):
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors")
+    monkeypatch.setattr(ovs, "OpenSearch", lambda *args, **kwargs: fake_client)
+    monkeypatch.setattr(ovs, "EMBEDDING_CAP_PROBE_AFTER_SUCCESSES", 2)
+
+    class FakeEmbeddingBatchLimitError(RuntimeError):
+        def __init__(self) -> None:
+            super().__init__("provider rejected embedding batch")
+            self.status_code = 400
+            self.code = "3210"
+            self.type = "invalid_request_prompt"
+            self.body = {
+                "code": "3210",
+                "type": "invalid_request_prompt",
+                "raw_status_code": 400,
+            }
+
+    class FakeVectorSearch:
+        created: list["FakeVectorSearch"] = []
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.calls: list[tuple[int, list[str]]] = []
+            self.rejected_once = False
+            FakeVectorSearch.created.append(self)
+
+        def add_documents(self, documents: list[Document], ids: list[str] | None = None) -> list[str]:
+            assert ids is not None
+            self.calls.append((len(documents), list(ids)))
+            # Reject the first oversized attempt only: the provider was briefly
+            # saturated by a dense batch, later batches of the same size fit.
+            if len(documents) > 2 and not self.rejected_once:
+                self.rejected_once = True
+                raise FakeEmbeddingBatchLimitError()
+            return list(ids)
+
+    monkeypatch.setattr(ovs, "OpenSearchVectorSearch", FakeVectorSearch)
+
+    store = ovs.OpenSearchVectorStoreAdapter(
+        embedding_model=DummyEmbeddings(size=8),
+        embedding_model_name="custom-model",
+        kpi=None,
+        host="http://localhost:9200",
+        index="fred-vectors",
+        username="admin",
+        password=TEST_OPENSEARCH_PASSWORD,
+        bulk_size=4,
+    )
+
+    docs = [
+        Document(
+            page_content=f"chunk {i}",
+            metadata={ovs.CHUNK_ID_FIELD: f"cid-{i}", "document_uid": "doc-1"},
+        )
+        for i in range(16)
+    ]
+
+    assigned_ids = store.add_documents(docs)
+
+    assert assigned_ids == [f"cid-{i}" for i in range(16)]
+    # 4 fails once -> cap 2; after 2 successes at the cap, the next slice probes
+    # 4 again, succeeds, and the cap is adopted back at 4 for the rest.
+    assert [size for size, _ in FakeVectorSearch.created[0].calls] == [4, 2, 2, 4, 4, 4]
+
+
+def test_opensearch_vector_store_failed_probe_relowers_cap_and_continues(monkeypatch):
+    fake_client = FakeOpenSearchClient(index_name="fred-vectors")
+    monkeypatch.setattr(ovs, "OpenSearch", lambda *args, **kwargs: fake_client)
+    monkeypatch.setattr(ovs, "EMBEDDING_CAP_PROBE_AFTER_SUCCESSES", 2)
+
+    class FakeEmbeddingBatchLimitError(RuntimeError):
+        def __init__(self) -> None:
+            super().__init__("provider rejected embedding batch")
+            self.status_code = 400
+            self.code = "3210"
+            self.type = "invalid_request_prompt"
+            self.body = {
+                "code": "3210",
+                "type": "invalid_request_prompt",
+                "raw_status_code": 400,
+            }
+
+    class FakeVectorSearch:
+        created: list["FakeVectorSearch"] = []
+
+        def __init__(self, *args, **kwargs) -> None:
+            self.calls: list[tuple[int, list[str]]] = []
+            FakeVectorSearch.created.append(self)
+
+        def add_documents(self, documents: list[Document], ids: list[str] | None = None) -> list[str]:
+            assert ids is not None
+            self.calls.append((len(documents), list(ids)))
+            if len(documents) > 2:
+                raise FakeEmbeddingBatchLimitError()
+            return list(ids)
+
+    monkeypatch.setattr(ovs, "OpenSearchVectorSearch", FakeVectorSearch)
+
+    store = ovs.OpenSearchVectorStoreAdapter(
+        embedding_model=DummyEmbeddings(size=8),
+        embedding_model_name="custom-model",
+        kpi=None,
+        host="http://localhost:9200",
+        index="fred-vectors",
+        username="admin",
+        password=TEST_OPENSEARCH_PASSWORD,
+        bulk_size=4,
+    )
+
+    docs = [
+        Document(
+            page_content=f"chunk {i}",
+            metadata={ovs.CHUNK_ID_FIELD: f"cid-{i}", "document_uid": "doc-1"},
+        )
+        for i in range(12)
+    ]
+
+    assigned_ids = store.add_documents(docs)
+
+    assert assigned_ids == [f"cid-{i}" for i in range(12)]
+    # Each probe at 4 is rejected, the cap stays at 2, the probe batch is split
+    # and everything still lands; the streak resets so probes stay amortized.
+    assert [size for size, _ in FakeVectorSearch.created[0].calls] == [4, 2, 2, 4, 2, 2, 4, 2, 2]
+
+
 def test_opensearch_vector_store_retries_single_oversized_document_with_smaller_text_splitter(monkeypatch):
     fake_client = FakeOpenSearchClient(index_name="fred-vectors")
     monkeypatch.setattr(ovs, "OpenSearch", lambda *args, **kwargs: fake_client)


### PR DESCRIPTION
Closes #2282

## Problem

On large-document ingestion, every `bulk_size`=1000 slice was sent as-is to the embedding provider, which rejects it (400, code 3210 — Mistral limits **total tokens per request**). The adaptive splitter (from #1460) recovered by halving 1000 → 500 → 250, but remembered nothing: the next slice restarted at 1000, and the right half of a binary split re-attempted a size the left half had just seen fail. On a ~40k-chunk document that's ~100 doomed provider calls and several minutes of pure latency per ingestion.

## Fix

`OpenSearchVectorStoreAdapter` now records, on the instance, the size that triggered a split (`_learned_embedding_batch_cap`, only ever lowered):
- `add_documents` slices at `min(bulk_size, learned_cap)`, re-read each iteration;
- `_add_documents_with_adaptive_batching` pre-splits any batch above the cap without attempting the provider call.

The binary splitter, single-oversized-chunk re-split, and transient-error backoff are untouched — behaviour on error is unchanged, only the starting size gets smarter. Net effect: 2-3 discovery failures **per process lifetime** instead of per slice.

## Concurrency note

The store is a process-wide singleton reached from the FastAPI threadpool and the Temporal worker loop. The cap's check-then-set is deliberately lock-free: the worst interleaving transiently keeps the higher of two caps, costing at most one extra rejected call which re-lowers it (int assignment is GIL-atomic, no torn state). The cap is pod-local by design — each replica re-learns for the price of 2-3 calls; correctness never depends on sharing.

## Out of scope (pre-existing, worth its own issue)

`fast_store_vectors` (`features/scheduler/activities.py:218`) is an `async def` activity calling the fully synchronous `add_documents` chain (sync HTTP + `time.sleep` backoff) inline on the worker event loop — the `asyncio_0` thread visible in the logs. This change shortens time spent there but does not fix the pattern (neighbouring `output_process` already offloads via `asyncio.to_thread`).

## Tests

- Updated the existing splitting test: the doomed 3-doc re-attempt disappears (that's the improvement).
- `test_..._reuses_learned_embedding_batch_size_across_bulk_slices`: only the first slice pays a failed call.
- `test_..._does_not_reattempt_a_batch_size_that_just_failed`: size 4 attempted exactly once.

`make test`: 229 passed. `make code-quality`: clean. `fred-performance-reviewer` run: no new latency/blocking, no new metric needed, benign self-healing race documented above.