### PR TITLE
fix(FRONT): admin analytics — vertical BarChart renders again, KPI tiles no longer touch the chart grid

### DIFF
--- a/apps/frontend/src/rework/components/pages/admin/AnalyticsPage/AnalyticsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/admin/AnalyticsPage/AnalyticsPage.module.css
@@ -12,6 +12,13 @@
   gap: var(--spacing-s);
 }
 
+/* Disclosure's content wrapper is a plain block container, so these two grids
+   would otherwise sit flush — the KPI tiles touching the chart cards below.
+   Space them on the chart grid's own rhythm rather than the tighter tile gap. */
+.kpiRow + .chartGrid {
+  margin-top: var(--spacing-m);
+}
+
 /* Bento grid: 3 base columns. Most charts take one cell; the busy multi-series
    gets two (.cellWide) and the prompt-length distribution the full width
    (.cellFull) — "space for the ones that need it". */

--- a/apps/frontend/src/rework/components/shared/molecules/BarChart/BarChart.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/BarChart/BarChart.tsx
@@ -120,7 +120,15 @@ export default function BarChart({
                   angle={compact ? 0 : -35}
                   textAnchor={compact ? "middle" : "end"}
                   interval={0}
-                  height={compact ? 14 : undefined}
+                  // Only pass `height` in compact mode. Spreading it instead of
+                  // `height={compact ? 14 : undefined}` matters: Recharts reads
+                  // `child.props.height` directly when it computes the chart
+                  // offset, and React's defaultProps substitution does not apply
+                  // to a prop that is present-but-undefined. An explicit
+                  // `undefined` therefore left offset.bottom/height null, which
+                  // collapsed the plot area — axes and grid never rendered and
+                  // the bars came out as empty <g> elements.
+                  {...(compact ? { height: 14 } : {})}
                 />
                 <YAxis
                   type="number"


### PR DESCRIPTION
Two independent fixes to the admin analytics page (`/admin/analytics`).

---

## 1. Vertical BarChart rendered nothing

### Problem

The **"Distribution de la longueur des prompts systèmes"** chart displayed nothing — no axes, no grid, no bars — while every other chart on the page rendered fine.

It was not a data problem. The control-plane preset was returning correct rows the whole time; querying OpenSearch directly reproduced the preset's three passes and yielded `0-500: 6`, `500-1000: 2`, `20000+: 0`.

### Root cause

This chart is the only `AnalyticsPage` consumer of `BarChart`'s `orientation="vertical"` branch, which passed:

```tsx
height={compact ? 14 : undefined}
```

In non-compact mode that sets `height` to an **explicit `undefined`**, which is not equivalent to omitting the prop:

- Recharts reads `child.props.height` directly when computing the chart offset.
- React's `defaultProps` substitution does not apply to a prop that is *present-but-undefined*, so `XAxis.defaultProps.height = 30` never took effect.

Inspecting the live chart fiber confirmed it — `XAxis` had `keyPresent=true, height=undefined`, while `YAxis`/`CartesianGrid` (whose keys were absent) got their defaults normally. Recharts then computed:

```
offset.bottom = null
offset.height = null
```

With a null plot height the axes and grid never rendered and the bars were emitted as empty `<g class="recharts-bar-rectangle">` elements containing no `<path>`.

### Fix

Spread the prop so the key is genuinely absent outside compact mode, letting Recharts apply its own default.

### Verification

Measured on the running app, before → after:

| | before | after |
|---|---|---|
| `offset.height` | `null` | `142` |
| `offset.bottom` | `null` | `70` |
| `.recharts-cartesian-axis` | 0 | 2 |
| `.recharts-cartesian-grid` | 0 | 1 |
| bar `<path>` elements | 0 | 2 |

Axis ticks now read `0-500`, `500-1000`, `20000+` against a 0–8 value axis, matching the backend exactly. (Only 2 paths because the `20000+` bucket has value 0 and draws no bar.)

### Scope

`orientation="vertical"` has two consumers: this chart and the compact `ResourceStatsCards` tiles on the resources dashboard. The compact path already passed a real height (`14`) and is behaviourally unchanged.

No test added: reproducing this requires Recharts' real layout pass, which jsdom does not perform (it renders charts at zero dimensions, so the collapsed-offset condition is indistinguishable from normal there). Verified against the running app instead.

---

## 2. KPI tiles touched the chart grid

Inside the "Vue d'ensemble" Disclosure, `.kpiRow` and `.chartGrid` are siblings in a plain `display: block` content wrapper, so the two grids stacked flush — the KPI number tiles sat directly against the chart cards below them, with a measured gap of **0px**.

Added a top margin on the chart grid when it follows the KPI row, using the chart grid's own `--spacing-m` (16px) rhythm rather than the tighter tile gap, so the seam matches the spacing between the chart cards themselves. Measured gap after: **16px**.

---

`tsc --noEmit` clean, prettier clean, existing `AnalyticsPage`/`BarChart` tests pass.
