### PR TITLE
feat(ingestion): resources full-page folder drag-and-drop + nested tags mirroring dropped structure

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -572,6 +572,8 @@
     "makeSearchable": "Make searchable",
     "maxSize": "or click to select (max 200Mb per file)",
     "modifySearch": "Try to modify your search criteria",
+    "nestedFoldersHint_one": "{{count}} subfolder will be created to mirror the dropped folder",
+    "nestedFoldersHint_other": "{{count}} subfolders will be created to mirror the dropped folder",
     "newFilesSize": "Upload Size: ",
     "noDocument": "No document found",
     "noSummary": "No summary available.",
@@ -1529,6 +1531,7 @@
         "author": "Added by"
       },
       "embeddedTitleHint": "Embedded title: {{title}}",
+      "dropInFolder": "Drop your files to add them to \"{{folder}}\"",
       "action": {
         "addFile": "Add files",
         "addFileHint": "Select a folder first",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -561,6 +561,7 @@
     "downloadStarting": "Getting ready to start downloading...",
     "dropFiles": "Drop your files here",
     "excessSize": "Excess: ",
+    "folderRequired": "Only files inside a folder can be added here — loose files were skipped.",
     "folders": "Folders",
     "ingestionMode": "Ingestion mode",
     "keywords": "Keywords",
@@ -1532,6 +1533,13 @@
       },
       "embeddedTitleHint": "Embedded title: {{title}}",
       "dropInFolder": "Drop your files to add them to \"{{folder}}\"",
+      "dropAtRoot": "Drop a folder to create it here with its structure",
+      "rootDrop": {
+        "rejectedTitle": "Drop a folder",
+        "rejectedDetail": "Loose files can't land at the top level — drop a folder (it becomes a library), or drop the files into an existing folder.",
+        "skippedDetail_one": "{{count}} loose file was skipped — only the dropped folders' content was kept.",
+        "skippedDetail_other": "{{count}} loose files were skipped — only the dropped folders' content was kept."
+      },
       "action": {
         "addFile": "Add files",
         "addFileHint": "Select a folder first",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -572,6 +572,8 @@
     "makeSearchable": "Rendre recherchable",
     "maxSize": "ou cliquez pour sélectionner (max 200Mo par fichier)",
     "modifySearch": "Essayez de modifier vos critères de recherche",
+    "nestedFoldersHint_one": "{{count}} sous-dossier sera créé pour refléter le dossier déposé",
+    "nestedFoldersHint_other": "{{count}} sous-dossiers seront créés pour refléter le dossier déposé",
     "newFilesSize": "Taille de l'upload : ",
     "noDocument": "Aucun document trouvé",
     "noSummary": "Aucun résumé disponible.",
@@ -1529,6 +1531,7 @@
         "author": "Ajouté par"
       },
       "embeddedTitleHint": "Titre intégré au fichier : {{title}}",
+      "dropInFolder": "Déposez vos fichiers pour les ajouter à « {{folder}} »",
       "action": {
         "addFile": "Ajouter des fichiers",
         "addFileHint": "Sélectionnez d'abord un dossier",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -561,6 +561,7 @@
     "downloadStarting": "Préparation du téléchargement...",
     "dropFiles": "Déposez vos fichiers ici",
     "excessSize": "Dépassement : ",
+    "folderRequired": "Seuls les fichiers contenus dans un dossier peuvent être ajoutés ici — les fichiers seuls ont été ignorés.",
     "folders": "Dossiers",
     "ingestionMode": "Mode d'ingestion",
     "keywords": "Mots-clés",
@@ -1532,6 +1533,13 @@
       },
       "embeddedTitleHint": "Titre intégré au fichier : {{title}}",
       "dropInFolder": "Déposez vos fichiers pour les ajouter à « {{folder}} »",
+      "dropAtRoot": "Déposez un dossier pour le créer ici avec son arborescence",
+      "rootDrop": {
+        "rejectedTitle": "Déposez un dossier",
+        "rejectedDetail": "Les fichiers seuls ne peuvent pas être déposés à la racine — déposez un dossier (il deviendra une bibliothèque), ou déposez les fichiers dans un dossier existant.",
+        "skippedDetail_one": "{{count}} fichier seul a été ignoré — seul le contenu des dossiers déposés a été conservé.",
+        "skippedDetail_other": "{{count}} fichiers seuls ont été ignorés — seul le contenu des dossiers déposés a été conservé."
+      },
       "action": {
         "addFile": "Ajouter des fichiers",
         "addFileHint": "Sélectionnez d'abord un dossier",

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.backNav.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.backNav.test.tsx
@@ -44,6 +44,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [vi.fn()],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.bulkToolbar.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.bulkToolbar.test.tsx
@@ -52,6 +52,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.deleteFolderCount.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.deleteFolderCount.test.tsx
@@ -74,6 +74,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [browseDocumentsByTag],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.download.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.download.test.tsx
@@ -52,6 +52,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.errorDetail.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.errorDetail.test.tsx
@@ -69,6 +69,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.excludedIndicator.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.excludedIndicator.test.tsx
@@ -87,6 +87,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.folderSize.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.folderSize.test.tsx
@@ -65,6 +65,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [vi.fn()],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [tagSizes],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.justDone.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.justDone.test.tsx
@@ -71,6 +71,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.labels.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.labels.test.tsx
@@ -74,6 +74,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.liveStatus.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.liveStatus.test.tsx
@@ -80,6 +80,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.module.css
@@ -15,10 +15,34 @@
 
 .workspace {
   display: flex;
+  position: relative; /* anchors .pageDropOverlay */
   flex: 1;
   flex-direction: column;
   gap: var(--spacing-s);
   min-height: 0;
+}
+
+/* Full-page "drop here" affordance while an OS-file drag hovers the opened
+ * folder — same visual language as the folder row's data-drag-over below.
+ * pointer-events: none so the overlay never steals the dragleave/drop events
+ * from the workspace element that owns them. */
+.workspace[data-page-drag-over] {
+  outline: 1.5px dashed var(--primary);
+  outline-offset: -1.5px;
+}
+
+.pageDropOverlay {
+  display: flex;
+  position: absolute;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-xs);
+  z-index: 3;
+  inset: 0;
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+  pointer-events: none;
+  color: var(--primary);
+  font: var(--font-title-small);
 }
 
 .nameButton {

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.rename.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.rename.test.tsx
@@ -53,6 +53,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.reprocessLabel.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.reprocessLabel.test.tsx
@@ -59,6 +59,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.search.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.search.test.tsx
@@ -43,6 +43,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [vi.fn()],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.searchToggle.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.searchToggle.test.tsx
@@ -82,6 +82,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.stopIngestion.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.stopIngestion.test.tsx
@@ -80,6 +80,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [cancelTask],
 }));

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.test.tsx
@@ -33,6 +33,7 @@ const probe = vi.hoisted(() => ({
   drawerProps: [] as Record<string, unknown>[],
   canUpdateResources: true,
   createTagCalls: [] as Record<string, unknown>[],
+  browseCalls: [] as { tag_id: string }[],
 }));
 
 vi.mock("react-i18next", () => ({
@@ -48,7 +49,12 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
     isLoading: false,
     refetch: () => {},
   }),
-  useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [vi.fn()],
+  useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [
+    (arg: { browseDocumentsByTagRequest: { tag_id: string } }) => {
+      probe.browseCalls.push(arg.browseDocumentsByTagRequest);
+      return { unwrap: () => Promise.resolve({ documents: [], total: 0 }) };
+    },
+  ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
   useCreateTagKnowledgeFlowV1TagsPostMutation: () => [
@@ -103,6 +109,7 @@ beforeEach(() => {
   probe.drawerProps.length = 0;
   probe.canUpdateResources = true;
   probe.createTagCalls.length = 0;
+  probe.browseCalls.length = 0;
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -237,17 +244,42 @@ describe("DocumentWorkspace folder drag-and-drop", () => {
   });
 });
 
+async function navigateInto(name: string) {
+  await act(async () => {
+    folderToggle(name).click();
+    // flush the entry effect's browse promise so perTag settles inside act
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 describe("DocumentWorkspace full-page drop (one folder per page)", () => {
-  it("ignores a page drop at the corpus root — no open folder to attach files to", async () => {
+  it("rejects loose files dropped at the corpus root — only folders can land there", async () => {
     await drop(container.firstElementChild as HTMLElement, filesTransfer([new File(["a"], "a.pdf")]));
 
     expect(lastDrawerProps().isOpen).toBe(false);
   });
 
+  it("accepts a folder dropped at the corpus root, keeping its structure", async () => {
+    const dir = fakeDirEntry("batch", [
+      fakeFileEntry("/batch/a.pdf", new File(["a"], "a.pdf")),
+      fakeDirEntry("sub", [fakeFileEntry("/batch/sub/b.docx", new File(["b"], "b.docx"))]),
+    ]);
+    await drop(container.firstElementChild as HTMLElement, directoryTransfer(dir));
+
+    const props = lastDrawerProps();
+    expect(props.isOpen).toBe(true);
+    expect(props.destinationPath).toBeUndefined();
+    expect((props.metadata as { tags: string[] }).tags).toEqual([]);
+    expect(typeof props.ensureFolderPath).toBe("function");
+    expect(props.requireFolderPerFile).toBe(true);
+    expect((props.initialFiles as File[]).map((f) => f.name).sort((a, b) => a.localeCompare(b))).toEqual([
+      "a.pdf",
+      "b.docx",
+    ]);
+  });
+
   it("dropping anywhere inside an open folder opens the drawer targeting that folder", async () => {
-    act(() => {
-      folderToggle("CIR").click();
-    });
+    await navigateInto("CIR");
     await drop(container.firstElementChild as HTMLElement, filesTransfer([new File(["a"], "a.pdf")]));
 
     const props = lastDrawerProps();
@@ -257,12 +289,29 @@ describe("DocumentWorkspace full-page drop (one folder per page)", () => {
   });
 
   it("a drop on a subfolder row targets that subfolder, not the page's open folder", async () => {
-    act(() => {
-      folderToggle("CIR").click();
-    });
+    await navigateInto("CIR");
     await drop(folderToggle("Sub"), filesTransfer([new File(["a"], "a.pdf")]));
 
     expect(lastDrawerProps().destinationPath).toBe("CIR/Sub");
+  });
+});
+
+describe("DocumentWorkspace folder page reload on entry", () => {
+  it("reloads the folder's document page on every entry, not just the first", async () => {
+    await navigateInto("CIR");
+    const backButton = [...container.querySelectorAll("button")].find((b) =>
+      b.getAttribute("aria-label")?.includes("rework.resources.action.back"),
+    );
+    if (!backButton) throw new Error("back button not rendered");
+    await act(async () => {
+      backButton.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    await navigateInto("CIR");
+
+    // One browse per entry: a folder first opened while its files were still
+    // uploading must not stay frozen on that first empty snapshot.
+    expect(probe.browseCalls.filter((call) => call.tag_id === "tag-cir")).toHaveLength(2);
   });
 });
 

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.test.tsx
@@ -32,6 +32,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const probe = vi.hoisted(() => ({
   drawerProps: [] as Record<string, unknown>[],
   canUpdateResources: true,
+  createTagCalls: [] as Record<string, unknown>[],
 }));
 
 vi.mock("react-i18next", () => ({
@@ -40,13 +41,22 @@ vi.mock("react-i18next", () => ({
 vi.mock("react-redux", () => ({ useSelector: () => [] }));
 vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   useListAllTagsKnowledgeFlowV1TagsGetQuery: () => ({
-    data: [{ id: "tag-cir", name: "CIR", path: "", type: "document", item_ids: [] }],
+    data: [
+      { id: "tag-cir", name: "CIR", path: "", type: "document", item_ids: [] },
+      { id: "tag-sub", name: "Sub", path: "CIR", type: "document", item_ids: [] },
+    ],
     isLoading: false,
     refetch: () => {},
   }),
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [vi.fn()],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [
+    (arg: { tagCreate: { name: string } }) => {
+      probe.createTagCalls.push(arg.tagCreate);
+      return { unwrap: () => Promise.resolve({ id: `tag-${arg.tagCreate.name.toLowerCase()}` }) };
+    },
+  ],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));
@@ -92,6 +102,7 @@ let root: Root;
 beforeEach(() => {
   probe.drawerProps.length = 0;
   probe.canUpdateResources = true;
+  probe.createTagCalls.length = 0;
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -223,6 +234,64 @@ describe("DocumentWorkspace folder drag-and-drop", () => {
     const props = lastDrawerProps();
     expect(props.isOpen).toBe(false);
     expect(props.initialFiles).toBeUndefined();
+  });
+});
+
+describe("DocumentWorkspace full-page drop (one folder per page)", () => {
+  it("ignores a page drop at the corpus root — no open folder to attach files to", async () => {
+    await drop(container.firstElementChild as HTMLElement, filesTransfer([new File(["a"], "a.pdf")]));
+
+    expect(lastDrawerProps().isOpen).toBe(false);
+  });
+
+  it("dropping anywhere inside an open folder opens the drawer targeting that folder", async () => {
+    act(() => {
+      folderToggle("CIR").click();
+    });
+    await drop(container.firstElementChild as HTMLElement, filesTransfer([new File(["a"], "a.pdf")]));
+
+    const props = lastDrawerProps();
+    expect(props.isOpen).toBe(true);
+    expect(props.destinationPath).toBe("CIR");
+    expect((props.metadata as { tags: string[] }).tags).toEqual(["tag-cir"]);
+  });
+
+  it("a drop on a subfolder row targets that subfolder, not the page's open folder", async () => {
+    act(() => {
+      folderToggle("CIR").click();
+    });
+    await drop(folderToggle("Sub"), filesTransfer([new File(["a"], "a.pdf")]));
+
+    expect(lastDrawerProps().destinationPath).toBe("CIR/Sub");
+  });
+});
+
+describe("DocumentWorkspace nested tag creation (ensureFolderPath)", () => {
+  async function ensureAfterDropOnCir(segments: string[]): Promise<string | null> {
+    await drop(folderToggle("CIR"), filesTransfer([new File(["a"], "a.pdf")]));
+    const ensure = lastDrawerProps().ensureFolderPath as (segments: string[]) => Promise<string | null>;
+    let leaf: string | null = null;
+    await act(async () => {
+      leaf = await ensure(segments);
+    });
+    return leaf;
+  }
+
+  it("creates one document tag per missing level under the drop target and returns the leaf's id", async () => {
+    const leaf = await ensureAfterDropOnCir(["Alpha", "Beta"]);
+
+    expect(probe.createTagCalls).toEqual([
+      { name: "Alpha", path: "CIR", type: "document", team_id: "team-1" },
+      { name: "Beta", path: "CIR/Alpha", type: "document", team_id: "team-1" },
+    ]);
+    expect(leaf).toBe("tag-beta");
+  });
+
+  it("reuses an already-materialized folder instead of re-creating its tag", async () => {
+    const leaf = await ensureAfterDropOnCir(["Sub"]);
+
+    expect(probe.createTagCalls).toEqual([]);
+    expect(leaf).toBe("tag-sub");
   });
 });
 

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
@@ -38,12 +38,19 @@ import {
   type TagWithItemsId,
   useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation,
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation,
+  useCreateTagKnowledgeFlowV1TagsPostMutation,
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation,
   useListAllTagsKnowledgeFlowV1TagsGetQuery,
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation,
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation,
 } from "../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
-import { buildTree, collectDescendantTagIds, findNode, type TagNode } from "../../../../../shared/utils/tagTree.ts";
+import {
+  buildTree,
+  collectDescendantTagIds,
+  findNode,
+  fullPath,
+  type TagNode,
+} from "../../../../../shared/utils/tagTree.ts";
 import { selectAllTasks, selectActiveTasks } from "../../../../features/tasks/taskSlice";
 import type { TaskViewModel } from "../../../../features/tasks/taskTypes";
 import { useRefetchOnTaskSuccess } from "../../../../features/tasks/useRefetchOnTaskSuccess";
@@ -110,6 +117,9 @@ type DocMenuAction = "rename" | "download" | "searchable" | "process" | "delete"
 function rowKey(row: Row): string {
   return row.kind === "folder" ? `folder:${row.node.full}` : `doc:${row.doc.identity.document_uid}`;
 }
+
+/** An OS file drag (not a text/element drag) — shared by every drop surface. */
+const isFileDrag = (event: React.DragEvent) => event.dataTransfer.types.includes("Files");
 
 // identity.document_name is always "Original file name incl. extension" —
 // the source of truth for both display and extension, unlike identity.title
@@ -268,6 +278,14 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
   // without changing navigation. Cleared alongside droppedFiles on close.
   const [dropTargetNode, setDropTargetNode] = useState<TagNode | null>(null);
   const [dragOverFolder, setDragOverFolder] = useState<string | null>(null);
+  // OS-file drag hovering anywhere over the opened folder's page (not a
+  // specific folder row) — drives the full-page "drop here" overlay.
+  const [pageDragOver, setPageDragOver] = useState(false);
+  // Folder tags created (or resolved) while the CURRENT upload drawer is open,
+  // keyed by full path — sibling subdirectories of one dropped folder share
+  // parent chains through it instead of racing duplicate POST /tags. Cleared
+  // when the drawer closes: a folder deleted later must not resurrect its id.
+  const pendingFolderTagIds = useRef(new Map<string, string>());
   const [createOpen, setCreateOpen] = useState(false);
   // Client-side filter over the current folder's already-loaded rows — not
   // the deferred server-side search from RFC §13.4 (POST .../browse's
@@ -283,6 +301,7 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
   const [processDocuments] = useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation();
   const [deleteTag] = useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation();
   const [cancelTask] = useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation();
+  const [createTag] = useCreateTagKnowledgeFlowV1TagsPostMutation();
 
   const currentNode = currentFolderFull ? findNode(tree, currentFolderFull) : tree;
   const currentTag = currentNode.tagsHere[0] ?? null;
@@ -579,12 +598,25 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
     for (const { tagId, offset } of pages) void loadTagPage(tagId, offset);
   }, [runningDocIds, perTag, loadTagPage, prevRunningDocIdsRef]);
 
+  /** Seed the ingestion drawer with an OS-file drop, targeting `node`. */
+  const openDrawerWithDroppedFiles = (event: React.DragEvent, node: TagNode) => {
+    event.preventDefault();
+    // fromEvent must start synchronously: the DataTransfer entries needed to
+    // walk a dropped directory are dead once the drop handler has returned.
+    void fromEvent(event.nativeEvent).then((items) => {
+      const dropped = items.filter((item): item is File => item instanceof File);
+      if (dropped.length === 0) return;
+      setDropTargetNode(node);
+      setDroppedFiles(dropped);
+      setUploadOpen(true);
+    });
+  };
+
   /** OS-file drag-and-drop onto a folder row: pre-select that folder and open the
    * ingestion drawer seeded with the dropped files. Same gating as the row's
    * upload action. */
   const folderDropProps = (node: TagNode, droppable: boolean) => {
     if (!droppable) return {};
-    const isFileDrag = (event: React.DragEvent) => event.dataTransfer.types.includes("Files");
     return {
       "data-drag-over": dragOverFolder === node.full || undefined,
       onDragOver: (event: React.DragEvent) => {
@@ -601,17 +633,11 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
         setDragOverFolder((prev) => (prev === node.full ? null : prev));
       },
       onDrop: (event: React.DragEvent) => {
-        event.preventDefault();
+        // The whole page is a drop surface for the opened folder — a drop that
+        // landed on this row must not bubble up and hit that target too.
+        event.stopPropagation();
         setDragOverFolder(null);
-        // fromEvent must start synchronously: the DataTransfer entries needed to
-        // walk a dropped directory are dead once the drop handler has returned.
-        void fromEvent(event.nativeEvent).then((items) => {
-          const dropped = items.filter((item): item is File => item instanceof File);
-          if (dropped.length === 0) return;
-          setDropTargetNode(node);
-          setDroppedFiles(dropped);
-          setUploadOpen(true);
-        });
+        openDrawerWithDroppedFiles(event, node);
       },
     };
   };
@@ -1155,8 +1181,86 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
   const uploadTargetNode = dropTargetNode ?? currentNode;
   const uploadTargetTag = uploadTargetNode.tagsHere[0] ?? null;
 
+  // Walks/creates the tag chain for one dropped subdirectory under the upload
+  // target, returning the leaf's tag id — how a dropped folder keeps its
+  // on-disk structure as nested tags (the drawer calls this once per distinct
+  // subdirectory before uploading). Existing levels are resolved from the
+  // loaded tree or the pendingFolderTagIds cache; missing ones are created
+  // like CreateFolderModal would (same TagCreate shape). A 409 means the tag
+  // exists server-side but not in the loaded tree (stale list, concurrent
+  // creation elsewhere) — refetch and read its id from the fresh list.
+  const ensureFolderPath = useCallback(
+    async (segments: string[]): Promise<string | null> => {
+      let parentFull = uploadTargetNode.full;
+      let parentNode: TagNode | null = uploadTargetNode;
+      let tagId: string | null = uploadTargetNode.tagsHere[0]?.id ?? null;
+      for (const segment of segments) {
+        const full = parentFull ? `${parentFull}/${segment}` : segment;
+        const node: TagNode | null = parentNode?.children.get(segment) ?? null;
+        let id = pendingFolderTagIds.current.get(full) ?? node?.tagsHere[0]?.id ?? null;
+        if (!id) {
+          try {
+            const created = await createTag({
+              tagCreate: {
+                name: segment,
+                path: parentFull || null,
+                type: "document",
+                team_id: isPersonalTeam ? null : teamId,
+              },
+            }).unwrap();
+            id = created.id;
+          } catch (err) {
+            if ((err as { status?: number | string })?.status === 409) {
+              const fresh = await refetchTags().unwrap();
+              id = (fresh ?? []).find((tag) => tag.type === "document" && fullPath(tag) === full)?.id ?? null;
+            }
+            if (!id) {
+              const detail = (err as { data?: { detail?: string } })?.data?.detail;
+              throw new Error(detail ?? t("rework.resources.folderModal.error"));
+            }
+          }
+        }
+        pendingFolderTagIds.current.set(full, id);
+        parentFull = full;
+        parentNode = node;
+        tagId = id;
+      }
+      return tagId;
+    },
+    [uploadTargetNode, createTag, isPersonalTeam, teamId, refetchTags, t],
+  );
+
+  // The full page is a drop surface for the folder being viewed — the drill-down
+  // model shows one folder at a time, so "drop anywhere" reads as "add to this
+  // folder". Folder rows keep their own (more specific) drop target above this
+  // one. Same CAN_UPDATE_RESOURCES gate as the toolbar upload action, and only
+  // inside a folder: the corpus root has no tag to attach plain files to.
+  const pageDroppable = !!currentTag && canCreateFolder;
+  const pageDropProps = pageDroppable
+    ? {
+        onDragOver: (event: React.DragEvent) => {
+          if (!isFileDrag(event)) return;
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "copy";
+        },
+        onDragEnter: (event: React.DragEvent) => {
+          if (!isFileDrag(event)) return;
+          setPageDragOver(true);
+        },
+        onDragLeave: (event: React.DragEvent) => {
+          if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+          setPageDragOver(false);
+        },
+        onDrop: (event: React.DragEvent) => {
+          setPageDragOver(false);
+          openDrawerWithDroppedFiles(event, currentNode);
+        },
+      }
+    : {};
+  const pageDragActive = pageDroppable && pageDragOver && !dragOverFolder;
+
   return (
-    <div className={styles.workspace}>
+    <div className={styles.workspace} data-page-drag-over={pageDragActive || undefined} {...pageDropProps}>
       <ResourceExplorer<Row>
         breadcrumb={{
           segments: breadcrumbSegments,
@@ -1235,6 +1339,13 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
         }
       />
 
+      {pageDragActive && (
+        <div className={styles.pageDropOverlay} aria-hidden>
+          <Icon category="outlined" type="upload" />
+          <span>{t("rework.resources.dropInFolder", { folder: currentNode.name })}</span>
+        </div>
+      )}
+
       <InlineDrawer
         open={!!commands.previewTarget}
         onClose={commands.closePreview}
@@ -1261,11 +1372,13 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
           setUploadOpen(false);
           setDroppedFiles(undefined);
           setDropTargetNode(null);
+          pendingFolderTagIds.current.clear();
         }}
         initialFiles={droppedFiles}
         teamId={teamId}
         destinationPath={uploadTargetNode.full || undefined}
         metadata={{ tags: uploadTargetTag ? [uploadTargetTag.id] : [] }}
+        ensureFolderPath={canCreateFolder ? ensureFolderPath : undefined}
         onUploadComplete={() => {
           if (uploadTargetTag) void loadTagPage(uploadTargetTag.id, perTag[uploadTargetTag.id]?.offset ?? 0);
           void refetchTags();

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
@@ -25,6 +25,7 @@ import Icon from "@shared/atoms/Icon/Icon.tsx";
 import type { OptionModel } from "@models/Option.model.ts";
 import { FOLDER_ICON, fileIconSpec } from "../../../../utils/fileIconSpec.ts";
 import { DocumentUploadDrawer } from "@shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx";
+import { relativeDirSegments } from "@shared/organisms/DocumentUploadDrawer/droppedPaths.ts";
 import {
   DocumentViewer,
   DocumentViewerModeToggle,
@@ -166,7 +167,7 @@ function rowLabel(row: Row): string {
  */
 function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: DocumentWorkspaceProps) {
   const { t } = useTranslation();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess, showError, showWarn } = useToast();
   const { showConfirmationDialog } = useConfirmationDialog();
   const activeTasks = useSelector(selectActiveTasks);
 
@@ -353,12 +354,25 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
     });
   }, []);
 
-  // Load the current folder's document page on entry (and once when its tag
-  // first resolves) — mirrors the old "load on expand" behavior, now scoped
-  // to whichever single folder is being viewed.
+  // Load the current folder's document page on EVERY entry, not just the first:
+  // a folder opened while its files were still uploading (or their fresh ReBAC
+  // tuples still propagating server-side) would otherwise stay frozen on that
+  // first empty snapshot forever — none of the other refresh paths retries a
+  // page that doesn't yet SHOW the document (the 3s poll needs a visible
+  // processing row, useRefetchOnTaskSuccess needs the doc already in the page,
+  // useNotifyOnNewTaskTarget fires before this page exists). loadTagPage keeps
+  // the previous rows while reloading, so re-entering an already-loaded folder
+  // refreshes without a flash of empty.
+  const currentTagId = currentTag?.id ?? null;
   useEffect(() => {
-    if (currentTag && !perTag[currentTag.id]) void loadTagPage(currentTag.id, 0);
-  }, [currentTag, perTag, loadTagPage]);
+    if (currentTagId) void loadTagPage(currentTagId, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the
+    // folder identity alone: one load per ENTRY is the contract, so nothing
+    // else may retrigger it. loadTagPage is deliberately not a dep — its
+    // identity tracks rowsPerPage (whose change already reloads explicitly
+    // via handleRowsPerPageChange), and any harness that rebuilds the browse
+    // trigger per render would otherwise refire this into a reload loop.
+  }, [currentTagId]);
 
   // Drop an override once the backend visibly re-stamped the document (its
   // fresh stages no longer match the click-time snapshot — the real derived
@@ -397,11 +411,20 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
     // map) are the real dependencies.
     [perTag, reprocessOverrides, activeDocTaskByUid],
   );
+  // While any ingestion is live, poll the folder being viewed too, even if its
+  // loaded page shows no processing row yet: a subfolder entered before its
+  // files' uploads (or their fresh ReBAC tuples) landed keeps an empty
+  // snapshot that no other refresh path retries — this loop picks the rows up
+  // as they become visible, with their live "processing" badge.
+  const pollTagIds =
+    activeDocTaskByUid.size > 0 && currentTagId && !pendingTagIds.includes(currentTagId)
+      ? [...pendingTagIds, currentTagId]
+      : pendingTagIds;
   // Keyed on the ids themselves, not the array identity: the live task map is a
   // new object on every SSE event, and depending on it directly tore down and
   // restarted the interval on each one — so during a bulk ingestion, when this
   // refresh matters most, the 3s never elapsed and the folder never reloaded.
-  const pendingTagKey = pendingTagIds.join(",");
+  const pendingTagKey = pollTagIds.join(",");
   useEffect(() => {
     if (!pendingTagKey) return;
     const interval = setInterval(() => {
@@ -598,13 +621,33 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
     for (const { tagId, offset } of pages) void loadTagPage(tagId, offset);
   }, [runningDocIds, perTag, loadTagPage, prevRunningDocIdsRef]);
 
-  /** Seed the ingestion drawer with an OS-file drop, targeting `node`. */
-  const openDrawerWithDroppedFiles = (event: React.DragEvent, node: TagNode) => {
+  /** Seed the ingestion drawer with an OS-file drop, targeting `node`.
+   * `requireDir` (the corpus root, where a file can only live inside a
+   * library): keep only files that came out of a dropped folder — their
+   * chain becomes the library — and reject loose ones, with a toast. */
+  const openDrawerWithDroppedFiles = (event: React.DragEvent, node: TagNode, requireDir = false) => {
     event.preventDefault();
     // fromEvent must start synchronously: the DataTransfer entries needed to
     // walk a dropped directory are dead once the drop handler has returned.
     void fromEvent(event.nativeEvent).then((items) => {
-      const dropped = items.filter((item): item is File => item instanceof File);
+      let dropped = items.filter((item): item is File => item instanceof File);
+      if (requireDir) {
+        const foldered = dropped.filter((file) => relativeDirSegments(file).length > 0);
+        if (foldered.length === 0) {
+          if (dropped.length > 0)
+            showError?.({
+              summary: t("rework.resources.rootDrop.rejectedTitle"),
+              detail: t("rework.resources.rootDrop.rejectedDetail"),
+            });
+          return;
+        }
+        if (foldered.length < dropped.length)
+          showWarn?.({
+            summary: t("rework.resources.rootDrop.rejectedTitle"),
+            detail: t("rework.resources.rootDrop.skippedDetail", { count: dropped.length - foldered.length }),
+          });
+        dropped = foldered;
+      }
       if (dropped.length === 0) return;
       setDropTargetNode(node);
       setDroppedFiles(dropped);
@@ -1233,9 +1276,12 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
   // The full page is a drop surface for the folder being viewed — the drill-down
   // model shows one folder at a time, so "drop anywhere" reads as "add to this
   // folder". Folder rows keep their own (more specific) drop target above this
-  // one. Same CAN_UPDATE_RESOURCES gate as the toolbar upload action, and only
-  // inside a folder: the corpus root has no tag to attach plain files to.
-  const pageDroppable = !!currentTag && canCreateFolder;
+  // one. Same CAN_UPDATE_RESOURCES gate as the toolbar upload action. At the
+  // corpus root there is no tag to attach plain files to, so only dropped
+  // FOLDERS are accepted there — each one becomes a library mirroring its
+  // structure (openDrawerWithDroppedFiles filters loose files out).
+  const atRoot = !currentFolderFull;
+  const pageDroppable = canCreateFolder && (!!currentTag || atRoot);
   const pageDropProps = pageDroppable
     ? {
         onDragOver: (event: React.DragEvent) => {
@@ -1253,7 +1299,7 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
         },
         onDrop: (event: React.DragEvent) => {
           setPageDragOver(false);
-          openDrawerWithDroppedFiles(event, currentNode);
+          openDrawerWithDroppedFiles(event, currentNode, atRoot);
         },
       }
     : {};
@@ -1342,7 +1388,11 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
       {pageDragActive && (
         <div className={styles.pageDropOverlay} aria-hidden>
           <Icon category="outlined" type="upload" />
-          <span>{t("rework.resources.dropInFolder", { folder: currentNode.name })}</span>
+          <span>
+            {atRoot
+              ? t("rework.resources.dropAtRoot")
+              : t("rework.resources.dropInFolder", { folder: currentNode.name })}
+          </span>
         </div>
       )}
 
@@ -1379,6 +1429,7 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
         destinationPath={uploadTargetNode.full || undefined}
         metadata={{ tags: uploadTargetTag ? [uploadTargetTag.id] : [] }}
         ensureFolderPath={canCreateFolder ? ensureFolderPath : undefined}
+        requireFolderPerFile={!uploadTargetTag}
         onUploadComplete={() => {
           if (uploadTargetTag) void loadTagPage(uploadTargetTag.id, perTag[uploadTargetTag.id]?.offset ?? 0);
           void refetchTags();

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.uploaderName.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.uploaderName.test.tsx
@@ -61,6 +61,7 @@ vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   ],
   useTagSizesKnowledgeFlowV1DocumentsMetadataTagSizesPostMutation: () => [vi.fn()],
   useProcessDocumentsKnowledgeFlowV1ProcessDocumentsPostMutation: () => [vi.fn()],
+  useCreateTagKnowledgeFlowV1TagsPostMutation: () => [vi.fn()],
   useDeleteTagKnowledgeFlowV1TagsTagIdDeleteMutation: () => [vi.fn()],
   useCancelTaskKnowledgeFlowV1TasksTaskIdCancelPostMutation: () => [vi.fn()],
 }));

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.nestedFolders.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.nestedFolders.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Coverage for structure-preserving saves: files carrying a dropped-folder
+// relative path must upload under the tag `ensureFolderPath` resolves for
+// their subdirectory (one resolver call per DISTINCT subdirectory), while
+// root-level files keep the destination folder's base metadata — and a
+// resolver failure must abort the save before any upload starts, leaving the
+// drawer open. Kept separate from DocumentUploadDrawer.initialFiles.test.tsx,
+// which covers plain (flat) seeding.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const probe = vi.hoisted(() => ({
+  scheduled: [] as { name: string; metadata: Record<string, unknown> }[],
+  showError: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("react-redux", () => ({ useDispatch: () => () => {} }));
+vi.mock("react-dropzone", () => ({
+  useDropzone: () => ({ getRootProps: () => ({}), getInputProps: () => ({}), isDragActive: false }),
+}));
+vi.mock("@shared/utils/Portal", () => ({ Portal: ({ children }: { children: React.ReactNode }) => children }));
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({ useToast: () => ({ showError: probe.showError }) }));
+vi.mock("@shared/molecules/Select/Select", () => ({ default: () => null }));
+vi.mock("@shared/molecules/UploadWarningBanner/UploadWarningBanner", () => ({ default: () => null }));
+vi.mock("@hooks/useTeamCapabilities.ts", () => ({ useTeamCapabilities: () => ({ canUpdateResources: true }) }));
+vi.mock("../../../../../slices/streamDocumentUpload", () => ({
+  streamUploadOrProcessDocument: (file: File, _mode: string, metadata: Record<string, unknown>) => {
+    probe.scheduled.push({ name: file.name, metadata });
+    return Promise.resolve([]);
+  },
+}));
+vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({}));
+vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
+  useGetTeamQuery: () => ({ data: undefined }),
+}));
+vi.mock("../../../../features/tasks/taskSlice", () => ({
+  taskRegistered: (payload: unknown) => ({ type: "tasks/taskRegistered", payload }),
+}));
+
+import { DocumentUploadDrawer } from "./DocumentUploadDrawer";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  probe.scheduled.length = 0;
+  probe.showError.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function fileAt(name: string, path?: string): File {
+  const file = new File(["x"], name);
+  if (path) Object.defineProperty(file, "path", { value: path });
+  return file;
+}
+
+async function clickSave() {
+  const save = [...container.querySelectorAll("button")].find((b) => b.textContent?.includes("documentLibrary.save"));
+  if (!save) throw new Error("save button not rendered");
+  await act(async () => {
+    save.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("DocumentUploadDrawer nested-folder saves", () => {
+  it("uploads each file under its subdirectory's tag, resolving each distinct subdirectory once", async () => {
+    const ensureFolderPath = vi.fn(async (segments: string[]) => `tag-${segments.join("-")}`);
+    render(
+      <DocumentUploadDrawer
+        isOpen
+        onClose={() => {}}
+        metadata={{ tags: ["tag-base"] }}
+        ensureFolderPath={ensureFolderPath}
+        initialFiles={[
+          fileAt("root.pdf", "./root.pdf"),
+          fileAt("a.pdf", "/batch/a.pdf"),
+          fileAt("b.pdf", "/batch/sub/b.pdf"),
+          fileAt("c.pdf", "/batch/sub/c.pdf"),
+        ]}
+      />,
+    );
+
+    await clickSave();
+
+    expect(ensureFolderPath.mock.calls.map(([segments]) => segments)).toEqual([["batch"], ["batch", "sub"]]);
+    const byName = Object.fromEntries(probe.scheduled.map((s) => [s.name, s.metadata.tags]));
+    expect(byName["root.pdf"]).toEqual(["tag-base"]);
+    expect(byName["a.pdf"]).toEqual(["tag-batch"]);
+    expect(byName["b.pdf"]).toEqual(["tag-batch-sub"]);
+    expect(byName["c.pdf"]).toEqual(["tag-batch-sub"]);
+  });
+
+  it("shows the subfolder hint only when structured files and a resolver are both present", () => {
+    render(
+      <DocumentUploadDrawer
+        isOpen
+        onClose={() => {}}
+        ensureFolderPath={async () => null}
+        initialFiles={[fileAt("a.pdf", "/batch/a.pdf")]}
+      />,
+    );
+    expect(container.textContent).toContain("documentLibrary.nestedFoldersHint");
+    expect(container.textContent).toContain("batch/a.pdf");
+
+    render(<DocumentUploadDrawer isOpen onClose={() => {}} initialFiles={[fileAt("a.pdf", "/batch/a.pdf")]} />);
+    expect(container.textContent).not.toContain("documentLibrary.nestedFoldersHint");
+  });
+
+  it("aborts the save (nothing uploaded, drawer open) when folder resolution fails", async () => {
+    const onClose = vi.fn();
+    render(
+      <DocumentUploadDrawer
+        isOpen
+        onClose={onClose}
+        ensureFolderPath={async () => {
+          throw new Error("boom");
+        }}
+        initialFiles={[fileAt("a.pdf", "/batch/a.pdf")]}
+      />,
+    );
+
+    await clickSave();
+
+    expect(probe.scheduled).toEqual([]);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(probe.showError).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.nestedFolders.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.nestedFolders.test.tsx
@@ -147,6 +147,25 @@ describe("DocumentUploadDrawer nested-folder saves", () => {
     expect(container.textContent).not.toContain("documentLibrary.nestedFoldersHint");
   });
 
+  it("filters loose files out of the seed when requireFolderPerFile is set (tagless destination)", async () => {
+    render(
+      <DocumentUploadDrawer
+        isOpen
+        onClose={() => {}}
+        requireFolderPerFile
+        ensureFolderPath={async (segments: string[]) => `tag-${segments.join("-")}`}
+        initialFiles={[fileAt("root.pdf", "./root.pdf"), fileAt("a.pdf", "/batch/a.pdf")]}
+      />,
+    );
+
+    expect(container.textContent).toContain("batch/a.pdf");
+    expect(container.textContent).not.toContain("root.pdf");
+
+    await clickSave();
+    expect(probe.scheduled.map((s) => s.name)).toEqual(["a.pdf"]);
+    expect(probe.scheduled[0].metadata.tags).toEqual(["tag-batch"]);
+  });
+
   it("aborts the save (nothing uploaded, drawer open) when folder resolution fails", async () => {
     const onClose = vi.fn();
     render(

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx
@@ -30,6 +30,7 @@ import { IngestionProcessingProfile } from "../../../../../slices/knowledgeFlow/
 import { useGetTeamQuery } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import type { OptionModel } from "@models/Option.model";
 import { taskRegistered } from "../../../../features/tasks/taskSlice";
+import { displayPath, relativeDirSegments } from "./droppedPaths";
 import styles from "./DocumentUploadDrawer.module.css";
 
 interface DocumentUploadDrawerProps {
@@ -43,6 +44,12 @@ interface DocumentUploadDrawerProps {
   /** Files picked before the drawer opened (dropped on a folder row) — seeded into the
    * list on open so the user only has to choose mode/profile and save. */
   initialFiles?: File[];
+  /** Resolves (creating tags as needed) the nested folder chain `segments` under the
+   * upload destination and returns the tag id files in that folder attach to — how a
+   * dropped directory keeps its on-disk structure as nested corpus tags. Owned by the
+   * caller (it knows the tag tree); absent => structure is ignored and every file
+   * lands flat in the destination folder, the historical behavior. */
+  ensureFolderPath?: (segments: string[]) => Promise<string | null>;
 }
 
 /**
@@ -95,6 +102,7 @@ export function DocumentUploadDrawer({
   teamId,
   destinationPath,
   initialFiles,
+  ensureFolderPath,
 }: DocumentUploadDrawerProps) {
   const { t } = useTranslation();
   const { showError } = useToast();
@@ -148,6 +156,14 @@ export function DocumentUploadDrawer({
 
   const newFilesSize = useMemo(() => files.reduce((acc, f) => acc + f.size, 0), [files]);
 
+  // Distinct subdirectories carried by the listed files (a dropped folder) that
+  // saving will mirror as nested corpus tags — 0 when the list is flat or when
+  // the caller provided no ensureFolderPath (structure is then ignored).
+  const nestedDirCount = useMemo(() => {
+    if (!ensureFolderPath) return 0;
+    return new Set(files.map((f) => relativeDirSegments(f).join("/")).filter(Boolean)).size;
+  }, [files, ensureFolderPath]);
+
   const isQuotaExceeded = useMemo(() => {
     if (!team) return false;
     const current = team.current_resources_storage_size ?? 0;
@@ -179,6 +195,29 @@ export function DocumentUploadDrawer({
   const handleSave = async () => {
     if (!files.length || isLoading || isQuotaExceeded) return;
     setIsLoading(true);
+    // Mirror a dropped folder's structure first: one tag chain per distinct
+    // subdirectory, resolved before any upload starts so a failed/forbidden tag
+    // creation aborts the save with nothing half-uploaded (the drawer stays open
+    // for a retry). Sequential on purpose — sibling chains share parent
+    // prefixes, which the caller's resolver caches between calls.
+    const tagIdByDir = new Map<string, string | null>();
+    if (ensureFolderPath) {
+      const chains = new Map<string, string[]>();
+      for (const file of files) {
+        const segments = relativeDirSegments(file);
+        if (segments.length) chains.set(segments.join("/"), segments);
+      }
+      try {
+        for (const [key, segments] of chains) tagIdByDir.set(key, await ensureFolderPath(segments));
+      } catch (err) {
+        setIsLoading(false);
+        showError?.({
+          summary: t("documentLibrary.uploadDrawerTitle"),
+          detail: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+    }
     try {
       // Schedule every file concurrently rather than one-at-a-time: each
       // `scheduleFile` already only waits for its own task_id to be discovered
@@ -187,7 +226,11 @@ export function DocumentUploadDrawer({
       // not after the sum of every file's upload time.
       await Promise.all(
         files.map((file) => {
-          const requestMetadata = canSelectProfile ? { ...(metadata ?? {}), profile } : { ...(metadata ?? {}) };
+          const base = canSelectProfile ? { ...(metadata ?? {}), profile } : { ...(metadata ?? {}) };
+          // A file inside a dropped subdirectory attaches to that subdirectory's
+          // tag instead of the destination folder's (`base` keeps the latter).
+          const dirTagId = tagIdByDir.get(relativeDirSegments(file).join("/"));
+          const requestMetadata = dirTagId ? { ...base, tags: [dirTagId] } : base;
           // Register each task the instant the server first reports its id (the first
           // line of the stream), not after the whole upload finishes — so the tray
           // lights up and starts its SSE subscription while the upload streams.
@@ -304,8 +347,8 @@ export function DocumentUploadDrawer({
                 <ul className={styles.fileList}>
                   {files.map((f, i) => (
                     <li key={`${f.name}-${i}`} className={styles.fileRow}>
-                      <span className={styles.fileName} title={f.name}>
-                        {f.name}
+                      <span className={styles.fileName} title={displayPath(f)}>
+                        {displayPath(f)}
                       </span>
                       <span className={styles.fileSize}>{formatBytes(f.size)}</span>
                       <IconButton
@@ -323,6 +366,12 @@ export function DocumentUploadDrawer({
                 </ul>
               )}
             </div>
+
+            {nestedDirCount > 0 && (
+              <p className={styles.formatsCaption}>
+                {t("documentLibrary.nestedFoldersHint", { count: nestedDirCount })}
+              </p>
+            )}
 
             <p className={styles.formatsCaption}>{t("documentLibrary.supportedFormats")}</p>
 

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/DocumentUploadDrawer.tsx
@@ -50,6 +50,11 @@ interface DocumentUploadDrawerProps {
    * caller (it knows the tag tree); absent => structure is ignored and every file
    * lands flat in the destination folder, the historical behavior. */
   ensureFolderPath?: (segments: string[]) => Promise<string | null>;
+  /** Destination with no tag of its own (the corpus root): every file must sit
+   * inside a dropped folder — its chain becomes the file's library — because a
+   * loose file would upload tagless and be invisible in the corpus. Loose
+   * files are filtered out of the list (with a toast when it happens). */
+  requireFolderPerFile?: boolean;
 }
 
 /**
@@ -103,6 +108,7 @@ export function DocumentUploadDrawer({
   destinationPath,
   initialFiles,
   ensureFolderPath,
+  requireFolderPerFile,
 }: DocumentUploadDrawerProps) {
   const { t } = useTranslation();
   const { showError } = useToast();
@@ -145,10 +151,14 @@ export function DocumentUploadDrawer({
   const [isLoading, setIsLoading] = useState(false);
 
   // Seed on open only: `files` stays local state afterwards (user can still add
-  // or remove entries), and closing resets it via handleClose as usual.
+  // or remove entries), and closing resets it via handleClose as usual. The
+  // caller already filters loose files out of a root-drop seed — the filter
+  // here is for any other opener of a tagless destination.
   useEffect(() => {
-    if (isOpen && initialFiles?.length) setFiles(initialFiles);
-  }, [isOpen, initialFiles]);
+    if (isOpen && initialFiles?.length) {
+      setFiles(requireFolderPerFile ? initialFiles.filter((f) => relativeDirSegments(f).length > 0) : initialFiles);
+    }
+  }, [isOpen, initialFiles, requireFolderPerFile]);
 
   const resolvedTeamId = teamId ?? "personal";
   const { data: team } = useGetTeamQuery({ teamId: resolvedTeamId });
@@ -177,9 +187,16 @@ export function DocumentUploadDrawer({
     // Enter/Space opens the file dialog (react-dropzone), so adding files no
     // longer depends on a mouse/drag. Focus-visible styling lives in the CSS.
     onDrop: (accepted) => {
+      const usable = requireFolderPerFile ? accepted.filter((f) => relativeDirSegments(f).length > 0) : accepted;
+      if (usable.length < accepted.length) {
+        showError?.({
+          summary: t("documentLibrary.uploadDrawerTitle"),
+          detail: t("documentLibrary.folderRequired"),
+        });
+      }
       setFiles((prev) => {
         const existing = new Set(prev.map((f) => `${f.name}-${f.size}-${f.lastModified}`));
-        return [...prev, ...accepted.filter((f) => !existing.has(`${f.name}-${f.size}-${f.lastModified}`))];
+        return [...prev, ...usable.filter((f) => !existing.has(`${f.name}-${f.size}-${f.lastModified}`))];
       });
     },
   });

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/droppedPaths.test.ts
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/droppedPaths.test.ts
@@ -1,0 +1,57 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The relative-path readers behind structure-preserving folder drops: they must
+// see the same directory chain whether the file came from file-selector's drop
+// traversal (`path`, "/batch/sub/a.pdf") or a webkitdirectory input
+// (`webkitRelativePath`, "batch/sub/a.pdf"), and see NO chain for a file
+// dropped or picked on its own ("./a.pdf", bare name, or nothing).
+
+import { describe, expect, it } from "vitest";
+import { displayPath, relativeDirSegments } from "./droppedPaths";
+
+function fileWith(name: string, extra: { path?: string; webkitRelativePath?: string } = {}): File {
+  const file = new File(["x"], name);
+  for (const [key, value] of Object.entries(extra)) {
+    Object.defineProperty(file, key, { value });
+  }
+  return file;
+}
+
+describe("relativeDirSegments", () => {
+  it("reads the directory chain from a dropped-directory path", () => {
+    expect(relativeDirSegments(fileWith("a.pdf", { path: "/batch/sub/a.pdf" }))).toEqual(["batch", "sub"]);
+  });
+
+  it("reads the directory chain from a webkitdirectory relative path", () => {
+    expect(relativeDirSegments(fileWith("a.pdf", { webkitRelativePath: "batch/a.pdf" }))).toEqual(["batch"]);
+  });
+
+  it("sees no chain for a file dropped on its own", () => {
+    expect(relativeDirSegments(fileWith("a.pdf", { path: "./a.pdf" }))).toEqual([]);
+    expect(relativeDirSegments(fileWith("a.pdf", { path: "a.pdf" }))).toEqual([]);
+    expect(relativeDirSegments(fileWith("a.pdf"))).toEqual([]);
+  });
+
+  it("drops empty and whitespace-only segments", () => {
+    expect(relativeDirSegments(fileWith("a.pdf", { path: "//batch//  /a.pdf" }))).toEqual(["batch"]);
+  });
+});
+
+describe("displayPath", () => {
+  it("prefixes the directory chain when there is one, plain name otherwise", () => {
+    expect(displayPath(fileWith("a.pdf", { path: "/batch/sub/a.pdf" }))).toBe("batch/sub/a.pdf");
+    expect(displayPath(fileWith("a.pdf"))).toBe("a.pdf");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/droppedPaths.ts
+++ b/apps/frontend/src/rework/components/shared/organisms/DocumentUploadDrawer/droppedPaths.ts
@@ -1,0 +1,47 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Relative-path helpers for files that came out of a dropped or picked FOLDER.
+ *
+ * file-selector's `fromEvent` (drop) stamps each traversed file with a `path`
+ * like "/batch/sub/a.pdf"; a `webkitdirectory` input stamps
+ * `webkitRelativePath` like "batch/sub/a.pdf". A file dropped or picked on its
+ * own carries "./a.pdf", "a.pdf", or nothing — no directory either way. These
+ * helpers read whichever is present so callers can rebuild the folder chain
+ * (nested corpus tags) a file belongs under.
+ */
+
+type FileWithOptionalPath = File & { path?: string; webkitRelativePath?: string };
+
+/**
+ * The directory chain a file sits in, relative to the drop/pick root —
+ * `["batch", "sub"]` for "/batch/sub/a.pdf", `[]` for a file with no folder.
+ */
+export function relativeDirSegments(file: File): string[] {
+  const { path, webkitRelativePath } = file as FileWithOptionalPath;
+  const raw = path || webkitRelativePath || "";
+  const segments = raw
+    .split("/")
+    .map((seg) => seg.trim())
+    .filter((seg) => seg && seg !== ".");
+  // Last segment is the file's own name, not a directory.
+  return segments.slice(0, -1);
+}
+
+/** "batch/sub/a.pdf" for a file inside a dropped folder, plain name otherwise. */
+export function displayPath(file: File): string {
+  const dir = relativeDirSegments(file);
+  return dir.length ? `${dir.join("/")}/${file.name}` : file.name;
+}

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -2552,23 +2552,41 @@ server-side: sub-folders and the untagging of contained documents are the
 backend's `delete_tag_for_user`. Errors surface as a toast with the backend
 detail. (Found live 2026-07-20: no delete affordance existed at all.)
 
-### `DocumentWorkspace` — drag-and-drop onto folder rows
+### `DocumentWorkspace` — drag-and-drop: folder rows, full page, corpus root (2026-08-12)
 
-Dropping OS files anywhere on a corpus folder's subtree — its row or, when
-expanded, its document rows/hints — opens the ingestion drawer
-(`DocumentUploadDrawer`) pre-seeded with the dropped files and targeting that
-folder (innermost tagged folder wins when subtrees nest), so the user only
-picks mode/profile (fast/medium/rich) and saves. A dropped directory is
-expanded into all its files, recursively and flat — same `file-selector`
-traversal as the drawer's own dropzone, which already accepted folders.
-Folder-originated files upload under their leaf name: browsers put the
-relative path in the multipart filename (this surfaced as one opaque
-"Upload failed: 404" per file, found live 2026-07-23), now pinned frontend-side
-and sanitized backend-side (`upload_basename`). The
-targeted row shows the drawer dropzone's affordance (dashed `--primary`
-outline + 6% tint) while hovered with files. Same `canUpdateResources` gate as
-the row's explicit upload action; rows without a tag (pure path prefixes) are
-not drop targets.
+Three drop surfaces, all behind the same `canUpdateResources` gate as the
+explicit upload action, all opening the ingestion drawer
+(`DocumentUploadDrawer`) pre-seeded with the dropped files so the user only
+picks mode/profile (fast/medium/rich) and saves:
+
+- **Folder row** (since 2026-07-23): targets that folder; the row shows the
+  drawer dropzone's affordance (dashed `--primary` outline + 6% tint) while
+  hovered with files, and its drop wins over the page surface below
+  (`stopPropagation`).
+- **Full page of an open folder**: the drill-down model shows one folder at a
+  time, so dropping anywhere on the page reads as "add to this folder" — an
+  overlay names the destination while a file drag hovers.
+- **Corpus root**: only dropped FOLDERS are accepted — each becomes a library
+  mirroring its structure (see below). Loose files are rejected with an error
+  toast (they have no tag to land in and would upload invisible); a mixed
+  drop keeps the folders' content and warns about the skipped loose files.
+
+A dropped directory keeps its on-disk structure: each subdirectory becomes a
+nested document tag (created exactly like `CreateFolderModal` would, existing
+levels reused), and every file uploads under its own subdirectory's tag
+instead of being flattened into the drop target. The drawer lists files under
+their relative path and announces how many subfolders the save will create; a
+failed/forbidden tag creation aborts the save before any upload starts.
+Folder-originated files still upload under their leaf name: browsers put the
+relative path in the multipart filename (one opaque "Upload failed: 404" per
+file, found live 2026-07-23), pinned frontend-side and sanitized backend-side
+(`upload_basename`).
+
+Status refresh: a folder's document page reloads on every entry (not just the
+first), and while any ingestion is live the 3s status poll also covers the
+folder being viewed — a subfolder opened before its files' uploads (or fresh
+ReBAC tuples) landed used to freeze forever on its first empty snapshot,
+hiding the live "processing" rows (found live 2026-08-12).
 
 ### `DocumentWorkspace` — embedded-title hint on the Name column
 


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**ID:** no formal ID — resources UX restoration + bug fix, tracked in the issue below.

**Problem in one sentence:** the resources rework made #2080's drag-and-drop practically unreachable (drop targets are folder rows, the drill-down view rarely shows any), dropped directories were flattened (structure lost), nothing could be dropped at the corpus root, and a freshly created subfolder froze on its first empty page snapshot, hiding live "processing" rows.

**Tracking:** Closes #2340

## 2. Before you wrote a single line of code

**RFC written?**

Not required — no new design decision: this restores the shipped #2080 behavior onto the reworked drill-down view and composes existing, settled mechanics (tags nest via `path`, upload already targets a tag per file via `metadata.tags`, tag creation is the same `TagCreate` shape `CreateFolderModal` uses). No contract, schema, or endpoint change.

**Plan presented to the team before implementation?**

Yes — cost assessment + file-by-file plan presented in the working session before any code; the status-bug diagnosis (one-shot page load + poll gated on visible processing rows) was walked through before the fix.

**Confirmation received?**

Yes — developer (simcariou) explicitly requested the implementation, the root-drop extension, and this PR.

## 3. What you built

- **Full-page drop surface** for the open folder in `DocumentWorkspace`: the drill-down model shows one folder at a time, so dropping anywhere on the page adds to that folder (overlay names the destination). Folder rows keep their own, more specific drop target (`stopPropagation`).
- **Structure-preserving drops**: `ensureFolderPath` (DocumentWorkspace) walks/creates the tag chain for each distinct subdirectory of a dropped folder (existing levels reused, per-save cache, 409 → refetch fallback); `DocumentUploadDrawer` resolves one tag per subdirectory before uploading and attaches each file to its own subdirectory's tag. New `droppedPaths.ts` reads the relative paths (`file-selector` `path` / `webkitRelativePath`). The drawer lists files under their relative path and announces how many subfolders the save will create; a failed tag creation aborts the save before any upload starts.
- **Root drops, folders only**: a folder dropped at the corpus root becomes a library mirroring its structure; loose files are rejected with an error toast (tagless uploads would be invisible), mixed drops keep the folders' content and warn about skipped loose files. The drawer gains `requireFolderPerFile` for tagless destinations.
- **Status fix**: the folder page reloads on every entry (was: first entry only), and while any ingestion is live the 3s poll also covers the folder being viewed — a subfolder opened before its files' uploads (or fresh ReBAC tuples) landed no longer freezes on an empty snapshot; "processing" rows appear within one poll tick.

Frontend-only; no backend change.

## 4. Proof of quality

**Tests added or updated:**

| Test | File | What it covers |
| ---- | ---- | -------------- |
| relativeDirSegments/displayPath cases (5) | `droppedPaths.test.ts` | path parsing: drop traversal, webkitdirectory, loose files, junk segments |
| uploads each file under its subdirectory's tag, one resolver call per distinct dir | `DocumentUploadDrawer.nestedFolders.test.tsx` | per-file tag metadata on save |
| subfolder hint + relative-path listing | `DocumentUploadDrawer.nestedFolders.test.tsx` | structure surfaced in the drawer UI |
| filters loose files when requireFolderPerFile | `DocumentUploadDrawer.nestedFolders.test.tsx` | tagless-destination guard |
| aborts save when folder resolution fails | `DocumentUploadDrawer.nestedFolders.test.tsx` | no half-uploaded batch |
| rejects loose files at root / accepts a folder at root | `DocumentWorkspace.test.tsx` | root drop gating |
| page drop targets the open folder; row drop wins over page | `DocumentWorkspace.test.tsx` | drop-surface precedence |
| creates one tag per missing level / reuses existing levels | `DocumentWorkspace.test.tsx` | ensureFolderPath chain semantics |
| reloads the folder page on every entry | `DocumentWorkspace.test.tsx` | the frozen-empty-snapshot fix |

Plus one mechanical line in 17 DocumentWorkspace test harnesses (mock of the newly imported `useCreateTag` hook).

**`make code-quality` output:**

```
npx tsc --noEmit
npx prettier . --check
All matched files use Prettier code style!
```

**Raw `basedpyright` output (required if a touched package keeps a non-empty baseline file):**

```
n/a — frontend-only change, no Python touched
```

**`make test` output:**

```
Test Files  25 passed | 1 skipped (26)
Tests       163 passed | 2 skipped (165)
```

(full `apps/frontend` vitest run of the touched suites; complete frontend suite also green under tsc/prettier)

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — issue-tracked (#2340), backlog files frozen |
| New behaviour, API field, or contract change                      | n/a — no contract change (frontend consumes existing endpoints) |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — untouched |
| UX component implemented or visual status changed                 | `docs/swift/ux/COMPONENT-UX.md` — DocumentWorkspace drag-and-drop section rewritten (three surfaces + status refresh) |
| Phase progress row exists for this area                           | n/a |
| WORKPLAN sprint item finished                                     | n/a — WORKPLAN frozen |
| Code and a design doc now diverge                                 | n/a — none diverge |

## 6. Close-out statement

```
## Task close-out
- Code: full-page + root folder drops with nested tags mirroring dropped structure; folder-page reload on entry + poll extension fixing frozen "processing" rows
- Tests: pass — 13 tests added across droppedPaths/DocumentUploadDrawer/DocumentWorkspace suites (163 pass on touched suites)
- Docs updated: docs/swift/ux/COMPONENT-UX.md
- Tracking: #2340 (closed by this PR)
- Skipped steps: Step 1 RFC (no open design question — restores shipped #2080 design onto the reworked view)
```

## 7. Risk and rollback

**What breaks if this is wrong?** Worst realistic failures are contained: a mis-resolved tag chain would file documents under a wrong (but visible, deletable) nested folder; the entry reload adds one paginated browse per folder entry and the poll one per 3s while an ingestion is live — same cadence the poll already used. Tag creation reuses the exact `TagCreate` path `CreateFolderModal` ships today.

**How do we roll back?** Revert the three commits (pure frontend + one docs commit); no migration, no contract, no stored-data impact.
