### PR TITLE
style(frontend): mainNavPanel minor form tweaks

### DIFF
--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/HomeNavPanel/HomeNavPanel.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/HomeNavPanel/HomeNavPanel.module.scss
@@ -21,23 +21,6 @@
   min-height: 0;
 }
 
-.header {
-  display: flex;
-  flex-direction: column;
-  padding: 0 var(--spacing-s) var(--spacing-xs);
-}
-
-.titleContainer {
-  display: flex;
-  align-items: center;
-  height: 48px;
-}
-
-.title {
-  color: var(--on-surface-retreat);
-  font: var(--font-title-medium);
-}
-
 /* Dividers above and below frame the personal space apart from the team list. */
 .personalSpace {
   border-top: 1px solid var(--outline-muted);
@@ -62,6 +45,10 @@
 .teamListHeaderLabel {
   color: var(--on-surface-retreat);
   font: var(--font-body-small);
+}
+
+.teamSearch {
+  padding: 0 var(--spacing-s) var(--spacing-xs);
 }
 
 /* The team list fills the remaining height and scrolls on overflow.

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/HomeNavPanel/HomeNavPanel.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/HomeNavPanel/HomeNavPanel.tsx
@@ -15,6 +15,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import styles from "./HomeNavPanel.module.scss";
+import NavPanelHeader from "@shared/molecules/NavPanelHeader/NavPanelHeader.tsx";
 import SearchInput from "@shared/molecules/SearchInput/SearchInput.tsx";
 import TeamSelectionListItem from "@shared/molecules/TeamSelectionListItem/TeamSelectionListItem.tsx";
 import { PERSONAL_TEAM_COLOR } from "@shared/atoms/TeamInitials/teamColor.ts";
@@ -48,19 +49,7 @@ export default function HomeNavPanel() {
 
   return (
     <div className={styles.panel}>
-      <div className={styles.header}>
-        <div className={styles.titleContainer}>
-          <span className={styles.title}>{t("rework.home.title")}</span>
-        </div>
-        <SearchInput
-          size="xs"
-          value={search}
-          onChange={setSearch}
-          placeholder={t("rework.home.searchPlaceholder")}
-          ariaLabel={t("rework.home.searchPlaceholder")}
-          clearAriaLabel={t("rework.home.searchClear")}
-        />
-      </div>
+      <NavPanelHeader title={t("rework.home.title")} />
 
       <div className={styles.personalSpace}>
         <TeamSelectionListItem
@@ -75,6 +64,16 @@ export default function HomeNavPanel() {
       <div className={styles.teamList}>
         <div className={styles.teamListHeader}>
           <span className={styles.teamListHeaderLabel}>{t("rework.home.yourTeams")}</span>
+        </div>
+        <div className={styles.teamSearch}>
+          <SearchInput
+            size="xs"
+            value={search}
+            onChange={setSearch}
+            placeholder={t("rework.home.searchPlaceholder")}
+            ariaLabel={t("rework.home.searchPlaceholder")}
+            clearAriaLabel={t("rework.home.searchClear")}
+          />
         </div>
         <div className={styles.scroll}>
           {visibleTeams.map((team) => (

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/MarketplaceNavbar/MarketplaceNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/MarketplaceNavbar/MarketplaceNavbar.module.scss
@@ -1,13 +1,3 @@
 .marketplace-navbar-container {
   width: 240px;
 }
-
-.marketplace-navbar-title {
-  display: flex;
-  align-items: end;
-  padding: 0 0 var(--spacing-xs) var(--spacing-m);
-  height: 56px;
-  color: var(--on-surface);
-
-  font: var(--font-title-medium);
-}

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/MarketplaceNavbar/MarketplaceNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/MarketplaceNavbar/MarketplaceNavbar.tsx
@@ -16,6 +16,7 @@ import styles from "./MarketplaceNavbar.module.scss";
 import { useTranslation } from "react-i18next";
 import NavigationMenu from "@shared/molecules/NavigationMenu/NavigationMenu.tsx";
 import type { NavigationMenuItemProps } from "@shared/molecules/NavigationMenu/NavigationMenuItem/NavigationMenuItem.tsx";
+import NavPanelHeader from "@shared/molecules/NavPanelHeader/NavPanelHeader.tsx";
 
 export default function MarketplaceNavbar() {
   const { t } = useTranslation();
@@ -31,7 +32,7 @@ export default function MarketplaceNavbar() {
 
   return (
     <div className={styles["marketplace-navbar-container"]}>
-      <div className={styles["marketplace-navbar-title"]}>{t("rework.sidebar.marketplace.title")}</div>
+      <NavPanelHeader title={t("rework.sidebar.marketplace.title")} />
       <NavigationMenu items={navigationItems} />
     </div>
   );

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -20,6 +20,7 @@
   gap: var(--spacing-xs);
   background-color: var(--surface-container-high);
   padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-xs) var(--spacing-m);
+  min-height: 48px;
   color: var(--on-surface);
 }
 
@@ -72,5 +73,6 @@
 /* "Back" out of team settings, above the settings section menu. */
 .settings-back-container {
   display: flex;
-  padding: var(--spacing-xs) 0 var(--spacing-xs) var(--spacing-xs);
+  background-color: var(--surface-container);
+  padding: var(--spacing-2xs) 0 var(--spacing-2xs) var(--spacing-2xs);
 }

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -196,7 +196,7 @@ export default function TeamContentNavbar() {
       <Button
         color={"primary"}
         variant={"text"}
-        size={"medium"}
+        size={"small"}
         onClick={handleBack}
         icon={{ category: "outlined", type: "arrow_back", filled: true }}
       >

--- a/apps/frontend/src/rework/components/shared/molecules/NavPanelHeader/NavPanelHeader.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/NavPanelHeader/NavPanelHeader.module.scss
@@ -1,0 +1,23 @@
+/* Copyright Thales 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.header {
+  display: flex;
+  align-items: end;
+  padding: 0 var(--spacing-xs) var(--spacing-xs) var(--spacing-m);
+  height: 56px;
+  color: var(--on-surface);
+  font: var(--font-title-medium);
+}

--- a/apps/frontend/src/rework/components/shared/molecules/NavPanelHeader/NavPanelHeader.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/NavPanelHeader/NavPanelHeader.tsx
@@ -1,0 +1,28 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import styles from "./NavPanelHeader.module.scss";
+
+interface NavPanelHeaderProps {
+  title: string;
+}
+
+/**
+ * Shared title row for the mainNavPanel's top-level sections (Home,
+ * Marketplace, …) — one identical header so the panels never drift apart
+ * visually as they're edited independently.
+ */
+export default function NavPanelHeader({ title }: NavPanelHeaderProps) {
+  return <div className={styles.header}>{title}</div>;
+}


### PR DESCRIPTION
Minor visual polish on the mainNavPanel (follow-up to #2298).

## What changes
- **settings-back-container**: `surface-container` background, padding tightened to `2xs` (was `xs`); the back `Button` drops from `medium` to `small`.
- **teamPanelHeader**: `min-height: 48px` so the personal space header doesn't shrink when the settings gear (hidden while in usage) disappears — same height in and out of the settings/usage view.
- **NavPanelHeader** (new shared molecule): extracted from the Marketplace panel's title row and reused for the Home panel, so the two headers can't drift apart visually. Same styling as before, plus the 8px right padding that was missing.
- **Home panel search**: moved below the "Vos équipes" header into its own container (12px left/right, 8px bottom padding) instead of sitting in the page header above the personal space.

## Verification
Type-check / eslint / prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)