### PR TITLE
impr(#2358): show the chat character counter only when over the limit

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -409,7 +409,7 @@
       "reasoningHint": "Higher effort gives a more thorough answer — and takes longer to produce.",
       "selectLibraryFirst": "Select a library first."
     },
-    "characterCounter": "{{count}} / {{limit}} characters",
+    "characterCounter": "{{used}} / {{limit}} characters",
     "conversationAriaLabel": "Conversation",
     "conversationFiles": "Conversation files",
     "copyMessage": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -409,7 +409,7 @@
       "reasoningHint": "Plus l'effort est élevé, plus la réponse est approfondie — et plus elle est longue à produire.",
       "selectLibraryFirst": "Sélectionnez d'abord une bibliothèque."
     },
-    "characterCounter": "{{count}} / {{limit}} caractères",
+    "characterCounter": "{{used}} / {{limit}} caractères",
     "conversationAriaLabel": "Conversation",
     "conversationFiles": "Fichiers de conversation",
     "copyMessage": {

--- a/apps/frontend/src/rework/components/shared/atoms/CharacterLimitNotice/CharacterLimitNotice.module.css
+++ b/apps/frontend/src/rework/components/shared/atoms/CharacterLimitNotice/CharacterLimitNotice.module.css
@@ -1,0 +1,22 @@
+/* Within the limit: empty and out of flow, so it adds neither a visible line
+   nor a flex gap to the field it sits under — while staying in the
+   accessibility tree, which is what makes the message announceable when it
+   later appears. */
+.notice {
+  position: absolute;
+}
+
+/* Over the limit: message on the left, count on the right, always the error
+   treatment — this notice never renders as an at-rest counter. */
+.notice.visible {
+  display: flex;
+  position: static;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  color: var(--error);
+  font: var(--font-body-small);
+}
+
+.count {
+  flex-shrink: 0;
+}

--- a/apps/frontend/src/rework/components/shared/atoms/CharacterLimitNotice/CharacterLimitNotice.test.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/CharacterLimitNotice/CharacterLimitNotice.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The notice is silent at rest and speaks only over the limit, so what matters
+// is the *transition*, not any single snapshot: the polite live region has to
+// already be in the accessibility tree when the message appears (an inserted
+// live region is not announced), and it has to empty out again — with its id
+// intact — when the draft comes back under the limit, so the field's
+// `aria-describedby` never dangles. A static render cannot show any of that;
+// these tests drive it through real mounts with `createRoot` + `act`, the
+// repo's idiom (no @testing-library/react here).
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CharacterLimitNotice } from "./CharacterLimitNotice";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${values.used ?? ""}:${values.limit ?? ""}` : key,
+    i18n: { language: "en" },
+  }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(count: number | undefined, limit: number | undefined) {
+  act(() => {
+    root.render(<CharacterLimitNotice id="notice" count={count} limit={limit} />);
+  });
+}
+
+function liveRegion(): HTMLElement | null {
+  return container.querySelector("[aria-live]");
+}
+
+describe("CharacterLimitNotice", () => {
+  it("stays mounted and silent while the value is within the limit", () => {
+    render(5, 5);
+
+    expect(container.querySelector("#notice")).not.toBeNull();
+    expect(liveRegion()?.textContent).toBe("");
+    expect(container.textContent).toBe("");
+  });
+
+  it("fills the already-mounted live region when the value crosses the limit", () => {
+    render(5, 5);
+    const regionBefore = liveRegion();
+
+    render(6, 5);
+
+    // Same node, new text: the announcement the change relies on. A region
+    // created together with its text is the pattern screen readers skip.
+    expect(liveRegion()).toBe(regionBefore);
+    expect(liveRegion()?.textContent).toBe("chatbot.errors.chatInputTooLong::5");
+    expect(container.textContent).toContain("chatbot.characterCounter:6:5");
+  });
+
+  it("keeps the count out of the live region so typing does not re-announce", () => {
+    render(6, 5);
+
+    expect(liveRegion()?.textContent).not.toContain("chatbot.characterCounter");
+  });
+
+  it("empties without unmounting when the value comes back under the limit", () => {
+    render(6, 5);
+
+    render(5, 5);
+
+    expect(container.querySelector("#notice")).not.toBeNull();
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing when the runtime publishes no limit", () => {
+    render(6, undefined);
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/atoms/CharacterLimitNotice/CharacterLimitNotice.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/CharacterLimitNotice/CharacterLimitNotice.tsx
@@ -1,0 +1,65 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useTranslation } from "react-i18next";
+import styles from "./CharacterLimitNotice.module.css";
+
+interface CharacterLimitNoticeProps {
+  /** Id the described field points at with `aria-describedby`. */
+  id: string;
+  /** Code-point count of the exact value the field will submit. */
+  count: number | undefined;
+  /** Runtime-published code-point limit; nothing renders when the runtime publishes none. */
+  limit: number | undefined;
+  /** Extra class on the root — used to align the notice with a padded field. */
+  className?: string;
+}
+
+/**
+ * Over-limit notice for the chat composer and the HITL free-text prompt.
+ *
+ * Deliberately silent at rest: an ordinary message sits far below the limit, so
+ * a counter that is always on screen reports a non-problem for the whole life
+ * of the draft (issue #2358). Only the message and count are shown here — the
+ * `aria-invalid` state and the send gating stay with the field that owns them.
+ */
+export function CharacterLimitNotice({ id, count, limit, className }: CharacterLimitNoticeProps) {
+  const { t, i18n } = useTranslation();
+
+  if (count === undefined || limit === undefined) return null;
+
+  const isOver = count > limit;
+  const formattedLimit = limit.toLocaleString(i18n.language);
+
+  return (
+    // The element stays mounted for the life of the field so the polite live
+    // region is in the accessibility tree before the message appears — a live
+    // region inserted at the same time as its text is not announced. While the
+    // draft is within the limit it is empty and out of flow, so it costs no
+    // space. The count is deliberately outside the live region: inside, it
+    // would re-announce on every keystroke.
+    <div id={id} className={`${styles.notice} ${isOver ? styles.visible : ""} ${className ?? ""}`}>
+      <span aria-live="polite">{isOver ? t("chatbot.errors.chatInputTooLong", { limit: formattedLimit }) : ""}</span>
+      {isOver && (
+        <span className={styles.count}>
+          {t("chatbot.characterCounter", {
+            count,
+            used: count.toLocaleString(i18n.language),
+            limit: formattedLimit,
+          })}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.module.css
@@ -43,20 +43,3 @@
   flex-direction: column;
   gap: var(--spacing-xs);
 }
-
-.characterInfo {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--spacing-s);
-  color: var(--on-surface-retreat);
-  font: var(--font-body-small);
-}
-
-.characterInfoError {
-  color: var(--error);
-}
-
-.characterCount {
-  flex-shrink: 0;
-  margin-left: auto;
-}

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.test.tsx
@@ -19,10 +19,18 @@ import { HitlPrompt } from "./HitlPrompt";
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, values?: Record<string, unknown>) =>
-      values ? `${key}:${values.count ?? ""}:${values.limit ?? ""}` : key,
+      values ? `${key}:${values.used ?? ""}:${values.limit ?? ""}` : key,
     i18n: { language: "en" },
   }),
 }));
+
+function buttonTag(html: string, label: string): string {
+  const tag = html.match(new RegExp(`<button[^>]*>[^<]*<div[^>]*>${label}</div></button>`))?.[0] ?? "";
+  // A regex that stops matching (any Button markup change) would otherwise make
+  // every `not.toContain("disabled")` below pass while checking nothing.
+  expect(tag).not.toBe("");
+  return tag;
+}
 
 const event = {
   session_id: "session-1",
@@ -44,11 +52,26 @@ describe("HitlPrompt chat-input limit", () => {
 
     expect(html).toContain("chatbot.characterCounter:6:5");
     expect(html).toContain("chatbot.errors.chatInputTooLong::5");
+    expect(html).toContain('aria-live="polite"');
     expect(html).not.toContain("maxLength=");
-    const proceedButton = html.match(/<button[^>]*>[^<]*<div[^>]*>Proceed<\/div><\/button>/)?.[0] ?? "";
-    const sendButton = html.match(/<button[^>]*>[^<]*<div[^>]*>chatbot\.sendHitlAnswer<\/div><\/button>/)?.[0] ?? "";
-    expect(proceedButton).not.toContain("disabled");
-    expect(sendButton).toContain('disabled=""');
+    expect(buttonTag(html, "Proceed")).not.toContain("disabled");
+    expect(buttonTag(html, "chatbot\\.sendHitlAnswer")).toContain('disabled=""');
+  });
+
+  it("hides the counter while the free text is within the limit", () => {
+    const html = renderToStaticMarkup(
+      <HitlPrompt
+        event={event}
+        onAnswer={() => undefined}
+        maxChatInputChars={5}
+        freeTextValue="🙂🙂🙂🙂🙂"
+        onFreeTextChange={() => undefined}
+      />,
+    );
+
+    expect(html).not.toContain("chatbot.characterCounter");
+    expect(html).not.toContain("chatbot.errors.chatInputTooLong");
+    expect(buttonTag(html, "chatbot\\.sendHitlAnswer")).not.toContain("disabled");
   });
 
   it("omits limit UI for an older runtime while preserving free text", () => {

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.tsx
@@ -16,6 +16,7 @@ import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@shared/atoms/Button/Button";
 import TextArea from "@shared/atoms/TextArea/TextArea";
+import { CharacterLimitNotice } from "@shared/atoms/CharacterLimitNotice/CharacterLimitNotice";
 import { countUnicodeCodePoints } from "@core/utils/chatInput";
 import type { ButtonVariant, ColorTheme } from "@shared/utils/Type.ts";
 import type { RuntimeAwaitingHumanEvent } from "@hooks/useChatSse";
@@ -59,7 +60,7 @@ export function HitlPrompt({
   freeTextValue,
   onFreeTextChange,
 }: HitlPromptProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const payload = event.payload;
   const [localFreeText, setLocalFreeText] = useState("");
   const freeText = freeTextValue ?? localFreeText;
@@ -112,27 +113,7 @@ export function HitlPrompt({
             aria-invalid={isOverLimit || undefined}
             aria-describedby={maxChatInputChars !== undefined ? characterInfoId : undefined}
           />
-          {maxChatInputChars !== undefined && (
-            <div
-              id={characterInfoId}
-              className={`${styles.characterInfo} ${isOverLimit ? styles.characterInfoError : ""}`}
-              aria-live="polite"
-            >
-              <span>
-                {isOverLimit
-                  ? t("chatbot.errors.chatInputTooLong", {
-                      limit: maxChatInputChars.toLocaleString(i18n.language),
-                    })
-                  : null}
-              </span>
-              <span className={styles.characterCount}>
-                {t("chatbot.characterCounter", {
-                  count: characterCount,
-                  limit: maxChatInputChars.toLocaleString(i18n.language),
-                })}
-              </span>
-            </div>
-          )}
+          <CharacterLimitNotice id={characterInfoId} count={characterCount} limit={maxChatInputChars} />
           <Button
             color="primary"
             variant="filled"

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.module.css
@@ -83,22 +83,10 @@
   color: var(--state-on-surface-disabled);
 }
 
+/* Aligns the over-limit notice with the textarea's own inline padding; the
+   notice itself is styled by CharacterLimitNotice. */
 .characterInfo {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--spacing-s);
   padding: 0 var(--spacing-xs);
-  color: var(--on-surface-retreat);
-  font: var(--font-body-small);
-}
-
-.characterInfoError {
-  color: var(--error);
-}
-
-.characterCount {
-  flex-shrink: 0;
-  margin-left: auto;
 }
 
 /* Bottom row: options (left, flex-1) + send button (right) */

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.test.tsx
@@ -19,13 +19,17 @@ import { RichInputField } from "./RichInputField";
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, values?: Record<string, unknown>) =>
-      values ? `${key}:${values.count ?? ""}:${values.limit ?? ""}` : key,
+      values ? `${key}:${values.used ?? ""}:${values.limit ?? ""}` : key,
     i18n: { language: "en" },
   }),
 }));
 
 function sendButtonOpeningTag(html: string): string {
   return html.match(/<button[^>]*aria-label="chatbot\.sendMessage"[^>]*>/)?.[0] ?? "";
+}
+
+function textareaOpeningTag(html: string): string {
+  return html.match(/<textarea[^>]*>/)?.[0] ?? "";
 }
 
 function render(props: { sendDisabled?: boolean; characterCount?: number; characterLimit?: number }): string {
@@ -47,21 +51,37 @@ describe("RichInputField send gating", () => {
     expect(tag).toContain("disabled");
   });
 
-  it("renders an accessible counter without a native maxLength at the exact limit", () => {
+  it("shows no counter at the exact limit and sets no native maxLength", () => {
     const html = render({ characterCount: 5, characterLimit: 5 });
+    const textarea = textareaOpeningTag(html);
 
-    expect(html).toContain("chatbot.characterCounter:5:5");
+    expect(html).not.toContain("chatbot.characterCounter");
     expect(html).not.toContain("chatbot.errors.chatInputTooLong");
     expect(html).not.toContain("maxLength=");
-    expect(html).not.toContain('aria-invalid="true"');
+    expect(textarea).not.toBe("");
+    expect(textarea).not.toContain("aria-invalid");
   });
 
-  it("marks an over-limit draft invalid and keeps the full textarea value", () => {
+  it("marks an over-limit draft invalid, reveals the counter, and keeps the full textarea value", () => {
     const html = render({ characterCount: 6, characterLimit: 5, sendDisabled: true });
+    const textarea = textareaOpeningTag(html);
 
-    expect(html).toContain('aria-invalid="true"');
+    expect(textarea).toContain('aria-invalid="true"');
     expect(html).toContain("chatbot.errors.chatInputTooLong::5");
+    expect(html).toContain("chatbot.characterCounter:6:5");
     expect(html).toContain(">hello</textarea>");
     expect(sendButtonOpeningTag(html)).toContain("disabled");
+  });
+
+  it("describes the textarea with the notice whenever the runtime publishes a limit", () => {
+    // The notice stays mounted below the limit, so the description never
+    // points at a removed node when the draft crosses back and forth.
+    const describedBy = (html: string) => /aria-describedby="([^"]*)"/.exec(textareaOpeningTag(html))?.[1];
+
+    expect(describedBy(render({ characterCount: 5, characterLimit: 5 }))).toBeDefined();
+    expect(describedBy(render({ characterCount: 6, characterLimit: 5 }))).toBe(
+      describedBy(render({ characterCount: 5, characterLimit: 5 })),
+    );
+    expect(describedBy(render({ characterCount: 6 }))).toBeUndefined();
   });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.tsx
@@ -15,6 +15,7 @@
 import { KeyboardEvent, ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton";
+import { CharacterLimitNotice } from "@shared/atoms/CharacterLimitNotice/CharacterLimitNotice";
 import { appendVoiceTranscript, audioFileExtensionForMimeType } from "./voiceInputUtils";
 import styles from "./RichInputField.module.css";
 
@@ -100,7 +101,7 @@ export function RichInputField({
   maxHeight = 200,
   focusEndRequestId,
 }: RichInputFieldProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const characterInfoId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const valueRef = useRef(value);
@@ -198,9 +199,8 @@ export function RichInputField({
   const hasDefaultAction = canUseVoiceInput || showStop || showSend;
   const showBottomRow = !!(topSlot || leftSlot || rightSlot || hasDefaultAction);
   const voiceControlDisabled = disabled || voiceInputDisabled || voiceInputState === "transcribing";
-  const showCharacterInfo = characterLimit !== undefined && characterCount !== undefined;
-  const isOverCharacterLimit = showCharacterInfo && characterCount > characterLimit;
-  const formattedCharacterLimit = characterLimit?.toLocaleString(i18n.language);
+  const hasCharacterLimit = characterLimit !== undefined && characterCount !== undefined;
+  const isOverCharacterLimit = hasCharacterLimit && characterCount > characterLimit;
 
   const reportVoiceError = useCallback(
     (message: string) => {
@@ -356,7 +356,7 @@ export function RichInputField({
           disabled={disabled}
           placeholder={placeholder}
           aria-invalid={isOverCharacterLimit || undefined}
-          aria-describedby={showCharacterInfo ? characterInfoId : undefined}
+          aria-describedby={hasCharacterLimit ? characterInfoId : undefined}
           onChange={(e) => {
             onChange(e.target.value);
             resize();
@@ -364,23 +364,12 @@ export function RichInputField({
           onKeyDown={handleKeyDown}
         />
 
-        {showCharacterInfo && (
-          <div
-            id={characterInfoId}
-            className={`${styles.characterInfo} ${isOverCharacterLimit ? styles.characterInfoError : ""}`}
-            aria-live="polite"
-          >
-            <span>
-              {isOverCharacterLimit ? t("chatbot.errors.chatInputTooLong", { limit: formattedCharacterLimit }) : null}
-            </span>
-            <span className={styles.characterCount}>
-              {t("chatbot.characterCounter", {
-                count: characterCount,
-                limit: formattedCharacterLimit,
-              })}
-            </span>
-          </div>
-        )}
+        <CharacterLimitNotice
+          id={characterInfoId}
+          count={characterCount}
+          limit={characterLimit}
+          className={styles.characterInfo}
+        />
 
         {showBottomRow && (
           <div className={styles.bottomRow}>

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -698,25 +698,36 @@ library:
 
 ---
 
-### Chat input length states (`RichInputField`, `HitlPrompt`, 2026-08-12)
+### Chat input length states (`RichInputField`, `HitlPrompt`, 2026-08-12, updated 2026-08-13)
 
-**Location:** `src/rework/components/shared/molecules/RichInputField/`,
+**Location:** `src/rework/components/shared/atoms/CharacterLimitNotice/`,
+`src/rework/components/shared/molecules/RichInputField/`,
 `src/rework/components/shared/molecules/HitlPrompt/`,
 `src/rework/components/pages/ManagedChatPage/`
 
 **Status:** `Functional`
 
-The managed-chat composer and active HITL free-text prompt display the optional
+The managed-chat composer and active HITL free-text prompt enforce the optional
 runtime-published character policy from execution preparation. Both count Unicode code points;
 ordinary chat counts the trimmed value that will be submitted, while HITL counts the exact free
-text.
+text. Both render the shared `CharacterLimitNotice`, which owns the states below — the field
+itself owns only `aria-invalid` and its send gating.
 
-- At or below the limit, the counter remains informational and send stays available.
-- Above the limit, the input uses `aria-invalid`, the counter/error region announces changes with
-  `aria-live="polite"`, and only the corresponding free-text send action is disabled. Fixed HITL
-  choices remain available because selecting one submits the identifier without the oversized
-  free-text draft; the runtime still validates any submitted `choice_id`, `answer`, and `text`
-  fields.
+- At or below the limit, nothing is visible — no counter, no error colour — and send stays
+  available. An ordinary message sits far below a limit measured in thousands of code points
+  (5,000 in the default template, but it is per-template and admin-configurable), so a
+  permanently visible counter would report a non-problem for the whole life of the draft
+  (2026-08-13, issue #2358).
+- Above the limit, the error copy and the counter appear together as one error-coloured region,
+  the input is marked `aria-invalid`, and only the corresponding free-text send action is
+  disabled. Fixed HITL choices remain available because selecting one submits the identifier
+  without the oversized free-text draft; the runtime still validates any submitted `choice_id`,
+  `answer`, and `text` fields.
+- The notice stays mounted whenever a limit is published, empty and out of flow while the draft is
+  within it: an `aria-live` region inserted into the DOM at the same time as its text is not
+  announced, and a permanently mounted node also keeps the field's `aria-describedby` from
+  pointing at a removed id as the draft crosses back and forth. The count sits outside the live
+  region — inside, it would re-announce on every keystroke.
 - Text remains fully editable: neither component sets native `maxLength`, truncates pasted or
   dictated content, nor clears an oversized draft. A backend length rejection restores the
   ordinary draft or pending HITL prompt safely.


### PR DESCRIPTION
Closes #2358.

## What changes

The chat character counter is no longer permanently on screen. It appears only
once the draft is actually over the runtime-published limit — below it, the
composer looks like it did before #2349.

Same for the HITL free-text prompt.

## How

- New shared atom `CharacterLimitNotice` owns the at-rest and over-limit states
  for both chat text inputs. `RichInputField` and `HitlPrompt` consume it; their
  duplicated markup and CSS blocks (introduced in #2349) are deleted, so the
  accessibility decision below has a single owner rather than two copies to keep
  in sync.
- The notice stays **mounted** whenever a limit is published — empty and out of
  flow while the draft is within it. An `aria-live` region inserted into the DOM
  at the same time as its text is not announced, and a permanently mounted node
  also keeps `aria-describedby` from pointing at a removed id as the draft
  crosses the limit back and forth. The count sits outside the live region:
  inside, it would re-announce on every keystroke.
- Drive-by, made visible by the change: the counter formatted its limit through
  `toLocaleString` but not its count. Easy to miss while it showed small
  numbers, impossible to miss now that it only ever appears with both sides at
  four or five digits (`5001 / 5 000` in French). It now interpolates a
  formatted `used` value; `count` is still passed so i18next plural selection
  keeps working.

Enforcement is untouched: no native `maxLength`, no truncation, same send
gating, same draft preservation on a backend rejection, same "older runtime
publishes no limit → no counter" behaviour.

## Tests

`CharacterLimitNotice.test.tsx` drives real mounts across the limit boundary —
the transition is the whole point of the design and `renderToStaticMarkup`
cannot show it. The consumer suites keep the wiring checks (`aria-invalid`,
`aria-describedby`, send gating), scoped to the textarea tag, with the
button-matching regexes guarded so they can no longer pass vacuously when they
stop matching.

Frontend: 1,228 passed, 2 skipped. Root `make code-quality`: green.

## Known gap, deliberately not fixed here

Over the limit the textarea itself gets no visual invalid treatment:
`aria-invalid` is styled nowhere in the codebase, and `HitlPrompt` never passes
the `error` prop its own `TextArea` atom already implements (red border, red
label). That predates this change and is its own issue, per the repo's scope
discipline.
