### PR TITLE
feat(knowledge-flow): vision-enrich corpus ImageProcessor markdown

### DIFF
--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/common/image_describer.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/common/image_describer.py
@@ -14,6 +14,10 @@ from knowledge_flow_backend.core.processors.input.common.base_image_describer im
 
 logger = logging.getLogger(__name__)
 
+# Sentinel returned by VisionImageDescriber when description fails or comes back
+# empty. Callers use it to decide whether to inject the text into their output.
+IMAGE_DESCRIPTION_UNAVAILABLE = "Image description not available."
+
 VISION_DESCRIBE_PROMPT_V1 = """
 Describe the image.
 Start with this sentence: "There is an image showing".
@@ -177,7 +181,7 @@ class VisionImageDescriber(BaseImageDescriber):
             # NOTE: model kwargs already bound; no 'config' needed here.
             result = self.model.invoke(messages)
             text = _stringify_content(getattr(result, "content", "")).strip()
-            return text or "Image description not available."
+            return text or IMAGE_DESCRIPTION_UNAVAILABLE
         except Exception as e:
             logger.warning("Vision description failed: %s", e)
-            return "Image description not available."
+            return IMAGE_DESCRIPTION_UNAVAILABLE

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/fast_text_processor/fast_lite_image_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/fast_text_processor/fast_lite_image_processor.py
@@ -20,7 +20,10 @@ import mimetypes
 from pathlib import Path
 
 from knowledge_flow_backend.application_context import get_configuration
-from knowledge_flow_backend.core.processors.input.common.image_describer import build_image_describer
+from knowledge_flow_backend.core.processors.input.common.image_describer import (
+    IMAGE_DESCRIPTION_UNAVAILABLE,
+    build_image_describer,
+)
 from knowledge_flow_backend.core.processors.input.fast_text_processor.base_fast_text_processor import (
     BaseFastTextProcessor,
     FastTextOptions,
@@ -81,7 +84,7 @@ class FastLiteImageProcessor(BaseFastTextProcessor):
         describer = self._resolve_image_describer()
         if describer is not None:
             description = describer.describe(self._to_data_url(file_path)).strip()
-            if description and description != "Image description not available.":
+            if description and description != IMAGE_DESCRIPTION_UNAVAILABLE:
                 text = f"{text}\n\nVision summary:\n{description}"
 
         return FastTextResult(

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/image_processor/image_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/image_processor/image_processor.py
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import logging
+import mimetypes
+import threading
 from pathlib import Path
 
+from knowledge_flow_backend.application_context import get_configuration
+from knowledge_flow_backend.core.processors.input.common.base_image_describer import BaseImageDescriber
 from knowledge_flow_backend.core.processors.input.common.base_input_processor import BaseMarkdownProcessor
+from knowledge_flow_backend.core.processors.input.common.image_describer import (
+    IMAGE_DESCRIPTION_UNAVAILABLE,
+    build_image_describer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +34,45 @@ SUPPORTED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", "
 
 class ImageProcessor(BaseMarkdownProcessor):
     """
-    Processor for image files that stores image metadata and generates a markdown file
-    with the image title/name for searching and indexing.
+    Processor for standalone image files ingested into a document library.
 
-    The image filename (without extension) is used as the searchable title/keyword.
-    For example: "Apple.png" -> title="Apple", "Nvidia.jpg" -> title="Nvidia"
+    The generated markdown always contains the filename-based title so the image
+    stays retrievable by name. When a vision model is configured, a vision
+    description is appended so the image content itself becomes searchable —
+    same behaviour as the fast-path FastLiteImageProcessor for chat attachments.
     """
 
-    description = "Processes image files and extracts metadata for searchable indexing."
+    description = "Processes image files into searchable markdown, with a vision description when a vision model is configured."
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Same reasoning as PdfMarkdownProcessor: this instance is a shared
+        # singleton (application_context.get_input_processor_instance) called from
+        # concurrent Temporal activity threads, and build_image_describer builds a
+        # real provider client — so build it once and reuse it.
+        self._image_describer: BaseImageDescriber | None = None
+        self._image_describer_lock = threading.Lock()
+        self._warned_missing_vision_model = False
+
+    def _resolve_image_describer(self) -> BaseImageDescriber | None:
+        if self._image_describer is not None:
+            return self._image_describer
+        vision_model = get_configuration().vision_model
+        if not vision_model:
+            if not self._warned_missing_vision_model:
+                logger.info("[PROCESSOR][IMAGE] Vision model missing; markdown keeps filename-based content only.")
+                self._warned_missing_vision_model = True
+            return None
+        with self._image_describer_lock:
+            if self._image_describer is None:
+                self._image_describer = build_image_describer(vision_model)
+        return self._image_describer
+
+    @staticmethod
+    def _to_data_url(file_path: Path) -> str:
+        mime = mimetypes.guess_type(file_path.name)[0] or "image/png"
+        encoded = base64.b64encode(file_path.read_bytes()).decode("utf-8")
+        return f"data:{mime};base64,{encoded}"
 
     def check_file_validity(self, file_path: Path) -> bool:
         """Check if the file is a valid image format."""
@@ -75,8 +115,8 @@ class ImageProcessor(BaseMarkdownProcessor):
 
     def convert_file_to_markdown(self, file_path: Path, output_dir: Path, document_uid: str | None) -> dict:
         """
-        Generate a minimal markdown file containing the image title and metadata.
-        This allows the image to be searchable by its filename.
+        Generate a markdown file with the image title, metadata and — when a
+        vision model is configured — a vision description of the image content.
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         md_path = output_dir / "output.md"
@@ -91,6 +131,12 @@ class ImageProcessor(BaseMarkdownProcessor):
 
 This is an image asset that can be used in templates. Search for "{image_title}" to find this image.
 """
+
+        describer = self._resolve_image_describer()
+        if describer is not None:
+            description = describer.describe(self._to_data_url(file_path)).strip()
+            if description and description != IMAGE_DESCRIPTION_UNAVAILABLE:
+                markdown_content += f"\n## Vision summary\n\n{description}\n"
 
         with open(md_path, "w", encoding="utf-8") as f:
             f.write(markdown_content)

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/tests/test_image_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/tests/test_image_processor.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -101,8 +102,12 @@ def test_extract_file_metadata(image_processor):
         tmp_path.unlink()
 
 
-def test_convert_file_to_markdown(image_processor):
-    """Test markdown conversion for image files"""
+def test_convert_file_to_markdown(image_processor, monkeypatch):
+    """Test markdown conversion for image files (no vision model: filename fallback)"""
+    monkeypatch.setattr(
+        "knowledge_flow_backend.core.processors.input.image_processor.image_processor.get_configuration",
+        lambda: SimpleNamespace(vision_model=None),
+    )
     # Create a test image file named "Nvidia.png"
     png_data = (
         b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"

--- a/apps/knowledge-flow-backend/tests/processors/input/image_processor/test_image_processor.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/image_processor/test_image_processor.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from knowledge_flow_backend.core.processors.input.common.image_describer import IMAGE_DESCRIPTION_UNAVAILABLE
+from knowledge_flow_backend.core.processors.input.image_processor.image_processor import ImageProcessor
+
+_ONE_PIXEL_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc`\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+_MODULE = "knowledge_flow_backend.core.processors.input.image_processor.image_processor"
+
+
+def _convert(tmp_path: Path, image_name: str = "Nvidia_logo.png") -> str:
+    image_path = tmp_path / image_name
+    image_path.write_bytes(_ONE_PIXEL_PNG)
+    output_dir = tmp_path / "out"
+    result = ImageProcessor().convert_file_to_markdown(image_path, output_dir, document_uid=None)
+    return Path(result["md_file"]).read_text(encoding="utf-8")
+
+
+def test_image_processor_keeps_filename_markdown_without_vision(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(f"{_MODULE}.get_configuration", lambda: SimpleNamespace(vision_model=None))
+
+    markdown = _convert(tmp_path)
+
+    assert "# Nvidia_logo" in markdown
+    assert 'Search for "Nvidia_logo"' in markdown
+    assert "Vision summary" not in markdown
+
+
+def test_image_processor_appends_vision_summary_when_available(tmp_path: Path, monkeypatch) -> None:
+    class FakeDescriber:
+        def describe(self, data_url: str) -> str:
+            assert data_url.startswith("data:image/png;base64,")
+            return "There is an image showing a green logo on a black background."
+
+    monkeypatch.setattr(f"{_MODULE}.get_configuration", lambda: SimpleNamespace(vision_model=object()))
+    monkeypatch.setattr(f"{_MODULE}.build_image_describer", lambda _: FakeDescriber())
+
+    markdown = _convert(tmp_path)
+
+    assert "## Vision summary" in markdown
+    assert "green logo on a black background" in markdown
+    assert "# Nvidia_logo" in markdown
+
+
+def test_image_processor_skips_vision_section_when_description_unavailable(tmp_path: Path, monkeypatch) -> None:
+    class FailingDescriber:
+        def describe(self, _: str) -> str:
+            return IMAGE_DESCRIPTION_UNAVAILABLE
+
+    monkeypatch.setattr(f"{_MODULE}.get_configuration", lambda: SimpleNamespace(vision_model=object()))
+    monkeypatch.setattr(f"{_MODULE}.build_image_describer", lambda _: FailingDescriber())
+
+    markdown = _convert(tmp_path)
+
+    assert "Vision summary" not in markdown
+    assert 'Search for "Nvidia_logo"' in markdown
+
+
+def test_image_processor_builds_describer_once_across_documents(tmp_path: Path, monkeypatch) -> None:
+    build_calls = []
+
+    class FakeDescriber:
+        def describe(self, _: str) -> str:
+            return "There is an image showing a single pixel."
+
+    def _build(_) -> FakeDescriber:
+        build_calls.append(1)
+        return FakeDescriber()
+
+    monkeypatch.setattr(f"{_MODULE}.get_configuration", lambda: SimpleNamespace(vision_model=object()))
+    monkeypatch.setattr(f"{_MODULE}.build_image_describer", _build)
+
+    processor = ImageProcessor()
+    for name in ("first.png", "second.png"):
+        image_path = tmp_path / name
+        image_path.write_bytes(_ONE_PIXEL_PNG)
+        processor.convert_file_to_markdown(image_path, tmp_path / "out" / name, document_uid=None)
+
+    assert len(build_calls) == 1


### PR DESCRIPTION
## Summary

Images ingested into a document library were only retrievable by filename: the corpus-path `ImageProcessor` wrote a filename-based markdown stub with no vision call, while the fast path (chat attachments, `FastLiteImageProcessor`) already appended a vision summary.

This PR aligns the corpus path with the fast path:

- `ImageProcessor.convert_file_to_markdown` appends a **Vision summary** section when a vision model is configured — lazy, thread-safe describer resolution (shared-singleton instance called from concurrent Temporal activity threads, same lock pattern as `PdfMarkdownProcessor`).
- No vision model configured → behaviour unchanged (filename-based fallback).
- The describer failure sentinel is extracted into a shared `IMAGE_DESCRIPTION_UNAVAILABLE` constant in `common/image_describer.py` and reused by the fast processor (was duplicated).

Closes #2310

## Verification

- `make code-quality` from the monorepo root: all modules green.
- `make test` (knowledge-flow-backend): 833 passed — 4 new tests (`tests/processors/input/image_processor/`: no-vision fallback, vision summary, unavailable description, describer built once), legacy `test_image_processor.py` pinned to the no-vision fallback.
- fred-performance-reviewer: no blocking finding — vision call runs in a Temporal worker thread via `to_thread_with_heartbeat`, not on the event loop; model timeout bounded by the fred-core factory. Pre-existing, unchanged: no image-size guard before base64 encoding (same as fast path), no per-image vision-latency KPI (gap shared with docx/pdf/pptx).
- `docs/FEATURES.html` already claimed vision-based image processing — that claim is now accurate, no doc change needed.