### PR TITLE
feat(#2253): limit chat input message length

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -344,6 +344,15 @@ class ExecutionPreparation(BaseModel):
     supports_streaming: bool = True
     supports_hitl: bool = True
     supports_ui_parts: bool = True
+    max_chat_input_chars: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Maximum Unicode code points accepted in one submitted chat message, "
+            "as advertised by the selected runtime pod. Null when an older runtime "
+            "does not publish the policy."
+        ),
+    )
     chat_controls: list[ChatControlDescriptor] = Field(
         default_factory=list,
         description=(

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -177,6 +177,7 @@ class _RuntimeTemplatePayload:
         default_tuning: ManagedAgentTuning | None = None,
         available_capabilities: list[CapabilityCatalogEntry] | None = None,
         default_capability_ids: list[str] | None = None,
+        max_chat_input_chars: int | None = None,
     ) -> None:
         self.template_agent_id = template_agent_id
         self.title = title
@@ -195,6 +196,7 @@ class _RuntimeTemplatePayload:
         # so `_apply_capability_selection` can ReBAC-check the None case instead of
         # skipping it.
         self.default_capability_ids = default_capability_ids or []
+        self.max_chat_input_chars = max_chat_input_chars
 
     @classmethod
     def model_validate(cls, data: dict) -> "_RuntimeTemplatePayload":
@@ -223,6 +225,14 @@ class _RuntimeTemplatePayload:
                 "description": data["description"],
             }
         )
+        raw_max_chat_input_chars = data.get("max_chat_input_chars")
+        max_chat_input_chars = (
+            raw_max_chat_input_chars
+            if isinstance(raw_max_chat_input_chars, int)
+            and not isinstance(raw_max_chat_input_chars, bool)
+            and raw_max_chat_input_chars > 0
+            else None
+        )
         return cls(
             template_agent_id=data["template_agent_id"],
             title=data["title"],
@@ -247,6 +257,9 @@ class _RuntimeTemplatePayload:
                 for cid in data.get("default_capability_ids", [])
                 if isinstance(cid, str) and cid
             ],
+            # Optional during rolling upgrades: older runtime pods do not
+            # advertise this deployment policy yet.
+            max_chat_input_chars=max_chat_input_chars,
         )
 
 
@@ -570,18 +583,39 @@ async def _available_capabilities_for_source(
     unreachable pod yields an empty list (no chat controls this prep).
     """
 
+    available_capabilities, _ = await _runtime_execution_metadata_for_source(base_url)
+    return available_capabilities
+
+
+async def _runtime_execution_metadata_for_source(
+    base_url: str,
+) -> tuple[list[CapabilityCatalogEntry], int | None]:
+    """Fetch pod-scoped metadata needed by one execution preparation.
+
+    Capability descriptors and the chat-input policy live on the same runtime
+    template response. Reading them together preserves the existing single
+    request per preparation and keeps older runtimes compatible.
+    """
+
     try:
         templates = await _fetch_runtime_templates(base_url, include_non_public=True)
     except Exception as exc:
-        # Best-effort (see docstring): an unreachable pod is expected/handled, not
-        # a fault worth WARNING-level attention on every poll cycle it recurs.
-        logger.debug("Failed to fetch capability catalog from %s: %s", base_url, exc)
-        return []
+        # Best-effort: an unreachable or older pod must not make preparation fail.
+        logger.debug("Failed to fetch runtime metadata from %s: %s", base_url, exc)
+        return [], None
     merged: OrderedDict[str, CapabilityCatalogEntry] = OrderedDict()
     for template in templates:
         for entry in template.available_capabilities:
             merged.setdefault(entry.id, entry)
-    return list(merged.values())
+    max_chat_input_chars = next(
+        (
+            template.max_chat_input_chars
+            for template in templates
+            if template.max_chat_input_chars is not None
+        ),
+        None,
+    )
+    return list(merged.values()), max_chat_input_chars
 
 
 AGENT_CAPABILITY_NAMESPACE_PREFIX = "agent__"
@@ -3169,7 +3203,10 @@ async def prepare_execution(
     # Descriptors ship on ExecutionPreparation — the slot the retired
     # `effective_chat_options` occupied. Best-effort: an unreachable pod yields
     # no controls this prep (logged), never a failed prep.
-    available_capabilities = await _available_capabilities_for_source(source.base_url)
+    (
+        available_capabilities,
+        max_chat_input_chars,
+    ) = await _runtime_execution_metadata_for_source(source.base_url)
     chat_controls = await _resolve_chat_controls(
         instance.tuning,
         available_capabilities,
@@ -3226,6 +3263,7 @@ async def prepare_execution(
         chat_default_profile_id=chat_default_profile_id,
         operation_route_rules=operation_route_rules,
         reasoning_enabled_model_ids=sorted_reasoning_model_ids,
+        max_chat_input_chars=max_chat_input_chars,
     )
 
 

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -1599,6 +1599,104 @@ async def test_prepare_execution_returns_ingress_relative_urls(
     assert payload["capability_base_urls"] == {}
 
 
+def test_runtime_template_payload_accepts_new_and_legacy_chat_input_metadata() -> None:
+    """Rolling upgrades accept template responses with or without the policy."""
+
+    base = {
+        "template_agent_id": "rags.sample.echo",
+        "title": "Echo",
+        "description": "Echo agent",
+        "kind": "assistant",
+    }
+
+    assert _RuntimeTemplatePayload.model_validate(base).max_chat_input_chars is None
+    assert (
+        _RuntimeTemplatePayload.model_validate(
+            {**base, "max_chat_input_chars": 321}
+        ).max_chat_input_chars
+        == 321
+    )
+    for malformed in (True, False, "321", 0, -1):
+        assert (
+            _RuntimeTemplatePayload.model_validate(
+                {**base, "max_chat_input_chars": malformed}
+            ).max_chat_input_chars
+            is None
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("published_limit", [321, None])
+async def test_prepare_execution_propagates_optional_runtime_chat_input_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    published_limit: int | None,
+) -> None:
+    """Preparation reuses one template fetch and tolerates an older runtime."""
+
+    monkeypatch.setattr(
+        "control_plane_backend.product.api.require_team_access",
+        _fake_require_team_access,
+    )
+    store = _FakeAgentInstanceStore(
+        [
+            _make_record(
+                agent_instance_id="inst-limit",
+                source_runtime_id="agents-v2",
+                template_id="agents-v2:rags.sample.echo",
+                source_agent_id="rags.sample.echo",
+            )
+        ]
+    )
+    app = create_app()
+    _patch_store(monkeypatch, store)
+    container = get_application_container_from_app(app)
+    container.configuration.platform.runtime_catalog_sources = [
+        RuntimeCatalogSourceConfig(
+            runtime_id="agents-v2",
+            base_url="http://agents-v2-svc.fred.svc.cluster.local/api/v1",
+            enabled=True,
+            ingress_prefix="/runtime/agents-v2",
+        )
+    ]
+    fetch_calls = 0
+
+    async def _fake_fetch_runtime_templates(
+        _base_url: str, include_non_public: bool = False
+    ) -> list[_RuntimeTemplatePayload]:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        assert include_non_public is True
+        return [
+            _RuntimeTemplatePayload(
+                template_agent_id="rags.sample.echo",
+                title="Echo",
+                description="Echo agent",
+                kind="assistant",
+                max_chat_input_chars=published_limit,
+            )
+        ]
+
+    monkeypatch.setattr(
+        product_service,
+        "_fetch_runtime_templates",
+        _fake_fetch_runtime_templates,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/control-plane/v1/teams/personal/agent-instances/inst-limit/prepare-execution"
+        )
+
+    assert response.status_code == 200
+    assert fetch_calls == 1
+    if published_limit is None:
+        assert "max_chat_input_chars" not in response.json()
+    else:
+        assert response.json()["max_chat_input_chars"] == published_limit
+
+
 @pytest.mark.asyncio
 async def test_prepare_execution_advertises_capability_base_urls(
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/fred-agents/config/configuration.yaml
+++ b/apps/fred-agents/config/configuration.yaml
@@ -8,6 +8,8 @@ app:
   # Optional hard ceiling on concurrent HTTP/WebSocket connections accepted by
   # Uvicorn. Set to null to disable the limit.
   limit_concurrency: null
+  # Maximum Unicode code points accepted in one submitted chat message.
+  max_chat_input_chars: 5000
   openai_compat: true
 
 

--- a/apps/fred-agents/config/configuration_prod.yaml
+++ b/apps/fred-agents/config/configuration_prod.yaml
@@ -8,6 +8,8 @@ app:
   # Optional hard ceiling on concurrent HTTP/WebSocket connections accepted by
   # Uvicorn. Set to null to disable the limit.
   limit_concurrency: null
+  # Maximum Unicode code points accepted in one submitted chat message.
+  max_chat_input_chars: 5000
   openai_compat: true
 
 security:

--- a/apps/fred-agents/config/schema/configuration.schema.json
+++ b/apps/fred-agents/config/schema/configuration.schema.json
@@ -382,6 +382,13 @@
           "description": "Optional maximum number of concurrent HTTP or WebSocket connections accepted by Uvicorn. Leave unset to disable the limit.",
           "title": "Limit Concurrency"
         },
+        "max_chat_input_chars": {
+          "default": 5000,
+          "description": "Maximum number of Unicode code points accepted in one submitted chat message, including supported HITL resume text fields.",
+          "minimum": 1,
+          "title": "Max Chat Input Chars",
+          "type": "integer"
+        },
         "gcu_version": {
           "anyOf": [
             {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -409,6 +409,7 @@
       "reasoningHint": "Higher effort gives a more thorough answer — and takes longer to produce.",
       "selectLibraryFirst": "Select a library first."
     },
+    "characterCounter": "{{count}} / {{limit}} characters",
     "conversationAriaLabel": "Conversation",
     "conversationFiles": "Conversation files",
     "copyMessage": {
@@ -424,14 +425,18 @@
       "contextPromptSaveFailedDetail": "Could not save the selected prompts — reverted to the last saved selection. Please try again.",
       "attachmentDeleteFailedSummary": "File not deleted",
       "attachmentDeleteFailedDetail": "Could not delete this file. Please try again.",
-      "attachmentDeleteForbiddenDetail": "You don't have permission to delete this file."
+      "attachmentDeleteForbiddenDetail": "You don't have permission to delete this file.",
+      "chatInputTooLong": "Your message exceeds the {{limit}}-character limit."
     },
+    "hitlFreeTextLabel": "Your answer",
+    "hitlWaitingAria": "Agent is waiting for your input",
     "loadingHistory": "Loading conversation history...",
     "markdownPreview": {
       "closeAria": "Close markdown preview",
       "empty": "No markdown preview available."
     },
     "recordAudio": "Record audio",
+    "sendHitlAnswer": "Send",
     "sendMessage": "Send message",
     "sessionAttachments": {
       "deleteAria": "Delete {{name}}",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -409,6 +409,7 @@
       "reasoningHint": "Plus l'effort est élevé, plus la réponse est approfondie — et plus elle est longue à produire.",
       "selectLibraryFirst": "Sélectionnez d'abord une bibliothèque."
     },
+    "characterCounter": "{{count}} / {{limit}} caractères",
     "conversationAriaLabel": "Conversation",
     "conversationFiles": "Fichiers de conversation",
     "copyMessage": {
@@ -424,14 +425,18 @@
       "contextPromptSaveFailedDetail": "Impossible d'enregistrer les prompts sélectionnés — la dernière sélection enregistrée a été restaurée. Veuillez réessayer.",
       "attachmentDeleteFailedSummary": "Fichier non supprimé",
       "attachmentDeleteFailedDetail": "Impossible de supprimer ce fichier. Veuillez réessayer.",
-      "attachmentDeleteForbiddenDetail": "Vous n'avez pas la permission de supprimer ce fichier."
+      "attachmentDeleteForbiddenDetail": "Vous n'avez pas la permission de supprimer ce fichier.",
+      "chatInputTooLong": "Votre message dépasse la limite de {{limit}} caractères."
     },
+    "hitlFreeTextLabel": "Votre réponse",
+    "hitlWaitingAria": "L'agent attend votre réponse",
     "loadingHistory": "Chargement de l'historique...",
     "markdownPreview": {
       "closeAria": "Fermer l'aperçu markdown",
       "empty": "Aucun aperçu markdown disponible."
     },
     "recordAudio": "Enregistrer de l'audio",
+    "sendHitlAnswer": "Envoyer",
     "sendMessage": "Envoyer le message",
     "sessionAttachments": {
       "deleteAria": "Supprimer {{name}}",

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.test.tsx
@@ -1,0 +1,69 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createRef, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("@shared/organisms/ChatMessagesArea/ChatMessagesArea", () => ({
+  ChatMessagesArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@shared/organisms/UserTurn/UserTurn", () => ({ UserTurn: () => null }));
+vi.mock("@shared/organisms/AssistantTurn/AssistantTurn", () => ({ AssistantTurn: () => null }));
+vi.mock("@shared/molecules/HitlPrompt/HitlPrompt.tsx", () => ({
+  HitlPrompt: (props: {
+    maxChatInputChars?: number;
+    freeTextValue?: string;
+    onAnswer: unknown;
+    onFreeTextChange?: unknown;
+  }) => (
+    <div
+      data-limit={props.maxChatInputChars}
+      data-free-text={props.freeTextValue}
+      data-has-answer-handler={typeof props.onAnswer === "function"}
+      data-has-change-handler={typeof props.onFreeTextChange === "function"}
+    />
+  ),
+}));
+
+import { ConversationThread } from "./ConversationThread";
+
+describe("ConversationThread HITL input policy wiring", () => {
+  it("forwards the runtime limit and controlled draft to the active HITL prompt", () => {
+    const html = renderToStaticMarkup(
+      <ConversationThread
+        messages={[]}
+        pendingHitl={{
+          type: "awaiting_human",
+          session_id: "session-1",
+          exchange_id: "exchange-1",
+          payload: { free_text: true },
+        }}
+        isLoading={false}
+        isStreaming={false}
+        scrollContainerRef={createRef<HTMLDivElement>()}
+        onHitlAnswer={() => undefined}
+        maxChatInputChars={5}
+        hitlFreeText="full draft"
+        onHitlFreeTextChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('data-limit="5"');
+    expect(html).toContain('data-free-text="full draft"');
+    expect(html).toContain('data-has-answer-handler="true"');
+    expect(html).toContain('data-has-change-handler="true"');
+  });
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
@@ -33,6 +33,9 @@ interface ConversationThreadProps {
   emptyState?: ReactNode;
   scrollContainerRef: RefObject<HTMLDivElement>;
   onHitlAnswer: (answer: string | boolean | undefined, freeText?: string) => void;
+  maxChatInputChars?: number;
+  hitlFreeText: string;
+  onHitlFreeTextChange: (value: string) => void;
 }
 
 // Memoized: ManagedChatPage re-renders on every composer keystroke (the input
@@ -47,6 +50,9 @@ export const ConversationThread = memo(function ConversationThread({
   emptyState,
   scrollContainerRef,
   onHitlAnswer,
+  maxChatInputChars,
+  hitlFreeText,
+  onHitlFreeTextChange,
 }: ConversationThreadProps) {
   const { t } = useTranslation();
   const turnKey = messages.filter((m) => m.role === "user").length;
@@ -96,7 +102,15 @@ export const ConversationThread = memo(function ConversationThread({
           />
         );
       })}
-      {pendingHitl && <HitlPrompt event={pendingHitl} onAnswer={onHitlAnswer} />}
+      {pendingHitl && (
+        <HitlPrompt
+          event={pendingHitl}
+          onAnswer={onHitlAnswer}
+          maxChatInputChars={maxChatInputChars}
+          freeTextValue={hitlFreeText}
+          onFreeTextChange={onHitlFreeTextChange}
+        />
+      )}
     </ChatMessagesArea>
   );
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.test.tsx
@@ -1,0 +1,160 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-router-dom", () => ({ useParams: () => ({ teamId: "team-1", agentInstanceId: "agent-1" }) }));
+vi.mock("react-redux", () => ({ useSelector: () => ({ requestId: 0, key: null }) }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+
+let chatValue: Record<string, unknown>;
+vi.mock("./useManagedChat", () => ({ useManagedChat: () => chatValue }));
+vi.mock("@shared/molecules/RichInputField/RichInputField", () => ({
+  RichInputField: (props: { sendDisabled?: boolean; characterCount?: number; characterLimit?: number }) => (
+    <div
+      data-testid="composer"
+      data-send-disabled={props.sendDisabled}
+      data-character-count={props.characterCount}
+      data-character-limit={props.characterLimit}
+    />
+  ),
+}));
+vi.mock("./ConversationThread/ConversationThread", () => ({
+  ConversationThread: (props: { maxChatInputChars?: number; hitlFreeText: string; onHitlFreeTextChange: unknown }) => (
+    <div
+      data-testid="thread"
+      data-character-limit={props.maxChatInputChars}
+      data-hitl-draft={props.hitlFreeText}
+      data-has-hitl-change-handler={typeof props.onHitlFreeTextChange === "function"}
+    />
+  ),
+}));
+
+vi.mock("@shared/molecules/ThoughtTrace/traceDrawerContext", () => ({
+  TraceDrawerProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("../../../../hooks/useFrontendBootstrap", () => ({
+  useFrontendBootstrap: () => ({ activeTeam: { id: "team-1" } }),
+}));
+vi.mock("../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
+  useGetTeamQuery: () => ({ data: undefined }),
+}));
+vi.mock("../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
+  useLazyGetTeamPromptControlPlaneV1TeamsTeamIdPromptsPromptIdGetQuery: () => [
+    () => ({ unwrap: async () => ({ text: "" }) }),
+  ],
+}));
+vi.mock("@hooks/useTeamCapabilities.ts", () => ({
+  useTeamCapabilities: () => ({ canAdministerAdmins: false }),
+}));
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({ showError: () => undefined }),
+}));
+vi.mock("../../../../security/KeycloakService", () => ({
+  KeyCloakService: { GetUserGivenName: () => "Ada" },
+}));
+vi.mock("../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
+  useTranscribeAudioKnowledgeFlowV1AudioTranscriptionsPostMutation: () => [() => ({ unwrap: async () => ({}) })],
+}));
+vi.mock("../../../core/hooks/useUploadWarningAcknowledgement", () => ({
+  useUploadWarningAcknowledgement: () => ({ requiresAcknowledgement: false, acknowledge: () => undefined }),
+}));
+
+vi.mock("@shared/molecules/SessionTitleEditor/SessionTitleEditor", () => ({ SessionTitleEditor: () => null }));
+vi.mock("@shared/molecules/DebugRawDrawer/DebugRawDrawer", () => ({ DebugRawDrawer: () => null }));
+vi.mock("@shared/molecules/AttachmentChips/AttachmentChips", () => ({ AttachmentChips: () => null }));
+vi.mock("@shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer", () => ({
+  SessionAttachmentsDrawer: () => null,
+}));
+vi.mock("@shared/molecules/DocumentScopePanel/DocumentScopePanel", () => ({ DocumentScopePanel: () => null }));
+vi.mock("@shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer", () => ({
+  TraceDetailDrawer: () => null,
+}));
+vi.mock("@shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog", () => ({
+  UploadWarningAckDialog: () => null,
+}));
+vi.mock("@shared/atoms/IconButton/IconButton", () => ({ default: () => null }));
+vi.mock("@shared/molecules/TokenUsageBadge/TokenUsageBadge", () => ({ TokenUsageBadge: () => null }));
+vi.mock("../../../features/capabilities/CapabilitySidePanelHost", () => ({ CapabilitySidePanelHost: () => null }));
+vi.mock("../../../features/capabilities/ComposerControlSlot", () => ({ ComposerControlSlot: () => null }));
+vi.mock("../../../features/capabilities/ComposerOptionChips", () => ({
+  COMPOSER_CHIP_WIDGETS: new Set<string>(),
+  ComposerOptionChips: () => null,
+}));
+vi.mock("@shared/molecules/ComposerActionsMenu/ComposerActionsMenu", () => ({
+  ComposerActionsMenu: () => null,
+}));
+
+import ManagedChatPage from "./ManagedChatPage";
+
+describe("ManagedChatPage chat-input policy wiring", () => {
+  it("passes the runtime policy to both the composer and active HITL prompt", () => {
+    const noop = () => undefined;
+    chatValue = {
+      agentDisplayName: "Agent",
+      attachments: [],
+      attachmentsUploading: false,
+      capabilityIds: [],
+      chatControls: [],
+      commitTitle: noop,
+      contextPrompts: [],
+      deletePersistedAttachment: noop,
+      handleAbort: noop,
+      handleAddAttachments: noop,
+      handleHitlAnswer: noop,
+      handleSend: noop,
+      hitlFreeText: "complete HITL draft",
+      input: "six!!",
+      inputCharacterCount: 6,
+      inputTooLong: true,
+      isHydratingAttachments: false,
+      isLoadingHistory: false,
+      maxChatInputChars: 5,
+      messages: [],
+      pendingHitl: { session_id: "session-1", exchange_id: "exchange-1", payload: { free_text: true } },
+      persistedAttachments: [],
+      ragScope: "all",
+      reasoning: false,
+      removeAttachment: noop,
+      searchPolicy: "hybrid",
+      selectedDocumentUids: [],
+      selectedLibraryIds: [],
+      sessionId: "session-1",
+      sessionTitle: "Chat",
+      setHitlFreeText: noop,
+      setInput: noop,
+      setRagScope: noop,
+      setReasoning: noop,
+      setSearchPolicy: noop,
+      setSelectedDocumentUids: noop,
+      setSelectedLibraryIds: noop,
+      threadMessages: [],
+      waitResponse: false,
+    };
+
+    const html = renderToStaticMarkup(<ManagedChatPage />);
+
+    expect(html).toContain('data-testid="composer"');
+    expect(html).toContain('data-send-disabled="true"');
+    expect(html).toContain('data-character-count="6"');
+    expect(html.match(/data-character-limit="5"/g)).toHaveLength(2);
+    expect(html).toContain('data-testid="thread"');
+    expect(html).toContain('data-hitl-draft="complete HITL draft"');
+    expect(html).toContain('data-has-hitl-change-handler="true"');
+  });
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -292,7 +292,9 @@ export default function ManagedChatPage() {
       onSend={chat.handleSend}
       onInterrupt={chat.handleAbort}
       disabled={chat.waitResponse || chat.isLoadingHistory}
-      sendDisabled={chat.attachmentsUploading}
+      sendDisabled={chat.attachmentsUploading || chat.inputTooLong}
+      characterCount={chat.inputCharacterCount}
+      characterLimit={chat.maxChatInputChars}
       enableVoiceInput
       onTranscribeAudio={handleTranscribeAudio}
       voiceInputDisabled={chat.waitResponse || chat.isLoadingHistory}
@@ -454,6 +456,9 @@ export default function ManagedChatPage() {
                   isStreaming={chat.waitResponse}
                   scrollContainerRef={scrollContainerRef}
                   onHitlAnswer={chat.handleHitlAnswer}
+                  maxChatInputChars={chat.maxChatInputChars}
+                  hitlFreeText={chat.hitlFreeText}
+                  onHitlFreeTextChange={chat.setHitlFreeText}
                 />
               )}
             </div>

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
@@ -86,7 +86,7 @@ vi.mock("@core/hooks/useApiErrorToast.ts", () => ({
 // a fresh `vi.fn()` per render would make those deps look "changed" every
 // render, re-firing the sessionId-change reset effect forever (observed as
 // an OOM from an actual infinite render loop while writing this test).
-const sendMock = vi.fn(async () => {});
+const sendMock = vi.fn(async (..._args: unknown[]) => {});
 const prepareChatControlsMock = vi.fn(async () => ({}));
 const chatSseResetMock = vi.fn();
 // Default: the resume reached the backend. `useManagedChat` calls `.then()` on
@@ -100,25 +100,33 @@ const replaceAllMessagesMock = vi.fn();
 // Mutable so the #2239 departure-snapshot test below can put a displayed
 // thread on screen; reset to [] in beforeEach.
 let chatSseMessages: unknown[] = [];
+let chatSseMaxChatInputChars: number | undefined;
 let capturedFlushPendingWrites: ((sid: string | null) => Promise<boolean>) | undefined;
 let capturedOnTurnStarted: (() => void) | undefined;
+let capturedOnTurnRejected: ((draft: string, sessionId: string) => void) | undefined;
+let capturedIsTurnCurrent: ((sessionId: string) => boolean) | undefined;
 let capturedOnError: ((msg: string) => void) | undefined;
 let capturedOnAwaitingHuman: ((event: unknown) => void) | undefined;
 vi.mock("@hooks/useChatSse", () => ({
   useChatSse: (params: {
     flushPendingWrites?: (sid: string | null) => Promise<boolean>;
     onTurnStarted?: () => void;
+    onTurnRejected?: (draft: string, sessionId: string) => void;
+    isTurnCurrent?: (sessionId: string) => boolean;
     onError?: (msg: string) => void;
     onAwaitingHuman?: (event: unknown) => void;
   }) => {
     capturedFlushPendingWrites = params.flushPendingWrites;
     capturedOnTurnStarted = params.onTurnStarted;
+    capturedOnTurnRejected = params.onTurnRejected;
+    capturedIsTurnCurrent = params.isTurnCurrent;
     capturedOnError = params.onError;
     capturedOnAwaitingHuman = params.onAwaitingHuman;
     return {
       messages: chatSseMessages,
       waitResponse: false,
       chatControls: [],
+      maxChatInputChars: chatSseMaxChatInputChars,
       prepareChatControls: prepareChatControlsMock,
       send: sendMock,
       sendHitlResume: sendHitlResumeMock,
@@ -275,6 +283,7 @@ describe("useManagedChat — session write reliability", () => {
   beforeEach(() => {
     clearSessionHistoryCache();
     chatSseMessages = [];
+    chatSseMaxChatInputChars = undefined;
     registerSessionImpl = async () => ({});
     patchSessionImpl = async () => ({});
     registerSessionCalls.length = 0;
@@ -312,6 +321,8 @@ describe("useManagedChat — session write reliability", () => {
     // lets an assertion pass against a component that is already unmounted.
     capturedFlushPendingWrites = undefined;
     capturedOnTurnStarted = undefined;
+    capturedOnTurnRejected = undefined;
+    capturedIsTurnCurrent = undefined;
     capturedOnError = undefined;
     capturedOnAwaitingHuman = undefined;
   });
@@ -354,6 +365,69 @@ describe("useManagedChat — session write reliability", () => {
     expect(capturedOnAwaitingHuman).toBe(firstOnAwaitingHuman);
     expect(capturedOnTurnStarted).toBe(firstOnTurnStarted);
     expect(latest.handleHitlAnswer).toBe(firstHandleHitlAnswer);
+  });
+
+  it("counts trimmed Unicode code points and blocks an over-limit draft without clearing it", async () => {
+    chatSseMaxChatInputChars = 5;
+    mount();
+
+    act(() => {
+      latest.setInput("  🙂🙂🙂🙂🙂🙂  ");
+    });
+    rerender();
+
+    expect(latest.inputCharacterCount).toBe(6);
+    expect(latest.inputTooLong).toBe(true);
+    await act(async () => {
+      await latest.handleSend();
+    });
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(registerSessionCalls).toHaveLength(0);
+    expect(latest.input).toBe("  🙂🙂🙂🙂🙂🙂  ");
+  });
+
+  it("accepts an exact-limit Unicode draft", async () => {
+    chatSseMaxChatInputChars = 5;
+    mount();
+
+    act(() => {
+      latest.setInput("🙂🙂🙂🙂🙂");
+    });
+    rerender();
+    await act(async () => {
+      await latest.handleSend();
+    });
+
+    expect(latest.inputTooLong).toBe(false);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the complete ordinary draft after a backend length rejection", async () => {
+    mount();
+    const draft = "  full draft 🙂  ";
+
+    act(() => {
+      latest.setInput(draft);
+    });
+    rerender();
+    await act(async () => {
+      await latest.handleSend();
+    });
+    act(() => capturedOnTurnStarted?.());
+    rerender();
+    expect(latest.input).toBe("");
+
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    expect(capturedIsTurnCurrent?.(sentSessionId)).toBe(true);
+    expect(capturedIsTurnCurrent?.("another-session")).toBe(false);
+    act(() => capturedOnTurnRejected?.(draft.trim(), "another-session"));
+    rerender();
+    expect(latest.input).toBe("");
+
+    act(() => capturedOnTurnRejected?.(draft.trim(), sentSessionId));
+    rerender();
+    expect(latest.input).toBe(draft);
   });
 
   it("selecting a context prompt persists it and a send proceeds", async () => {
@@ -1172,6 +1246,59 @@ describe("useManagedChat — session write reliability", () => {
     rerender();
   };
 
+  it("blocks over-limit HITL free text locally while leaving fixed choices available", async () => {
+    chatSseMaxChatInputChars = 5;
+    mount();
+    bindSession("session-1");
+    const freeTextEvent = {
+      ...awaitingHumanEvent,
+      payload: {
+        ...awaitingHumanEvent.payload,
+        free_text: true,
+        choices: [{ id: "proceed", label: "Proceed" }],
+      },
+    };
+
+    act(() => {
+      capturedOnAwaitingHuman?.(freeTextEvent);
+      latest.setHitlFreeText("🙂🙂🙂🙂🙂🙂");
+    });
+    rerender();
+    act(() => latest.handleHitlAnswer(undefined, latest.hitlFreeText));
+
+    expect(sendHitlResumeMock).not.toHaveBeenCalled();
+    expect(latest.pendingHitl).toEqual(freeTextEvent);
+    expect(latest.hitlFreeText).toBe("🙂🙂🙂🙂🙂🙂");
+
+    await act(async () => {
+      latest.handleHitlAnswer("proceed");
+    });
+    expect(sendHitlResumeMock).toHaveBeenCalledWith(freeTextEvent, "proceed", undefined);
+  });
+
+  it("accepts HITL free text at the exact configured code-point limit", async () => {
+    chatSseMaxChatInputChars = 5;
+    sendHitlResumeMock.mockResolvedValueOnce(true);
+    mount();
+    bindSession("session-1");
+    const freeTextEvent = {
+      ...awaitingHumanEvent,
+      payload: { ...awaitingHumanEvent.payload, free_text: true },
+    };
+
+    act(() => {
+      capturedOnAwaitingHuman?.(freeTextEvent);
+      latest.setHitlFreeText("🙂🙂🙂🙂🙂");
+    });
+    rerender();
+    await act(async () => {
+      latest.handleHitlAnswer(undefined, latest.hitlFreeText);
+      await Promise.resolve();
+    });
+
+    expect(sendHitlResumeMock).toHaveBeenCalledWith(freeTextEvent, undefined, "🙂🙂🙂🙂🙂");
+  });
+
   it("restores the HITL prompt when the resume never reached the backend", async () => {
     sendHitlResumeMock.mockResolvedValueOnce(false);
     mount();
@@ -1179,17 +1306,20 @@ describe("useManagedChat — session write reliability", () => {
 
     act(() => {
       capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setHitlFreeText("  complete answer 🙂  ");
     });
     rerender();
     expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
 
     await act(async () => {
-      latest.handleHitlAnswer("cancel");
+      latest.handleHitlAnswer(undefined, latest.hitlFreeText);
     });
     rerender();
 
     expect(sendHitlResumeMock).toHaveBeenCalledTimes(1);
+    expect(sendHitlResumeMock).toHaveBeenCalledWith(awaitingHumanEvent, undefined, "  complete answer 🙂  ");
     expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
+    expect(latest.hitlFreeText).toBe("  complete answer 🙂  ");
   });
 
   it("does not resurrect the prompt over a new turn started in the same session", async () => {
@@ -1384,5 +1514,39 @@ describe("useManagedChat — session write reliability", () => {
 
     expect(sendHitlResumeMock).toHaveBeenCalledTimes(1);
     expect(latest.pendingHitl).toBeNull();
+  });
+
+  it("does not clear a newer HITL prompt's draft when an older resume settles", async () => {
+    let resolveResume: (v: boolean) => void = () => {};
+    sendHitlResumeMock.mockImplementationOnce(() => new Promise<boolean>((r) => (resolveResume = r)));
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setHitlFreeText("answer for the first prompt");
+    });
+    rerender();
+    act(() => latest.handleHitlAnswer(undefined, latest.hitlFreeText));
+
+    const newerPrompt = {
+      ...awaitingHumanEvent,
+      exchange_id: "exch-2",
+      payload: { ...awaitingHumanEvent.payload, interrupt_id: "interrupt-b" },
+    };
+    act(() => {
+      capturedOnAwaitingHuman?.(newerPrompt);
+      latest.setHitlFreeText("answer for the newer prompt");
+    });
+    rerender();
+
+    await act(async () => {
+      resolveResume(true);
+      await Promise.resolve();
+    });
+    rerender();
+
+    expect(latest.pendingHitl).toEqual(newerPrompt);
+    expect(latest.hitlFreeText).toBe("answer for the newer prompt");
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
@@ -34,6 +34,7 @@ import { useChatAttachments } from "./useChatAttachments";
 import { buildComposerRuntimeContext } from "./runtimeContextBuilder";
 import { reconstructPendingHitl, toThreadMessages } from "./toThreadMessages";
 import type { ChatMessage } from "../../../../slices/runtime/runtimeOpenApi";
+import { countUnicodeCodePoints } from "@core/utils/chatInput";
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
@@ -50,7 +51,12 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
 
   const sessionId = searchParams.get("session");
   const [input, setInput] = useState("");
+  const submittedDraftRef = useRef<{ sessionId: string; draft: string } | null>(null);
   const [pendingHitl, setPendingHitl] = useState<RuntimeAwaitingHumanEvent | null>(null);
+  const [hitlFreeText, setHitlFreeText] = useState("");
+  // Identifies the HITL prompt that owns `hitlFreeText`. A resume can settle
+  // after another prompt has arrived; only its own draft may be cleared.
+  const hitlDraftOwnerRef = useRef(0);
   const [sessionTitle, setSessionTitle] = useState<string | null>(null);
   // Ordered chat-context prompts attached to this session (PROMPT-05). Source of
   // truth is the control-plane session; hydrated from sessionData and persisted
@@ -240,7 +246,11 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   // composer keystroke — would silently invalidate that memoization on every
   // keystroke too, cascading into handleHitlAnswer below and defeating
   // ConversationThread's React.memo (#2221).
-  const handleAwaitingHuman = useCallback((event: RuntimeAwaitingHumanEvent) => setPendingHitl(event), []);
+  const handleAwaitingHuman = useCallback((event: RuntimeAwaitingHumanEvent) => {
+    hitlDraftOwnerRef.current += 1;
+    setHitlFreeText("");
+    setPendingHitl(event);
+  }, []);
   const handleChatError = useCallback((msg: string) => showError({ summary: "Agent error", detail: msg }), [showError]);
   // Fires only once prepare-execution has actually succeeded and the turn is
   // really starting — clearing the composer any earlier would lose the
@@ -249,11 +259,18 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     setInput("");
     attachments.clearReadyAttachments();
   }, [attachments.clearReadyAttachments]);
+  const handleTurnRejected = useCallback((_wireDraft: string, rejectedSessionId: string) => {
+    const submitted = submittedDraftRef.current;
+    if (activeSessionIdRef.current !== rejectedSessionId || submitted?.sessionId !== rejectedSessionId) return;
+    setInput(submitted.draft);
+  }, []);
+  const isTurnCurrent = useCallback((turnSessionId: string) => activeSessionIdRef.current === turnSessionId, []);
 
   const {
     messages,
     waitResponse,
     chatControls,
+    maxChatInputChars,
     prepareChatControls,
     send,
     sendHitlResume,
@@ -269,6 +286,8 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     onAwaitingHuman: handleAwaitingHuman,
     onError: handleChatError,
     onTurnStarted: handleTurnStarted,
+    onTurnRejected: handleTurnRejected,
+    isTurnCurrent,
   });
   latestMessagesRef.current = messages;
 
@@ -325,6 +344,8 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     // already see "no live turn" or a cached thread would refuse to render.
     waitResponseRef.current = false;
     setPendingHitl(null);
+    hitlDraftOwnerRef.current += 1;
+    setHitlFreeText("");
     setInput("");
     setSessionTitle(null);
     setContextPromptIds([]);
@@ -364,6 +385,8 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   }, [sessionData, sessionId]);
 
   const threadMessages = useMemo(() => toThreadMessages(messages, waitResponse), [messages, waitResponse]);
+  const inputCharacterCount = useMemo(() => countUnicodeCodePoints(input.trim()), [input]);
+  const inputTooLong = maxChatInputChars !== undefined && inputCharacterCount > maxChatInputChars;
 
   // History load/switch always REPLACES pendingHitl with whatever the loaded
   // messages actually say — set when the trailing exchange has a HITL gate
@@ -374,6 +397,8 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   const handleHistoryLoaded = useCallback(
     (msgs: ChatMessage[]) => {
       replaceAllMessages(msgs);
+      hitlDraftOwnerRef.current += 1;
+      setHitlFreeText("");
       setPendingHitl(reconstructPendingHitl(msgs));
     },
     [replaceAllMessages],
@@ -450,11 +475,11 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     const text = input.trim();
     const attachmentContext = attachments.attachmentsMarkdown;
     console.debug(
-      `[useManagedChat] handleSend() — text="${text.slice(0, 40)}" waitResponse=${waitResponse} sessionId=${sessionId ?? "null"}`,
+      `[useManagedChat] handleSend() — inputChars=${inputCharacterCount} waitResponse=${waitResponse} sessionId=${sessionId ?? "null"}`,
     );
-    if ((!text && !attachmentContext) || waitResponse || attachments.hasUploadingAttachments) {
+    if ((!text && !attachmentContext) || waitResponse || attachments.hasUploadingAttachments || inputTooLong) {
       console.debug(
-        `[useManagedChat] handleSend() BLOCKED — text=${!!text} attachments=${!!attachmentContext} waitResponse=${waitResponse} uploading=${attachments.hasUploadingAttachments}`,
+        `[useManagedChat] handleSend() BLOCKED — hasText=${!!text} attachments=${!!attachmentContext} waitResponse=${waitResponse} uploading=${attachments.hasUploadingAttachments} inputTooLong=${inputTooLong}`,
       );
       return;
     }
@@ -533,6 +558,9 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       // with.
       const offersReasoning = chatControls.some((c) => c.widget === "reasoning_toggle");
       touchSessionActivity(sid);
+      // `send()` receives the trimmed wire value, but a backend rejection must
+      // restore the complete editable draft, including surrounding whitespace.
+      submittedDraftRef.current = { sessionId: sid, draft: input };
       send(
         text,
         sid,
@@ -554,6 +582,8 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     attachments.attachmentsMarkdown,
     attachments.hasUploadingAttachments,
     input,
+    inputCharacterCount,
+    inputTooLong,
     waitResponse,
     sessionId,
     chatControls,
@@ -572,7 +602,15 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   const handleHitlAnswer = useCallback(
     (answer: string | boolean | undefined, freeText?: string) => {
       if (!pendingHitl) return;
+      if (
+        freeText !== undefined &&
+        maxChatInputChars !== undefined &&
+        countUnicodeCodePoints(freeText) > maxChatInputChars
+      ) {
+        return;
+      }
       const prompt = pendingHitl;
+      const draftOwner = hitlDraftOwnerRef.current;
       setPendingHitl(null);
       // Restore the prompt when the resume never reached the backend: the
       // checkpoint is still paused, so dropping it would strand the turn with
@@ -602,7 +640,10 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       };
       void sendHitlResume(prompt, answer, freeText)
         .then((reached) => {
-          if (reached) return;
+          if (reached) {
+            if (hitlDraftOwnerRef.current === draftOwner) setHitlFreeText("");
+            return;
+          }
           restoreIfStillWanted();
         })
         // `pendingHitl` is already cleared, so these are the ONLY paths that can
@@ -614,11 +655,13 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
           restoreIfStillWanted();
         });
     },
-    [pendingHitl, sendHitlResume],
+    [maxChatInputChars, pendingHitl, sendHitlResume],
   );
 
   const startNewConversation = useCallback(() => {
     setPendingHitl(null);
+    hitlDraftOwnerRef.current += 1;
+    setHitlFreeText("");
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
@@ -705,7 +748,12 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     chatControls,
     input,
     setInput,
+    inputCharacterCount,
+    inputTooLong,
+    maxChatInputChars,
     pendingHitl,
+    hitlFreeText,
+    setHitlFreeText,
     selectedLibraryIds: composer.selectedLibraryIds,
     attachments: attachments.attachments,
     persistedAttachments: attachments.persistedAttachments,

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.module.css
@@ -43,3 +43,20 @@
   flex-direction: column;
   gap: var(--spacing-xs);
 }
+
+.characterInfo {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}
+
+.characterInfoError {
+  color: var(--error);
+}
+
+.characterCount {
+  flex-shrink: 0;
+  margin-left: auto;
+}

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.test.tsx
@@ -1,0 +1,62 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { HitlPrompt } from "./HitlPrompt";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${values.count ?? ""}:${values.limit ?? ""}` : key,
+    i18n: { language: "en" },
+  }),
+}));
+
+const event = {
+  session_id: "session-1",
+  exchange_id: "exchange-1",
+  payload: { free_text: true, choices: [{ id: "proceed", label: "Proceed" }] },
+};
+
+describe("HitlPrompt chat-input limit", () => {
+  it("counts the exact free-text value and blocks only its send action", () => {
+    const html = renderToStaticMarkup(
+      <HitlPrompt
+        event={event}
+        onAnswer={() => undefined}
+        maxChatInputChars={5}
+        freeTextValue=" 🙂🙂🙂🙂🙂"
+        onFreeTextChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("chatbot.characterCounter:6:5");
+    expect(html).toContain("chatbot.errors.chatInputTooLong::5");
+    expect(html).not.toContain("maxLength=");
+    const proceedButton = html.match(/<button[^>]*>[^<]*<div[^>]*>Proceed<\/div><\/button>/)?.[0] ?? "";
+    const sendButton = html.match(/<button[^>]*>[^<]*<div[^>]*>chatbot\.sendHitlAnswer<\/div><\/button>/)?.[0] ?? "";
+    expect(proceedButton).not.toContain("disabled");
+    expect(sendButton).toContain('disabled=""');
+  });
+
+  it("omits limit UI for an older runtime while preserving free text", () => {
+    const html = renderToStaticMarkup(
+      <HitlPrompt event={event} onAnswer={() => undefined} freeTextValue="🙂🙂🙂🙂🙂🙂" />,
+    );
+
+    expect(html).not.toContain("chatbot.characterCounter");
+    expect(html).toContain("🙂🙂🙂🙂🙂🙂");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.tsx
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState } from "react";
+import { useId, useState } from "react";
+import { useTranslation } from "react-i18next";
 import Button from "@shared/atoms/Button/Button";
 import TextArea from "@shared/atoms/TextArea/TextArea";
+import { countUnicodeCodePoints } from "@core/utils/chatInput";
 import type { ButtonVariant, ColorTheme } from "@shared/utils/Type.ts";
 import type { RuntimeAwaitingHumanEvent } from "@hooks/useChatSse";
 import styles from "./HitlPrompt.module.css";
@@ -23,6 +25,9 @@ interface HitlPromptProps {
   event: RuntimeAwaitingHumanEvent;
   onAnswer: (answer: string | boolean | undefined, freeText?: string) => void;
   readonly?: boolean;
+  maxChatInputChars?: number;
+  freeTextValue?: string;
+  onFreeTextChange?: (value: string) => void;
 }
 
 /**
@@ -46,16 +51,31 @@ function choiceButtonStyle(choice: { id: string; default?: boolean }): {
   };
 }
 
-export function HitlPrompt({ event, onAnswer, readonly = false }: HitlPromptProps) {
+export function HitlPrompt({
+  event,
+  onAnswer,
+  readonly = false,
+  maxChatInputChars,
+  freeTextValue,
+  onFreeTextChange,
+}: HitlPromptProps) {
+  const { t, i18n } = useTranslation();
   const payload = event.payload;
-
-  const [freeText, setFreeText] = useState("");
+  const [localFreeText, setLocalFreeText] = useState("");
+  const freeText = freeTextValue ?? localFreeText;
+  const characterInfoId = useId();
+  const characterCount = countUnicodeCodePoints(freeText);
+  const isOverLimit = maxChatInputChars !== undefined && characterCount > maxChatInputChars;
+  const setFreeText = (value: string) => {
+    if (onFreeTextChange) onFreeTextChange(value);
+    else setLocalFreeText(value);
+  };
 
   return (
     <div
       className={`${styles.card} ${!readonly ? styles.active : ""}`}
       role="group"
-      aria-label="Agent is waiting for your input"
+      aria-label={t("chatbot.hitlWaitingAria")}
     >
       {payload.title && <p className={styles.title}>{payload.title}</p>}
       {payload.question && <p className={styles.question}>{payload.question}</p>}
@@ -84,15 +104,43 @@ export function HitlPrompt({ event, onAnswer, readonly = false }: HitlPromptProp
 
       {payload.free_text && !readonly && (
         <div className={styles.freeText}>
-          <TextArea label="Your answer" value={freeText} onChange={(e) => setFreeText(e.target.value)} rows={2} />
+          <TextArea
+            label={t("chatbot.hitlFreeTextLabel")}
+            value={freeText}
+            onChange={(e) => setFreeText(e.target.value)}
+            rows={2}
+            aria-invalid={isOverLimit || undefined}
+            aria-describedby={maxChatInputChars !== undefined ? characterInfoId : undefined}
+          />
+          {maxChatInputChars !== undefined && (
+            <div
+              id={characterInfoId}
+              className={`${styles.characterInfo} ${isOverLimit ? styles.characterInfoError : ""}`}
+              aria-live="polite"
+            >
+              <span>
+                {isOverLimit
+                  ? t("chatbot.errors.chatInputTooLong", {
+                      limit: maxChatInputChars.toLocaleString(i18n.language),
+                    })
+                  : null}
+              </span>
+              <span className={styles.characterCount}>
+                {t("chatbot.characterCounter", {
+                  count: characterCount,
+                  limit: maxChatInputChars.toLocaleString(i18n.language),
+                })}
+              </span>
+            </div>
+          )}
           <Button
             color="primary"
             variant="filled"
             size="small"
-            disabled={!freeText.trim()}
+            disabled={!freeText.trim() || isOverLimit}
             onClick={() => onAnswer(undefined, freeText)}
           >
-            Send
+            {t("chatbot.sendHitlAnswer")}
           </Button>
         </div>
       )}

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
@@ -83,6 +83,24 @@
   color: var(--state-on-surface-disabled);
 }
 
+.characterInfo {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  padding: 0 var(--spacing-xs);
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}
+
+.characterInfoError {
+  color: var(--error);
+}
+
+.characterCount {
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
 /* Bottom row: options (left, flex-1) + send button (right) */
 .bottomRow {
   display: flex;

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.test.tsx
@@ -17,14 +17,18 @@ import { describe, expect, it, vi } from "vitest";
 import { RichInputField } from "./RichInputField";
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${values.count ?? ""}:${values.limit ?? ""}` : key,
+    i18n: { language: "en" },
+  }),
 }));
 
 function sendButtonOpeningTag(html: string): string {
   return html.match(/<button[^>]*aria-label="chatbot\.sendMessage"[^>]*>/)?.[0] ?? "";
 }
 
-function render(props: { sendDisabled?: boolean }): string {
+function render(props: { sendDisabled?: boolean; characterCount?: number; characterLimit?: number }): string {
   return renderToStaticMarkup(
     <RichInputField value="hello" onChange={() => undefined} onSend={() => undefined} showSendButton {...props} />,
   );
@@ -41,5 +45,23 @@ describe("RichInputField send gating", () => {
     const tag = sendButtonOpeningTag(render({ sendDisabled: true }));
     expect(tag).not.toBe("");
     expect(tag).toContain("disabled");
+  });
+
+  it("renders an accessible counter without a native maxLength at the exact limit", () => {
+    const html = render({ characterCount: 5, characterLimit: 5 });
+
+    expect(html).toContain("chatbot.characterCounter:5:5");
+    expect(html).not.toContain("chatbot.errors.chatInputTooLong");
+    expect(html).not.toContain("maxLength=");
+    expect(html).not.toContain('aria-invalid="true"');
+  });
+
+  it("marks an over-limit draft invalid and keeps the full textarea value", () => {
+    const html = render({ characterCount: 6, characterLimit: 5, sendDisabled: true });
+
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain("chatbot.errors.chatInputTooLong::5");
+    expect(html).toContain(">hello</textarea>");
+    expect(sendButtonOpeningTag(html)).toContain("disabled");
   });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { KeyboardEvent, ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { appendVoiceTranscript, audioFileExtensionForMimeType } from "./voiceInputUtils";
@@ -31,6 +31,10 @@ interface RichInputFieldProps {
   disabled?: boolean;
   /** Blocks sending (Enter + send button) while typing stays enabled — e.g. attachments still uploading. */
   sendDisabled?: boolean;
+  /** Code-point count for the exact value the caller will submit. */
+  characterCount?: number;
+  /** Runtime-published code-point limit; omitted for older runtime pods. */
+  characterLimit?: number;
   placeholder?: string;
   /** Rendered above the textarea — typically attachment chips that should stay close to the cursor. */
   aboveTextSlot?: ReactNode;
@@ -80,6 +84,8 @@ export function RichInputField({
   onInterrupt,
   disabled = false,
   sendDisabled = false,
+  characterCount,
+  characterLimit,
   placeholder,
   aboveTextSlot,
   topSlot,
@@ -94,7 +100,8 @@ export function RichInputField({
   maxHeight = 200,
   focusEndRequestId,
 }: RichInputFieldProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const characterInfoId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const valueRef = useRef(value);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -191,6 +198,9 @@ export function RichInputField({
   const hasDefaultAction = canUseVoiceInput || showStop || showSend;
   const showBottomRow = !!(topSlot || leftSlot || rightSlot || hasDefaultAction);
   const voiceControlDisabled = disabled || voiceInputDisabled || voiceInputState === "transcribing";
+  const showCharacterInfo = characterLimit !== undefined && characterCount !== undefined;
+  const isOverCharacterLimit = showCharacterInfo && characterCount > characterLimit;
+  const formattedCharacterLimit = characterLimit?.toLocaleString(i18n.language);
 
   const reportVoiceError = useCallback(
     (message: string) => {
@@ -345,12 +355,32 @@ export function RichInputField({
           rows={1}
           disabled={disabled}
           placeholder={placeholder}
+          aria-invalid={isOverCharacterLimit || undefined}
+          aria-describedby={showCharacterInfo ? characterInfoId : undefined}
           onChange={(e) => {
             onChange(e.target.value);
             resize();
           }}
           onKeyDown={handleKeyDown}
         />
+
+        {showCharacterInfo && (
+          <div
+            id={characterInfoId}
+            className={`${styles.characterInfo} ${isOverCharacterLimit ? styles.characterInfoError : ""}`}
+            aria-live="polite"
+          >
+            <span>
+              {isOverCharacterLimit ? t("chatbot.errors.chatInputTooLong", { limit: formattedCharacterLimit }) : null}
+            </span>
+            <span className={styles.characterCount}>
+              {t("chatbot.characterCounter", {
+                count: characterCount,
+                limit: formattedCharacterLimit,
+              })}
+            </span>
+          </div>
+        )}
 
         {showBottomRow && (
           <div className={styles.bottomRow}>

--- a/apps/frontend/src/rework/core/hooks/useChatSse.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.test.tsx
@@ -68,7 +68,12 @@ vi.mock("react-redux", () => ({
 // Fixed UI locale so language-forwarding tests are deterministic — no other
 // test in this file inspects request bodies, so a fixed value here is safe.
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ i18n: { language: "fr-FR" } }),
+  useTranslation: () => ({
+    i18n: {
+      language: "fr-FR",
+      t: (key: string, values?: Record<string, unknown>) => `${key}:${values?.limit ?? ""}`,
+    },
+  }),
 }));
 
 vi.mock("../../../security/KeycloakService", () => ({
@@ -119,14 +124,18 @@ function TestHost({ onRender }: { onRender: (hook: ReturnType<typeof useChatSse>
     flushPendingWrites,
     onError: (msg) => onErrorMock(msg),
     onTurnStarted: () => onTurnStartedMock(),
+    onTurnRejected: (draft, sessionId) => onTurnRejectedMock(draft, sessionId),
+    isTurnCurrent,
   });
   onRender(hook);
   return null;
 }
 
 let flushPendingWrites: ((sessionId: string) => Promise<boolean>) | undefined;
+let isTurnCurrent: ((sessionId: string) => boolean) | undefined;
 const onErrorMock = vi.fn();
 const onTurnStartedMock = vi.fn();
+const onTurnRejectedMock = vi.fn();
 
 describe("useChatSse — send() ordering barrier and prepare-execution failure handling", () => {
   let container: HTMLDivElement;
@@ -144,8 +153,10 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
 
   beforeEach(() => {
     flushPendingWrites = undefined;
+    isTurnCurrent = undefined;
     onErrorMock.mockClear();
     onTurnStartedMock.mockClear();
+    onTurnRejectedMock.mockClear();
     dispatchMock.mockClear();
     prepareExecutionCalls.length = 0;
     prepareExecutionImpl = async () => ({
@@ -217,6 +228,138 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     // a reason to have skipped clearing the composer.
     expect(onTurnStartedMock).toHaveBeenCalledTimes(1);
     fetchSpy.mockRestore();
+  });
+
+  it("parses a structured length rejection, removes the optimistic message, and restores the full draft", async () => {
+    flushPendingWrites = async () => true;
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: 5,
+    });
+    const rejectedDraft = "🙂🙂🙂🙂🙂🙂";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: 5,
+            actual_chars: 6,
+            input: rejectedDraft,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(onTurnStartedMock).toHaveBeenCalledTimes(1);
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(latest.maxChatInputChars).toBe(5);
+    expect(onErrorMock).toHaveBeenCalledWith("chatbot.errors.chatInputTooLong:5");
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain(rejectedDraft);
+    expect(errorSpy.mock.calls.flat().join(" ")).not.toContain(rejectedDraft);
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("suppresses a late length rejection after the request's session is reset", async () => {
+    flushPendingWrites = async () => true;
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: 10,
+    });
+    const response = deferred<Response>();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockReturnValue(response.promise);
+    mount();
+
+    let sendPromise!: Promise<void>;
+    await act(async () => {
+      sendPromise = latest.send("old session draft", "session-a");
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    });
+    act(() => latest.reset());
+    response.resolve(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: 5,
+            actual_chars: 17,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await act(async () => sendPromise);
+
+    expect(onTurnRejectedMock).not.toHaveBeenCalled();
+    expect(onErrorMock).not.toHaveBeenCalled();
+    expect(latest.maxChatInputChars).toBeUndefined();
+    expect(latest.messages).toHaveLength(0);
+    fetchSpy.mockRestore();
+  });
+
+  it("suppresses a late length rejection after navigation changes session before reset runs", async () => {
+    flushPendingWrites = async () => true;
+    let activeSessionId = "session-a";
+    isTurnCurrent = (turnSessionId) => turnSessionId === activeSessionId;
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: 10,
+    });
+    const response = deferred<Response>();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockReturnValue(response.promise);
+    mount();
+
+    let sendPromise!: Promise<void>;
+    await act(async () => {
+      sendPromise = latest.send("old session draft", "session-a");
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    });
+    activeSessionId = "session-b";
+    response.resolve(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: 5,
+            actual_chars: 17,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await act(async () => sendPromise);
+
+    expect(onTurnRejectedMock).not.toHaveBeenCalled();
+    expect(onErrorMock).not.toHaveBeenCalled();
+    expect(latest.maxChatInputChars).toBe(10);
+    fetchSpy.mockRestore();
+  });
+
+  it("omits the frontend limit when an older preparation does not publish it", async () => {
+    mount();
+
+    await act(async () => {
+      await latest.prepareChatControls();
+    });
+
+    expect(latest.maxChatInputChars).toBeUndefined();
   });
 
   it("surfaces onError, never throws, and never fires onTurnStarted when prepare-execution itself rejects", async () => {
@@ -819,6 +962,76 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
 
     expect(reached).toBe(false);
     expect(onErrorMock).toHaveBeenCalledTimes(1);
+    fetchSpy.mockRestore();
+  });
+
+  it("handles a structured HITL length rejection without echoing its content", async () => {
+    const rejectedText = "🙂🙂🙂🙂🙂🙂";
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: 10,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: 5,
+            actual_chars: 6,
+            input: rejectedText,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mount();
+
+    let reached: boolean | undefined;
+    await act(async () => {
+      reached = await latest.sendHitlResume(hitlEvent, undefined, rejectedText);
+    });
+
+    expect(reached).toBe(false);
+    expect(latest.maxChatInputChars).toBe(5);
+    expect(onErrorMock).toHaveBeenCalledWith("chatbot.errors.chatInputTooLong:5");
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain(rejectedText);
+    expect(errorSpy.mock.calls.flat().join(" ")).not.toContain(rejectedText);
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves exact HITL free text and canonical choice fields on the wire", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(JSON.stringify({ detail: "runtime unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    mount();
+
+    await act(async () => {
+      await latest.sendHitlResume(hitlEvent, undefined, "  a  ");
+    });
+    const choiceEvent = {
+      ...hitlEvent,
+      payload: { ...hitlEvent.payload, choices: [{ id: "proceed", label: "Proceed" }] },
+    } as RuntimeAwaitingHumanEvent;
+    await act(async () => {
+      await latest.sendHitlResume(choiceEvent, "proceed", " note ");
+    });
+
+    expect(requestBodies[0].resume_payload).toEqual({ answer: "  a  " });
+    expect(requestBodies[1].resume_payload).toEqual({
+      answer: "proceed",
+      choice_id: "proceed",
+      text: " note ",
+    });
     fetchSpy.mockRestore();
   });
 

--- a/apps/frontend/src/rework/core/hooks/useChatSse.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.ts
@@ -46,6 +46,7 @@ import {
   mergeRoutingPolicy,
   parseSseFrames,
 } from "../utils/runtimeStream";
+import { countUnicodeCodePoints } from "../utils/chatInput";
 import { personalTeamId } from "../../components/shared/utils/teamId";
 
 // The UI may still carry the bare "personal" placeholder (teamId.ts) in the URL
@@ -187,6 +188,42 @@ type AnyRuntimeEvent =
   | ({ kind: "turn_persisted" } & TurnPersistedEvent)
   | ({ kind: "execution_error" } & RuntimeErrorEvent);
 
+class RuntimeHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code?: string,
+    readonly limitChars?: number,
+    readonly actualChars?: number,
+    message = `Runtime request failed (${status})`,
+  ) {
+    super(message);
+    this.name = "RuntimeHttpError";
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+async function runtimeHttpError(response: Response): Promise<RuntimeHttpError> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return new RuntimeHttpError(response.status);
+  }
+  const detail = recordValue(recordValue(body)?.detail);
+  return new RuntimeHttpError(
+    response.status,
+    typeof detail?.code === "string" ? detail.code : undefined,
+    typeof detail?.limit_chars === "number" ? detail.limit_chars : undefined,
+    typeof detail?.actual_chars === "number" ? detail.actual_chars : undefined,
+    typeof detail?.message === "string" ? detail.message : undefined,
+  );
+}
+
 // ── HITL event/payload (#2216) ──────────────────────────────────────────────
 //
 // Explicit types based on the generated runtime `HumanInputRequest` contract.
@@ -223,6 +260,10 @@ export type ChatSseCallbacks = {
    * already covers showing the failure itself.
    */
   onTurnStarted?: () => void;
+  /** Restores an ordinary composer draft after a runtime length rejection. */
+  onTurnRejected?: (draft: string, sessionId: string) => void;
+  /** Reads current navigation ownership before applying late turn side effects. */
+  isTurnCurrent?: (sessionId: string) => boolean;
   /**
    * Ordering barrier awaited immediately before prepare-execution, keyed on
    * the session id this turn is about to use. Lets the caller flush any
@@ -260,6 +301,8 @@ export function useChatSse(
     onAwaitingHuman,
     onError,
     onTurnStarted,
+    onTurnRejected,
+    isTurnCurrent,
     flushPendingWrites,
   } = params;
 
@@ -311,6 +354,7 @@ export function useChatSse(
   // resolves each descriptor's `widget` id against the chat-turn-control
   // registry (plugin first, then the capability-agnostic stock kit).
   const [chatControls, setChatControls] = useState<ChatControlDescriptor[]>([]);
+  const [maxChatInputChars, setMaxChatInputChars] = useState<number | undefined>();
 
   const setAll = useCallback((next: ChatMessage[]) => {
     messagesRef.current = next;
@@ -322,6 +366,11 @@ export function useChatSse(
   const applyPreparation = useCallback(
     (prep: ExecutionPreparation) => {
       setChatControls(prep.chat_controls ?? []);
+      setMaxChatInputChars(
+        typeof prep.max_chat_input_chars === "number" && prep.max_chat_input_chars > 0
+          ? prep.max_chat_input_chars
+          : undefined,
+      );
       // #1979: publish the instance-bound capability route base URLs so each
       // capability's generated RTK slice can reach its pod routes directly.
       dispatch(setCapabilityBaseUrls(prep.capability_base_urls ?? {}));
@@ -342,6 +391,7 @@ export function useChatSse(
     thoughtBufsRef.current.clear();
     setAll([]);
     setChatControls([]);
+    setMaxChatInputChars(undefined);
   }, [setAll]);
   const replaceAllMessages = useCallback((msgs: ChatMessage[]) => setAll(msgs), [setAll]);
 
@@ -681,12 +731,7 @@ export function useChatSse(
 
       console.debug(`[useChatSse] fetch response — status=${response.status} ok=${response.ok}`);
       if (!response.ok) {
-        const text = await response.text().catch(() => String(response.status));
-        const httpError = new Error(`Runtime ${response.status}: ${text}`) as Error & { status?: number };
-        // The status is what tells a HITL resume whether the checkpoint is still
-        // answerable: 409 means the runtime already consumed or dropped it.
-        httpError.status = response.status;
-        throw httpError;
+        throw await runtimeHttpError(response);
       }
 
       if (!response.body) throw new Error("Empty response body from runtime");
@@ -715,7 +760,7 @@ export function useChatSse(
     ) => {
       const sendId = Math.random().toString(36).slice(2, 8);
       console.debug(
-        `[useChatSse][${sendId}] send() START — sessionId=${sessionId ?? "null"} input="${input.slice(0, 40)}"`,
+        `[useChatSse][${sendId}] send() START — sessionId=${sessionId ?? "null"} inputChars=${countUnicodeCodePoints(input)}`,
       );
 
       // Synchronous reentrancy lock — checked and acquired before the first
@@ -944,8 +989,24 @@ export function useChatSse(
       } catch (err) {
         const name = (err as Error)?.name;
         const msg = (err as Error)?.message ?? String(err);
-        if (name === "AbortError") {
+        if (ac.signal.aborted || abortRef.current !== ac || isTurnCurrent?.(effectiveSessionId) === false) {
+          console.debug(`[useChatSse][${sendId}] stream error settled after cancellation — side effects suppressed`);
+        } else if (name === "AbortError") {
           console.debug(`[useChatSse][${sendId}] streamToMessages aborted (AbortError) — swallowed`);
+        } else if (err instanceof RuntimeHttpError && err.code === "chat_input_too_long") {
+          messagesRef.current = messagesRef.current.filter(
+            (message) => !(message.exchange_id === exchangeId && message.metadata?.extras?.optimistic_user === true),
+          );
+          setMessages([...messagesRef.current]);
+          onTurnRejected?.(input, effectiveSessionId);
+          if (err.limitChars !== undefined) setMaxChatInputChars(err.limitChars);
+          onError?.(
+            err.limitChars === undefined
+              ? err.message
+              : i18n.t("chatbot.errors.chatInputTooLong", {
+                  limit: err.limitChars.toLocaleString(i18n.language),
+                }),
+          );
         } else {
           console.error(`[useChatSse][${sendId}] streamToMessages error — ${name}: ${msg}`);
           onError?.(`Streaming failed: ${msg}`);
@@ -966,6 +1027,8 @@ export function useChatSse(
       streamToMessages,
       onError,
       onTurnStarted,
+      onTurnRejected,
+      isTurnCurrent,
       flushPendingWrites,
       applyPreparation,
       i18n,
@@ -1126,8 +1189,8 @@ export function useChatSse(
       const exchangeId = pending.exchange_id;
       const hitlPayload = pending.payload;
       const hasChoices = Array.isArray(hitlPayload?.choices) && hitlPayload.choices.length > 0;
-      const normalizedFreeText = typeof freeText === "string" ? freeText.trim() || undefined : undefined;
-      const answerValue = !hasChoices && normalizedFreeText ? normalizedFreeText : answer;
+      const exactFreeText = typeof freeText === "string" && freeText.trim() ? freeText : undefined;
+      const answerValue = !hasChoices && exactFreeText ? exactFreeText : answer;
 
       setWaitResponse(true);
 
@@ -1159,7 +1222,7 @@ export function useChatSse(
             resume_payload: {
               answer: answerValue,
               choice_id: hasChoices && typeof answer === "string" ? answer : undefined,
-              text: hasChoices ? normalizedFreeText : undefined,
+              text: hasChoices ? exactFreeText : undefined,
             },
           },
           prep.execute_stream_url,
@@ -1184,7 +1247,18 @@ export function useChatSse(
           acceptedByRuntime = true;
         }
         if (!aborted) {
-          onError?.(`HITL resume failed: ${(err as Error)?.message ?? String(err)}`);
+          if (err instanceof RuntimeHttpError && err.code === "chat_input_too_long") {
+            if (err.limitChars !== undefined) setMaxChatInputChars(err.limitChars);
+            onError?.(
+              err.limitChars === undefined
+                ? err.message
+                : i18n.t("chatbot.errors.chatInputTooLong", {
+                    limit: err.limitChars.toLocaleString(i18n.language),
+                  }),
+            );
+          } else {
+            onError?.(`HITL resume failed: ${(err as Error)?.message ?? String(err)}`);
+          }
         }
       } finally {
         if (!ac.signal.aborted) {
@@ -1221,6 +1295,7 @@ export function useChatSse(
     messages,
     waitResponse,
     chatControls,
+    maxChatInputChars,
     prepareChatControls,
     send,
     sendHitlResume,

--- a/apps/frontend/src/rework/core/utils/chatInput.test.ts
+++ b/apps/frontend/src/rework/core/utils/chatInput.test.ts
@@ -1,0 +1,27 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { countUnicodeCodePoints } from "./chatInput";
+
+describe("countUnicodeCodePoints", () => {
+  it.each([
+    ["abcde", 5],
+    ["界界界界界", 5],
+    ["🙂🙂🙂🙂🙂", 5],
+    ["a🙂界", 3],
+  ])("counts %s as %i Unicode code points", (text, expected) => {
+    expect(countUnicodeCodePoints(text)).toBe(expected);
+  });
+});

--- a/apps/frontend/src/rework/core/utils/chatInput.ts
+++ b/apps/frontend/src/rework/core/utils/chatInput.ts
@@ -1,0 +1,20 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Count Unicode code points, matching Python's `len(text)` runtime policy. */
+export function countUnicodeCodePoints(text: string): number {
+  let count = 0;
+  for (const _codePoint of text) count += 1;
+  return count;
+}

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -2292,6 +2292,8 @@ export type ExecutionPreparation = {
   supports_streaming?: boolean;
   supports_hitl?: boolean;
   supports_ui_parts?: boolean;
+  /** Maximum Unicode code points accepted in one submitted chat message, as advertised by the selected runtime pod. Null when an older runtime does not publish the policy. */
+  max_chat_input_chars?: number | null;
   /** Computed chat-time composer controls for this instance (CAPAB-01 #1976, RFC §3.3/§3.7), evaluated per capability on the pod at session prep and flattened in capability-registration then returned-list order. Supersedes the retired `effective_chat_options`: the composer resolves each `widget` id against the owning capability's plugin registry (§9) and silently skips unknown ids. Never persisted — a cache-aside projection of stored config. */
   chat_controls?: ChatControlDescriptor[];
   runtime_display_name?: string | null;

--- a/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
+++ b/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
@@ -1015,6 +1015,7 @@ export type AgentTemplateSummary = {
     [key: string]: string;
   } | null;
   kind: ExecutionCategory;
+  max_chat_input_chars: number;
   template_agent_id: string;
   title: string;
 };

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -877,6 +877,13 @@
                       "description": "Optional maximum number of concurrent HTTP or WebSocket connections accepted by Uvicorn. Leave unset to disable the limit.",
                       "title": "Limit Concurrency"
                     },
+                    "max_chat_input_chars": {
+                      "default": 5000,
+                      "description": "Maximum number of Unicode code points accepted in one submitted chat message, including supported HITL resume text fields.",
+                      "minimum": 1,
+                      "title": "Max Chat Input Chars",
+                      "type": "integer"
+                    },
                     "gcu_version": {
                       "anyOf": [
                         {

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -618,6 +618,8 @@ applications:
         # Optional hard ceiling on concurrent HTTP/WebSocket connections
         # accepted by Uvicorn. Set to null to disable the limit.
         limit_concurrency: null
+        # Maximum Unicode code points accepted in one submitted chat message.
+        max_chat_input_chars: 5000
         openai_compat: true
 
       security:

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -2450,3 +2450,18 @@ The rename is API-surface deep but stops short of the database:
 The frontend uploads the image through an in-app square crop editor that
 exports a bounded 512×512 WebP, so avatars are small regardless of the source
 image (a backend image-resize safety net remains a follow-up).
+
+## 39. Contract Notes — runtime chat-input policy projection (2026-08-12, issue #2253)
+
+`ExecutionPreparation.max_chat_input_chars: int | null` is an optional,
+read-only projection of the selected runtime pod's deployment policy. Runtime
+`/agents/templates` publishes the value per template because it is pod-scoped;
+control-plane reads it from the same template response already used to resolve
+capability metadata. One preparation therefore performs no additional runtime
+request, stores no duplicate setting, and introduces no cache.
+
+The field remains optional for rolling compatibility with older runtime pods.
+When absent, control-plane omits it from the serialized preparation and managed
+chat omits its counter; the runtime backend remains the enforcement boundary.
+Control-plane does not interpret, override, or persist the value and does not
+apply a second chat-message validator.

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -2966,6 +2966,48 @@ Each was verified to fail against its pre-change implementation.
 
 ---
 
+### 8.52 ✅ Deployment-scoped chat-input length limit — issue #2253 (2026-08-12)
+
+One submitted chat message is bounded by the runtime-pod startup policy
+`app.max_chat_input_chars` (default `5000`, positive integer). The unit is a
+Unicode code point: Python uses `len(text)`, while managed chat iterates the
+string by code point without materializing a second array. This is deliberately
+a character policy, not a model-token, conversation-history, request-byte, or
+context-window budget.
+
+The runtime is authoritative and validates before exchange lookup, target
+resolution, history persistence, stream construction, or agent execution on
+`POST /agents/execute`, `/agents/execute/stream`, and `/agents/evaluate`.
+Ordinary turns count `RuntimeExecuteRequest.input`. HITL resumes count a bare
+string, or the combined string values of canonical `choice_id`, `answer`, and
+`text` fields; arbitrary JSON keys are not traversed. The OpenAI-compatible
+route applies the same code-point limit to the last user message Fred forwards.
+
+Fred-native rejection is HTTP 422 with `detail.code =
+"chat_input_too_long"`, `message`, `limit_chars`, and `actual_chars`.
+OpenAI compatibility returns HTTP 400 with the corresponding
+`invalid_request_error`, `param = "messages"`, and the same stable code/counts.
+Neither response, logs, metrics, nor traces may include the rejected content.
+A static Pydantic `max_length` is not used because the value is deployment
+policy, HITL is field-aware, and FastAPI's default validation response can echo
+the offending input.
+
+The effective pod-scoped value is mirrored on every `/agents/templates` item,
+following the existing pod-metadata publication pattern. Managed chat receives
+that optional projection through execution preparation, displays a counter,
+blocks an oversized draft without truncation or native `maxLength`, and relies
+on backend enforcement when an older runtime does not yet publish the field.
+During a rolling deployment, replicas configured with different limits may
+temporarily advertise and enforce different values: execution preparation can
+project one replica's value while the browser's execution request reaches
+another. The displayed limit is therefore advisory; the receiving runtime
+remains authoritative, returns its own `limit_chars` on rejection, and managed
+chat adopts that returned limit for subsequent validation.
+This semantic handler check occurs after HTTP body parsing; whole-request byte
+limits and HTTP 413 remain outside issue #2253.
+
+---
+
 ### 8.43 ✅ `DocumentMarkdownPort` — paginated full-content read for capabilities (DOCREAD-01, 2026-08-07)
 
 **New optional port on `RuntimeServices` (`fred-sdk`

--- a/docs/swift/platform/CONFIGURATION_AND_POLICY_CONVENTIONS.md
+++ b/docs/swift/platform/CONFIGURATION_AND_POLICY_CONVENTIONS.md
@@ -64,8 +64,15 @@ Fred policy behavior must come from files, not hardcoded values.
 Current policy sources:
 
 - Model/routing policy catalogs (agentic + knowledge-flow usage paths)
+- Runtime-pod request policy in `apps/fred-agents` configuration, including
+  `app.max_chat_input_chars` for the deployment-scoped chat-message limit
 - Conversation lifecycle policy catalog in control-plane:
   - `apps/control-plane-backend/config/conversation_policy_catalog.yaml`
+
+`app.max_chat_input_chars` is loaded once into `PodAppConfig`, enforced by the
+runtime, and published read-only to managed chat through runtime-template and
+execution-preparation metadata. It is not a database setting or a live
+platform-admin preference.
 
 When implementing behavior (for example purge delays), read from policy config and apply.
 Do not embed retention windows or team-specific rules in code.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -692,6 +692,33 @@ library:
 
 ---
 
+### Chat input length states (`RichInputField`, `HitlPrompt`, 2026-08-12)
+
+**Location:** `src/rework/components/shared/molecules/RichInputField/`,
+`src/rework/components/shared/molecules/HitlPrompt/`,
+`src/rework/components/pages/ManagedChatPage/`
+
+**Status:** `Functional`
+
+The managed-chat composer and active HITL free-text prompt display the optional
+runtime-published character policy from execution preparation. Both count Unicode code points;
+ordinary chat counts the trimmed value that will be submitted, while HITL counts the exact free
+text.
+
+- At or below the limit, the counter remains informational and send stays available.
+- Above the limit, the input uses `aria-invalid`, the counter/error region announces changes with
+  `aria-live="polite"`, and only the corresponding free-text send action is disabled. Fixed HITL
+  choices remain available because selecting one submits the identifier without the oversized
+  free-text draft; the runtime still validates any submitted `choice_id`, `answer`, and `text`
+  fields.
+- Text remains fully editable: neither component sets native `maxLength`, truncates pasted or
+  dictated content, nor clears an oversized draft. A backend length rejection restores the
+  ordinary draft or pending HITL prompt safely.
+- During a rolling upgrade, an older runtime may omit the policy. In that state no counter is
+  shown and the runtime remains the authoritative enforcement boundary.
+
+---
+
 ### Prompt library → insert into composer (`ContextPromptPicker`, 2026-08-03)
 
 **Location:** `src/rework/components/shared/molecules/ContextPromptPicker/`,

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -171,6 +171,7 @@ from ..runtime_context import (
 )
 from ..runtime_context import RuntimeContext as FredRuntimeContext
 from ..runtime_support import aclose_token_refresh_client
+from .chat_input_limit import validate_runtime_request
 from .config import AgentPodConfig
 from .container import build_pod_container
 from .context import AuditEventRecord, KpiTurnRecord, PodApplicationContext
@@ -945,6 +946,9 @@ class _AgentTemplateSummary(BaseModel):
     # for); this field is the one control-plane reads to resolve what a
     # `selected_capability_ids = None` instance activates (#1980).
     default_capability_ids: list[str] = Field(default_factory=list)
+    # Pod-scoped deployment policy mirrored per template so control-plane can
+    # publish it to the managed-chat composer without another runtime endpoint.
+    max_chat_input_chars: int
 
 
 class _McpCatalogEntry(BaseModel):
@@ -3426,6 +3430,7 @@ def _capability_route_base_url(base_url: str, capability_id: str) -> str:
 def _build_agent_router(
     registry: Mapping[str, ReActAgentDefinition | GraphAgentDefinition],
     security_enabled: bool,
+    max_chat_input_chars: int,
     base_url: str = "",
 ) -> APIRouter:
     """
@@ -3449,6 +3454,14 @@ def _build_agent_router(
     # handlers can perform the bearer-token / grant user_id correlation check.
     # Returns None in local-dev mode so dev pods start without Keycloak.
     _authenticated_user = _make_user_dependency(get_current_user, security_enabled)
+
+    def _enforce_chat_input_limit(request: RuntimeExecuteRequest) -> None:
+        violation = validate_runtime_request(request, max_chat_input_chars)
+        if violation is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=violation.native_detail(),
+            )
 
     @router.get("")
     async def list_agents() -> list[str]:
@@ -3584,6 +3597,7 @@ def _build_agent_router(
                 default_capability_ids=[
                     ref.id for ref in definition.default_mcp_servers
                 ],
+                max_chat_input_chars=max_chat_input_chars,
             )
             for definition in registry.values()
             if include_non_public or getattr(definition, "public", True)
@@ -4279,6 +4293,7 @@ def _build_agent_router(
         - This endpoint does not implement pod discovery or routing.
           Those concerns belong to Kubernetes Service, Ingress, and Argo CD.
         """
+        _enforce_chat_input_limit(request)
         auth = http_request.headers.get("Authorization", "")
         access_token = auth.removeprefix("Bearer ").strip() or None
 
@@ -4364,6 +4379,7 @@ def _build_agent_router(
         Intended for evaluation harnesses (DeepEval, Promptfoo) that need
         input, output, retrieval_context, tools_called, and steps in one response.
         """
+        _enforce_chat_input_limit(request)
         auth = http_request.headers.get("Authorization", "")
         access_token = auth.removeprefix("Bearer ").strip() or None
 
@@ -4475,6 +4491,7 @@ def _build_agent_router(
         - This endpoint does not implement pod discovery or routing.
           Those concerns belong to Kubernetes Service, Ingress, and Argo CD.
         """
+        _enforce_chat_input_limit(request)
         auth = http_request.headers.get("Authorization", "")
         access_token = auth.removeprefix("Bearer ").strip() or None
 
@@ -4757,7 +4774,10 @@ def create_agent_app(
     api_router = APIRouter(prefix=base_url)
     api_router.include_router(
         _build_agent_router(
-            registry, security_enabled=security_enabled, base_url=base_url
+            registry,
+            security_enabled=security_enabled,
+            max_chat_input_chars=config.app.max_chat_input_chars,
+            base_url=base_url,
         )
     )
 
@@ -4787,6 +4807,7 @@ def create_agent_app(
         openai_router = create_openai_compat_router(
             registry,
             security_enabled=security_enabled,
+            max_chat_input_chars=config.app.max_chat_input_chars,
         )
         app.include_router(openai_router, prefix="/v1")
         logger.info("[fred-runtime] OpenAI-compat endpoints enabled at /v1")

--- a/libs/fred-runtime/fred_runtime/app/chat_input_limit.py
+++ b/libs/fred-runtime/fred_runtime/app/chat_input_limit.py
@@ -1,0 +1,109 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Field-aware chat-input length validation shared by runtime HTTP surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from fred_sdk.contracts.execution import RuntimeExecuteRequest
+
+CHAT_INPUT_TOO_LONG_CODE = "chat_input_too_long"
+_HITL_TEXT_FIELDS = ("choice_id", "answer", "text")
+
+
+@dataclass(frozen=True, slots=True)
+class ChatInputTooLong:
+    """Safe error data for an oversized submitted message.
+
+    The rejected text is deliberately not retained on this object, so logging
+    or serializing the validation result cannot accidentally echo user content.
+    """
+
+    limit_chars: int
+    actual_chars: int
+
+    @property
+    def message(self) -> str:
+        return f"Your message exceeds the {self.limit_chars:,}-character limit."
+
+    def native_detail(self) -> dict[str, str | int]:
+        """Return the Fred-native ``HTTPException.detail`` payload."""
+
+        return {
+            "code": CHAT_INPUT_TOO_LONG_CODE,
+            "message": self.message,
+            "limit_chars": self.limit_chars,
+            "actual_chars": self.actual_chars,
+        }
+
+    def openai_error(self) -> dict[str, str | int]:
+        """Return the OpenAI-compatible ``error`` object."""
+
+        return {
+            "message": self.message,
+            "type": "invalid_request_error",
+            "param": "messages",
+            "code": CHAT_INPUT_TOO_LONG_CODE,
+            "limit_chars": self.limit_chars,
+            "actual_chars": self.actual_chars,
+        }
+
+
+def validate_chat_text(text: str, max_chars: int) -> ChatInputTooLong | None:
+    """Validate one string using Python's Unicode-code-point semantics."""
+
+    actual_chars = len(text)
+    if actual_chars <= max_chars:
+        return None
+    return ChatInputTooLong(limit_chars=max_chars, actual_chars=actual_chars)
+
+
+def runtime_request_chat_char_count(request: RuntimeExecuteRequest) -> int:
+    """Count the user-authored chat text that this runtime request submits.
+
+    Ordinary turns count ``input``. A HITL resume counts a bare string or the
+    combined string values of the canonical ``choice_id``, ``answer``, and
+    ``text`` fields. Values are summed per field without deduplication: callers
+    may use either ``choice_id`` or ``answer`` for a selection, and managed chat
+    currently mirrors the identifier in both. Arbitrary JSON keys are
+    intentionally not traversed.
+    """
+
+    resume_payload: Any = request.resume_payload
+    if resume_payload is None:
+        return len(request.input)
+    if isinstance(resume_payload, str):
+        return len(resume_payload)
+    if isinstance(resume_payload, Mapping):
+        return sum(
+            len(value)
+            for key in _HITL_TEXT_FIELDS
+            if isinstance((value := resume_payload.get(key)), str)
+        )
+    return 0
+
+
+def validate_runtime_request(
+    request: RuntimeExecuteRequest,
+    max_chars: int,
+) -> ChatInputTooLong | None:
+    """Validate the effective ordinary-turn or HITL text in one request."""
+
+    actual_chars = runtime_request_chat_char_count(request)
+    if actual_chars <= max_chars:
+        return None
+    return ChatInputTooLong(limit_chars=max_chars, actual_chars=actual_chars)

--- a/libs/fred-runtime/fred_runtime/app/config.py
+++ b/libs/fred-runtime/fred_runtime/app/config.py
@@ -120,6 +120,14 @@ class PodAppConfig(BaseModel):
             "limit."
         ),
     )
+    max_chat_input_chars: int = Field(
+        default=5_000,
+        ge=1,
+        description=(
+            "Maximum number of Unicode code points accepted in one submitted "
+            "chat message, including supported HITL resume text fields."
+        ),
+    )
     gcu_version: str | None = None
     openai_compat: bool = False
     """

--- a/libs/fred-runtime/fred_runtime/app/openai_compat_router.py
+++ b/libs/fred-runtime/fred_runtime/app/openai_compat_router.py
@@ -49,8 +49,8 @@ from collections.abc import AsyncIterator, Mapping
 from typing import Any, Callable
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse, StreamingResponse
 from fred_core import AuthorizationError, KeycloakUser, TeamPermission
 from fred_sdk.contracts.models import GraphAgentDefinition, ReActAgentDefinition
 from fred_sdk.contracts.openai_compat import (
@@ -67,6 +67,7 @@ from .agent_app import (
     _iterate_runtime_event_payloads,
     _resolve_agent_instance,
 )
+from .chat_input_limit import validate_chat_text
 from .dependencies import get_pod_container_from_app
 
 logger = logging.getLogger(__name__)
@@ -75,6 +76,7 @@ logger = logging.getLogger(__name__)
 def create_openai_compat_router(
     registry: Mapping[str, ReActAgentDefinition | GraphAgentDefinition],
     security_enabled: bool,
+    max_chat_input_chars: int,
     authenticated_user_dep: Callable[..., Any] | None = None,
 ) -> APIRouter:
     """
@@ -141,7 +143,7 @@ def create_openai_compat_router(
         request: OpenAIChatRequest,
         http_request: Request,
         authenticated_user: KeycloakUser | None = Depends(user_dep),
-    ) -> StreamingResponse:
+    ) -> Response:
         """
         Execute one agent turn over the OpenAI chat completions SSE protocol.
 
@@ -164,6 +166,20 @@ def create_openai_compat_router(
         - `fred.node_error`: graph node error message (finish_reason="stop")
         - `fred.token_usage`: input/output token counts (on the final chunk)
         """
+        user_messages = [m for m in request.messages if m.role == "user"]
+        if not user_messages:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Request must contain at least one user message.",
+            )
+        message = user_messages[-1].content
+        violation = validate_chat_text(message, max_chat_input_chars)
+        if violation is not None:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"error": violation.openai_error()},
+            )
+
         if request.model not in registry:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -172,14 +188,6 @@ def create_openai_compat_router(
                     f"Known: {list(registry.keys())}"
                 ),
             )
-
-        user_messages = [m for m in request.messages if m.role == "user"]
-        if not user_messages:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Request must contain at least one user message.",
-            )
-        message = user_messages[-1].content
 
         session_id = http_request.headers.get("X-Fred-Session-Id") or uuid4().hex
         team_id = http_request.headers.get("X-Fred-Team-Id")

--- a/libs/fred-runtime/tests/test_agent_app.py
+++ b/libs/fred-runtime/tests/test_agent_app.py
@@ -27,6 +27,7 @@ import json
 import logging
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -244,6 +245,7 @@ def _build_test_config(
     control_plane_url: str | None = None,
     metrics_backend: str = "logging",
     kpi_process_metrics_interval_sec: int = 0,
+    max_chat_input_chars: int = 5_000,
 ) -> AgentPodConfig:
     """
     Build an offline pod config for the authored-tool regression test.
@@ -270,6 +272,7 @@ def _build_test_config(
                 # OpenAI-compat is opt-in (off by default, RUNTIME-07 F-A); the
                 # broad app test below asserts the /v1 surface, so enable it here.
                 "openai_compat": True,
+                "max_chat_input_chars": max_chat_input_chars,
             },
             "security": {
                 "m2m": {
@@ -453,7 +456,7 @@ def test_create_agent_app_executes_local_authored_tools_and_honors_base_url(
     registry: dict[str, ReActAgentDefinition] = {definition.agent_id: definition}
     app = create_agent_app(
         registry=registry,
-        config=_build_test_config(tmp_path),
+        config=_build_test_config(tmp_path, max_chat_input_chars=37),
     )
 
     with TestClient(app) as client:
@@ -469,6 +472,14 @@ def test_create_agent_app_executes_local_authored_tools_and_honors_base_url(
         assert (
             templates_response.json()[0]["default_tuning"]["role"] == "Echo tool agent"
         )
+        assert templates_response.json()[0]["max_chat_input_chars"] == 37
+
+        configured_limit_response = client.post(
+            "/pod/v1/agents/execute",
+            json={"agent_id": "unknown", "input": "x" * 38},
+        )
+        assert configured_limit_response.status_code == 422
+        assert configured_limit_response.json()["detail"]["limit_chars"] == 37
 
         openapi_response = client.get("/pod/v1/openapi.json")
         assert openapi_response.status_code == 200
@@ -535,6 +546,97 @@ def test_create_agent_app_executes_local_authored_tools_and_honors_base_url(
     assert any(payload.get("kind") == "tool_result" for payload in payloads)
     assert payloads[-1]["kind"] == "final"
     assert payloads[-1]["content"] == "Echo complete."
+
+
+@pytest.mark.parametrize(
+    "text_factory",
+    [
+        pytest.param(lambda size: "a" * size, id="ascii"),
+        pytest.param(lambda size: "界" * size, id="cjk"),
+        pytest.param(lambda size: "🙂" * size, id="emoji"),
+    ],
+)
+def test_native_execution_routes_enforce_chat_input_limit_before_runtime_work(
+    monkeypatch, tmp_path, text_factory
+) -> None:
+    """All native entry points share the 4,999/5,000/5,001 boundary."""
+
+    model = ToolFriendlyFakeChatModel(responses=[AIMessage(content="unused")])
+    monkeypatch.setattr(
+        agent_app_module,
+        "_build_chat_model_factory",
+        lambda config: StaticChatModelFactory(model),
+    )
+    limit = 5_000
+    app = create_agent_app(registry={}, config=_build_test_config(tmp_path))
+    routes = (
+        "/pod/v1/agents/execute",
+        "/pod/v1/agents/execute/stream",
+        "/pod/v1/agents/evaluate",
+    )
+
+    with TestClient(app) as client:
+        for route in routes:
+            for size in (limit - 1, limit):
+                response = client.post(
+                    route,
+                    json={"agent_id": "unknown", "input": text_factory(size)},
+                )
+                assert response.status_code == 404
+
+        exchange_lookup = AsyncMock()
+        target_resolution = AsyncMock()
+        history_write = AsyncMock()
+        stream_construction = MagicMock()
+        event_iteration = MagicMock()
+        monkeypatch.setattr(agent_app_module, "_resolve_exchange_id", exchange_lookup)
+        monkeypatch.setattr(
+            agent_app_module, "_authorize_and_resolve", target_resolution
+        )
+        monkeypatch.setattr(agent_app_module, "_write_turn_history", history_write)
+        monkeypatch.setattr(agent_app_module, "_stream", stream_construction)
+        monkeypatch.setattr(
+            agent_app_module, "_iterate_runtime_event_payloads", event_iteration
+        )
+
+        rejected_text = text_factory(limit + 1)
+        for route in routes:
+            response = client.post(
+                route,
+                json={"agent_id": "unknown", "input": rejected_text},
+            )
+            assert response.status_code == 422
+            assert response.json() == {
+                "detail": {
+                    "code": "chat_input_too_long",
+                    "message": "Your message exceeds the 5,000-character limit.",
+                    "limit_chars": limit,
+                    "actual_chars": limit + 1,
+                }
+            }
+            assert rejected_text not in response.text
+
+        for route in routes:
+            response = client.post(
+                route,
+                json={
+                    "agent_id": "unknown",
+                    "resume_payload": {
+                        "choice_id": text_factory(2_000),
+                        "answer": text_factory(2_000),
+                        "text": text_factory(1_001),
+                        "ignored": text_factory(limit + 1),
+                    },
+                },
+            )
+            assert response.status_code == 422
+            assert response.json()["detail"]["actual_chars"] == limit + 1
+
+    exchange_lookup.assert_not_awaited()
+    target_resolution.assert_not_awaited()
+    history_write.assert_not_awaited()
+    stream_construction.assert_not_called()
+    event_iteration.assert_not_called()
 
 
 def test_delete_checkpoint_thread_returns_deleted_count(monkeypatch, tmp_path) -> None:
@@ -4674,7 +4776,9 @@ async def test_caller_can_manage_platform_false_when_no_caller(monkeypatch) -> N
 def _get_kpi_turns_endpoint():
     """Grab the `/kpi-turns` route's raw endpoint function, bypassing FastAPI's
     dependency-injection layer so it can be called directly with explicit args."""
-    router = agent_app_module._build_agent_router(registry={}, security_enabled=True)
+    router = agent_app_module._build_agent_router(
+        registry={}, security_enabled=True, max_chat_input_chars=5_000
+    )
     return next(
         route.endpoint
         for route in router.routes

--- a/libs/fred-runtime/tests/test_chat_input_limit.py
+++ b/libs/fred-runtime/tests/test_chat_input_limit.py
@@ -1,0 +1,84 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Chat-input limit semantics independent of the HTTP route wiring."""
+
+from __future__ import annotations
+
+import pytest
+from fred_runtime.app.chat_input_limit import (
+    runtime_request_chat_char_count,
+    validate_chat_text,
+    validate_runtime_request,
+)
+from fred_sdk.contracts.execution import RuntimeExecuteRequest
+
+
+@pytest.mark.parametrize("text", ["abcde", "界界界界界", "🙂🙂🙂🙂🙂"])
+def test_validate_chat_text_counts_unicode_code_points(text: str) -> None:
+    """ASCII, CJK, and non-BMP emoji share the same five-code-point boundary."""
+
+    assert validate_chat_text(text, 5) is None
+    violation = validate_chat_text(f"{text}x", 5)
+    assert violation is not None
+    assert violation.actual_chars == 6
+
+
+@pytest.mark.parametrize(
+    ("resume_payload", "expected"),
+    [
+        ("hello", 5),
+        ({"choice_id": "ab"}, 2),
+        ({"answer": "界界界"}, 3),
+        ({"text": "🙂🙂🙂🙂"}, 4),
+        ({"choice_id": "a", "answer": "bc", "text": "def"}, 6),
+        ({"notes": "ignored", "nested": {"text": "ignored"}}, 0),
+    ],
+)
+def test_runtime_request_counts_supported_hitl_text(
+    resume_payload: object, expected: int
+) -> None:
+    """HITL counting covers canonical fields without traversing arbitrary JSON."""
+
+    request = RuntimeExecuteRequest(agent_id="test", resume_payload=resume_payload)
+
+    assert runtime_request_chat_char_count(request) == expected
+
+
+def test_runtime_request_uses_input_only_for_ordinary_turns() -> None:
+    request = RuntimeExecuteRequest(agent_id="test", input="🙂界abc")
+
+    assert runtime_request_chat_char_count(request) == 5
+    assert validate_runtime_request(request, 5) is None
+    assert validate_runtime_request(request, 4) is not None
+
+
+@pytest.mark.parametrize(
+    "resume_payload",
+    [
+        "🙂" * 6,
+        {"choice_id": "界" * 6},
+        {"answer": "a" * 6},
+        {"text": "🙂" * 6},
+        {"choice_id": "ab", "answer": "界界", "text": "🙂🙂"},
+    ],
+)
+def test_runtime_request_rejects_each_supported_hitl_shape(
+    resume_payload: object,
+) -> None:
+    request = RuntimeExecuteRequest(agent_id="test", resume_payload=resume_payload)
+
+    violation = validate_runtime_request(request, 5)
+
+    assert violation is not None
+    assert violation.actual_chars == 6

--- a/libs/fred-runtime/tests/test_config_loader.py
+++ b/libs/fred-runtime/tests/test_config_loader.py
@@ -24,7 +24,10 @@ _MISSING = object()
 
 
 def _write_configuration_yaml(
-    config_dir: Path, *, limit_concurrency: int | None | object = None
+    config_dir: Path,
+    *,
+    limit_concurrency: int | None | object = None,
+    max_chat_input_chars: int | object = _MISSING,
 ) -> None:
     """
     Write one minimal pod `configuration.yaml` fixture.
@@ -47,6 +50,11 @@ def _write_configuration_yaml(
     if limit_concurrency is not _MISSING:
         literal = "null" if limit_concurrency is None else str(limit_concurrency)
         limit_concurrency_block = f"\n              limit_concurrency: {literal}"
+    max_chat_input_chars_block = ""
+    if max_chat_input_chars is not _MISSING:
+        max_chat_input_chars_block = (
+            f"\n              max_chat_input_chars: {max_chat_input_chars}"
+        )
 
     (config_dir / "configuration.yaml").write_text(
         dedent(
@@ -55,7 +63,7 @@ def _write_configuration_yaml(
               name: "Test Pod"
               base_url: "/pod/v1"
               port: 8000
-              log_level: "info"{limit_concurrency_block}
+              log_level: "info"{limit_concurrency_block}{max_chat_input_chars_block}
 
             security:
               m2m:
@@ -198,6 +206,7 @@ def test_load_agent_pod_config_loads_default_external_catalogs(
         "config/models_catalog.yaml"
     )
     assert config.app.limit_concurrency is None
+    assert config.app.max_chat_input_chars == 5_000
     assert config.ai.timeout.connect == 5.0
     assert config.ai.timeout.read == 30.0
     mcp_configuration = config.get_mcp_configuration()
@@ -388,3 +397,44 @@ def test_load_agent_pod_config_defaults_app_limit_concurrency_when_omitted(
     config = load_agent_pod_config()
 
     assert config.app.limit_concurrency is None
+
+
+def test_load_agent_pod_config_loads_chat_input_limit(tmp_path, monkeypatch) -> None:
+    """A positive YAML override becomes the pod's effective chat-input limit."""
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    _write_configuration_yaml(config_dir, max_chat_input_chars=37)
+    _write_models_catalog(config_dir / "models_catalog.yaml")
+    _write_mcp_catalog(config_dir / "mcp_catalog.yaml", server_id="mcp-default")
+    (config_dir / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CONFIG_FILE", str(config_dir / "configuration.yaml"))
+    monkeypatch.setenv("ENV_FILE", str(config_dir / ".env"))
+
+    config = load_agent_pod_config()
+
+    assert config.app.max_chat_input_chars == 37
+
+
+@pytest.mark.parametrize("invalid_limit", [0, -1])
+def test_load_agent_pod_config_rejects_non_positive_chat_input_limit(
+    tmp_path, monkeypatch, invalid_limit: int
+) -> None:
+    """Startup fails when the configured chat-input limit is not positive."""
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    _write_configuration_yaml(config_dir, max_chat_input_chars=invalid_limit)
+    _write_models_catalog(config_dir / "models_catalog.yaml")
+    _write_mcp_catalog(config_dir / "mcp_catalog.yaml", server_id="mcp-default")
+    (config_dir / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CONFIG_FILE", str(config_dir / "configuration.yaml"))
+    monkeypatch.setenv("ENV_FILE", str(config_dir / ".env"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        load_agent_pod_config()
+    assert exc_info.value.code == 1

--- a/libs/fred-runtime/tests/test_openai_compat_router.py
+++ b/libs/fred-runtime/tests/test_openai_compat_router.py
@@ -27,7 +27,9 @@ All tests run without any external services.
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock
 
+import fred_runtime.app.openai_compat_router as openai_compat_router_module
 from conftest import (
     StaticChatModelFactory,
     ToolFriendlyFakeChatModel,
@@ -67,7 +69,12 @@ class _HelloAgent(ReActAgent):
     tools = (_demo_hello,)
 
 
-def _build_test_config(tmp_path, *, openai_compat: bool = True) -> AgentPodConfig:
+def _build_test_config(
+    tmp_path,
+    *,
+    openai_compat: bool = True,
+    max_chat_input_chars: int = 5_000,
+) -> AgentPodConfig:
     """
     Build an offline pod config with openai_compat enabled.
 
@@ -86,6 +93,7 @@ def _build_test_config(tmp_path, *, openai_compat: bool = True) -> AgentPodConfi
                 "port": 8000,
                 "log_level": "info",
                 "openai_compat": openai_compat,
+                "max_chat_input_chars": max_chat_input_chars,
             },
             "security": {
                 "m2m": {
@@ -239,6 +247,69 @@ def test_chat_completions_no_user_message_returns_422(monkeypatch, tmp_path) -> 
             },
         )
     assert response.status_code == 422
+
+
+def test_chat_completions_enforces_only_last_user_message(
+    monkeypatch, tmp_path
+) -> None:
+    """The forwarded user message uses code-point counting and a safe error body."""
+
+    model = ToolFriendlyFakeChatModel(responses=[AIMessage(content="accepted")])
+    monkeypatch.setattr(
+        agent_app_module,
+        "_build_chat_model_factory",
+        lambda config: StaticChatModelFactory(model),
+    )
+
+    definition = _HelloAgent()
+    registry: dict[str, ReActAgentDefinition] = {definition.agent_id: definition}
+    app = create_agent_app(
+        registry=registry,
+        config=_build_test_config(tmp_path, max_chat_input_chars=5),
+    )
+
+    with TestClient(app) as client:
+        accepted = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": definition.agent_id,
+                "messages": [
+                    {"role": "user", "content": "historical message is much longer"},
+                    {"role": "assistant", "content": "history"},
+                    {"role": "user", "content": "🙂" * 5},
+                ],
+            },
+            headers={"X-Fred-Session-Id": "openai-limit-exact"},
+        )
+        target_resolution = AsyncMock()
+        monkeypatch.setattr(
+            openai_compat_router_module,
+            "_resolve_agent_instance",
+            target_resolution,
+        )
+        rejected_text = "界" * 6
+        rejected = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": definition.agent_id,
+                "messages": [{"role": "user", "content": rejected_text}],
+            },
+        )
+
+    assert accepted.status_code == 200
+    assert rejected.status_code == 400
+    assert rejected.json() == {
+        "error": {
+            "message": "Your message exceeds the 5-character limit.",
+            "type": "invalid_request_error",
+            "param": "messages",
+            "code": "chat_input_too_long",
+            "limit_chars": 5,
+            "actual_chars": 6,
+        }
+    }
+    assert rejected_text not in rejected.text
+    target_resolution.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `libs/fred-runtime`, `apps/fred-agents`: add the YAML/Helm-backed
  `app.max_chat_input_chars` policy (default 5,000 Unicode code points), publish
  the effective pod value through runtime templates, and reject oversized
  native, streaming, evaluation, canonical HITL, and OpenAI-compatible input
  before exchange lookup, target resolution, persistence, stream construction,
  or agent execution.
- `apps/control-plane-backend`: carry valid optional runtime-template metadata
  through the existing request-scoped template fetch into
  `ExecutionPreparation`, while tolerating old, absent, and malformed values
  without adding a database setting, cache, endpoint, or duplicate request.
- `apps/frontend`: use the runtime-published value for an accessible Unicode
  code-point counter, preserve oversized ordinary/HITL drafts without native
  `maxLength` or truncation, keep fixed HITL choices available, and handle the
  safe structured backend rejection—including stale cross-session responses.
- `deploy/charts/fred`, generated clients/schemas, and `docs/swift`: keep Helm,
  runtime/control-plane contracts, English/French UX, and checked-in generated
  artifacts aligned with the policy.

No RFC was required for this reduced scope: it extends existing startup config,
pod-template metadata, execution preparation, handler validation, and composer
patterns. The design and acceptance criteria were agreed and recorded in #2253
before implementation.

Closes #2253.

## Test plan

- [x] `make code-quality` from the monorepo root — all package quality gates
  passed; Python import-order checks and frontend Prettier/typecheck/lint also
  passed.
- [x] `make -C libs/fred-runtime test` — 920 passed, 2 deselected on the final
  amended tree.
- [x] `make -C apps/control-plane-backend test` — 722 passed.
- [x] `make -C apps/frontend test` — 1,167 passed, 2 skipped.
- [x] Focused post-amend runtime validation — 15 passed; Ruff check and format
  check passed.
- [x] `make generate-config-schema` followed by config/chart schema drift and
  values checks — passed; a second generation was clean.
- [x] `make -C apps/frontend update-control-plane-api update-runtime-api` —
  regenerated both clients; a second generation was clean.
- [x] Helm v3.19.5: `helm template fred deploy/charts/fred` — exit 0, 1,749
  rendered lines; `max_chat_input_chars: 5000` reached
  `ConfigMap/fred-agents-back` under `data.configuration.yaml`, and an override
  of 1,234 rendered at the same location. Setting zero was rejected by
  `values.schema.json` with `minimum: got 0, want 1`.
- [x] `helm lint deploy/charts/fred` — 1 chart linted, 0 failed (the only output
  beyond success was the informational recommendation to add a chart icon).

The full automated suites were run on the implementation tree before the final
rebase. The subsequent commit changes were documentation-only; the focused
runtime suite was rerun after the final amend. CI is the authoritative check on
the rebased head.

## Live verification (clean local stack)

### Boundary, encoding, ordering, and ingress coverage

- ASCII, CJK, and emoji inputs at 5,000 code points passed the semantic gate;
  5,001 returned `chat_input_too_long`. The CJK and emoji cases distinguish
  code-point counting from a 5,000-byte or JavaScript UTF-16-unit boundary.
- A deliberately unknown `agent_id` returned 404 at 5,000 and the length error
  at 5,001, proving rejection occurs before target resolution.
- `/agents/execute` and `/agents/evaluate` returned native HTTP 422 errors;
  `/agents/execute/stream` returned pre-stream JSON HTTP 422 rather than a 200
  SSE error frame; `/v1/chat/completions` returned HTTP 400 with
  `invalid_request_error`, `param: messages`, and the stable code.
- Canonical `resume_payload.answer` HITL text was rejected at the same boundary.
  An oversized earlier OpenAI history message did not trigger rejection when
  the last forwarded user message was within policy.
- Every rejection body was checked for content echo; none included the submitted
  text.

### Publication, replicas, and upgrade compatibility

- All 11 runtime templates advertised `max_chat_input_chars: 5000` through the
  existing pod-scoped metadata path.
- Two simultaneous runtime replicas configured with limits 5,000 and 100 each
  enforced and advertised their own startup value: 100 passed both; 101 failed
  only on the 100-limit replica; 5,000 passed only on the 5,000-limit replica;
  5,001 failed on both with each replica's own limit.
- An old config with the field omitted parsed and used the 5,000 default.
  Absent, null, non-numeric, zero, and negative template projections were
  tolerated by control-plane as `None`, preserving old-pod compatibility while
  runtime enforcement remains authoritative.
- During mixed-limit rolling deployments, execution preparation can advertise a
  different replica's value. The UI treats that projection as advisory and
  adopts the receiving runtime's returned `limit_chars` after rejection; the
  runtime remains authoritative.

### Browser UX

- The composer showed `0 / 5,000`, remained enabled at 4,000 and 5,000, and
  disabled send with the error state at 5,001. CJK and emoji were counted as
  5,001 code points, not bytes or UTF-16 units.
- The textarea had no `maxLength`; a 5,001-character draft remained intact and
  editable.
- A simulated stale/bypassed frontend guard produced the specific backend error
  and restored the original draft without echoing its content in diagnostics.
- French rendered `5001 / 5 000 caractères` with locale-appropriate grouping;
  English was restored after the test.
- A real no-LLM HITL interrupt confirmed that 5,001 free-text characters disable
  only the free-text action: all fixed choices remained enabled, the textarea
  stayed untruncated, and `aria-invalid` was set.
- `aria-live="polite"`, `aria-describedby`, and conditional `aria-invalid` were
  verified in the live DOM.

The throwaway HITL agent was deleted and the local stack was restored to its
original single-replica, English-locale state after verification.

## Scope, risk, and rollback

- This is a semantic current-message limit, not a whole-request byte limit.
  FastAPI has already parsed/buffered the request before handler validation, so
  HTTP 413 and transport-level pod-memory protection remain out of scope.
- Token/context-window budgeting, conversation compaction, automatic file
  conversion, attachments/context prompts, and recursive interpretation of
  arbitrary HITL JSON are deliberately not included.
- Mixed-version or mixed-limit replicas can temporarily make the displayed value
  stale; runtime enforcement and the returned `limit_chars` remain authoritative.
- Rollback is the single commit. Operators can adjust the positive YAML/Helm
  value without database migration; existing configs that omit it retain the
  5,000 default.

🤖 Generated with [Codex](https://Codex.com/Codex)
