### PR TITLE
feat(#2354): user authored model_display_name in models_catalog.yaml with model id splitting label as fallback

### DIFF
--- a/apps/control-plane-backend/alembic/versions/a7d2e9c41f38_model_reasoning_display_name.py
+++ b/apps/control-plane-backend/alembic/versions/a7d2e9c41f38_model_reasoning_display_name.py
@@ -1,0 +1,63 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""model_reasoning: snapshot the model's ops-authored display name
+
+Ops now name each model in `models_catalog.yaml` (`model_display_name`)
+instead of leaving the composer chip to derive a label by splitting the
+capability id apart. The send path performs no catalog fetch, so the value is
+snapshotted here when an admin (re-)toggles the model's reasoning — same
+lifecycle and rationale as `default_effort` (c9e1f74b2a63). NULL = unnamed,
+and the frontend falls back to the heuristic. Display only.
+
+Revision ID: a7d2e9c41f38
+Revises: c9e1f74b2a63
+Create Date: 2026-08-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7d2e9c41f38"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = (
+    "c9e1f74b2a63"  # pragma: allowlist secret
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "model_reasoning",
+        sa.Column(
+            "display_name",
+            sa.String(),
+            nullable=True,
+            comment=(
+                "The model's ops-authored model_display_name, snapshotted from "
+                "the catalog entry when reasoning was (re-)toggled. NULL = no "
+                "display name authored in models_catalog.yaml."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("model_reasoning", "display_name")

--- a/apps/control-plane-backend/control_plane_backend/capabilities/catalog.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/catalog.py
@@ -169,6 +169,14 @@ async def aggregate_capability_catalog(
                             existing.model_thinking_profile_ids,
                             entry.model_thinking_profile_ids,
                         ),
+                        # The union rule above applied to a scalar: a label
+                        # authored on one pod survives another that serves the
+                        # same model unnamed, so a partly rolled-out catalog
+                        # edit does not flicker the composer label back to the
+                        # heuristic. Both naming it: last wins, as elsewhere.
+                        "model_display_name": (
+                            entry.model_display_name or existing.model_display_name
+                        ),
                     }
                 )
             catalog[entry.id] = entry

--- a/apps/control-plane-backend/control_plane_backend/capabilities/reasoning_store.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/reasoning_store.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+from typing import NamedTuple
 
 from fred_core.sql import make_session_factory, use_session
 from sqlalchemy import select
@@ -23,6 +24,21 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from control_plane_backend.models.model_reasoning_models import ModelReasoningRow
 
 logger = logging.getLogger(__name__)
+
+
+class ModelReasoningDisplay(NamedTuple):
+    """One enabled model's toggle-time display snapshot.
+
+    Both fields are display only and both are `None`-able: `effort` is the
+    level a reasoning turn runs with (the pod always applies the live
+    `settings.reasoning_effort`, never this copy), `display_name` is the
+    composer chip's model label. One tuple rather than two parallel dicts so
+    the send path stays one query and a model cannot be paired with another
+    model's label.
+    """
+
+    effort: str | None
+    display_name: str | None
 
 
 class ModelReasoningStore:
@@ -50,12 +66,15 @@ class ModelReasoningStore:
         reasoning_enabled: bool,
         updated_by: str | None,
         default_effort: str | None = None,
+        display_name: str | None = None,
         session: AsyncSession | None = None,
     ) -> bool:
-        # `default_effort` is a display SNAPSHOT of the model's ops-authored
-        # `settings.reasoning_effort`, taken by the service at toggle time so
-        # the send path never fetches the catalog; the pod always applies the
-        # live settings value. NULL = no effort key on the thinking profile.
+        # `default_effort` and `display_name` are display SNAPSHOTs of the
+        # model's ops-authored `settings.reasoning_effort` and
+        # `model_display_name`, taken by the service at toggle time so the
+        # send path never fetches the catalog; the pod always applies the live
+        # settings value. NULL = no effort key on the thinking profile / no
+        # display name authored in `models_catalog.yaml`.
         async with use_session(self._sessions, session) as s:
             existing = (
                 await s.execute(
@@ -70,12 +89,14 @@ class ModelReasoningStore:
                         model_capability_id=model_capability_id,
                         reasoning_enabled=reasoning_enabled,
                         default_effort=default_effort,
+                        display_name=display_name,
                         updated_by=updated_by,
                     )
                 )
             else:
                 existing.reasoning_enabled = reasoning_enabled
                 existing.default_effort = default_effort
+                existing.display_name = display_name
                 existing.updated_by = updated_by
         return reasoning_enabled
 
@@ -102,15 +123,17 @@ class ModelReasoningStore:
             ).scalars()
             return set(rows)
 
-    async def list_enabled_default_efforts(
+    async def list_enabled_display_snapshots(
         self, *, session: AsyncSession | None = None
-    ) -> dict[str, str | None]:
-        """Enabled model ids → their snapshotted ops-authored effort.
+    ) -> dict[str, ModelReasoningDisplay]:
+        """Enabled model ids → their toggle-time display snapshot.
 
-        Same single indexed read as `list_enabled_model_ids`, one extra
-        column — feeds the composer control's `params.effort` at session
-        prep. `None` per model = the thinking profile ships no effort key
-        (the menu falls back to a generic On label)."""
+        Same single indexed read as `list_enabled_model_ids`, two extra
+        columns — feeds the composer control's `params.effort` and
+        `params.display_name` at session prep. Either field being `None` is
+        normal, not an error: no effort key on the thinking profile (the menu
+        falls back to a generic On label), no `model_display_name` authored
+        (the frontend derives a label from the capability id)."""
 
         async with use_session(self._sessions, session) as s:
             rows = (
@@ -118,7 +141,11 @@ class ModelReasoningStore:
                     select(
                         ModelReasoningRow.model_capability_id,
                         ModelReasoningRow.default_effort,
+                        ModelReasoningRow.display_name,
                     ).where(ModelReasoningRow.reasoning_enabled.is_(True))
                 )
             ).all()
-        return {model_id: effort for model_id, effort in rows}
+        return {
+            model_id: ModelReasoningDisplay(effort=effort, display_name=display_name)
+            for model_id, effort, display_name in rows
+        }

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -614,10 +614,12 @@ async def set_model_reasoning(
         model_capability_id=capability_id,
         reasoning_enabled=reasoning_enabled,
         updated_by=user.uid,
-        # Display snapshot of the ops-authored settings.reasoning_effort,
-        # taken HERE (the one write path already holding the catalog entry)
-        # so session prep never fetches the catalog. Refreshed per toggle.
+        # Display snapshots of the ops-authored settings.reasoning_effort and
+        # model_display_name, taken HERE (the one write path already holding
+        # the catalog entry) so session prep never fetches the catalog. Both
+        # refreshed per toggle.
         default_effort=entry.model_reasoning_effort,
+        display_name=entry.model_display_name,
     )
     logger.info(
         "[capability-reasoning] model=%s reasoning_enabled=%s by=%s",

--- a/apps/control-plane-backend/control_plane_backend/models/model_reasoning_models.py
+++ b/apps/control-plane-backend/control_plane_backend/models/model_reasoning_models.py
@@ -59,6 +59,19 @@ class ModelReasoningRow(Base):
             "(re-)toggled. NULL = no effort key on the thinking profile."
         ),
     )
+    # Second display snapshot on the same lifecycle as `default_effort`: the
+    # model's ops-authored `model_display_name`, so the composer can label the
+    # chip without the send path fetching the catalog. Same
+    # byte-identical-comment rule as above — migration a7d2e9c41f38.
+    display_name: Mapped[str | None] = mapped_column(
+        String,
+        nullable=True,
+        comment=(
+            "The model's ops-authored model_display_name, snapshotted from "
+            "the catalog entry when reasoning was (re-)toggled. NULL = no "
+            "display name authored in models_catalog.yaml."
+        ),
+    )
     reasoning_enabled: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -52,6 +52,7 @@ from control_plane_backend.capabilities.authz import (
     filter_entries_by_usable,
     usable_capability_ids,
 )
+from control_plane_backend.capabilities.reasoning_store import ModelReasoningDisplay
 from control_plane_backend.config.models import (
     ManagedAgentFieldSpec,
     ManagedAgentTuning,
@@ -817,6 +818,10 @@ async def _model_capabilities_for_source_uncached(
             # `settings.reasoning_effort` — the single source of truth for the
             # level a reasoning turn runs with (review 2026-08-12).
             model_reasoning_effort=entry.get("reasoning_effort"),
+            # Ops-authored display label, carried verbatim. Absent on an older
+            # pod, which reads as unnamed and leaves the frontend on its
+            # id-splitting heuristic — the previous behaviour exactly.
+            model_display_name=entry.get("display_name"),
         )
         for entry in payload.get("models", [])
         if isinstance(entry, dict) and "id" in entry and "name" in entry
@@ -967,7 +972,7 @@ def _platform_reasoning_control(
     reasoning_enabled: bool,
     reasoning_default_on: bool,
     reasoning_enabled_model_ids: Sequence[str],
-    default_efforts_by_model: Mapping[str, str | None] | None = None,
+    display_by_model: Mapping[str, ModelReasoningDisplay] | None = None,
 ) -> ChatControlDescriptor | None:
     """The composer's reasoning toggle, or `None` when a gate upstream is closed
     (`MODEL-REASONING-ENABLEMENT-RFC.md` §7/§8).
@@ -1020,23 +1025,29 @@ def _platform_reasoning_control(
     # the enabled models agree on one distinct value; omitted otherwise, and
     # the composer menu falls back to a generic On label. `params` is
     # schema-free on the wire, so this needs no contract regeneration.
+    snapshots = display_by_model or {}
     distinct_efforts = {
-        value
-        for value in (default_efforts_by_model or {}).values()
-        if value is not None
+        snapshot.effort
+        for snapshot in snapshots.values()
+        if snapshot.effort is not None
     }
     effort = distinct_efforts.pop() if len(distinct_efforts) == 1 else None
     # The model identity the composer button displays next to the reasoning
     # state ("Mistral Small · Élevé") — the enabled reasoning model's own
     # capability id, emitted when it is unambiguous (exactly one enabled).
     # Multi-model is coming (the button becomes a model picker, with a
-    # per-model reasoning mode); until then the frontend derives a display
-    # label from this id and shows it read-only.
+    # per-model reasoning mode); until then the frontend shows it read-only.
     model_id = (
         reasoning_enabled_model_ids[0]
         if len(reasoning_enabled_model_ids) == 1
         else None
     )
+    # That model's ops-authored label. Emitted only alongside an unambiguous
+    # `model_id` — a name without the id it belongs to would let the button
+    # claim an identity the rest of the payload doesn't back. Omitted when
+    # unnamed, and the frontend falls back to splitting the id apart.
+    snapshot = snapshots.get(model_id) if model_id else None
+    display_name = snapshot.display_name if snapshot else None
     return ChatControlDescriptor(
         capability_id=PLATFORM_CHAT_CONTROL_OWNER,
         widget=_REASONING_TOGGLE_WIDGET,
@@ -1050,6 +1061,7 @@ def _platform_reasoning_control(
             "default": reasoning_default_on,
             **({"effort": effort} if effort else {}),
             **({"model_id": model_id} if model_id else {}),
+            **({"display_name": display_name} if display_name else {}),
         },
     )
 
@@ -3228,15 +3240,15 @@ async def prepare_execution(
     # gathered rather than chained — this is a user-facing send path.
     (
         (chat_default_profile_id, operation_route_rules),
-        reasoning_efforts_by_model,
+        reasoning_display_by_model,
     ) = await asyncio.gather(
         resolve_execution_routing_snapshot(team_id, deps),
-        # Same single indexed read as the former list_enabled_model_ids, one
-        # extra column: the toggle-time snapshot of each model's ops-authored
-        # effort — still no catalog fetch on this send path.
-        deps.get_model_reasoning_store().list_enabled_default_efforts(),
+        # Same single indexed read as the former list_enabled_model_ids, two
+        # extra columns: the toggle-time snapshot of each model's ops-authored
+        # effort and display name — still no catalog fetch on this send path.
+        deps.get_model_reasoning_store().list_enabled_display_snapshots(),
     )
-    sorted_reasoning_model_ids = sorted(reasoning_efforts_by_model)
+    sorted_reasoning_model_ids = sorted(reasoning_display_by_model)
     # The reasoning toggle (REASON-01 §7) is contributed by the PLATFORM, not by
     # a capability — appended last so it sits after the capability-owned rows in
     # the composer menu, and omitted entirely when a gate upstream is closed (§8).
@@ -3244,7 +3256,7 @@ async def prepare_execution(
         reasoning_enabled=instance.tuning.reasoning_enabled,
         reasoning_default_on=instance.tuning.reasoning_default_on,
         reasoning_enabled_model_ids=sorted_reasoning_model_ids,
-        default_efforts_by_model=reasoning_efforts_by_model,
+        display_by_model=reasoning_display_by_model,
     )
     if reasoning_control is not None:
         chat_controls = [*chat_controls, reasoning_control]

--- a/apps/control-plane-backend/tests/test_model_capability_projection.py
+++ b/apps/control-plane-backend/tests/test_model_capability_projection.py
@@ -121,6 +121,50 @@ async def test_carries_thinking_profile_ids_through_the_projection(
 
 
 @pytest.mark.asyncio
+async def test_carries_the_ops_authored_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The label ops authored reaches control-plane verbatim.
+
+    Verbatim matters more here than for the derived fields: the string is
+    shown to users as-is, so normalizing it would be a second opinion about a
+    name ops already settled. A pod that sends none reads as None, leaving
+    the frontend on its id-splitting heuristic — the previous behaviour.
+    """
+
+    payload = {
+        "models": [
+            {
+                "id": "model__anthropic__claude-sonnet-4-6",
+                "provider": "anthropic",
+                "name": "claude-sonnet-4-6",
+                "display_name": "Claude Sonnet 4.6",
+            },
+            {
+                "id": "model__openai__gpt-4o",
+                "provider": "openai",
+                "name": "gpt-4o",
+            },
+        ]
+    }
+
+    async def _fake_get(self, url, *args, **kwargs):  # noqa: ANN001
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, json=payload, request=request)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+
+    entries = await _model_capabilities_for_source("http://pod")
+
+    assert entries is not None
+    assert entries[0].model_display_name == "Claude Sonnet 4.6"
+    assert entries[1].model_display_name is None
+    # The technical name is untouched — routing, the capability id and the
+    # admin table all still key on it.
+    assert entries[0].name == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
 async def test_ignores_malformed_entries_without_crashing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/control-plane-backend/tests/test_model_reasoning_toggle.py
+++ b/apps/control-plane-backend/tests/test_model_reasoning_toggle.py
@@ -34,7 +34,10 @@ from control_plane_backend.capabilities.enablement import (
     CapabilityNotFound,
     ReasoningNotSupported,
 )
-from control_plane_backend.capabilities.reasoning_store import ModelReasoningStore
+from control_plane_backend.capabilities.reasoning_store import (
+    ModelReasoningDisplay,
+    ModelReasoningStore,
+)
 from fred_core import KeycloakUser
 from fred_core.common import PostgresStoreConfig
 from fred_core.sql import create_async_engine_from_config
@@ -114,11 +117,10 @@ async def test_a_stored_false_is_indistinguishable_from_no_row(tmp_path) -> None
 
 
 @pytest.mark.asyncio
-async def test_default_effort_snapshot_round_trips(tmp_path) -> None:
-    # The composer menu's level label comes from this toggle-time snapshot of
-    # the model's own settings.reasoning_effort (single source of truth — no
-    # separate supported-efforts declaration); NULL must read back as "no
-    # effort key", never as a level.
+async def test_display_snapshot_round_trips(tmp_path) -> None:
+    # Both composer-chip labels come from this toggle-time snapshot: the level
+    # from settings.reasoning_effort, the model name from model_display_name.
+    # NULL on either must read back as "not authored", never as a value.
     store = await _make_store(tmp_path)
 
     await store.set_enabled(
@@ -126,16 +128,49 @@ async def test_default_effort_snapshot_round_trips(tmp_path) -> None:
         reasoning_enabled=True,
         updated_by="admin-1",
         default_effort="high",
+        display_name="Mistral Small",
     )
-    assert await store.list_enabled_default_efforts() == {THINKING_MODEL: "high"}
+    assert await store.list_enabled_display_snapshots() == {
+        THINKING_MODEL: ModelReasoningDisplay(
+            effort="high", display_name="Mistral Small"
+        )
+    }
 
     await store.set_enabled(
         model_capability_id=THINKING_MODEL,
         reasoning_enabled=True,
         updated_by="admin-1",
         default_effort=None,
+        display_name=None,
     )
-    assert await store.list_enabled_default_efforts() == {THINKING_MODEL: None}
+    assert await store.list_enabled_display_snapshots() == {
+        THINKING_MODEL: ModelReasoningDisplay(effort=None, display_name=None)
+    }
+
+
+@pytest.mark.asyncio
+async def test_re_toggling_refreshes_a_renamed_model(tmp_path) -> None:
+    # The snapshot has a deliberate staleness window: editing
+    # models_catalog.yaml does not reach open sessions, the next re-toggle
+    # does. Pinned because a snapshot that never refreshed would keep the old
+    # name forever.
+    store = await _make_store(tmp_path)
+
+    await store.set_enabled(
+        model_capability_id=THINKING_MODEL,
+        reasoning_enabled=True,
+        updated_by="admin-1",
+        display_name="Mistral Small",
+    )
+    await store.set_enabled(
+        model_capability_id=THINKING_MODEL,
+        reasoning_enabled=True,
+        updated_by="admin-1",
+        display_name="Mistral Small 4",
+    )
+
+    snapshots = await store.list_enabled_display_snapshots()
+    assert snapshots[THINKING_MODEL].display_name == "Mistral Small 4"
 
 
 # ---------------------------------------------------------------------------
@@ -143,8 +178,18 @@ async def test_default_effort_snapshot_round_trips(tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _snapshot(
+    effort: str | None, display_name: str | None = None
+) -> ModelReasoningDisplay:
+    return ModelReasoningDisplay(effort=effort, display_name=display_name)
+
+
 def _model_entry(
-    capability_id: str, *, thinking_profile_ids: tuple[str, ...] = ()
+    capability_id: str,
+    *,
+    thinking_profile_ids: tuple[str, ...] = (),
+    reasoning_effort: str | None = None,
+    display_name: str | None = None,
 ) -> CapabilityCatalogEntry:
     return CapabilityCatalogEntry(
         id=capability_id,
@@ -155,14 +200,17 @@ def _model_entry(
         kind="model",
         model_profile_ids=("chat.some.profile",),
         model_thinking_profile_ids=thinking_profile_ids,
+        model_reasoning_effort=reasoning_effort,
+        model_display_name=display_name,
     )
 
 
 class _RecordingStore:
     def __init__(self, enabled: set[str] | None = None) -> None:
         self.writes: list[tuple[str, bool]] = []
-        # (model_id, effort) captured by set_enabled — the display snapshot.
-        self.effort_snapshots: list[tuple[str, str | None]] = []
+        # (model_id, effort, display_name) captured by set_enabled — the
+        # display snapshot the composer chip is labelled from.
+        self.display_snapshots: list[tuple[str, str | None, str | None]] = []
         self._enabled = enabled or set()
 
     async def set_enabled(
@@ -172,16 +220,22 @@ class _RecordingStore:
         reasoning_enabled: bool,
         updated_by: str | None,
         default_effort: str | None = None,
+        display_name: str | None = None,
     ) -> bool:
         self.writes.append((model_capability_id, reasoning_enabled))
-        self.effort_snapshots.append((model_capability_id, default_effort))
+        self.display_snapshots.append(
+            (model_capability_id, default_effort, display_name)
+        )
         return reasoning_enabled
 
     async def list_enabled_model_ids(self) -> set[str]:
         return set(self._enabled)
 
-    async def list_enabled_default_efforts(self) -> dict[str, str | None]:
-        return {model_id: None for model_id in self._enabled}
+    async def list_enabled_display_snapshots(self) -> dict[str, ModelReasoningDisplay]:
+        return {
+            model_id: ModelReasoningDisplay(effort=None, display_name=None)
+            for model_id in self._enabled
+        }
 
 
 class _FakeDeps:
@@ -211,7 +265,10 @@ def _stub_gate_and_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
 
     catalog = {
         THINKING_MODEL: _model_entry(
-            THINKING_MODEL, thinking_profile_ids=("chat.mistral.small",)
+            THINKING_MODEL,
+            thinking_profile_ids=("chat.mistral.small",),
+            reasoning_effort="high",
+            display_name="Mistral Small",
         ),
         PLAIN_MODEL: _model_entry(PLAIN_MODEL),
         "doc_access": CapabilityCatalogEntry(
@@ -245,6 +302,9 @@ async def test_enabling_reasoning_on_a_thinking_model_stores_the_row() -> None:
 
     assert result.reasoning_enabled is True
     assert store.writes == [(THINKING_MODEL, True)]
+    # The one write path already holds the catalog entry, so it is where both
+    # snapshots are taken; missing them leaves the chip unlabelled silently.
+    assert store.display_snapshots == [(THINKING_MODEL, "high", "Mistral Small")]
 
 
 @pytest.mark.asyncio
@@ -475,7 +535,7 @@ def test_params_effort_carries_the_models_own_level() -> None:
         reasoning_enabled=True,
         reasoning_default_on=False,
         reasoning_enabled_model_ids=[THINKING_MODEL],
-        default_efforts_by_model={THINKING_MODEL: "high"},
+        display_by_model={THINKING_MODEL: _snapshot("high")},
     )
 
     assert control is not None
@@ -496,7 +556,7 @@ def test_params_model_id_carries_the_single_enabled_model() -> None:
         reasoning_enabled=True,
         reasoning_default_on=False,
         reasoning_enabled_model_ids=[THINKING_MODEL],
-        default_efforts_by_model={THINKING_MODEL: "high"},
+        display_by_model={THINKING_MODEL: _snapshot("high")},
     )
     assert single is not None
     assert single.params == {
@@ -509,10 +569,54 @@ def test_params_model_id_carries_the_single_enabled_model() -> None:
         reasoning_enabled=True,
         reasoning_default_on=False,
         reasoning_enabled_model_ids=[THINKING_MODEL, PLAIN_MODEL],
-        default_efforts_by_model={THINKING_MODEL: "high", PLAIN_MODEL: "high"},
+        display_by_model={
+            THINKING_MODEL: _snapshot("high"),
+            PLAIN_MODEL: _snapshot("high"),
+        },
     )
     assert two is not None
     assert "model_id" not in (two.params or {})
+
+
+def test_params_display_name_rides_with_the_model_id() -> None:
+    # The label belongs to the model it names, so it ships only alongside an
+    # unambiguous model_id, and only when ops actually named the model.
+    from control_plane_backend.product.service import _platform_reasoning_control
+
+    named = _platform_reasoning_control(
+        reasoning_enabled=True,
+        reasoning_default_on=False,
+        reasoning_enabled_model_ids=[THINKING_MODEL],
+        display_by_model={THINKING_MODEL: _snapshot("high", "Mistral Small 4")},
+    )
+    assert named is not None
+    assert named.params == {
+        "default": False,
+        "effort": "high",
+        "model_id": THINKING_MODEL,
+        "display_name": "Mistral Small 4",
+    }
+
+    unnamed = _platform_reasoning_control(
+        reasoning_enabled=True,
+        reasoning_default_on=False,
+        reasoning_enabled_model_ids=[THINKING_MODEL],
+        display_by_model={THINKING_MODEL: _snapshot("high")},
+    )
+    assert unnamed is not None
+    assert "display_name" not in (unnamed.params or {})
+
+    ambiguous = _platform_reasoning_control(
+        reasoning_enabled=True,
+        reasoning_default_on=False,
+        reasoning_enabled_model_ids=[THINKING_MODEL, PLAIN_MODEL],
+        display_by_model={
+            THINKING_MODEL: _snapshot("high", "Mistral Small 4"),
+            PLAIN_MODEL: _snapshot("high", "GPT-4o"),
+        },
+    )
+    assert ambiguous is not None
+    assert "display_name" not in (ambiguous.params or {})
 
 
 def test_params_effort_omitted_when_unknown_or_ambiguous() -> None:
@@ -524,7 +628,7 @@ def test_params_effort_omitted_when_unknown_or_ambiguous() -> None:
         reasoning_enabled=True,
         reasoning_default_on=False,
         reasoning_enabled_model_ids=[THINKING_MODEL],
-        default_efforts_by_model={THINKING_MODEL: None},
+        display_by_model={THINKING_MODEL: _snapshot(None)},
     )
     assert unknown is not None and unknown.params == {
         "default": False,
@@ -535,7 +639,10 @@ def test_params_effort_omitted_when_unknown_or_ambiguous() -> None:
         reasoning_enabled=True,
         reasoning_default_on=False,
         reasoning_enabled_model_ids=[THINKING_MODEL, PLAIN_MODEL],
-        default_efforts_by_model={THINKING_MODEL: "high", PLAIN_MODEL: "medium"},
+        display_by_model={
+            THINKING_MODEL: _snapshot("high"),
+            PLAIN_MODEL: _snapshot("medium"),
+        },
     )
     assert ambiguous is not None and ambiguous.params == {"default": False}
 

--- a/apps/fred-agents/config/models_catalog.yaml
+++ b/apps/fred-agents/config/models_catalog.yaml
@@ -19,6 +19,7 @@ default_profile_by_capability:
 profiles:
   - profile_id: chat.mistral.medium
     capability: chat
+    model_display_name: "Mistral Medium 3.5"
     # Non-reasoning model: structured output (JSON) and tool loops are reliable.
     # A reasoning model (mistral-small-2603 + reasoning_effort) emits its content
     # as `thinking` blocks → structured/JSON parsing fails ("expected value at
@@ -31,6 +32,7 @@ profiles:
         max_retries: 2
   - profile_id: language.mistral.medium
     capability: language
+    model_display_name: "Mistral Medium 3.5"
     model:
       provider: openai
       name: mistral-medium-latest
@@ -39,6 +41,7 @@ profiles:
         max_retries: 2
   - profile_id: chat.mistral.small
     capability: chat
+    model_display_name: "Mistral Small 4"
     description: "Faster and lower-cost Mistral Small profile for everyday chat tasks."
     # Declared aptitude, NOT activation (REASON-01 §4): this profile ships
     # `reasoning_effort`, so it must say so — a reasoning setting without this
@@ -78,6 +81,7 @@ profiles:
 
   - profile_id: language.mistral.small
     capability: language
+    model_display_name: "Mistral Small 4"
     description: "Faster and lower-cost Mistral Small profile for lightweight language tasks."
     model:
       provider: openai
@@ -88,6 +92,7 @@ profiles:
 
   - profile_id: default.chat.openai.prod
     capability: chat
+    model_display_name: "GPT-5.1"
     description: "Default balanced chat model for production conversations."
     model:
       provider: openai
@@ -96,6 +101,7 @@ profiles:
 
   - profile_id: default.language.openai.prod
     capability: language
+    model_display_name: "GPT-5.1"
     description: "Default balanced language model for structured text tasks."
     model:
       provider: openai
@@ -104,6 +110,7 @@ profiles:
 
   - profile_id: default.chat.local
     capability: chat
+    model_display_name: "GPT-5.1"
     description: "Local default chat profile with retries and shorter timeout."
     model:
       provider: openai
@@ -115,6 +122,7 @@ profiles:
 
   - profile_id: default.language.local
     capability: language
+    model_display_name: "GPT-5.1"
     description: "Local default language profile with retries and shorter timeout."
     model:
       provider: openai
@@ -126,6 +134,7 @@ profiles:
 
   - profile_id: chat.openai.gpt52
     capability: chat
+    model_display_name: "GPT-5.2"
     description: "Highest-quality GPT-5.2 profile for complex reasoning and synthesis."
     model:
       provider: openai
@@ -134,6 +143,7 @@ profiles:
 
   - profile_id: language.openai.gpt52
     capability: language
+    model_display_name: "GPT-5.2"
     description: "Highest-quality GPT-5.2 profile for demanding language workloads."
     model:
       provider: openai
@@ -142,6 +152,7 @@ profiles:
 
   - profile_id: chat.openai.gpt5
     capability: chat
+    model_display_name: "GPT-5"
     description: "Strong general-purpose GPT-5 profile, balanced quality and latency."
     model:
       provider: openai
@@ -150,6 +161,7 @@ profiles:
 
   - profile_id: language.openai.gpt5
     capability: language
+    model_display_name: "GPT-5"
     description: "General-purpose GPT-5 language profile with strong overall quality."
     model:
       provider: openai
@@ -158,6 +170,7 @@ profiles:
 
   - profile_id: chat.openai.gpt5mini
     capability: chat
+    model_display_name: "GPT-5 mini"
     description: "Faster and lower-cost GPT-5 Mini profile for everyday chat tasks."
     model:
       provider: openai
@@ -166,6 +179,7 @@ profiles:
 
   - profile_id: language.openai.gpt5mini
     capability: language
+    model_display_name: "GPT-5 mini"
     description: "Faster and lower-cost GPT-5 Mini profile for lightweight language tasks."
     model:
       provider: openai
@@ -174,6 +188,7 @@ profiles:
 
   - profile_id: chat.openai.gpt5nano
     capability: chat
+    model_display_name: "GPT-5 nano"
     description: "Ultra-fast, budget-oriented GPT-5 Nano profile for simple prompts."
     model:
       provider: openai
@@ -182,6 +197,7 @@ profiles:
 
   - profile_id: language.openai.gpt5nano
     capability: language
+    model_display_name: "GPT-5 nano"
     description: "Ultra-fast, budget-oriented GPT-5 Nano profile for simple language tasks."
     model:
       provider: openai
@@ -190,6 +206,7 @@ profiles:
 
   - profile_id: chat.openai.gpt41
     capability: chat
+    model_display_name: "GPT-4.1"
     description: "Reliable GPT-4.1 profile for broad compatibility and stable outputs."
     model:
       provider: openai
@@ -198,6 +215,7 @@ profiles:
 
   - profile_id: language.openai.gpt41
     capability: language
+    model_display_name: "GPT-4.1"
     description: "Reliable GPT-4.1 language profile for stable text generation."
     model:
       provider: openai
@@ -206,6 +224,7 @@ profiles:
 
   - profile_id: chat.openai.gpt41mini
     capability: chat
+    model_display_name: "GPT-4.1 mini"
     description: "Cost-efficient GPT-4.1 Mini profile for quick conversational responses."
     model:
       provider: openai
@@ -214,6 +233,7 @@ profiles:
 
   - profile_id: language.openai.gpt41mini
     capability: language
+    model_display_name: "GPT-4.1 mini"
     description: "Cost-efficient GPT-4.1 Mini profile for lightweight language work."
     model:
       provider: openai
@@ -222,6 +242,7 @@ profiles:
 
   - profile_id: chat.azure_apim.gpt4o
     capability: chat
+    model_display_name: "GPT-4o (Azure)"
     description: "GPT-4o served via Azure APIM endpoint for enterprise integration."
     model:
       provider: azure-apim
@@ -236,6 +257,7 @@ profiles:
 
   - profile_id: chat.ollama.mistral
     capability: chat
+    model_display_name: "Mistral (Ollama)"
     description: "Local Ollama Mistral profile for private/offline chat experimentation."
     model:
       provider: ollama
@@ -245,6 +267,7 @@ profiles:
 
   - profile_id: language.ollama.mistral
     capability: language
+    model_display_name: "Mistral (Ollama)"
     description: "Local Ollama Mistral profile for private/offline language tasks."
     model:
       provider: ollama
@@ -253,6 +276,7 @@ profiles:
         base_url: "http://host.docker.internal:11434"
   - profile_id: default.chat.mock
     capability: chat
+    model_display_name: "Mock OpenAI Chat"
     model:
       provider: openai
       name: mock-openai-chat
@@ -262,6 +286,7 @@ profiles:
 
   - profile_id: default.language.mock
     capability: language
+    model_display_name: "Mock OpenAI Chat"
     model:
       provider: openai
       name: mock-openai-chat
@@ -271,6 +296,7 @@ profiles:
 
   - profile_id: mock.chat.gpt4o
     capability: chat
+    model_display_name: "GPT-4o (mock)"
     model:
       provider: openai
       name: gpt-4o
@@ -280,6 +306,7 @@ profiles:
 
   - profile_id: mock.chat.latest
     capability: chat
+    model_display_name: "ChatGPT-4o (mock)"
     model:
       provider: openai
       name: chatgpt-4o-latest
@@ -289,6 +316,7 @@ profiles:
 
   - profile_id: chat.anthropic.claude-sonnet
     capability: chat
+    model_display_name: "Claude Sonnet 4.6"
     description: "Claude Sonnet 4.6 via Synapse Gateway (Anthropic-native). Set ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY in .env."
     model:
       provider: anthropic
@@ -296,6 +324,7 @@ profiles:
 
   - profile_id: chat.anthropic.claude-haiku
     capability: chat
+    model_display_name: "Claude Haiku 3.5"
     description: "Claude Haiku via Synapse Gateway, fast and cost-efficient. Set ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY in .env."
     model:
       provider: anthropic
@@ -303,6 +332,7 @@ profiles:
 
   - profile_id: language.anthropic.claude-sonnet
     capability: language
+    model_display_name: "Claude Sonnet 4.6"
     description: "Claude Sonnet 4.6 via Synapse Gateway for structured language tasks. Set ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY in .env."
     model:
       provider: anthropic

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.test.tsx
@@ -20,7 +20,13 @@
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { COMPOSER_CHIP_WIDGETS, ReasoningChip, effortLabelKey, modelLabelFromCapabilityId } from "./ReasoningChip";
+import {
+  COMPOSER_CHIP_WIDGETS,
+  ReasoningChip,
+  effortLabelKey,
+  modelLabel,
+  modelLabelFromCapabilityId,
+} from "./ReasoningChip";
 import type { ChatControlDescriptor } from "../../../slices/controlPlane/controlPlaneOpenApi";
 import type { ChatTurnControlComposerState } from "./types";
 
@@ -103,6 +109,23 @@ describe("ReasoningChip (REASON-01 level 4, mockup text button)", () => {
     expect(html).not.toContain("Mistral");
   });
 
+  it("shows the ops-authored display name instead of the derived guess", () => {
+    const html = render(
+      [
+        reasoningControl({
+          default: false,
+          effort: "high",
+          model_id: "model__anthropic__claude-sonnet-4-6",
+          display_name: "Claude Sonnet 4.6",
+        }),
+      ],
+      true,
+    );
+    expect(html).toContain("Claude Sonnet 4.6");
+    // What the heuristic gets wrong: it reads "4-6" as two words.
+    expect(html).not.toContain("Claude Sonnet 4 6");
+  });
+
   it("owns the reasoning_toggle promotion out of the tune popover", () => {
     // ComposerControlSlot and ManagedChatPage filter on this set; the button
     // and the filters must agree or the setting shows up twice (or nowhere).
@@ -123,7 +146,7 @@ describe("effortLabelKey", () => {
   });
 });
 
-describe("modelLabelFromCapabilityId (temporary heuristic until multi-model)", () => {
+describe("modelLabelFromCapabilityId (the fallback when ops named nothing)", () => {
   it("handles the major providers' real model names", () => {
     // OpenAI — version dots survive, GPT/ChatGPT cased, "latest" kept.
     expect(modelLabelFromCapabilityId("model__openai__gpt-4o")).toBe("GPT 4o");
@@ -147,5 +170,29 @@ describe("modelLabelFromCapabilityId (temporary heuristic until multi-model)", (
   it("rejects anything that is not a model capability id", () => {
     expect(modelLabelFromCapabilityId("document_access")).toBeNull();
     expect(modelLabelFromCapabilityId(undefined)).toBeNull();
+  });
+});
+
+describe("modelLabel (ops-authored name wins, heuristic is the fallback)", () => {
+  it("returns the authored name verbatim", () => {
+    // Verbatim: no re-casing, no token rewriting. Ops already decided.
+    expect(modelLabel("Mistral Small", "model__openai__mistral-small-latest")).toBe("Mistral Small");
+    expect(modelLabel("Mistral (Ollama)", "model__ollama__mistral:latest")).toBe("Mistral (Ollama)");
+  });
+
+  it("falls back to the derived label when the catalog names nothing", () => {
+    expect(modelLabel(undefined, "model__openai__gpt-4.1-mini")).toBe("GPT 4.1 Mini");
+    expect(modelLabel(null, "model__openai__gpt-4o")).toBe("GPT 4o");
+  });
+
+  it("treats a blank or non-string name as unauthored", () => {
+    // A YAML key left as `model_display_name: ""` must not blank the button.
+    expect(modelLabel("   ", "model__openai__gpt-4o")).toBe("GPT 4o");
+    expect(modelLabel(42, "model__openai__gpt-4o")).toBe("GPT 4o");
+  });
+
+  it("stays null when neither source can name the model", () => {
+    expect(modelLabel(undefined, "document_access")).toBeNull();
+    expect(modelLabel(undefined, undefined)).toBeNull();
   });
 });

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.tsx
@@ -45,12 +45,20 @@ import styles from "./ReasoningChip.module.css";
 
 export const COMPOSER_CHIP_WIDGETS = new Set(["reasoning_toggle"]);
 
-/** Display label derived from a `model__{provider}__{name}` capability id —
- *  "model__openai__mistral-small-latest" → "Mistral Small Latest",
- *  "model__openai__gpt-4.1-mini" → "GPT 4.1 Mini". TEMPORARY heuristic until
- *  the multi-model feature serves real catalog display names — the button is
- *  deliberately shaped as the future model picker (model identity first,
- *  reasoning state second). Exported for tests. */
+/** The model name the button shows: whatever ops authored as
+ *  `model_display_name` in `models_catalog.yaml`, else the derived guess
+ *  below. Ops win because only they know whether a hyphen is a version
+ *  separator ("claude-sonnet-4-6") or a variant one ("gpt-4.1-mini").
+ *  Exported for tests. */
+export function modelLabel(displayName: unknown, modelId: unknown): string | null {
+  if (typeof displayName === "string" && displayName.trim()) return displayName.trim();
+  return modelLabelFromCapabilityId(modelId);
+}
+
+/** Fallback label derived from a `model__{provider}__{name}` capability id —
+ *  "model__openai__gpt-4.1-mini" → "GPT 4.1 Mini". Used only when the catalog
+ *  names no `model_display_name`; it is a guess, and ops override it per
+ *  model rather than grow another special case here. Exported for tests. */
 export function modelLabelFromCapabilityId(modelId: unknown): string | null {
   if (typeof modelId !== "string") return null;
   const parts = modelId.split("__");
@@ -131,16 +139,16 @@ export function ReasoningChip({ chatControls, composer, disabled = false }: Reas
 
   const on = composer.reasoning;
   const title = t("chatbot.composerSettings.reasoningRowLabel");
-  const params = control.params as { effort?: unknown; model_id?: unknown } | undefined;
+  const params = control.params as { effort?: unknown; model_id?: unknown; display_name?: unknown } | undefined;
   const levelKey = effortLabelKey(params?.effort);
   const onLabel = levelKey ? t(levelKey) : t("chatbot.composerSettings.reasoningOn");
   const offLabel = t("chatbot.composerSettings.reasoningOff");
-  // Model identity first, Claude-style ("Mistral Small Latest Élevé"): model
-  // in the regular button text, reasoning state one step fainter
+  // Model identity first, Claude-style ("Mistral Small Élevé"): model in the
+  // regular button text, reasoning state one step fainter
   // (--on-surface-muted) — the color contrast is the separator. Read-only
   // today, the model picker slot tomorrow. Without an unambiguous model the
   // button falls back to the mockup's bare labels.
-  const modelLabel = modelLabelFromCapabilityId(params?.model_id);
+  const displayLabel = modelLabel(params?.display_name, params?.model_id);
   const stateLabel = on ? onLabel : offLabel;
 
   const pick = (next: boolean) => {
@@ -162,9 +170,9 @@ export function ReasoningChip({ chatControls, composer, disabled = false }: Reas
         aria-label={`${title}: ${on ? onLabel : offLabel}`}
         onClick={() => setOpen((current) => !current)}
       >
-        {modelLabel ? (
+        {displayLabel ? (
           <>
-            <span className={styles.model}>{modelLabel}</span>
+            <span className={styles.model}>{displayLabel}</span>
             <span className={styles.state}>{stateLabel}</span>
           </>
         ) : (

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1925,6 +1925,7 @@ export type CapabilityCatalogEntry = {
   model_profile_ids?: string[];
   model_thinking_profile_ids?: string[];
   model_reasoning_effort?: string | null;
+  model_display_name?: string | null;
 };
 export type AgentTemplateSummary = {
   template_id: string;

--- a/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
+++ b/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
@@ -717,6 +717,7 @@ export type McpCatalogResponse = {
 };
 export type ModelCatalogEntry = {
   description?: string | null;
+  display_name?: string | null;
   id: string;
   name: string;
   profile_ids?: string[];
@@ -930,6 +931,7 @@ export type CapabilityCatalogEntry = {
   icon: string;
   id: string;
   kind?: "tool" | "agent" | "model";
+  model_display_name?: string | null;
   model_profile_ids?: string[];
   model_reasoning_effort?: string | null;
   model_thinking_profile_ids?: string[];

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -737,6 +737,7 @@ applications:
       profiles:
         - profile_id: default.chat.openai.prod
           capability: chat
+          model_display_name: "GPT-5.1"
           description: "Default balanced chat model for production conversations."
           model:
             provider: openai
@@ -744,6 +745,7 @@ applications:
             settings: {}
         - profile_id: default.language.openai.prod
           capability: language
+          model_display_name: "GPT-5.1"
           description: "Default balanced language model for structured text tasks."
           model:
             provider: openai
@@ -751,6 +753,7 @@ applications:
             settings: {}
         - profile_id: default.chat.local
           capability: chat
+          model_display_name: "GPT-5.1"
           description: "Local default chat profile with retries and shorter timeout."
           model:
             provider: openai
@@ -761,6 +764,7 @@ applications:
               temperature: 0.0
         - profile_id: default.language.local
           capability: language
+          model_display_name: "GPT-5.1"
           description: "Local default language profile with retries and shorter timeout."
           model:
             provider: openai
@@ -771,6 +775,7 @@ applications:
               temperature: 0.0
         - profile_id: chat.openai.gpt52
           capability: chat
+          model_display_name: "GPT-5.2"
           description: "Highest-quality GPT-5.2 profile for complex reasoning and synthesis."
           model:
             provider: openai
@@ -778,6 +783,7 @@ applications:
             settings: {}
         - profile_id: language.openai.gpt52
           capability: language
+          model_display_name: "GPT-5.2"
           description: "Highest-quality GPT-5.2 profile for demanding language workloads."
           model:
             provider: openai
@@ -785,6 +791,7 @@ applications:
             settings: {}
         - profile_id: chat.openai.gpt5
           capability: chat
+          model_display_name: "GPT-5"
           description: "Strong general-purpose GPT-5 profile, balanced quality and latency."
           model:
             provider: openai
@@ -792,6 +799,7 @@ applications:
             settings: {}
         - profile_id: language.openai.gpt5
           capability: language
+          model_display_name: "GPT-5"
           description: "General-purpose GPT-5 language profile with strong overall quality."
           model:
             provider: openai
@@ -799,6 +807,7 @@ applications:
             settings: {}
         - profile_id: chat.openai.gpt5mini
           capability: chat
+          model_display_name: "GPT-5 mini"
           description: "Faster and lower-cost GPT-5 Mini profile for everyday chat tasks."
           model:
             provider: openai
@@ -806,6 +815,7 @@ applications:
             settings: {}
         - profile_id: language.openai.gpt5mini
           capability: language
+          model_display_name: "GPT-5 mini"
           description: "Faster and lower-cost GPT-5 Mini profile for lightweight language tasks."
           model:
             provider: openai
@@ -813,6 +823,7 @@ applications:
             settings: {}
         - profile_id: chat.openai.gpt5nano
           capability: chat
+          model_display_name: "GPT-5 nano"
           description: "Ultra-fast, budget-oriented GPT-5 Nano profile for simple prompts."
           model:
             provider: openai
@@ -820,6 +831,7 @@ applications:
             settings: {}
         - profile_id: language.openai.gpt5nano
           capability: language
+          model_display_name: "GPT-5 nano"
           description: "Ultra-fast, budget-oriented GPT-5 Nano profile for simple language tasks."
           model:
             provider: openai
@@ -827,6 +839,7 @@ applications:
             settings: {}
         - profile_id: chat.openai.gpt41
           capability: chat
+          model_display_name: "GPT-4.1"
           description: "Reliable GPT-4.1 profile for broad compatibility and stable outputs."
           model:
             provider: openai
@@ -834,6 +847,7 @@ applications:
             settings: {}
         - profile_id: language.openai.gpt41
           capability: language
+          model_display_name: "GPT-4.1"
           description: "Reliable GPT-4.1 language profile for stable text generation."
           model:
             provider: openai
@@ -841,6 +855,7 @@ applications:
             settings: {}
         - profile_id: chat.openai.gpt41mini
           capability: chat
+          model_display_name: "GPT-4.1 mini"
           description: "Cost-efficient GPT-4.1 Mini profile for quick conversational responses."
           model:
             provider: openai
@@ -848,6 +863,7 @@ applications:
             settings: {}
         - profile_id: language.openai.gpt41mini
           capability: language
+          model_display_name: "GPT-4.1 mini"
           description: "Cost-efficient GPT-4.1 Mini profile for lightweight language work."
           model:
             provider: openai
@@ -855,6 +871,7 @@ applications:
             settings: {}
         - profile_id: chat.azure_apim.gpt4o
           capability: chat
+          model_display_name: "GPT-4o (Azure)"
           description: "GPT-4o served via Azure APIM endpoint for enterprise integration."
           model:
             provider: azure-apim
@@ -868,6 +885,7 @@ applications:
               azure_ad_client_scope: "${AZURE_AD_CLIENT_SCOPE}"
         - profile_id: chat.ollama.mistral
           capability: chat
+          model_display_name: "Mistral (Ollama)"
           description: "Local Ollama Mistral profile for private/offline chat experimentation."
           model:
             provider: ollama
@@ -876,6 +894,7 @@ applications:
               base_url: "http://host.docker.internal:11434"
         - profile_id: language.ollama.mistral
           capability: language
+          model_display_name: "Mistral (Ollama)"
           description: "Local Ollama Mistral profile for private/offline language tasks."
           model:
             provider: ollama

--- a/deploy/local/k3d/values-bench.yaml
+++ b/deploy/local/k3d/values-bench.yaml
@@ -69,6 +69,7 @@ applications:
       profiles:
         - profile_id: default.chat.mock
           capability: chat
+          model_display_name: "Mock OpenAI Chat"
           model:
             provider: openai
             name: mock-openai-chat
@@ -76,6 +77,7 @@ applications:
               base_url: http://mock-openai-server:8383/v1
         - profile_id: default.language.mock
           capability: language
+          model_display_name: "Mock OpenAI Chat"
           model:
             provider: openai
             name: mock-openai-chat

--- a/deploy/local/k3d/values-local.yaml
+++ b/deploy/local/k3d/values-local.yaml
@@ -307,6 +307,7 @@ applications:
       profiles:
         - profile_id: default.chat.mistral
           capability: chat
+          model_display_name: "Mistral Medium 3.5"
           model:
             provider: openai
             name: mistral-medium-latest
@@ -314,6 +315,7 @@ applications:
               base_url: https://api.mistral.ai/v1
         - profile_id: default.language.mistral
           capability: language
+          model_display_name: "Mistral Medium 3.5"
           model:
             provider: openai
             name: mistral-medium-latest

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -3492,6 +3492,35 @@ next "let users pick the effort" idea starts from the measured constraint.
 
 ---
 
+### 8.54 ✅ Ops name the model — `model_display_name` in `models_catalog.yaml` (2026-08-13)
+
+The composer chip (§8.48) derived its model label by splitting the capability
+id on hyphens. That heuristic cannot tell a version separator from a variant
+one — `claude-sonnet-4-6` rendered "Claude Sonnet 4 6" — and only whoever
+pinned the model knows which it is.
+
+**What changed.**
+
+- `ModelProfile.model_display_name` (optional, per profile) in
+  `models_catalog.yaml`. Display only: routing, enablement and the capability
+  id still key on `(provider, name)`.
+- `GET /agents/models-catalog` gains `ModelCatalogEntry.display_name`, taken
+  from the first profile in the `(provider, name)` group that declares one —
+  same first-seen rule as `description`. `CapabilityCatalogEntry` gains
+  `model_display_name`, carried verbatim; the multi-pod catalog union keeps a
+  name authored on one pod when another serves the model unnamed.
+- control-plane snapshots it into `model_reasoning.display_name` at toggle
+  time (migration `a7d2e9c41f38`), exactly like `default_effort` — the send
+  path still performs no catalog fetch — and serves it on the reasoning
+  control's `params.display_name`, only alongside an unambiguous `model_id`.
+- The frontend prefers that string verbatim and keeps the old heuristic as
+  the fallback, so a catalog that never adopts the key renders as before.
+
+Staleness is deliberate and bounded: editing the catalog reaches the composer
+at the next admin re-toggle, not on open sessions.
+
+---
+
 ## 8. Developer CLI — `fred-agents-cli`
 
 > **Platform convention:** every Fred backend exposes `make cli`.

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -990,6 +990,12 @@ class _ModelCatalogEntry(BaseModel):
     shows no reasoning control at all — aptitude is not a choice, an
     administrator cannot make a model reason. Non-empty means the row carries
     the toggle. Same established join as `profile_ids` above."""
+    display_name: str | None = None
+    """The ops-authored `model_display_name` of this model's first profile that
+    declares one — the label the composer shows instead of splitting the
+    capability id apart. None means no profile named this model and the
+    frontend falls back to that heuristic. First-declared wins, same
+    first-seen rule as `description` above."""
     reasoning_effort: str | None = None
     """The ops-authored `settings.reasoning_effort` of this model's first
     thinking profile — DERIVED from the settings (never declared twice; the
@@ -1036,11 +1042,15 @@ def _project_model_catalog_entries(catalog: Any) -> list[_ModelCatalogEntry]:
                 provider=provider,
                 name=name,
                 description=profile.description,
+                display_name=profile.model_display_name,
                 profile_ids=[profile.profile_id],
             )
             seen[key] = existing
         else:
             existing.profile_ids.append(profile.profile_id)
+            # First declaring profile wins; a later one only fills a gap.
+            if existing.display_name is None:
+                existing.display_name = profile.model_display_name
         # REASON-01 §5.3: aptitude is per profile, the toggle is per model —
         # this one condition is the whole projection between them.
         if profile.supports_thinking:

--- a/libs/fred-runtime/fred_runtime/model_routing/contracts.py
+++ b/libs/fred-runtime/fred_runtime/model_routing/contracts.py
@@ -231,6 +231,18 @@ class ModelProfile(FrozenModel):
     capability: ModelCapability
     model: ModelConfiguration
     description: str | None = None
+    model_display_name: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Human-readable model name for the UI. Absent means the frontend "
+            "derives one by splitting `model.name` — a heuristic that cannot "
+            "tell a version separator from a variant one ('claude-sonnet-4-6' "
+            "renders 'Claude Sonnet 4 6'). Display only. Declared per profile, "
+            "but describes the model: siblings sharing one (provider, name) "
+            "should agree, and the catalog projection takes the first declared."
+        ),
+    )
     supports_thinking: bool = Field(
         default=False,
         description=(

--- a/libs/fred-runtime/tests/test_models_catalog_projection.py
+++ b/libs/fred-runtime/tests/test_models_catalog_projection.py
@@ -36,6 +36,7 @@ def _profile(
     provider: str | None = "openai",
     name: str | None = "gpt-5.1",
     description: str | None = None,
+    display_name: str | None = None,
     supports_thinking: bool = False,
     settings: dict | None = None,
 ) -> ModelProfile:
@@ -44,6 +45,7 @@ def _profile(
         capability=capability,
         model=ModelConfiguration(provider=provider, name=name, settings=settings),
         description=description,
+        model_display_name=display_name,
         supports_thinking=supports_thinking,
     )
 
@@ -233,3 +235,99 @@ def test_reasoning_effort_is_none_without_a_thinking_profile_effort() -> None:
     catalog = _catalog((_profile("p1", supports_thinking=True),))
 
     assert _project_model_catalog_entries(catalog)[0].reasoning_effort is None
+
+
+# ---------------------------------------------------------------------------
+# display_name — ops name the model, the frontend stops guessing
+# ---------------------------------------------------------------------------
+
+
+def test_display_name_is_carried_from_the_declaring_profile() -> None:
+    # The whole point of the field: "claude-sonnet-4-6" cannot be turned into
+    # "Claude Sonnet 4.6" by any id-splitting rule, because the same hyphen is
+    # a variant separator elsewhere ("gpt-4.1-mini"). Ops decide.
+    catalog = _catalog(
+        (
+            _profile(
+                "chat.anthropic.claude-sonnet",
+                provider="anthropic",
+                name="claude-sonnet-4-6",
+                display_name="Claude Sonnet 4.6",
+            ),
+        )
+    )
+
+    assert _project_model_catalog_entries(catalog)[0].display_name == (
+        "Claude Sonnet 4.6"
+    )
+
+
+def test_display_name_is_none_when_no_profile_declares_one() -> None:
+    # None keeps the frontend on its heuristic: the field is additive, so a
+    # catalog that never adopts it renders as it always did.
+    catalog = _catalog((_profile("p1"),))
+
+    assert _project_model_catalog_entries(catalog)[0].display_name is None
+
+
+def test_the_first_declaring_profile_names_the_model() -> None:
+    # Sibling profiles share one (provider, name) and so one display name.
+    # A later sibling only fills a gap the first left; it never overrides a
+    # name already declared, so the label cannot depend on YAML ordering
+    # between two profiles that both named the model.
+    catalog = _catalog(
+        (
+            _profile(
+                "chat.mistral.small",
+                provider="openai",
+                name="mistral-small-latest",
+                display_name="Mistral Small",
+            ),
+            _profile(
+                "language.mistral.small",
+                capability=ModelCapability.LANGUAGE,
+                provider="openai",
+                name="mistral-small-latest",
+                display_name="Mistral Small (language)",
+            ),
+        )
+    )
+
+    entries = _project_model_catalog_entries(catalog)
+
+    assert len(entries) == 1
+    assert entries[0].display_name == "Mistral Small"
+
+
+def test_a_later_sibling_can_name_an_unnamed_model() -> None:
+    catalog = _catalog(
+        (
+            _profile("chat.mistral.small", name="mistral-small-latest"),
+            _profile(
+                "language.mistral.small",
+                capability=ModelCapability.LANGUAGE,
+                name="mistral-small-latest",
+                display_name="Mistral Small",
+            ),
+        )
+    )
+
+    assert _project_model_catalog_entries(catalog)[0].display_name == "Mistral Small"
+
+
+def test_display_name_never_leaks_across_models() -> None:
+    catalog = _catalog(
+        (
+            _profile(
+                "named", name="mistral-small-latest", display_name="Mistral Small"
+            ),
+            _profile("unnamed", name="gpt-4o"),
+        )
+    )
+
+    entries = _project_model_catalog_entries(catalog)
+
+    assert {e.name: e.display_name for e in entries} == {
+        "mistral-small-latest": "Mistral Small",
+        "gpt-4o": None,
+    }

--- a/libs/fred-sdk/fred_sdk/contracts/capability/manifest.py
+++ b/libs/fred-sdk/fred_sdk/contracts/capability/manifest.py
@@ -398,6 +398,11 @@ class CapabilityCatalogEntry(BaseModel):
     # with; None when no thinking profile ships the key. Only `kind="model"`
     # entries populate it.
     model_reasoning_effort: str | None = None
+    # The ops-authored `model_display_name` from `models_catalog.yaml` — the
+    # label the composer shows for this model. None = unnamed, and the
+    # frontend derives one from the capability id. Display only; nothing
+    # routes or authorizes on it. Only `kind="model"` entries populate it.
+    model_display_name: str | None = None
 
     @classmethod
     def from_manifest(


### PR DESCRIPTION
Closes #2354. Follows #2339 (`397b994c`), which shipped the composer chip.

## Problem

The chip guessed the model name by splitting the capability id on hyphens
(`modelLabelFromCapabilityId`). The heuristic cannot tell a version separator
from a variant one, so it was wrong for models already in the catalog:

| catalog `name`      | before            | now               |
| ------------------- | ----------------- | ----------------- |
| `claude-sonnet-4-6` | Claude Sonnet 4 6 | Claude Sonnet 4.6 |
| `claude-haiku-3-5`  | Claude Haiku 3 5  | Claude Haiku 3.5  |
| `mistral-small-latest` | Mistral Small Latest | Mistral Small 4 |
| `mistral:latest`    | Mistral:latest    | Mistral (Ollama)  |

## Change

`models_catalog.yaml` profiles take an optional `model_display_name`. It flows
along the path `reasoning_effort` already took in #2339:

1. `ModelProfile.model_display_name` (fred-runtime)
2. `ModelCatalogEntry.display_name` — first declaring profile in the
   `(provider, name)` group wins, same first-seen rule as `description`
3. `CapabilityCatalogEntry.model_display_name`, carried verbatim; the multi-pod
   catalog union keeps a name authored on one pod when another serves the model
   unnamed
4. snapshotted into `model_reasoning.display_name` at toggle time (migration
   `a7d2e9c41f38`, alongside `default_effort`) — the send path still performs
   no catalog fetch
5. served on `params.display_name`, only alongside an unambiguous `model_id`
6. `ReasoningChip` prefers it verbatim, falls back to the heuristic

Display only: routing, enablement and the capability id still key on
`(provider, name)`. A catalog that never adopts the key renders exactly as
before. Staleness is bounded: a catalog edit reaches the composer at the next
admin re-toggle, not on open sessions.

`ModelReasoningStore.list_enabled_default_efforts` becomes
`list_enabled_display_snapshots`, returning one `ModelReasoningDisplay` tuple
per model — one query, and a model cannot be paired with another's label.

## Catalog seeding

Every profile in `models_catalog.yaml`, the chart values and the k3d values is
now named. Mistral names checked against current aliases: `mistral-small-latest`
→ Mistral Small 4, `mistral-medium-latest` → Mistral Medium 3.5.

## Tests

`make code-quality` green at the monorepo root; `make test` green in
fred-runtime (937), fred-sdk (242) and control-plane (729); the chip's vitest
suite passes (16).

- projection: declared / absent / first-declared-wins / later sibling fills a
  gap / never leaks across models
- control-plane: carried verbatim, snapshot round-trip, re-toggle refreshes a
  renamed model, `params.display_name` rides with `model_id` and is omitted
  when unnamed or ambiguous
- frontend: authored name wins, blank/non-string treated as unauthored,
  fallback preserved

## Out of scope

The admin capabilities table still shows the technical `name` (an admin picking
a model wants the routable name). No change to how effort is resolved (§8.48).
