### PR TITLE
fix(OBSERV-02): diff OpenSearch mappings instead of listing fields by hand

### DIFF
--- a/libs/fred-core/fred_core/kpi/opensearch_kpi_store.py
+++ b/libs/fred-core/fred_core/kpi/opensearch_kpi_store.py
@@ -26,7 +26,7 @@ from fred_core.kpi.kpi_reader_structures import (
     KPIQueryResultRow,
 )
 from fred_core.kpi.kpi_writer_structures import KPIEvent
-from fred_core.store import validate_index_mapping
+from fred_core.store import ensure_index_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -175,74 +175,17 @@ class OpenSearchKPIStore(BaseKPIStore):
                 logger.info("[OPENSEARCH][KPI] created index '%s'", self.index)
             else:
                 logger.info("[OPENSEARCH][KPI] index '%s' already exists.", self.index)
-                # CTRLP-12: session_id was added to KPI_INDEX_MAPPING for RGPD
-                # conversation erasure. Existing indices predate it, so add it
-                # additively (put_mapping) before validation — otherwise startup
-                # fails with "Missing nested field: 'dims.session_id'".
-                self._ensure_dim_mapping("session_id", {"type": "keyword"})
-                self._ensure_dim_mapping("service", {"type": "keyword"})
-                self._ensure_dim_mapping("team_id", {"type": "keyword"})
-                self._ensure_dim_mapping("agent_instance_id", {"type": "keyword"})
-                self._ensure_dim_mapping("template_agent_id", {"type": "keyword"})
-                self._ensure_dim_mapping("agent_instance_name", {"type": "keyword"})
-                self._ensure_dim_mapping("runtime_id", {"type": "keyword"})
-                self._ensure_dim_mapping("model_name", {"type": "keyword"})
-                self._ensure_dim_mapping("finish_reason", {"type": "keyword"})
-                self._ensure_dim_mapping("system_prompt_chars", {"type": "keyword"})
-                self._ensure_dim_mapping("template_id", {"type": "keyword"})
-                self._ensure_dim_mapping("source_runtime_id", {"type": "keyword"})
-                # OBSERV-02: quantities.input_tokens/output_tokens were written by
-                # agent.turn_completed since Phase 7 but never mapped, so they were
-                # unaggregatable. Added additively for existing indices.
-                self._ensure_quantities_mapping("input_tokens", {"type": "long"})
-                self._ensure_quantities_mapping("output_tokens", {"type": "long"})
-                # Validate existing mapping matches expected mapping
-                validate_index_mapping(self.client, self.index, KPI_INDEX_MAPPING)
+                # Repair, then validate. An index created by an older version is
+                # missing whatever KPI_INDEX_MAPPING gained since (CTRLP-12's
+                # `dims.session_id`, OBSERV-02's `quantities.*_tokens`, and
+                # whatever the next dim turns out to be) — all of them fields
+                # `put_mapping` can add in place, none of them worth taking
+                # startup down for. What remains fatal is the drift it cannot
+                # repair. See `ensure_index_mapping`.
+                ensure_index_mapping(self.client, self.index, KPI_INDEX_MAPPING)
         except OpenSearchException as e:
             logger.error("[OPENSEARCH][KPI] ensure_ready failed: %s", e)
             raise
-
-    def _ensure_dim_mapping(self, name: str, mapping: Dict[str, Any]) -> None:
-        try:
-            current_mapping_resp = self.client.indices.get_mapping(index=self.index)
-            current_mapping = current_mapping_resp.get(self.index, {}).get(
-                "mappings", {}
-            )
-            dims_props = (
-                current_mapping.get("properties", {})
-                .get("dims", {})
-                .get("properties", {})
-            )
-            if name in dims_props:
-                return
-            body = {"properties": {"dims": {"properties": {name: mapping}}}}
-            self.client.indices.put_mapping(index=self.index, body=body)
-            logger.info("[OPENSEARCH][KPI] added dims.%s mapping", name)
-        except OpenSearchException as e:
-            logger.warning(
-                "[OPENSEARCH][KPI] failed to add dims.%s mapping: %s", name, e
-            )
-
-    def _ensure_quantities_mapping(self, name: str, mapping: Dict[str, Any]) -> None:
-        try:
-            current_mapping_resp = self.client.indices.get_mapping(index=self.index)
-            current_mapping = current_mapping_resp.get(self.index, {}).get(
-                "mappings", {}
-            )
-            quantities_props = (
-                current_mapping.get("properties", {})
-                .get("quantities", {})
-                .get("properties", {})
-            )
-            if name in quantities_props:
-                return
-            body = {"properties": {"quantities": {"properties": {name: mapping}}}}
-            self.client.indices.put_mapping(index=self.index, body=body)
-            logger.info("[OPENSEARCH][KPI] added quantities.%s mapping", name)
-        except OpenSearchException as e:
-            logger.warning(
-                "[OPENSEARCH][KPI] failed to add quantities.%s mapping: %s", name, e
-            )
 
     # -- writes ----------------------------------------------------------------
     def index_event(self, event: KPIEvent) -> None:

--- a/libs/fred-core/fred_core/logs/opensearch_log_store.py
+++ b/libs/fred-core/fred_core/logs/opensearch_log_store.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from opensearchpy import OpenSearch, OpenSearchException, RequestsHttpConnection
 
 from fred_core.logs.base_log_store import BaseLogStore, LogEventDTO
+from fred_core.store import ensure_index_mapping
 
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
@@ -162,31 +163,22 @@ class OpenSearchLogStore(BaseLogStore):
                 logger.info("[OPENSEARCH][LOG] created index '%s'.", self.index)
             else:
                 logger.info("[OPENSEARCH][LOG] index '%s' already exists.", self.index)
-                # `category` was added to LOG_INDEX_MAPPING after some indices
-                # were already created. Existing indices predate it, so add it
-                # additively (put_mapping) — otherwise `category` silently
-                # falls under dynamic="false" and is never indexed for search.
-                self._ensure_category_mapping()
-                # If you have a generic validator like KPI does, call it here:
-                # validate_index_mapping(self.client, self.index, LOG_INDEX_MAPPING)
+                # Same repair as the KPI store: an index created before a field
+                # was added to LOG_INDEX_MAPPING (`category` was the first) never
+                # indexes it, since dynamic="false" silently drops what the
+                # mapping doesn't declare. Diffed, not hand-listed — this store
+                # used to patch `category` by name and would have missed the
+                # next one exactly as the KPI store did.
+                #
+                # `validate=False` keeps the existing policy: a log index whose
+                # mapping drifted in a way put_mapping cannot fix degrades search
+                # over old rows, which is not worth refusing to boot over.
+                ensure_index_mapping(
+                    self.client, self.index, LOG_INDEX_MAPPING, validate=False
+                )
         except OpenSearchException as e:
             logger.error("[OPENSEARCH][LOG] ensure_ready failed: %s", e)
             raise
-
-    def _ensure_category_mapping(self) -> None:
-        try:
-            current_mapping_resp = self.client.indices.get_mapping(index=self.index)
-            current_mapping = current_mapping_resp.get(self.index, {}).get(
-                "mappings", {}
-            )
-            top_level_props = current_mapping.get("properties", {})
-            if "category" in top_level_props:
-                return
-            body = {"properties": {"category": {"type": "keyword"}}}
-            self.client.indices.put_mapping(index=self.index, body=body)
-            logger.info("[OPENSEARCH][LOG] added category mapping")
-        except OpenSearchException as e:
-            logger.warning("[OPENSEARCH][LOG] failed to add category mapping: %s", e)
 
     # -- writes ----------------------------------------------------------------
     def index_event(self, event: LogEventDTO) -> None:

--- a/libs/fred-core/fred_core/store/__init__.py
+++ b/libs/fred-core/fred_core/store/__init__.py
@@ -18,6 +18,7 @@ from fred_core.store.local_content_store import LocalContentStore
 from fred_core.store.minio_content_store import MinioContentStore
 from fred_core.store.opensearch_mapping_validator import (
     MappingValidationError,
+    ensure_index_mapping,
     validate_index_mapping,
 )
 from fred_core.store.vector_search import VectorSearchHit
@@ -29,5 +30,6 @@ __all__ = [
     "MappingValidationError",
     "MinioContentStore",
     "VectorSearchHit",
+    "ensure_index_mapping",
     "validate_index_mapping",
 ]

--- a/libs/fred-core/fred_core/store/opensearch_mapping_validator.py
+++ b/libs/fred-core/fred_core/store/opensearch_mapping_validator.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+from opensearchpy import OpenSearchException
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +24,90 @@ class MappingValidationError(Exception):
     """Exception raised when OpenSearch index mapping validation fails."""
 
 
+def ensure_index_mapping(
+    client,  # OpenSearch client instance (avoiding circular import)
+    index_name: str,
+    expected_mapping: Dict[str, Any],
+    *,
+    validate: bool = True,
+    strict: bool = True,
+) -> None:
+    """Reconcile a live index with the mapping the code expects, then validate it.
+
+    This is what a store's `ensure_ready` should call on an index that already
+    exists. An index created by an older version lacks every field the expected
+    mapping has gained since, and under `dynamic: "false"` those fields are
+    silently never indexed — or, when the store validates strictly, take startup
+    down with "Missing nested field: '<x>'" and no recovery but deleting the
+    index. Adding them with `put_mapping` is purely additive and idempotent, so
+    the reconcile runs first and validation only ever judges what is left.
+
+    Which fields to add is *diffed* against `expected_mapping`, never listed by
+    hand: the KPI store used to enumerate the names it knew to be recent, and
+    the field that forgot to register itself there crashed every pre-existing
+    index (2026-08-11). See `missing_mapping_branches` for what the diff
+    deliberately leaves alone (type drift, which `put_mapping` cannot fix).
+
+    One `get_mapping` in the steady state: the same response feeds the diff and
+    the validation. A boot that actually patches something re-reads, so the
+    validation judges the live index rather than an optimistic local merge.
+
+    The reconcile is best-effort — an OpenSearch failure here is logged and
+    validation still runs, because "Missing nested field: 'dims.session_id'"
+    names the problem better than a failed put_mapping does.
+
+    Args:
+        client: OpenSearch client instance
+        index_name: Name of the index to reconcile
+        expected_mapping: Expected mapping structure (with "mappings" key)
+        validate: Run `validate_index_mapping` after the reconcile. False for a
+            store that wants its index repaired but not its startup blocked.
+        strict: Passed through to `validate_index_mapping`.
+    """
+    current_mapping: Optional[Dict[str, Any]] = None
+    try:
+        current_mapping = (
+            client.indices.get_mapping(index=index_name)
+            .get(index_name, {})
+            .get("mappings", {})
+        )
+        missing = missing_mapping_branches(
+            expected_mapping.get("mappings", {}).get("properties", {}),
+            (current_mapping or {}).get("properties", {}),
+        )
+        if missing:
+            client.indices.put_mapping(index=index_name, body={"properties": missing})
+            current_mapping = None  # the live mapping moved on — re-read it below
+            logger.info(
+                "[OPENSEARCH][MAPPING] index '%s': added %s",
+                index_name,
+                ", ".join(_leaf_paths(missing)),
+            )
+    except OpenSearchException as e:
+        logger.warning(
+            "[OPENSEARCH][MAPPING] index '%s': could not add missing fields: %s",
+            index_name,
+            e,
+        )
+        current_mapping = None
+
+    if validate:
+        validate_index_mapping(
+            client,
+            index_name,
+            expected_mapping,
+            strict=strict,
+            current_mapping=current_mapping,
+        )
+
+
 def validate_index_mapping(
     client,  # OpenSearch client instance (avoiding circular import)
     index_name: str,
     expected_mapping: Dict[str, Any],
     strict: bool = True,
     allow_missing_fields: bool = False,
+    current_mapping: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Validate that an existing OpenSearch index has the expected field mappings.
@@ -38,18 +118,23 @@ def validate_index_mapping(
         expected_mapping: Expected mapping structure (with "mappings" key)
         strict: If True, raises exception on critical mismatches. If False, only logs warnings.
         allow_missing_fields: If True, missing fields only generate warnings. If False, they are errors.
+        current_mapping: The index's live "mappings" block, when the caller has
+            just read it (`ensure_index_mapping`) — saves a second round trip.
 
     Raises:
         MappingValidationError: When critical mapping mismatches are found
     """
     try:
-        # Get current mapping from OpenSearch
-        current_mapping_resp = client.indices.get_mapping(index=index_name)
-        current_mapping = current_mapping_resp.get(index_name, {}).get("mappings", {})
+        if current_mapping is None:
+            # Get current mapping from OpenSearch
+            current_mapping_resp = client.indices.get_mapping(index=index_name)
+            current_mapping = current_mapping_resp.get(index_name, {}).get(
+                "mappings", {}
+            )
 
         # Extract expected properties
         expected_properties = expected_mapping.get("mappings", {}).get("properties", {})
-        current_properties = current_mapping.get("properties", {})
+        current_properties = (current_mapping or {}).get("properties", {})
 
         # Validate field mappings
         mismatches: List[str] = []
@@ -96,6 +181,56 @@ def validate_index_mapping(
             raise MappingValidationError(
                 f"Mapping validation failed for index '{index_name}': {e}"
             ) from e
+
+
+def missing_mapping_branches(
+    expected_properties: Dict[str, Any], current_properties: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Return the part of `expected_properties` that the live index does not have.
+
+    The result is a `properties` sub-tree ready to hand to `put_mapping`: only
+    the branches that are strictly absent, each carried with its full expected
+    definition. Empty when the live index already covers everything. Callers
+    normally want `ensure_index_mapping`, which wraps this with the I/O.
+
+    A field whose *type* drifted is deliberately left alone: `put_mapping`
+    cannot change an existing field's type, and including it would make
+    OpenSearch reject the whole request, so the legitimately-missing siblings
+    in the same call would be lost too. `validate_index_mapping` reports that
+    case, which is the actionable error anyway.
+    """
+    missing: Dict[str, Any] = {}
+    for name, expected_field in expected_properties.items():
+        current_field = current_properties.get(name)
+        if current_field is None:
+            missing[name] = expected_field
+            continue
+
+        expected_nested = expected_field.get("properties")
+        if not expected_nested:
+            # Leaf already present — type drift is the validator's business.
+            continue
+        if not isinstance(current_field.get("properties"), dict):
+            # Expected an object, live index has something else: unpatchable.
+            continue
+
+        nested = missing_mapping_branches(expected_nested, current_field["properties"])
+        if nested:
+            missing[name] = {"properties": nested}
+    return missing
+
+
+def _leaf_paths(properties: Dict[str, Any], prefix: str = "") -> List[str]:
+    """Dotted paths of every leaf in a `properties` tree, for the log line."""
+    paths: List[str] = []
+    for name, field in properties.items():
+        path = f"{prefix}{name}"
+        nested = field.get("properties")
+        if isinstance(nested, dict) and nested:
+            paths.extend(_leaf_paths(nested, f"{path}."))
+        else:
+            paths.append(path)
+    return paths
 
 
 def _get_field_type(field_config: Dict[str, Any]) -> str | None:

--- a/libs/fred-core/fred_core/tests/kpi/test_opensearch_kpi_store_ensure_ready.py
+++ b/libs/fred-core/fred_core/tests/kpi/test_opensearch_kpi_store_ensure_ready.py
@@ -33,7 +33,6 @@ import copy
 from typing import Any, Dict, List, cast
 
 import pytest
-
 from fred_core.kpi.opensearch_kpi_store import KPI_INDEX_MAPPING, OpenSearchKPIStore
 from fred_core.store import MappingValidationError
 

--- a/libs/fred-core/fred_core/tests/kpi/test_opensearch_kpi_store_ensure_ready.py
+++ b/libs/fred-core/fred_core/tests/kpi/test_opensearch_kpi_store_ensure_ready.py
@@ -20,6 +20,11 @@ against the expected mapping and hard-fails on a missing field — so it must fi
 add new dims *additively* (put_mapping), exactly as it already does for other
 fields. This is the regression guard for the "Missing nested field:
 'dims.session_id'" startup crash.
+
+Guarded beyond that one field since 2026-08-11: what to patch is diffed against
+KPI_INDEX_MAPPING rather than read off a hand-kept list of recent names, because
+the list was one more thing to remember and the field that forgot it took
+startup down on every pre-existing index.
 """
 
 from __future__ import annotations
@@ -27,7 +32,24 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, cast
 
+import pytest
+
 from fred_core.kpi.opensearch_kpi_store import KPI_INDEX_MAPPING, OpenSearchKPIStore
+from fred_core.store import MappingValidationError
+
+
+def _deep_merge(target: Dict[str, Any], patch: Dict[str, Any]) -> None:
+    """Apply a `put_mapping` body the way OpenSearch does — merge, never replace.
+
+    A shallow merge would model the index wrongly now that the store sends whole
+    missing branches (a root field, or a nested object with its own properties)
+    rather than only leaves under `dims`/`quantities`.
+    """
+    for name, value in patch.items():
+        if isinstance(value, dict) and isinstance(target.get(name), dict):
+            _deep_merge(target[name], value)
+        else:
+            target[name] = value
 
 
 class _FakeIndices:
@@ -37,6 +59,7 @@ class _FakeIndices:
         self._mappings = mappings
         self._index = index
         self.put_calls: List[Dict[str, Any]] = []
+        self.get_mapping_calls = 0
 
     def exists(self, *, index: str) -> bool:
         return True
@@ -45,17 +68,14 @@ class _FakeIndices:
         raise AssertionError("must not create an index that already exists")
 
     def get_mapping(self, *, index: str) -> Dict[str, Any]:
+        self.get_mapping_calls += 1
         return {self._index: {"mappings": self._mappings}}
 
     def put_mapping(self, *, index: str, body: Dict[str, Any]) -> None:
         self.put_calls.append(body)
-        incoming = body.get("properties", {}).get("dims", {}).get("properties", {})
-        dims = (
-            self._mappings.setdefault("properties", {})
-            .setdefault("dims", {})
-            .setdefault("properties", {})
+        _deep_merge(
+            self._mappings.setdefault("properties", {}), body.get("properties", {})
         )
-        dims.update(incoming)
 
 
 class _FakeClient:
@@ -88,9 +108,55 @@ def test_ensure_ready_adds_missing_session_id_dim_on_existing_index() -> None:
     assert "session_id" in patched
 
 
-def test_ensure_ready_is_noop_put_when_session_id_already_present() -> None:
-    """A fresh/complete index needs no put_mapping for session_id (idempotent)."""
+def test_ensure_ready_patches_every_missing_field_in_one_round_trip() -> None:
+    """Startup must not re-read the whole index mapping once per field.
+
+    Each missing field used to trigger its own `get_mapping` + `put_mapping`
+    (~15 round trips per store on every boot) for an answer the first response
+    already contained.
+    """
+    store = _store_on_existing_index_missing("session_id")
+    mappings = cast(_FakeIndices, cast(_FakeClient, store.client).indices)._mappings
+    mappings["properties"]["dims"]["properties"].pop("team_id", None)
+    mappings["properties"]["quantities"]["properties"].pop("input_tokens", None)
+
+    store.ensure_ready()
+
+    indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
+    # One read to diff, one after patching — validation judges the live index,
+    # not an optimistic local merge of what we believe we just wrote.
+    assert indices.get_mapping_calls == 2
+    assert len(indices.put_calls) == 1
+    body = indices.put_calls[0]["properties"]
+    assert set(body["dims"]["properties"]) == {"session_id", "team_id"}
+    assert set(body["quantities"]["properties"]) == {"input_tokens"}
+
+
+def test_ensure_ready_adds_a_field_no_hardcoded_list_ever_knew_about() -> None:
+    """The real regression: the patch set is diffed, not enumerated.
+
+    `dims.tool_name` shipped with the very first mapping, so it never appeared in
+    the hand-kept "fields added since v1" list. Under that list an index lacking
+    it — any index whose mapping drifted, or that predates a dim someone added
+    without touching the second list — crashed startup with no recovery but
+    deleting the kpi index. Every field of KPI_INDEX_MAPPING must be patchable,
+    not just the ones somebody remembered to register.
+    """
+    store = _store_on_existing_index_missing("tool_name")
+
+    store.ensure_ready()
+
+    indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
+    assert len(indices.put_calls) == 1
+    assert set(indices.put_calls[0]["properties"]["dims"]["properties"]) == {
+        "tool_name"
+    }
+
+
+def test_ensure_ready_adds_a_whole_missing_top_level_branch() -> None:
+    """An index predating a whole object (here `trace`) gets it with its leaves."""
     mappings = copy.deepcopy(KPI_INDEX_MAPPING["mappings"])
+    mappings["properties"].pop("trace")
     store = OpenSearchKPIStore.__new__(OpenSearchKPIStore)
     store.index = "kpi-index"
     store.client = _FakeClient(mappings, "kpi-index")  # type: ignore[assignment]
@@ -98,7 +164,43 @@ def test_ensure_ready_is_noop_put_when_session_id_already_present() -> None:
     store.ensure_ready()
 
     indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
-    patched = [
-        next(iter(b["properties"]["dims"]["properties"])) for b in indices.put_calls
-    ]
-    assert "session_id" not in patched
+    added = indices.put_calls[0]["properties"]["trace"]["properties"]
+    assert set(added) == {"trace_id", "span_id", "parent_span_id"}
+
+
+def test_ensure_ready_leaves_type_drift_to_the_validator() -> None:
+    """A field whose type drifted is reported, not silently put_mapping'd.
+
+    OpenSearch cannot change an existing field's type, so sending it would make
+    it reject the whole request — taking the legitimately-missing fields in the
+    same call down with it. The store patches what is absent and lets
+    validate_index_mapping raise on the rest.
+    """
+    store = _store_on_existing_index_missing("session_id")
+    mappings = cast(_FakeIndices, cast(_FakeClient, store.client).indices)._mappings
+    mappings["properties"]["dims"]["properties"]["model"] = {"type": "text"}
+
+    with pytest.raises(MappingValidationError):
+        store.ensure_ready()
+
+    indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
+    patched = indices.put_calls[0]["properties"]["dims"]["properties"]
+    assert set(patched) == {"session_id"}  # the drifted `model` is not in there
+
+
+def test_ensure_ready_writes_nothing_when_the_index_is_current() -> None:
+    """The common case — an up-to-date index — costs exactly one read, no write.
+
+    Every boot but a migrating one lands here, so the diff and the validation
+    share the single `get_mapping` response rather than asking twice.
+    """
+    store = OpenSearchKPIStore.__new__(OpenSearchKPIStore)
+    store.index = "kpi-index"
+    client = _FakeClient(copy.deepcopy(KPI_INDEX_MAPPING["mappings"]), "kpi-index")
+    store.client = client  # type: ignore[assignment]
+
+    store.ensure_ready()
+
+    indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
+    assert indices.put_calls == []
+    assert indices.get_mapping_calls == 1

--- a/libs/fred-core/fred_core/tests/logs/test_log_store_factory.py
+++ b/libs/fred-core/fred_core/tests/logs/test_log_store_factory.py
@@ -14,13 +14,15 @@
 
 from __future__ import annotations
 
+import copy
+
 import pytest
 from fred_core.common.resilient_sink import ResilientSinkStore
 from fred_core.common.structures import OpenSearchIndexConfig, OpenSearchStoreConfig
 from fred_core.logs.log_store_factory import build_log_store
 from fred_core.logs.log_structures import InMemoryLogStorageConfig
 from fred_core.logs.memory_log_store import RamLogStore
-from fred_core.logs.opensearch_log_store import OpenSearchLogStore
+from fred_core.logs.opensearch_log_store import LOG_INDEX_MAPPING, OpenSearchLogStore
 
 
 def _fake_opensearch_client(*args: object, **kwargs: object) -> object:
@@ -29,15 +31,15 @@ def _fake_opensearch_client(*args: object, **kwargs: object) -> object:
             return True
 
         def get_mapping(self, index: str) -> dict:
-            # Already has `category` — ensure_ready's migration is a no-op;
-            # the migration itself is covered by
-            # test_opensearch_log_store_ensure_ready.py.
-            return {
-                index: {"mappings": {"properties": {"category": {"type": "keyword"}}}}
-            }
+            # An index already matching LOG_INDEX_MAPPING — ensure_ready's
+            # migration is a no-op here; the migration itself is covered by
+            # test_opensearch_log_store_ensure_ready.py. It must be the whole
+            # expected mapping, not just the one field the migration used to
+            # look at: ensure_index_mapping now patches anything absent.
+            return {index: {"mappings": copy.deepcopy(LOG_INDEX_MAPPING["mappings"])}}
 
         def put_mapping(self, index: str, body: dict) -> None:
-            raise AssertionError("must not migrate a mapping that already has category")
+            raise AssertionError("must not migrate an index that is already current")
 
     class _Client:
         indices = _Indices()

--- a/libs/fred-core/fred_core/tests/logs/test_opensearch_log_store_ensure_ready.py
+++ b/libs/fred-core/fred_core/tests/logs/test_opensearch_log_store_ensure_ready.py
@@ -18,7 +18,11 @@
 already created. An existing index predates it, so `ensure_ready` must add
 it additively (put_mapping) — otherwise `category` silently falls under
 `dynamic="false"` and is never indexed for search, the same class of gap
-`OpenSearchKPIStore._ensure_dim_mapping` closes for `dims.session_id`.
+`ensure_index_mapping` closes for the KPI index's `dims.session_id`.
+
+Since 2026-08-11 the store no longer patches `category` by name: it diffs the
+live index against `LOG_INDEX_MAPPING`, so the *next* field added there is
+covered without anyone remembering to register it.
 """
 
 from __future__ import annotations
@@ -97,6 +101,25 @@ def test_ensure_ready_adds_missing_category_mapping_on_existing_index() -> None:
     indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
     assert len(indices.put_calls) == 1
     assert indices.put_calls[0] == {"properties": {"category": {"type": "keyword"}}}
+
+
+def test_ensure_ready_adds_any_missing_field_not_just_category() -> None:
+    """The migration is a diff, not a hand-kept list of one field name.
+
+    `category` was simply the first field to be added late; a store that patches
+    it by name leaves every later addition silently unindexed under
+    `dynamic="false"`.
+    """
+    mappings = copy.deepcopy(LOG_INDEX_MAPPING["mappings"])
+    mappings["properties"].pop("category", None)
+    mappings["properties"].pop("logger", None)
+    store = _store_on_existing_index(mappings)
+
+    store.ensure_ready()
+
+    indices = cast(_FakeIndices, cast(_FakeClient, store.client).indices)
+    assert len(indices.put_calls) == 1
+    assert set(indices.put_calls[0]["properties"]) == {"category", "logger"}
 
 
 def test_ensure_ready_is_noop_put_when_category_already_present() -> None:

--- a/libs/fred-core/fred_core/tests/store/test_opensearch_mapping_validator.py
+++ b/libs/fred-core/fred_core/tests/store/test_opensearch_mapping_validator.py
@@ -1,0 +1,72 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the additive-mapping diff shared by the OpenSearch stores.
+
+`missing_mapping_branches` is what lets `ensure_index_mapping` repair an index
+created by an older version instead of hard-failing startup on it. Its contract
+is narrow on purpose: report what is *absent*, never what merely differs.
+
+The orchestration around it (read once, patch, validate) is exercised end to end
+through the stores that call it — see `tests/kpi/test_opensearch_kpi_store_
+ensure_ready.py` and `tests/logs/test_opensearch_log_store_ensure_ready.py`.
+"""
+
+from __future__ import annotations
+
+from fred_core.store.opensearch_mapping_validator import missing_mapping_branches
+
+
+def test_reports_nothing_when_the_live_index_already_matches() -> None:
+    expected = {"dims": {"properties": {"env": {"type": "keyword"}}}}
+
+    assert missing_mapping_branches(expected, expected) == {}
+
+
+def test_reports_a_missing_leaf_with_its_expected_definition() -> None:
+    expected = {
+        "dims": {
+            "properties": {"env": {"type": "keyword"}, "team_id": {"type": "keyword"}}
+        }
+    }
+    current = {"dims": {"properties": {"env": {"type": "keyword"}}}}
+
+    assert missing_mapping_branches(expected, current) == {
+        "dims": {"properties": {"team_id": {"type": "keyword"}}}
+    }
+
+
+def test_reports_a_missing_object_whole() -> None:
+    """A branch the live index never had is carried over with all its leaves."""
+    expected = {"trace": {"properties": {"trace_id": {"type": "keyword"}}}}
+
+    assert missing_mapping_branches(expected, {}) == expected
+
+
+def test_ignores_a_field_whose_type_drifted() -> None:
+    """put_mapping cannot retype a field, and one rejected field fails the whole
+    request — so drift is left for validate_index_mapping to report."""
+    expected = {"dims": {"properties": {"env": {"type": "keyword"}}}}
+    current = {"dims": {"properties": {"env": {"type": "text"}}}}
+
+    assert missing_mapping_branches(expected, current) == {}
+
+
+def test_ignores_an_object_the_live_index_holds_as_a_leaf() -> None:
+    """Same reasoning one level up: `dims` mapped as a keyword cannot grow
+    properties, so nothing under it is patchable."""
+    expected = {"dims": {"properties": {"env": {"type": "keyword"}}}}
+    current = {"dims": {"type": "keyword"}}
+
+    assert missing_mapping_branches(expected, current) == {}


### PR DESCRIPTION
An index created by an older version lacks every field its expected mapping gained since. `validate_index_mapping(strict=True)` hard-fails startup on that, so the only recovery was deleting the index by hand — which is what just happened to kpi-index in local dev.

The guard against it was a hand-kept list of "fields added since v1" in the KPI store: a second place every new dim had to remember to register itself in. The one that didn't took startup down on every pre-existing index. The log store had the same shape, one field wide (`category`), plus a comment inviting whoever came next to wire in the generic validator.

Replace both with one shared entry point, `ensure_index_mapping`: read the live mapping once, diff it against the expected one, put_mapping whatever is strictly absent, then validate what is left. Nothing to keep in sync — a field added to KPI_INDEX_MAPPING or LOG_INDEX_MAPPING is repaired on the next boot by virtue of being in the mapping.

Deliberately narrow: type drift is never sent to put_mapping (OpenSearch cannot retype a field, and one rejected field fails the whole request), so it still raises — the repair covers the safe case, strict validation keeps guarding the unsafe one. The log store keeps `validate=False`, its existing policy.

Also collapses the round trips: the steady-state boot now costs one get_mapping for the diff and the validation together, instead of one per known field plus one for validation.

Verified against the local OpenSearch: an index missing dims.session_id, dims.tool_name and quantities.input_tokens raised MappingValidationError before, boots and repairs now, and a KPI row then writes and aggregates on the repaired fields. Same for a log index missing `category`/`logger`.

# Pull Request

> **Read this before you type anything.**
>
> Opening a PR is the _last_ step, not the first. If you designed this alone,
> implemented it without sharing the plan, and are now hoping the review will
> validate the approach — stop. Close this tab. Go read
> [`docs/swift/platform/DEVELOPER_CONTRACT.md`](../docs/swift/platform/DEVELOPER_CONTRACT.md)
> and come back when the steps below are already done.
>
> This is not process theater. Every question below exists because something
> went wrong when it was skipped. Fill them in honestly. A short honest answer
> beats a long evasive one every time.

---

## 1. What problem does this solve — and where is it tracked?

<!-- GitHub issue # this PR closes/addresses (title, label, milestone are the
     tracking unit — there is no separate ID registry). If there is no issue,
     explain why this work exists at all. -->

**Issue:** <!-- #1234 / … / "no issue — mechanical fix because …" -->

**Problem in one sentence:**

**Backlog ref:** <!-- link to the [ ] checkbox in the relevant backlog file -->

---

## 2. Before you wrote a single line of code

This section cannot be skipped. If the answer to any question is "no" or
"I didn't", explain why — do not leave it blank.

**RFC written?**

<!-- For any design choice, schema change, new endpoint, or new component:
     paste the link to the RFC in docs/swift/rfc/.
     For a purely mechanical fix (one-function bug, typo, missing field
     already agreed on): write "not required — mechanical fix" and explain. -->

**Plan presented to the team before implementation?**

<!-- Did you share what you were going to build, which files you'd touch,
     which tests you'd add, which docs you'd update — and wait for a
     confirmation before starting? Yes / No + one line of context. -->

**Confirmation received?**

<!-- Who confirmed ("yes go ahead" / "ok" / "looks good")?
     If you were explicitly told "implement immediately", say so. -->

---

## 3. What you built

<!-- Be concrete. Not "updated the service" — say which function, which model,
     which endpoint, which component, and what it now does differently.
     Two or three sentences is enough. Ten vague words is not. -->

---

## 4. Proof of quality

**Tests added or updated:**

<!-- List exact test function names and the file they live in.
     If you added none, explain why none were needed. -->

| Test | File | What it covers |
| ---- | ---- | -------------- |
|      |      |                |

**`make code-quality` output (paste the last line or "all checks passed"):**

```

```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```

```

**`make test` output (paste the summary line — pass count, 0 failures):**

```

```

If you touched multiple packages, paste one block per package.

---

## 5. Docs updated

Work through this line by line. If an item does not apply, write "n/a" and say why.

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    |              |
| New behaviour, API field, or contract change                      |              |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) |              |
| UX component implemented or visual status changed                 |              |
| Phase progress row exists for this area                           |              |
| WORKPLAN sprint item finished                                     |              |
| Code and a design doc now diverge                                 |              |

---

## 6. Close-out statement

<!--
Copy the exact block from the end of your implementation session.
If you don't have one, write it now — and wonder why you don't have it.
-->

```
## Task close-out
- Code:
- Tests:
- Docs updated:
- Backlog:
- Skipped steps:
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

**How do we roll back?**
