### PR TITLE
fix(2289): ship a real alembic.ini in all prod images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,16 @@
 **/*.err
 **/*.pid
 
+# Ignore the per-project alembic.ini symlinks (NOT the real file at the repo root).
+# alembic.ini exists once, at the root; apps/control-plane-backend, apps/knowledge-flow-backend
+# and libs/fred-runtime each carry a symlink to it purely for local-dev ergonomics (so a bare
+# `alembic ...` works from the project directory). Kaniko copies symlinks verbatim instead of
+# resolving them, so letting one into the build context lands a DANGLING link in the image.
+# Keeping them out of the context means every Dockerfile-prod can just COPY the real root file
+# to where it is needed — no per-image "rm the broken link first" dance.
+apps/*/alembic.ini
+libs/*/alembic.ini
+
 # Ignore build artifacts
 build/
 dist/

--- a/apps/control-plane-backend/dockerfiles/Dockerfile-prod
+++ b/apps/control-plane-backend/dockerfiles/Dockerfile-prod
@@ -53,10 +53,12 @@ COPY --chown=${USER_ID}:${GROUP_ID} apps/control-plane-backend/control_plane_bac
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-core /workspace/libs/fred-core
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-sdk /workspace/libs/fred-sdk
 
-# Remove the broken alembic.ini symlink before copying the real file —
-# Kaniko preserves symlinks as-is and would fail resolving the target.
 COPY --chown=${USER_ID}:${GROUP_ID} apps/control-plane-backend/. /app/
-RUN rm -f /app/alembic.ini
+
+# alembic.ini is a real file only at the repo root; the per-project ones are dev-only
+# symlinks kept out of the build context (see .dockerignore), because Kaniko would copy
+# them verbatim and land a dangling link here. Ship the real file next to /app/pyproject.toml,
+# whose [tool.alembic] script_location resolves to /app/alembic.
 COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /app/alembic.ini
 
 USER ${USER_NAME}

--- a/apps/fred-agents/dockerfiles/Dockerfile-prod
+++ b/apps/fred-agents/dockerfiles/Dockerfile-prod
@@ -58,6 +58,15 @@ COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-sdk /workspace/libs/fred-sdk
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-writable-document /workspace/libs/fred-capability-writable-document
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-ppt-filler /workspace/libs/fred-capability-ppt-filler
 
+# alembic.ini is a real file only at the repo root; the per-project ones are dev-only
+# symlinks kept out of the build context (see .dockerignore), because Kaniko would copy
+# them verbatim — which is exactly the dangling link this image used to ship (#2289).
+# `python -m fred_runtime migrate` (the Helm migration hook) upgrades fred-runtime's tree
+# then every installed capability's own tree, all rooted under /workspace/libs/..., so the
+# ini belongs beside fred-runtime's pyproject.toml whose [tool.alembic] script_location
+# resolves to /workspace/libs/fred-runtime/alembic.
+COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /workspace/libs/fred-runtime/alembic.ini
+
 # Runtime pods keep the startup contract externalized: .env + configuration
 # are mounted at /app/config, while the default catalogs can ship in-image.
 COPY --chown=${USER_ID}:${GROUP_ID} apps/fred-agents/config/models_catalog.yaml /app/config/models_catalog.yaml

--- a/apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod
+++ b/apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod
@@ -125,10 +125,12 @@ COPY --chown=${USER_ID}:${GROUP_ID} scripts /workspace/scripts
 # HF_HUB_OFFLINE must be unset here — download_models.py fetches docling models from HuggingFace
 RUN HF_HUB_OFFLINE=0 TRANSFORMERS_OFFLINE=0 python /workspace/scripts/download_models.py --models-dir ${PADDLE_MODELS_DIR}
 
-# Remove the broken alembic.ini symlink before copying the real file —
-# Kaniko preserves symlinks as-is and would fail resolving the target.
 COPY --chown=${USER_ID}:${GROUP_ID} apps/knowledge-flow-backend/. /app/
-RUN rm -f /app/alembic.ini
+
+# alembic.ini is a real file only at the repo root; the per-project ones are dev-only
+# symlinks kept out of the build context (see .dockerignore), because Kaniko would copy
+# them verbatim and land a dangling link here. Ship the real file next to /app/pyproject.toml,
+# whose [tool.alembic] script_location resolves to /app/alembic.
 COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /app/alembic.ini
 
 # Set environment


### PR DESCRIPTION
## What & why

`alembic.ini` is a real file only at the repo root. `apps/control-plane-backend`,
`apps/knowledge-flow-backend` and `libs/fred-runtime` each carry a **symlink** to it,
purely so a bare `alembic ...` works from the project directory during local development.

**Kaniko copies symlinks verbatim instead of resolving them**, so a plain `COPY` of a
project directory lands a *dangling* link inside the image. `control-plane-backend` and
`knowledge-flow-backend` worked around this with a 3-line stanza (`COPY app/.` →
`RUN rm -f /app/alembic.ini` → `COPY alembic.ini /app/alembic.ini`). `fred-agents` had no
equivalent: it copies `libs/fred-runtime` (which brings the dangling link) and never copied
the real root file, so the image shipped a broken
`/workspace/libs/fred-runtime/alembic.ini` — the bug in #2289.

Instead of adding a third copy of that stanza, this PR **removes the symlinks from the build
context** and copies the real root file directly everywhere:

- `.dockerignore` now excludes `apps/*/alembic.ini` and `libs/*/alembic.ini` (the root
  `alembic.ini` is **not** matched by either pattern and is untouched). The Kaniko rationale
  is documented once, there.
- Each `Dockerfile-prod` `COPY`s the real root `alembic.ini` to where that image needs it.
  The `RUN rm -f /app/alembic.ini` layer disappears from both existing backends.
- The symlinks stay on disk for local-dev ergonomics — they simply never reach an image.

Placement per image:

| image | path | why |
| --- | --- | --- |
| control-plane-backend | `/app/alembic.ini` | beside `/app/pyproject.toml`, whose `[tool.alembic] script_location = "%(here)s/alembic"` resolves to `/app/alembic` |
| knowledge-flow-backend | `/app/alembic.ini` | same |
| fred-agents | `/workspace/libs/fred-runtime/alembic.ini` | exactly where the dangling link used to be, beside fred-runtime's `pyproject.toml` and its `alembic/` tree |

### One correction to the issue's diagnosis

Worth recording, because it changes what the production symptom can have been:
`python -m fred_runtime migrate` does **not** read `alembic.ini`. `fred_runtime/migrations.py`
builds a bare `alembic.config.Config()` and sets `script_location` programmatically to the
absolute `RUNTIME_ALEMBIC_DIR` (and to each capability's `migrations_location()`);
`libs/fred-runtime/alembic/env.py` guards its `fileConfig` call with
`if config.config_file_name is not None`. Verified both by unit-level reproduction against
alembic 1.18.4 and inside the built image (below) — migrations resolve and run with **no**
`alembic.ini` present at all. So the fred-agents image did ship a dangling symlink (real, and
now fixed), but that alone would not have blocked the migration hook — if migrations failed in
production, the cause is likely elsewhere and worth a separate look. The `.ini` still matters
for logging configuration and for any manual `alembic -c ...` run in the pod, so shipping a
real one in all three images is still the right fix.

## Verification

Ran locally (Docker 29.5.3 / BuildKit, on the repo root as build context):

1. **Build-context probe** — `COPY . /ctx` from the repo root after the `.dockerignore` change:
   - `/ctx/alembic.ini` present, `-rw-rw-r--`, 776 bytes (real file) ✅
   - `/ctx/apps/control-plane-backend/alembic.ini`, `/ctx/apps/knowledge-flow-backend/alembic.ini`,
     `/ctx/libs/fred-runtime/alembic.ini` — all absent (excluded) ✅
   - all three `alembic/` script trees still present ✅
2. **`docker build -f apps/fred-agents/dockerfiles/Dockerfile-prod .`** — succeeded. Inside the image:
   - `/workspace/libs/fred-runtime/alembic.ini` is a **regular file**, not a symlink ✅
   - `alembic -c /workspace/libs/fred-runtime/alembic.ini history` from `/workspace/libs/fred-runtime`
     → exit 0, lists all 3 runtime revisions ✅
   - `python -m fred_runtime migrate` reaches
     `[MIGRATE] upgrading fred-runtime (/workspace/libs/fred-runtime/alembic)` and then fails only on
     `FileNotFoundError: Configuration file not found: ./config/configuration.yaml` — i.e. the Alembic
     config and script tree resolved and `env.py` executed; it stopped at the pod config that is
     mounted at deploy time. No DB was touched. ✅
   - the writable_document capability migration tree is present in the image ✅
3. **`docker build -f apps/control-plane-backend/dockerfiles/Dockerfile-prod .`** — succeeded.
   `/app/alembic.ini` is a regular file; `alembic history` from `/app` → exit 0 ✅
4. **knowledge-flow-backend** — full build **not** run locally: its final stage runs
   `download_models.py` (PaddleOCR + docling from HuggingFace), which is a multi-GB network fetch not
   worth spending here. Instead a probe Dockerfile replicated exactly the two alembic-relevant
   `COPY` lines of its final stage against the same context: `/app/alembic.ini` is a regular file,
   `/app/pyproject.toml` `[tool.alembic] script_location = %(here)s/alembic`, and `/app/alembic` +
   `/app/alembic/versions` exist ✅. Its full build is exercised by CI.

**Not verified here — needs CI or a manual Kaniko build:** the acceptance criterion
"`python -m fred_runtime migrate` runs successfully inside a **Kaniko**-built fred-agents prod
image". Local Docker/BuildKit resolves symlinks differently from Kaniko, so the local build above
proves the `COPY` destinations and the runtime resolution but *not* Kaniko's behaviour. Note the
`.dockerignore` change makes the two builders converge — the symlinks no longer exist in the
context for either engine — so the remaining Kaniko-specific risk is only whether Kaniko honours
`.dockerignore` for the context in use (it does for directory and tar contexts). Also note this
repo's own image CI (`.github/workflows/Build-and-push-docker.yml`) uses
`docker/build-push-action`, not Kaniko, so the Kaniko path must be checked wherever that build runs.

No code-quality target applies: this change touches only `.dockerignore` and three `Dockerfile-prod`
files — no Python, TypeScript, or generated API client. No docs describe the alembic.ini/image
relationship (`grep` over `docs/` finds none), so nothing to update there.

Closes #2289
