### PR TITLE
fix(FRONT): Team members table — long identifiers no longer overflow into the next column

### DIFF
--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.module.scss
@@ -101,6 +101,11 @@
   padding: 0 var(--spacing-s);
   min-width: 0;
   min-height: var(--datatable-row-height, 3.5rem);
+  /* Containment: whatever a cellRenderer produces, it must never spill under
+   * the neighbouring column. Headers already truncate (`.header-content`
+   * below); this is the body-cell half. Popover content (IconButtonMenu,
+   * Tooltip) is portaled to document.body, so clipping here can't touch it. */
+  overflow: hidden;
   color: var(--on-surface);
   font: var(--font-body-medium);
 
@@ -109,6 +114,16 @@
     overflow-x: hidden;
     color: var(--on-surface-retreat);
     font: var(--font-label-large);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Primitive cell values (DataTable.tsx wraps them in this span): same
+   * single-line ellipsis the header already applies, so free-length text
+   * truncates inside its own track; the full value stays readable via the
+   * span's `title`. */
+  .cell-text {
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DataTable/DataTable.tsx
@@ -348,9 +348,23 @@ export default function DataTable<T>({
                 </div>
               )}
               {columns.map((column, columnIndex) => {
+                const cellContent = column.cellRenderer?.(line);
+                const isPrimitive = typeof cellContent === "string" || typeof cellContent === "number";
                 return (
                   <div className={styles["datatable-cell"]} key={columnIndex}>
-                    {column.cellRenderer?.(line)}
+                    {/* Primitive cell values get single-line ellipsis
+                     * truncation, with the full value readable via the
+                     * native title tooltip — free-length text (usernames,
+                     * team names) must never spill under the neighbouring
+                     * column. Element values are the caller's own layout
+                     * and pass through untouched. */}
+                    {isPrimitive ? (
+                      <span className={styles["cell-text"]} title={String(cellContent)}>
+                        {cellContent}
+                      </span>
+                    ) : (
+                      cellContent
+                    )}
                   </div>
                 );
               })}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsMembers/TeamSettingsMembersTable/TeamSettingsMembersTable.tsx
@@ -172,17 +172,21 @@ export default function TeamSettingsMembersTable({ team, search, size = "medium"
 
   const columns = useMemo((): DataTableColumn<TeamMember>[] => {
     const cols: DataTableColumn<TeamMember>[] = [
+      // Plain strings on purpose: DataTable ellipsis-truncates primitive
+      // cell values inside their own column (full value on hover via
+      // `title`), which is exactly what these free-length identity fields
+      // need — a long email must not run under the next column.
       {
         label: t("rework.teamSettings.members.table.identifiant"),
-        cellRenderer: (teamMember) => <div>{teamMember.user.username}</div>,
+        cellRenderer: (teamMember) => teamMember.user.username,
       },
       {
         label: t("rework.teamSettings.members.table.firstName"),
-        cellRenderer: (teamMember) => <div>{teamMember.user.first_name}</div>,
+        cellRenderer: (teamMember) => teamMember.user.first_name,
       },
       {
         label: t("rework.teamSettings.members.table.lastName"),
-        cellRenderer: (teamMember) => <div>{teamMember.user.last_name}</div>,
+        cellRenderer: (teamMember) => teamMember.user.last_name,
       },
       {
         label: t("rework.teamSettings.members.table.role"),

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1349,6 +1349,42 @@ the input exactly; the popover's only remaining offset is the deliberate
 
 ---
 
+### `DataTable` — body cells contain their content; primitive values truncate (#2284, 2026-08-07)
+
+**Location:** `src/rework/components/shared/molecules/DataTable/DataTable.tsx`,
+`src/rework/components/shared/molecules/DataTable/DataTable.module.scss`
+**Status:** `Functional`
+
+Reported on the Team members table: long values in the "Identifiant" column
+(usernames are full email addresses) ran under the First name column, and
+some wrapped onto two lines. Fixed in the molecule, not the call site, since
+any table with free-length text had the same bug (`AdminTeamsPage` team
+names, `MigrationPage` team names):
+
+- `.datatable-cell` gained `overflow: hidden` — whatever a `cellRenderer`
+  produces, it can no longer spill under the neighbouring column. Safe with
+  in-cell popovers (`IconButtonMenu`, `Tooltip`): their content portals to
+  `document.body`, so cell clipping can't touch it. Headers already
+  truncated (`.header-content`); this is the body-cell half.
+- Primitive `cellRenderer` values (string/number) are wrapped by DataTable
+  in a `.cell-text` span: single-line `text-overflow: ellipsis`, full value
+  readable via the span's native `title` on hover — same idiom as
+  `CorpusAuditPage`/`CapabilitiesPage` name cells. Element values pass
+  through untouched (the caller owns their layout).
+
+`TeamSettingsMembersTable`'s three text columns (Identifiant, First name,
+Last name) now return plain strings and get this behaviour for free.
+
+#### Open UX issues
+
+- The hover reveal is the native browser tooltip, not the design-system
+  `Tooltip` atom (and it also shows for values that aren't cut). A styled
+  only-when-truncated variant was prototyped and dropped as
+  disproportionate; revisit if design review wants tooltip consistency in
+  tables.
+
+---
+
 ### `TeamSettingsMembers` — member search field (2026-07-26)
 
 **Location:**


### PR DESCRIPTION
Closes #2284

## Problem

On Team settings → Team members, long "Identifiant" values (usernames are full email addresses) ran under the First name column; some wrapped onto two lines, making rows uneven. Same latent bug in every `DataTable` call site with free-length text (`AdminTeamsPage`, `MigrationPage` team names).

## Fix — in the `DataTable` molecule, not the call site

- `.datatable-cell` gains `overflow: hidden`: whatever a `cellRenderer` produces can no longer spill under the neighbouring column. Safe with in-cell popovers (`IconButtonMenu`, `Tooltip`) — they portal to `document.body`. Headers already truncated; this is the body-cell half.
- Primitive `cellRenderer` values (string/number) are wrapped by DataTable in a `.cell-text` span: single-line ellipsis, full value on hover via native `title` — the existing idiom (`CorpusAuditPage`, `CapabilitiesPage`). Element values pass through untouched.
- `TeamSettingsMembersTable`'s three text columns now return plain strings and get this for free.

A dedicated `TruncatedText` component with design-system `Tooltip` + hover-time measurement was prototyped and dropped as disproportionate (noted as an open UX issue in `COMPONENT-UX.md`).

## Tests

- `make code-quality` and the frontend suite pass (65 tests across Tooltip / DataTable / members table / ResourceExplorer; full `make test` green).
- Manual check pending — draft until then.

## Docs

- `docs/swift/ux/COMPONENT-UX.md`: new dated `DataTable` entry (#2284).