### PR TITLE
fix(#2350): ReAct size-based turn budget, above the message-count trim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,20 @@ client/cache, or anything else that runs per-turn or per-request under
 concurrent load, also run the `fred-performance-reviewer` skill before
 reporting done.
 
+**Self-review is not enough for non-trivial logic changes.** Before reporting
+done, run `/code-review` on your own diff — default effort at minimum, higher
+for anything touching correctness-sensitive shared code. Tests you write from
+the same reasoning pass that wrote the code confirm your own assumptions
+instead of falsifying them; an agent checking its own work shares whatever
+blind spot produced the bug in the first place. (2026-08-13: a same-day
+ReAct size-budget fix — issue #2350, PR #2352 — passed its own tests,
+`make code-quality`, and a `fred-performance-reviewer` pass, then shipped
+with three P1 correctness bugs that an independent reviewer bot caught on
+first read of the cold diff — each one a case not covered by the tests
+written alongside the code they were breaking.) Do not skip this under time
+pressure — that is exactly when a design's blind spots survive to
+production instead of being caught same-session.
+
 **Step 6 — Doc update checklist.**
 
 | What changed                                                      | File to update                                                                           |

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -343,7 +343,7 @@ Every implementation and review must preserve these invariants:
 | MCP activation | **Needs load evidence (P1)** — sequential cold discovery, token-scoped pod cache, no singleflight | [TURN-02](../reviews/performance/2026-07-26-agent-turn-core/TURN-02-mcp-cold-path-and-cache-scope.md) |
 | ReAct/Deep model/tool boundary | **Mostly meets design** — canonical KPI/audit middleware and per-tool ReBAC; the authorization cost needs an explicit stage metric and load budget | [core review](../reviews/performance/2026-07-26-agent-turn-core/README.md) |
 | Graph model/tool boundary | **Gap (P1)** — bypasses canonical LLM/tool KPI, tool audit, and per-call ReBAC | [TURN-03](../reviews/performance/2026-07-26-agent-turn-core/TURN-03-graph-runtime-observability-and-authz.md) |
-| Turn resource budgets | **Gap (P1)** — 500-message model window, no default tool-call cap, unused parallel-call policy | [TURN-04](../reviews/performance/2026-07-26-agent-turn-core/TURN-04-turn-resource-bounds.md) |
+| Turn resource budgets | **Partially fixed** — ReAct now has a size-based model-input budget alongside the message-count window (§8.52, 2026-08-13) and a shipped tool-call cap (`apps/fred-agents/tool_pacing.py`, 2026-08-01); **Gap (P1) remains** for Deep, Graph, persisted-checkpoint compaction, and the unused parallel-call policy | [TURN-04](../reviews/performance/2026-07-26-agent-turn-core/TURN-04-turn-resource-bounds.md), [#2343](https://github.com/ThalesGroup/fred/issues/2343) |
 | SSE/history lifecycle | **Needs load evidence (P2)** — full payload buffering and unbounded fire-and-forget persistence tasks | [TURN-05](../reviews/performance/2026-07-26-agent-turn-core/TURN-05-sse-buffering-and-history-backpressure.md) |
 | Pod/SQL admission | **Needs load evidence (P1)** — Uvicorn limit unset; shared async SQL pool defaults to 15 maximum connections | [TURN-06](../reviews/performance/2026-07-26-agent-turn-core/TURN-06-admission-and-sql-capacity.md) |
 | Token refresh | **Fixed offline 2026-08-07** — the refresh is async, coalesced and bounded; the synchronous helper was removed (§8.48). The pod-level forced-expiry proof is still owed and cannot run until delegated refresh is reachable again | [TURN-07](../reviews/performance/2026-07-26-agent-turn-core/TURN-07-sync-token-refresh-in-async-path.md) |
@@ -2963,6 +2963,91 @@ the exception; and, for the gate, `useChatSse.test.tsx`'s pair — a token under
 the floor that the rescue refresh clears (turn proceeds, second refresh asks
 for 30 s not 120 s) and one it cannot (refusal, but only after the attempt).
 Each was verified to fail against its pre-change implementation.
+
+---
+
+### 8.52 ✅ ReAct model-input size budget, in addition to the message-count trim — TURN-04 partial (#2350, 2026-08-13)
+
+**ReAct-only slice of TURN-04's "turn resource bounds" finding** (full finding
+still open for Deep and Graph, and for persisted-checkpoint compaction — see
+[#2343](https://github.com/ThalesGroup/fred/issues/2343)). Field incident
+(2026-08-12, `mistral-small-2603`): a session stayed at ~25 turns, far under
+`_V2_MAX_HISTORY_MESSAGES = 500`, while a 115k-character tool result followed
+a few turns later by a 22k-character generated document pushed one call's
+input to 178,670 tokens — still accepted — and the very next turn then failed
+outright (`finish_reason="error"`, 0 output tokens). The message-count trim
+never engages on payload size; whether the failure itself was specifically a
+provider context-length rejection could not be confirmed from the persisted
+turn history — Fred's own error-path token reporting attaches the last
+successful sub-call's usage to the turn, not the failing request's real size,
+which is exactly the separate `execution_error` persistence gap #2343 flags
+for its own fix.
+
+`CheckpointHygieneMiddleware.awrap_model_call`
+(`fred_runtime/react/middleware/checkpoint_hygiene.py`) now applies a second,
+size-based trim after the existing message-count trim:
+`trim_to_char_budget` (`fred_runtime/support/tool_loop.py`) keeps as many
+trailing messages as fit under `_V2_MAX_HISTORY_CHARS` (200,000 characters,
+`fred_runtime/react/react_tool_loop.py`), then advances to the same safe
+HumanMessage/orphan-ToolMessage boundary as the message-count trim so it
+never hands a provider a payload that starts mid tool-call/result pair.
+
+Character count, not tokens: no exact tokenizer covers every provider this
+deployment can point at (Mistral, Azure, OpenAI, ...), so this is a
+deliberately provider-agnostic proxy, the same reasoning `max_chat_input_chars`
+(#2253) uses for a single message. The 200,000-character default is
+calibrated off the same field incident, not a generic "~4 chars/token" rule
+of thumb: replaying that incident's persisted turn history against its own
+reported token usage gives roughly 1.35 characters per token for this
+deployment's French/HTML-heavy content (240,395 visible characters of prior
+turns fed the call that reported 178,670 input tokens) — a naive 4x
+assumption would correspond to ~800k characters and would never have trimmed
+before this exact failure. 200,000 characters (~148k tokens at the measured
+ratio) sits comfortably below the 178,670 tokens that already nearly failed
+while still covering the incident's own single-document/single-tool-result
+payloads (each well under 150k characters) without trimming them on their
+own. This is one deployment's measured ratio, not a portable constant — see
+`react_tool_loop.py`'s comment for the full derivation and re-check it if the
+configured models or typical content mix change materially. When even the
+trimmed window still exceeds the budget — the CURRENT turn's own content is
+the culprit, and no amount of dropping older history helps — the middleware
+raises `ChatTurnTooLargeError` (numbers only, never the oversized content)
+instead of forwarding a payload the provider will reject anyway. It
+propagates through the existing generic `except Exception` →
+`RuntimeErrorEvent` path (`agent_app.py`) unchanged, so no new frontend
+handling was needed.
+
+**Observability.** A production robustness audit of this exact failure mode
+(same day) found the rejection was only a DEBUG log — invisible without
+digging through OpenSearch, and not how the 200,000-character default (a
+first-pass estimate) would get validated or re-tuned from real traffic. Two
+additions, both numbers/identifiers only, never content: the log is now
+WARNING; and `CheckpointHygieneMiddleware` gained `binding`/`kpi` (following
+`TracingKpiMiddleware`/`ToolObservabilityMiddleware`'s own required-not-
+optional convention for those two params) to emit `agent.turn_rejected_total`
+— a counter, same shape as the sibling `agent.tool_failed_total`
+(`status`/`error_code`/`exception_type` dims, `KPIActor(type="system")`),
+reaching Grafana through the existing `PROMETHEUS_ALLOWED_LABELS` allow-list
+with no new label needed. The identity/correlation dims (`session_id`,
+`user_id`, `team_id`, `agent_instance_id`, `template_agent_id`,
+`correlation_id`, `trace_id`) are built by a new shared
+`identity_kpi_dims(binding)` helper (`react/middleware/shared.py`), factored
+out of `ToolObservabilityMiddleware._base_dims`'s identical logic rather than
+hand-rolling a second copy — that method itself was left untouched to avoid
+touching already-shipped, tested code same-day.
+
+Deliberately out of scope here: Deep and Graph runtimes, persisted-checkpoint
+compaction (`CheckpointHygieneMiddleware` trims only the outgoing model
+request by design, never graph state), and #2330 (making
+`_V2_MAX_HISTORY_MESSAGES` itself configurable) — all tracked separately
+under #2343.
+
+Regression tests: `test_char_budget_*` (`test_tool_loop_trim.py`, pure
+function), `test_history_is_trimmed_by_char_budget`,
+`test_current_turn_alone_over_char_budget_fails_cleanly`, and
+`test_current_turn_too_large_emits_a_kpi_counter`
+(`test_react_loop_regressions_1972.py`, full loop through
+`agent.astream`).
 
 ---
 

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -3091,6 +3091,33 @@ function), `test_history_is_trimmed_by_char_budget`,
 (`test_react_loop_regressions_1972.py`, full loop through
 `agent.astream`).
 
+**Three PR-review fixes to the counting itself (same day), each verified by
+reverting and confirming its regression test fails without the fix:**
+
+1. `_message_char_len` only read `AIMessage.content`, which LangChain leaves
+   empty on a pure tool-calling turn — the real payload sits in
+   `tool_calls[*]["args"]` instead (exactly `write_document`'s shape in the
+   motivating field incident). Now sums tool-call arguments
+   (JSON-serialized) too.
+2. The budget ran BEFORE `thread_reasoning_within_open_turn`, so a large
+   open-turn reasoning trace — invisible to `_message_char_len` as
+   structured `thinking`-block content — could pass unmeasured and only
+   balloon past the limit once rehomed into ordinary text. Reordered so the
+   budget measures what the handler actually receives.
+3. `trim_to_char_budget` can legitimately collapse to `[]` when the only
+   message it could keep under budget is a lone trailing ToolMessage with
+   no preceding AIMessage in the window (one oversized tool result, e.g. a
+   big RAG hit) — an unsafe orphan boundary. Measuring that now-empty
+   result silently passed the check and sent the model NO messages at
+   all — worse than a raw crash. The collapse itself is now detected and
+   measured against the pre-trim total instead.
+
+Additional regression tests: `test_char_budget_counts_tool_call_arguments_not_just_content`
+(`test_tool_loop_trim.py`), `test_history_is_trimmed_by_char_budget_from_tool_call_arguments`,
+`test_oversized_reasoning_trace_is_budgeted_after_rehoming`, and
+`test_oversized_trailing_tool_result_fails_cleanly_not_silently_empty`
+(`test_react_loop_regressions_1972.py`).
+
 ---
 
 ### 8.43 ✅ `DocumentMarkdownPort` — paginated full-content read for capabilities (DOCREAD-01, 2026-08-07)

--- a/docs/swift/reviews/performance/2026-07-26-agent-turn-core/TURN-04-turn-resource-bounds.md
+++ b/docs/swift/reviews/performance/2026-07-26-agent-turn-core/TURN-04-turn-resource-bounds.md
@@ -60,4 +60,29 @@ and enforce them consistently in ReAct, Deep, and Graph.
 
 ## Resolution evidence
 
-Not resolved.
+**Partially resolved.** Split into per-runtime issues under
+[#2343](https://github.com/ThalesGroup/fred/issues/2343) rather than one
+combined fix, to keep each change single-purpose and reviewable:
+
+- **ReAct model-input size budget:** fixed 2026-08-13
+  ([#2350](https://github.com/ThalesGroup/fred/issues/2350)) — see
+  `RUNTIME-EXECUTION-CONTRACT.md` §8.52 for the full account. The
+  message-count window (`_V2_MAX_HISTORY_MESSAGES`) now has a size-based
+  companion (`_V2_MAX_HISTORY_CHARS`) so a handful of large tool outputs
+  cannot blow a provider's context window while staying under the message
+  cap; a turn whose own content alone still exceeds the budget fails
+  cleanly instead of crashing on a raw provider error.
+- **Tool-call cap:** already shipped for ReAct independently of this
+  finding — `apps/fred-agents/tool_pacing.py` (2026-08-01) sets
+  `max_tool_calls_per_turn=12` on the five agents that use tools, closing
+  the "no shipped agent sets one" gap this finding originally noted.
+
+**Still open, tracked under #2343:**
+
+- Deep and Graph runtimes have neither a message/size budget nor a
+  tool-call cap — Deep in fact refuses to start if a policy sets
+  `max_tool_calls_per_turn` at all.
+- Persisted checkpoint growth is still untrimmed (only the outgoing model
+  request is trimmed, by design).
+- `allow_parallel_calls` is still declared and rendered but not consumed by
+  any runtime.

--- a/libs/fred-runtime/fred_runtime/react/middleware/checkpoint_hygiene.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/checkpoint_hygiene.py
@@ -95,6 +95,23 @@ class CheckpointHygieneMiddleware(AgentMiddleware):
             # it already ran on the untrimmed list above. Re-run it: idempotent
             # on an already-clean list, closes the gap on a freshly-cut one.
             messages = sanitize_dangling_tool_calls(trimmed)
+        # Reasoning continuity (RUNTIME-05 Layer 2c, RFC Amendment E §E.3).
+        # Provider-native reasoning blocks cannot be replayed as such — the model
+        # client drops them — so the reasoning of the turn IN PROGRESS is carried
+        # back as ordinary text and reasoning from closed turns is dropped.
+        # Without this the model gets its own message back with the content
+        # emptied, re-derives the plan, and re-issues the identical tool call:
+        # measured 9/12 turns and 67 duplicate calls on a bare prompt, 0/12 with
+        # this (p = 1.7e-4). Raw reasoning blocks are still never replayed.
+        #
+        # Must run BEFORE the size budget below (found in PR review): a
+        # `thinking` block's own text isn't counted by `_message_char_len`
+        # (it's structured reasoning content, not the plain `content` string
+        # or a tool-call argument) until this call flattens it into ordinary
+        # text. Budgeting first would measure the pre-flatten shape and miss
+        # however large the rehomed reasoning trace turns out to be — the
+        # budget must see what the handler will actually receive.
+        messages = thread_reasoning_within_open_turn(messages)
         if self._max_history_chars is not None:
             # Message-count trim above says nothing about payload size: a
             # handful of large tool outputs (a generated document, a big RAG
@@ -102,7 +119,21 @@ class CheckpointHygieneMiddleware(AgentMiddleware):
             # provider's real context window (#2350 field evidence: ~60
             # messages, 178k+ tokens). Trim again, this time by size.
             trimmed = trim_to_char_budget(messages, self._max_history_chars)
-            actual_chars = total_char_len(trimmed)
+            if not trimmed and messages:
+                # `trim_to_char_budget` can legitimately collapse to `[]`
+                # when the only message it could keep under budget is a lone
+                # trailing ToolMessage with no preceding AIMessage in the
+                # window — an unsafe orphan boundary (e.g. one oversized RAG
+                # result). `total_char_len([])` is then 0, which would
+                # silently pass the check below and send the model an EMPTY
+                # context — no user question, no tool result — instead of
+                # failing the turn (found in PR review). Treat the collapse
+                # itself as the over-budget signal: measure the pre-trim
+                # total instead, guaranteed > budget since
+                # `trim_to_char_budget` only trims when that already holds.
+                actual_chars = total_char_len(messages)
+            else:
+                actual_chars = total_char_len(trimmed)
             if actual_chars > self._max_history_chars:
                 # Even the trimmed window is too big: the CURRENT turn's own
                 # content is the culprit, and no amount of dropping older
@@ -155,15 +186,6 @@ class CheckpointHygieneMiddleware(AgentMiddleware):
                     self._max_history_chars,
                 )
                 messages = sanitize_dangling_tool_calls(trimmed)
-        # Reasoning continuity (RUNTIME-05 Layer 2c, RFC Amendment E §E.3).
-        # Provider-native reasoning blocks cannot be replayed as such — the model
-        # client drops them — so the reasoning of the turn IN PROGRESS is carried
-        # back as ordinary text and reasoning from closed turns is dropped.
-        # Without this the model gets its own message back with the content
-        # emptied, re-derives the plan, and re-issues the identical tool call:
-        # measured 9/12 turns and 67 duplicate calls on a bare prompt, 0/12 with
-        # this (p = 1.7e-4). Raw reasoning blocks are still never replayed.
-        messages = thread_reasoning_within_open_turn(messages)
         response = await handler(
             request.override(messages=cast(list[AnyMessage], messages))
         )

--- a/libs/fred-runtime/fred_runtime/react/middleware/checkpoint_hygiene.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/checkpoint_hygiene.py
@@ -20,18 +20,23 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import cast
 
+from fred_core.kpi import BaseKPIWriter, KPIActor
+from fred_sdk.contracts.context import BoundRuntimeContext
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, AnyMessage
 
 from fred_runtime.support.thinking import thread_reasoning_within_open_turn
 from fred_runtime.support.tool_loop import (
+    ChatTurnTooLargeError,
     collect_tool_outputs,
     sanitize_dangling_tool_calls,
+    total_char_len,
+    trim_to_char_budget,
     trim_to_human_boundary,
 )
 
-from .shared import state_messages
+from .shared import identity_kpi_dims, state_messages
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +61,19 @@ class CheckpointHygieneMiddleware(AgentMiddleware):
       model request
     """
 
-    def __init__(self, *, max_history_messages: int | None) -> None:
+    def __init__(
+        self,
+        *,
+        max_history_messages: int | None,
+        binding: BoundRuntimeContext,
+        kpi: BaseKPIWriter | None,
+        max_history_chars: int | None = None,
+    ) -> None:
         super().__init__()
         self._max_history_messages = max_history_messages
+        self._max_history_chars = max_history_chars
+        self._binding = binding
+        self._kpi = kpi
 
     async def awrap_model_call(
         self,
@@ -80,6 +95,66 @@ class CheckpointHygieneMiddleware(AgentMiddleware):
             # it already ran on the untrimmed list above. Re-run it: idempotent
             # on an already-clean list, closes the gap on a freshly-cut one.
             messages = sanitize_dangling_tool_calls(trimmed)
+        if self._max_history_chars is not None:
+            # Message-count trim above says nothing about payload size: a
+            # handful of large tool outputs (a generated document, a big RAG
+            # hit) can stay far under the message cap while blowing past a
+            # provider's real context window (#2350 field evidence: ~60
+            # messages, 178k+ tokens). Trim again, this time by size.
+            trimmed = trim_to_char_budget(messages, self._max_history_chars)
+            actual_chars = total_char_len(trimmed)
+            if actual_chars > self._max_history_chars:
+                # Even the trimmed window is too big: the CURRENT turn's own
+                # content is the culprit, and no amount of dropping older
+                # history can fix that. Fail the turn cleanly here rather
+                # than forward a payload the provider will reject anyway.
+                #
+                # Both a log AND a counter, not just one: the log is the
+                # per-occurrence detail for OpenSearch/incident digging; the
+                # counter (`agent.turn_rejected_total`, same shape as the
+                # sibling `agent.tool_failed_total` in
+                # `ToolObservabilityMiddleware`) is what actually reaches
+                # Grafana, since this middleware has no paired latency timer
+                # to piggyback a `status` dim on. Whether
+                # `_V2_MAX_HISTORY_CHARS` (calibrated off one field incident,
+                # #2350) is well-tuned is exactly what this counter is for —
+                # silent-by-default would hide that until a user complains
+                # again. Numbers/identifiers only in both: no message
+                # content, nothing GDPR-sensitive (`identity_kpi_dims` never
+                # carries content, only opaque correlation identifiers, and
+                # only the Prometheus-allow-listed subset of those ever
+                # reaches Grafana — see `PROMETHEUS_ALLOWED_LABELS`).
+                logger.warning(
+                    "[TOOL LOOP] turn rejected: content too large even after "
+                    "trim (%d chars > %d char budget)",
+                    actual_chars,
+                    self._max_history_chars,
+                )
+                if self._kpi is not None:
+                    self._kpi.count(
+                        "agent.turn_rejected_total",
+                        1,
+                        dims={
+                            **identity_kpi_dims(self._binding),
+                            "status": "error",
+                            "error_code": ChatTurnTooLargeError.__name__,
+                            "exception_type": ChatTurnTooLargeError.__name__,
+                        },
+                        actor=KPIActor(type="system"),
+                    )
+                raise ChatTurnTooLargeError(
+                    limit_chars=self._max_history_chars,
+                    actual_chars=actual_chars,
+                )
+            if len(trimmed) != len(messages):
+                logger.debug(
+                    "[TOOL LOOP] history trimmed by size: %d → %d chars "
+                    "(max_history_chars=%d)",
+                    total_char_len(messages),
+                    actual_chars,
+                    self._max_history_chars,
+                )
+                messages = sanitize_dangling_tool_calls(trimmed)
         # Reasoning continuity (RUNTIME-05 Layer 2c, RFC Amendment E §E.3).
         # Provider-native reasoning blocks cannot be replayed as such — the model
         # client drops them — so the reasoning of the turn IN PROGRESS is carried

--- a/libs/fred-runtime/fred_runtime/react/middleware/frame.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/frame.py
@@ -51,6 +51,7 @@ def build_react_platform_middleware_frame(
     tracer: TracerPort | None,
     kpi: BaseKPIWriter | None,
     max_history_messages: int | None,
+    max_history_chars: int | None = None,
     max_tool_calls_per_turn: int | None = None,
     capability_middleware: Sequence[AgentMiddleware] = (),
     capability_hitl: Mapping[str, CapabilityHitlBinding] | None = None,
@@ -76,7 +77,12 @@ def build_react_platform_middleware_frame(
     """
 
     frame: list[AgentMiddleware] = [
-        CheckpointHygieneMiddleware(max_history_messages=max_history_messages),
+        CheckpointHygieneMiddleware(
+            max_history_messages=max_history_messages,
+            max_history_chars=max_history_chars,
+            binding=binding,
+            kpi=kpi,
+        ),
         ModelRoutingMiddleware(
             chat_model_factory=chat_model_factory,
             definition=definition,

--- a/libs/fred-runtime/fred_runtime/react/middleware/shared.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/shared.py
@@ -23,7 +23,45 @@ Why this module exists:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
+
+from fred_sdk.contracts.context import BoundRuntimeContext
+
+
+def identity_kpi_dims(binding: BoundRuntimeContext) -> dict[str, Optional[str]]:
+    """
+    Identity/correlation dims for a KPI or audit event tied to one bound turn.
+
+    Why this exists:
+    - mirrors `ToolObservabilityMiddleware._base_dims`'s identity block
+      (only identifiers, never content — session/user/team/correlation, never
+      message text); factored out here so a second KPI call site
+      (`CheckpointHygieneMiddleware`, #2350) doesn't hand-roll a diverging copy
+    - only identifiers, on purpose: `PROMETHEUS_ALLOWED_LABELS`
+      (`prometheus_kpi_store.py`) strips user/session/team identity before a
+      metric reaches Prometheus, but the full set still carries through to the
+      KPI store's other consumers (e.g. audit-adjacent product analytics) —
+      see `docs/swift/platform/OBSERVABILITY-AND-AUDIT.md` §3
+    """
+    portable = binding.portable_context
+    dims: dict[str, Optional[str]] = {}
+    if portable.session_id:
+        dims["session_id"] = portable.session_id
+    if portable.user_id:
+        dims["user_id"] = portable.user_id
+    if portable.team_id:
+        dims["team_id"] = portable.team_id
+    agent_instance_id = portable.baggage.get("agent_instance_id")
+    if agent_instance_id:
+        dims["agent_instance_id"] = agent_instance_id
+    template_agent_id = portable.baggage.get("template_agent_id")
+    if template_agent_id:
+        dims["template_agent_id"] = template_agent_id
+    if portable.correlation_id:
+        dims["correlation_id"] = portable.correlation_id
+    if portable.trace_id:
+        dims["trace_id"] = portable.trace_id
+    return dims
 
 
 def state_messages(state_like: object) -> list[Any]:

--- a/libs/fred-runtime/fred_runtime/react/react_tool_loop.py
+++ b/libs/fred-runtime/fred_runtime/react/react_tool_loop.py
@@ -50,6 +50,38 @@ logger = logging.getLogger(__name__)
 # and prevents unbounded LangGraph checkpointer growth from contaminating queries.
 _V2_MAX_HISTORY_MESSAGES = 500
 
+# Size-based companion to the message-count window above (#2350, TURN-04).
+#
+# Why this exists: a handful of large tool outputs (a generated document, a
+# big RAG hit) can push the model input tokens far past a provider's context
+# window while the session stays well under _V2_MAX_HISTORY_MESSAGES. Field
+# incident (2026-08-12, mistral-small-2603): a session stayed at ~25 turns
+# / well under the message cap while a 115k-character tool result followed
+# a few turns later by a 22k-character generated document pushed one call's
+# input to 178,670 tokens (still accepted); the very next turn then failed
+# outright (finish_reason="error", 0 output tokens). Message count alone
+# cannot catch that.
+#
+# Character count, not tokens: no exact tokenizer covers every provider this
+# deployment can point at (Mistral, Azure, OpenAI, ...), so this is a
+# deliberately provider-agnostic proxy — same reasoning as `max_chat_input_chars`
+# (#2253) for a single message. The naive "~4 chars/token" rule of thumb (used
+# in an earlier revision of this constant) does NOT hold for this deployment's
+# actual traffic: replaying the same field incident's persisted turn history
+# against its own reported token usage gives ~1.35 characters per token for
+# this French/HTML-heavy content mix (240,395 visible characters of prior
+# turns fed the call that reported 178,670 input tokens) — a plain 4x
+# assumption would have UNDER-protected by roughly 3x and never trimmed
+# before this exact failure. 200,000 characters is calibrated off that
+# measured ratio (~148k tokens equivalent): comfortably below the 178,670
+# tokens that already nearly failed, while still covering routine
+# single-document/single-tool-result payloads (both well under 150k
+# characters here) without trimming them on their own. This is one
+# deployment's measured ratio, not a universal constant — re-derive it (or at
+# least sanity-check it) if the configured models or typical content mix
+# change materially, and tune the raw number per deployment either way.
+_V2_MAX_HISTORY_CHARS = 200_000
+
 
 def build_tool_loop_compiled_react_agent(
     *,
@@ -105,6 +137,7 @@ def build_tool_loop_compiled_react_agent(
         tracer=tracer,
         kpi=kpi,
         max_history_messages=_V2_MAX_HISTORY_MESSAGES,
+        max_history_chars=_V2_MAX_HISTORY_CHARS,
         max_tool_calls_per_turn=max_tool_calls_per_turn,
         capability_middleware=capability_middleware,
         capability_hitl=capability_hitl,

--- a/libs/fred-runtime/fred_runtime/support/tool_loop.py
+++ b/libs/fred-runtime/fred_runtime/support/tool_loop.py
@@ -44,6 +44,27 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 logger = logging.getLogger(__name__)
 
 
+class ChatTurnTooLargeError(RuntimeError):
+    """
+    Raised when even the trimmed model-input window still exceeds the
+    deployment's character budget (#2350) — i.e. the CURRENT turn's own
+    content (the latest human message plus whatever tool rounds it produced)
+    is too large on its own, so no amount of trimming older history helps.
+
+    Deliberately carries only numbers, never message content: this message
+    reaches the user as-is via the generic `execution_error` path
+    (`agent_app.py`), and submitted/generated text must never be echoed back.
+    """
+
+    def __init__(self, *, limit_chars: int, actual_chars: int) -> None:
+        self.limit_chars = limit_chars
+        self.actual_chars = actual_chars
+        super().__init__(
+            f"This turn's content ({actual_chars:,} characters) exceeds the "
+            f"{limit_chars:,}-character model-input budget for this deployment."
+        )
+
+
 def sanitize_dangling_tool_calls(messages: List[Any]) -> List[Any]:
     """
     Remove any AIMessage(tool_calls=...) whose call_ids are not all answered
@@ -128,38 +149,24 @@ def sanitize_dangling_tool_calls(messages: List[Any]) -> List[Any]:
     return result
 
 
-def trim_to_human_boundary(messages: list, max_messages: int) -> list:
+def _advance_to_safe_boundary(trimmed: list) -> list:
     """
-    Keep the last `max_messages` entries, then advance to a safe boundary so the
-    trimmed context never starts mid tool-call/result pair.
-
-    Why this matters:
-    - A tool round replays as one AIMessage(tool_calls) immediately followed by
-      its ToolMessages. A naive tail slice can land inside that group, so the
-      window starts on orphan ToolMessages whose AIMessage was cut off the front.
-      OpenAI-compatible providers (Mistral, OpenAI) then reject the whole request
-      with "messages with role 'tool' must be a response to a preceding message
-      with 'tool_calls'", which crashes the turn instead of answering the user.
-    - This is easy to hit when a single reasoning step fans out many tool calls
-      (e.g. a batch of failed `read_query` calls) that alone exceed
-      `max_messages`: every message in the window is then a bare tool result.
+    Shared post-trim boundary rule for both the message-count and the
+    char-budget trims (#2350): a tail slice can land inside an
+    AIMessage(tool_calls)/ToolMessage group, so the window must be advanced to
+    a point where it is valid to send to a provider on its own.
 
     Boundary rule:
-    - prefer to start on the first HumanMessage inside the window (keeps the most
-      context while remaining a valid start);
-    - otherwise drop any leading orphan ToolMessages so the window starts on an
-      AIMessage or later — never on a bare tool result. A ToolMessage's matching
-      AIMessage always precedes it, so a leading ToolMessage here is provably an
-      orphan and safe to drop.
+    - prefer to start on the first HumanMessage inside the window (keeps the
+      most context while remaining a valid start);
+    - otherwise drop any leading orphan ToolMessages so the window starts on
+      an AIMessage or later — never on a bare tool result. A ToolMessage's
+      matching AIMessage always precedes it, so a leading ToolMessage here is
+      provably an orphan and safe to drop.
     """
-    if len(messages) <= max_messages:
-        return messages
-    trimmed = messages[-max_messages:]
     for i, msg in enumerate(trimmed):
         if isinstance(msg, HumanMessage):
             return trimmed[i:]
-    # No HumanMessage in the window: strip leading orphan ToolMessages so the
-    # payload does not begin with a tool result that has no matching tool_calls.
     for i, msg in enumerate(trimmed):
         if not isinstance(msg, ToolMessage):
             if i:
@@ -176,6 +183,89 @@ def trim_to_human_boundary(messages: list, max_messages: int) -> list:
         "an invalid provider payload"
     )
     return []
+
+
+def trim_to_human_boundary(messages: list, max_messages: int) -> list:
+    """
+    Keep the last `max_messages` entries, then advance to a safe boundary so the
+    trimmed context never starts mid tool-call/result pair.
+
+    Why this matters:
+    - A tool round replays as one AIMessage(tool_calls) immediately followed by
+      its ToolMessages. A naive tail slice can land inside that group, so the
+      window starts on orphan ToolMessages whose AIMessage was cut off the front.
+      OpenAI-compatible providers (Mistral, OpenAI) then reject the whole request
+      with "messages with role 'tool' must be a response to a preceding message
+      with 'tool_calls'", which crashes the turn instead of answering the user.
+    - This is easy to hit when a single reasoning step fans out many tool calls
+      (e.g. a batch of failed `read_query` calls) that alone exceed
+      `max_messages`: every message in the window is then a bare tool result.
+    """
+    if len(messages) <= max_messages:
+        return messages
+    return _advance_to_safe_boundary(messages[-max_messages:])
+
+
+def _message_char_len(message: Any) -> int:
+    """
+    Character length of one message's content, robust to multimodal content
+    (a list of content blocks) as well as plain string content.
+
+    Why character count, not tokens (#2350):
+    - no exact tokenizer covers every provider this deployment can point at
+      (Mistral, Azure, OpenAI, ...); a character count is a cheap, provider-
+      agnostic, deterministic proxy for the same over-large-payload problem
+      `max_chat_input_chars` (#2253) already counts on a single message.
+    """
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        total = 0
+        for block in content:
+            if isinstance(block, str):
+                total += len(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    total += len(text)
+        return total
+    return 0
+
+
+def total_char_len(messages: list) -> int:
+    """Total character length across a message list (see `_message_char_len`)."""
+    return sum(_message_char_len(m) for m in messages)
+
+
+def trim_to_char_budget(messages: list, max_chars: int) -> list:
+    """
+    Keep as many trailing messages as fit under `max_chars`, then advance to
+    the same safe boundary as `trim_to_human_boundary` (#2350).
+
+    Why this exists in addition to the message-count trim:
+    - a handful of large tool outputs (a generated document, a big RAG hit)
+      can blow past a provider's real context window while the session stays
+      far under any message-COUNT cap — the message count trim alone never
+      engages, and the next turn fails with a raw provider context-length
+      error instead of a clean, structured one.
+
+    Always keeps at least the last message, even if it alone exceeds
+    `max_chars` — the caller (`CheckpointHygieneMiddleware`) is responsible
+    for detecting that the trimmed result is still over budget and failing
+    the turn cleanly instead of sending a payload no trim can shrink further.
+    """
+    if total_char_len(messages) <= max_chars:
+        return messages
+    running = 0
+    cut = len(messages) - 1
+    for i in range(len(messages) - 1, -1, -1):
+        msg_len = _message_char_len(messages[i])
+        if running > 0 and running + msg_len > max_chars:
+            break
+        running += msg_len
+        cut = i
+    return _advance_to_safe_boundary(messages[cut:])
 
 
 def collect_tool_outputs(messages: List[Any]) -> Dict[str, Any]:

--- a/libs/fred-runtime/fred_runtime/support/tool_loop.py
+++ b/libs/fred-runtime/fred_runtime/support/tool_loop.py
@@ -206,10 +206,46 @@ def trim_to_human_boundary(messages: list, max_messages: int) -> list:
     return _advance_to_safe_boundary(messages[-max_messages:])
 
 
+def _tool_calls_char_len(message: Any) -> int:
+    """
+    Character length of a message's proposed tool-call arguments.
+
+    Why this matters (found in PR review, #2350): a tool-calling AIMessage's
+    own `content` is typically empty or a short preamble — LangChain/the
+    provider put the actual payload in `tool_calls[*]["args"]` instead. The
+    motivating field incident's `write_document` call is exactly this shape:
+    an empty-content AIMessage carrying a 22k-character `content_markdown`
+    argument. Without this, that argument was invisible to
+    `_message_char_len` and the whole point of this budget — catching a
+    large-tool-output turn before it blows the provider's context window —
+    would silently not engage on the one case it was built for.
+
+    JSON-serialized (not just summing string leaf values): args can nest
+    dicts/lists/non-string values, and this approximates what actually goes
+    over the wire to the provider closely enough for a proxy budget — the
+    small serialization overhead (quotes, braces, commas) only makes the
+    estimate more conservative, never less.
+    """
+    tool_calls = getattr(message, "tool_calls", None)
+    if not tool_calls:
+        return 0
+    total = 0
+    for call in tool_calls:
+        args = call.get("args") if isinstance(call, dict) else None
+        if not args:
+            continue
+        try:
+            total += len(json.dumps(args, ensure_ascii=False, default=str))
+        except (TypeError, ValueError):
+            total += len(str(args))
+    return total
+
+
 def _message_char_len(message: Any) -> int:
     """
-    Character length of one message's content, robust to multimodal content
-    (a list of content blocks) as well as plain string content.
+    Character length of one message: its content (robust to multimodal
+    content blocks as well as plain string content) plus any proposed
+    tool-call arguments (see `_tool_calls_char_len`).
 
     Why character count, not tokens (#2350):
     - no exact tokenizer covers every provider this deployment can point at
@@ -218,10 +254,10 @@ def _message_char_len(message: Any) -> int:
       `max_chat_input_chars` (#2253) already counts on a single message.
     """
     content = getattr(message, "content", None)
+    total = 0
     if isinstance(content, str):
-        return len(content)
-    if isinstance(content, list):
-        total = 0
+        total = len(content)
+    elif isinstance(content, list):
         for block in content:
             if isinstance(block, str):
                 total += len(block)
@@ -229,8 +265,7 @@ def _message_char_len(message: Any) -> int:
                 text = block.get("text")
                 if isinstance(text, str):
                     total += len(text)
-        return total
-    return 0
+    return total + _tool_calls_char_len(message)
 
 
 def total_char_len(messages: list) -> int:

--- a/libs/fred-runtime/tests/test_react_loop_regressions_1972.py
+++ b/libs/fred-runtime/tests/test_react_loop_regressions_1972.py
@@ -833,6 +833,69 @@ async def test_current_turn_alone_over_char_budget_fails_cleanly() -> None:
     assert model.calls == []
 
 
+@pytest.mark.asyncio
+async def test_oversized_reasoning_trace_is_budgeted_after_rehoming() -> None:
+    """
+    Regression (found in PR review): the char budget must run AFTER
+    `thread_reasoning_within_open_turn`, not before. A `thinking` block's
+    own text isn't visible to `_message_char_len` as structured reasoning
+    content — only once rehomed into ordinary `content` text does its size
+    become measurable. Budgeting before that rehoming would let an oversized
+    reasoning trace slip through unmeasured and then expand past the limit
+    on the way to the provider.
+    """
+    model = RecordingModel(script=[AIMessage(content="unreachable")])
+    agent = _compile_agent(model, approval_enabled=False)
+
+    huge_reasoning = "x" * (_V2_MAX_HISTORY_CHARS + 20_000)
+    history: list[BaseMessage] = [
+        HumanMessage("investigate the contract"),
+        # Open-turn reasoning (after the last HumanMessage) — invisible to a
+        # budget that only reads plain `content` strings or tool-call args.
+        AIMessage(content=[{"type": "thinking", "thinking": huge_reasoning}]),
+    ]
+
+    with pytest.raises(ChatTurnTooLargeError) as exc_info:
+        await _drive(agent, {"messages": history}, "t-reasoning-too-big")
+
+    assert exc_info.value.actual_chars > _V2_MAX_HISTORY_CHARS
+    assert model.calls == []
+
+
+@pytest.mark.asyncio
+async def test_oversized_trailing_tool_result_fails_cleanly_not_silently_empty() -> (
+    None
+):
+    """
+    Regression (found in PR review): when the latest ToolMessage alone
+    exceeds the char budget (e.g. one huge RAG result), the reverse-scan
+    trim keeps only that lone ToolMessage — a window with no preceding
+    AIMessage(tool_calls) in it, which `_advance_to_safe_boundary` treats as
+    entirely orphaned and collapses to `[]`. Measuring the now-empty result
+    would silently pass the budget check and call the model with NO
+    messages at all — worse than a raw crash. It must fail with
+    `ChatTurnTooLargeError` instead.
+    """
+    model = RecordingModel(script=[AIMessage(content="unreachable")])
+    agent = _compile_agent(model, approval_enabled=False)
+
+    huge_result = "x" * (_V2_MAX_HISTORY_CHARS + 20_000)
+    history: list[BaseMessage] = [
+        HumanMessage("search the corpus"),
+        AIMessage(
+            content="",
+            tool_calls=[_tool_call("search_documents", {"query": "corpus"}, "c-rag")],
+        ),
+        ToolMessage(content=huge_result, tool_call_id="c-rag", name="search_documents"),
+    ]
+
+    with pytest.raises(ChatTurnTooLargeError) as exc_info:
+        await _drive(agent, {"messages": history}, "t-tool-result-too-big")
+
+    assert exc_info.value.actual_chars > _V2_MAX_HISTORY_CHARS
+    assert model.calls == []
+
+
 class _RecordingKPIStore(BaseKPIStore):
     """
     Minimal BaseKPIStore that just remembers every emitted event (#2350).

--- a/libs/fred-runtime/tests/test_react_loop_regressions_1972.py
+++ b/libs/fred-runtime/tests/test_react_loop_regressions_1972.py
@@ -756,6 +756,61 @@ async def test_history_is_trimmed_by_char_budget() -> None:
 
 
 @pytest.mark.asyncio
+async def test_history_is_trimmed_by_char_budget_from_tool_call_arguments() -> None:
+    """
+    Regression for the exact field incident, found missing in PR review: a
+    tool-calling AIMessage's own `content` is typically empty — the real
+    payload (e.g. `write_document`'s `content_markdown`) lives in
+    `tool_calls[*]["args"]`. A budget that only looked at `content` would
+    barely register a session shaped exactly like the one that motivated
+    this fix. This drives the full compiled agent, not just the pure trim
+    function, so it also proves the huge argument doesn't survive as
+    "current turn" content forever — a later, small turn still gets through.
+    """
+    # Bigger than the whole budget on its own: if the argument were correctly
+    # counted, the trim MUST engage on the next turn (this is the regression
+    # check — under the pre-fix code, an all-empty-`content` history like
+    # this one measured as ~0 chars and the trim never engaged at all).
+    huge_doc = "x" * (_V2_MAX_HISTORY_CHARS + 20_000)
+    model = RecordingModel(script=[AIMessage(content="ok")])
+    agent = _compile_agent(model, approval_enabled=False)
+
+    history: list[BaseMessage] = [
+        HumanMessage("write the RTM document"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                _tool_call(
+                    "write_document",
+                    {"title": "RTM", "content_markdown": huge_doc},
+                    "c-doc",
+                )
+            ],
+        ),
+        ToolMessage(
+            content="Document 'RTM' saved (id=abc123).",
+            tool_call_id="c-doc",
+            name="write_document",
+        ),
+        HumanMessage("now add the real requirements"),
+    ]
+
+    await _drive(agent, {"messages": history}, "t-tool-call-args")
+
+    assert len(model.calls) == 1
+    model_input = model.calls[0]
+    non_system = [m for m in model_input if not isinstance(m, SystemMessage)]
+    # The huge write_document call is old history by the time this new turn
+    # runs — it must have been trimmed away, not silently carried forward
+    # forever because it never registered as large in the first place.
+    for m in non_system:
+        assert huge_doc not in str(m.content)
+        for tc in getattr(m, "tool_calls", None) or []:
+            assert huge_doc not in str(tc.get("args", {}))
+    assert non_system[-1].content == "now add the real requirements"
+
+
+@pytest.mark.asyncio
 async def test_current_turn_alone_over_char_budget_fails_cleanly() -> None:
     """
     When the CURRENT turn's own content already exceeds the char budget, no

--- a/libs/fred-runtime/tests/test_react_loop_regressions_1972.py
+++ b/libs/fred-runtime/tests/test_react_loop_regressions_1972.py
@@ -44,6 +44,10 @@ from __future__ import annotations
 from typing import Any, cast
 
 import pytest
+from fred_core.kpi.base_kpi_store import BaseKPIStore
+from fred_core.kpi.kpi_reader_structures import KPIQuery, KPIQueryResult
+from fred_core.kpi.kpi_writer import KPIWriter
+from fred_core.kpi.kpi_writer_structures import KPIEvent
 from fred_runtime.react.react_model_adapter import (
     REACT_MODEL_OPERATION_PLANNING,
     REACT_MODEL_OPERATION_ROUTING,
@@ -51,9 +55,11 @@ from fred_runtime.react.react_model_adapter import (
 )
 from fred_runtime.react.react_stream_adapter import extract_interrupt_request
 from fred_runtime.react.react_tool_loop import (
+    _V2_MAX_HISTORY_CHARS,
     _V2_MAX_HISTORY_MESSAGES,
     build_tool_loop_compiled_react_agent,
 )
+from fred_runtime.support.tool_loop import ChatTurnTooLargeError
 from fred_sdk.contracts.context import (
     BoundRuntimeContext,
     PortableContext,
@@ -145,6 +151,7 @@ def _compile_agent(
     approval_enabled: bool = True,
     always_require_tools: tuple[str, ...] = (),
     chat_model_factory: object | None = None,
+    kpi: object | None = None,
 ) -> Any:
     return build_tool_loop_compiled_react_agent(
         model=model,
@@ -161,6 +168,7 @@ def _compile_agent(
         infer_operation_from_messages=infer_react_model_operation_from_messages,
         default_operation=REACT_MODEL_OPERATION_ROUTING,
         available_tool_names={"update_ticket", "get_info"},
+        kpi=cast(Any, kpi),
     )
 
 
@@ -707,6 +715,130 @@ async def test_history_is_trimmed_to_human_boundary() -> None:
         m.content for m in history[len(history) - len(non_system) :]
     ]
     assert non_system[-1].content == f"question {pairs + 1}"
+
+
+# ---------------------------------------------------------------------------
+# History trim by size budget (#2350) — a companion to the message-count trim
+# above: a handful of large messages can blow the char budget while staying
+# far under `_V2_MAX_HISTORY_MESSAGES`, which never engages on message count
+# alone.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_is_trimmed_by_char_budget() -> None:
+    model = RecordingModel(script=[AIMessage(content="trimmed answer")])
+    agent = _compile_agent(model, approval_enabled=False)
+
+    # Few messages (far under `_V2_MAX_HISTORY_MESSAGES`), but each one large
+    # enough that the total blows past `_V2_MAX_HISTORY_CHARS` — the exact
+    # shape of the field incident this guards against (a `write_document`
+    # tool output ballooning input tokens while message count stayed ~60).
+    big = "x" * (_V2_MAX_HISTORY_CHARS // 3 + 1000)
+    history: list[BaseMessage] = [
+        HumanMessage(f"q1 {big}"),
+        AIMessage(content=f"a1 {big}"),
+        HumanMessage(f"q2 {big}"),
+        AIMessage(content=f"a2 {big}"),
+        HumanMessage("current question"),
+    ]
+
+    await _drive(agent, {"messages": history}, "t-char-trim")
+
+    assert len(model.calls) == 1
+    model_input = model.calls[0]
+    non_system = [m for m in model_input if not isinstance(m, SystemMessage)]
+    total_chars = sum(len(str(m.content)) for m in non_system)
+    assert total_chars <= _V2_MAX_HISTORY_CHARS
+    assert isinstance(non_system[0], HumanMessage)
+    # The latest turn is always preserved.
+    assert non_system[-1].content == "current question"
+
+
+@pytest.mark.asyncio
+async def test_current_turn_alone_over_char_budget_fails_cleanly() -> None:
+    """
+    When the CURRENT turn's own content already exceeds the char budget, no
+    amount of trimming older history can help — the turn must fail with a
+    clean, structured error instead of a raw provider context-length crash.
+    """
+    model = RecordingModel(script=[AIMessage(content="unreachable")])
+    agent = _compile_agent(model, approval_enabled=False)
+
+    oversized = "x" * (_V2_MAX_HISTORY_CHARS + 1)
+    history: list[BaseMessage] = [HumanMessage(oversized)]
+
+    with pytest.raises(ChatTurnTooLargeError) as exc_info:
+        await _drive(agent, {"messages": history}, "t-char-too-big")
+
+    assert exc_info.value.limit_chars == _V2_MAX_HISTORY_CHARS
+    assert exc_info.value.actual_chars > _V2_MAX_HISTORY_CHARS
+    # Never echo the oversized content back.
+    assert oversized not in str(exc_info.value)
+    assert model.calls == []
+
+
+class _RecordingKPIStore(BaseKPIStore):
+    """
+    Minimal BaseKPIStore that just remembers every emitted event (#2350).
+
+    Mirrors `test_tool_observability_middleware.py`'s own established
+    pattern for stubbing the KPI writer — duplicated locally rather than
+    imported, matching that file's own stated convention.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[KPIEvent] = []
+
+    def ensure_ready(self) -> None:
+        return
+
+    def index_event(self, event: KPIEvent) -> None:
+        self.events.append(event)
+
+    def bulk_index(self, events: list[KPIEvent]) -> None:
+        self.events.extend(events)
+
+    def query(self, q: KPIQuery) -> KPIQueryResult:
+        return KPIQueryResult(rows=[])
+
+
+def _install_recording_kpi_writer() -> tuple[_RecordingKPIStore, KPIWriter]:
+    store = _RecordingKPIStore()
+    return store, KPIWriter(store=store)
+
+
+@pytest.mark.asyncio
+async def test_current_turn_too_large_emits_a_kpi_counter() -> None:
+    """
+    `agent.turn_rejected_total` is the production signal for whether
+    `_V2_MAX_HISTORY_CHARS` is well-tuned (#2350) — same shape as the
+    sibling `agent.tool_failed_total` counter in `ToolObservabilityMiddleware`
+    (status/error_code/exception_type dims, `KPIActor(type="system")`), so it
+    reaches Grafana through the same allow-listed labels without needing a
+    new one.
+    """
+    store, kpi = _install_recording_kpi_writer()
+    model = RecordingModel(script=[AIMessage(content="unreachable")])
+    agent = _compile_agent(model, approval_enabled=False, kpi=kpi)
+
+    oversized = "x" * (_V2_MAX_HISTORY_CHARS + 1)
+    with pytest.raises(ChatTurnTooLargeError):
+        await _drive(agent, {"messages": [HumanMessage(oversized)]}, "t-kpi")
+
+    matches = [
+        e
+        for e in store.events
+        if e.metric and e.metric.name == "agent.turn_rejected_total"
+    ]
+    assert len(matches) == 1
+    dims = matches[0].dims or {}
+    assert dims.get("status") == "error"
+    assert dims.get("error_code") == "ChatTurnTooLargeError"
+    assert dims.get("exception_type") == "ChatTurnTooLargeError"
+    # Never the oversized content, on a KPI event any more than in the error
+    # message itself.
+    assert oversized not in str(matches[0].model_dump())
 
 
 # ---------------------------------------------------------------------------

--- a/libs/fred-runtime/tests/test_tool_loop_trim.py
+++ b/libs/fred-runtime/tests/test_tool_loop_trim.py
@@ -43,6 +43,24 @@ def _ai_with_calls(*call_ids: str) -> AIMessage:
     )
 
 
+def _ai_proposing_write_document(call_id: str, content_markdown: str) -> AIMessage:
+    """
+    Shapes the motivating field incident exactly: `content` empty (LangChain
+    leaves it that way on a pure tool-calling turn), the real payload in the
+    tool call's own `args` (found missing from the char budget in PR review).
+    """
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "write_document",
+                "args": {"title": "doc", "content_markdown": content_markdown},
+                "id": call_id,
+            }
+        ],
+    )
+
+
 def _tool_result(call_id: str) -> ToolMessage:
     return ToolMessage(content="err", tool_call_id=call_id, name="read_query")
 
@@ -163,6 +181,28 @@ def test_char_budget_advances_to_human_boundary_like_message_trim() -> None:
     # AIMessage(tool_calls) — collapsing to empty is the safe outcome.
     trimmed = trim_to_char_budget(messages, 15)
     assert trimmed == []
+
+
+def test_char_budget_counts_tool_call_arguments_not_just_content() -> None:
+    """
+    Regression for the exact field incident (found in PR review): a
+    tool-calling AIMessage's own `content` is empty, and the large payload
+    lives entirely in `tool_calls[*]["args"]`. If the budget only looked at
+    `content`, a `write_document` call carrying a huge document would be
+    almost invisible to it — precisely defeating the point of this fix.
+    """
+    huge = "x" * 50_000
+    messages = [
+        HumanMessage(content="please write it"),
+        _ai_proposing_write_document("c1", huge),
+    ]
+    assert total_char_len(messages) >= len(huge)
+
+    # And the trim actually engages on it: a budget well under the
+    # argument's own size must still trim, not silently let it through
+    # because `content` alone was short.
+    trimmed = trim_to_char_budget(messages, 100)
+    assert total_char_len(trimmed) < total_char_len(messages)
 
 
 def test_char_budget_never_raises_even_when_unfixable() -> None:

--- a/libs/fred-runtime/tests/test_tool_loop_trim.py
+++ b/libs/fred-runtime/tests/test_tool_loop_trim.py
@@ -28,7 +28,11 @@ All tests are offline — no model or network required.
 
 from __future__ import annotations
 
-from fred_runtime.support.tool_loop import trim_to_human_boundary
+from fred_runtime.support.tool_loop import (
+    total_char_len,
+    trim_to_char_budget,
+    trim_to_human_boundary,
+)
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 
@@ -103,3 +107,70 @@ def test_window_advances_to_first_non_tool_message() -> None:
     assert isinstance(trimmed[0], AIMessage)
     assert trimmed[0].tool_calls[0]["id"] == "y"
     assert not isinstance(trimmed[0], ToolMessage)
+
+
+# ---------------------------------------------------------------------------
+# trim_to_char_budget (#2350) — size-based companion to the message-count trim
+# above: a handful of large messages (a generated document, a big RAG hit)
+# can blow a provider's context window while the message count stays low.
+# ---------------------------------------------------------------------------
+
+
+def test_char_budget_returns_unchanged_when_under_budget() -> None:
+    messages = [HumanMessage(content="hi"), AIMessage(content="hello")]
+    assert trim_to_char_budget(messages, 1000) == messages
+
+
+def test_char_budget_drops_oldest_messages_first() -> None:
+    """Trailing messages are kept as long as they fit; older ones are dropped."""
+    messages = [
+        HumanMessage(content="q1 " + "a" * 20),
+        AIMessage(content="a1 " + "b" * 20),
+        HumanMessage(content="q2 " + "c" * 20),
+        AIMessage(content="a2 " + "d" * 20),
+    ]
+    # Budget fits only the last two messages (~23 chars each).
+    trimmed = trim_to_char_budget(messages, 46)
+    assert trimmed == messages[-2:]
+    assert total_char_len(trimmed) <= 46
+
+
+def test_char_budget_always_keeps_at_least_the_last_message() -> None:
+    """
+    Even when the single last message alone exceeds the budget, it is kept
+    rather than collapsed to an empty list — the caller (middleware) is
+    responsible for detecting the still-over-budget result and failing the
+    turn cleanly, not this pure trim function.
+    """
+    messages = [HumanMessage(content="short"), HumanMessage(content="x" * 100)]
+    trimmed = trim_to_char_budget(messages, 10)
+    assert trimmed == [messages[-1]]
+    assert total_char_len(trimmed) > 10
+
+
+def test_char_budget_advances_to_human_boundary_like_message_trim() -> None:
+    """The same tool-call/tool-result pairing safety applies to the char trim."""
+    messages = [
+        HumanMessage(content="q" * 5),
+        _ai_with_calls("a", "b", "c", "d"),
+        ToolMessage(content="r" * 10, tool_call_id="a", name="read_query"),
+        ToolMessage(content="r" * 10, tool_call_id="b", name="read_query"),
+        ToolMessage(content="r" * 10, tool_call_id="c", name="read_query"),
+        ToolMessage(content="r" * 10, tool_call_id="d", name="read_query"),
+    ]
+    # Budget only fits the trailing orphan ToolMessages (mid tool-round): a
+    # naive tail slice would start on a bare tool result with no preceding
+    # AIMessage(tool_calls) — collapsing to empty is the safe outcome.
+    trimmed = trim_to_char_budget(messages, 15)
+    assert trimmed == []
+
+
+def test_char_budget_never_raises_even_when_unfixable() -> None:
+    """
+    `trim_to_char_budget` never raises: `ChatTurnTooLargeError` is the
+    middleware's responsibility once it sees the trimmed result is still
+    over budget (unit-tested in the middleware layer, not here).
+    """
+    messages = [HumanMessage(content="x" * 1000)]
+    trimmed = trim_to_char_budget(messages, 1)
+    assert trimmed == messages


### PR DESCRIPTION
## Summary

ReAct-only slice of #2343 (TURN-04 "turn resource bounds"), split out to keep this PR single-purpose — Deep, Graph, and checkpoint compaction stay tracked under #2343.

- `libs/fred-runtime`: `CheckpointHygieneMiddleware` now applies a character-count trim (`trim_to_char_budget`, `_V2_MAX_HISTORY_CHARS = 200_000`) in addition to the existing message-count trim, before every ReAct model call. A handful of large tool outputs (a generated document, a big RAG hit) can blow a provider's context window while staying far under the message-count cap — the message trim never engages on payload size alone.
- The default (200,000 characters) is calibrated off a real field incident (2026-08-12, `mistral-small-2603`), not a generic "~4 chars/token" assumption — the measured ratio for this deployment's actual traffic is ~1.35 chars/token. Full derivation is in the `react_tool_loop.py` comment.
- When even the trimmed window is still too large, the turn fails cleanly with `ChatTurnTooLargeError` (numbers only, never the oversized content) instead of forwarding a payload the provider will reject anyway. It propagates through the existing generic `execution_error` path unchanged — no frontend change needed.
- Added `agent.turn_rejected_total`, a Prometheus counter shaped exactly like the sibling `agent.tool_failed_total` (`status`/`error_code`/`exception_type` dims, `KPIActor(type="system")`), so the rejection rate — and whether the 200k default needs retuning — is Grafana-visible instead of log-only. Reuses `PROMETHEUS_ALLOWED_LABELS`, no new label needed. `identity_kpi_dims(binding)` was factored out of `ToolObservabilityMiddleware._base_dims`'s identical logic into `react/middleware/shared.py` rather than duplicated.
- Verified empirically (not just by code reading): a session that hits `ChatTurnTooLargeError` recovers on the next turn — the oversized content is dropped from what the model sees, not a permanently stuck session.

## Test plan

- [x] `make test` — 906 passed, 2 deselected (postgres-only tests, unrelated)
- [x] `make code-quality` — ruff, bandit, basedpyright all clean
- [x] `fred-performance-reviewer` skill run — no blocking findings; confirmed no new I/O, no CPU-bound cost worth offloading (`len()` on a Python string is O(1), so the trim is O(≤500 messages), not O(content size))
- [x] New regression tests: pure-function trim behavior (`test_tool_loop_trim.py`), full-loop trim/rejection through `agent.astream` (`test_react_loop_regressions_1972.py`), and KPI counter emission via a real `KPIWriter` + recording store

## Docs

- `docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md` §8.52 (dated entry, full account)
- `docs/swift/reviews/performance/2026-07-26-agent-turn-core/TURN-04-turn-resource-bounds.md` — resolution evidence updated (partially resolved; Deep/Graph/compaction still open under #2343)

Closes #2350.