### PR TITLE
fix(#2366): CSV ingest wrong-delimiter crash + task error popover fixes

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1864,6 +1864,8 @@
       "popover": {
         "acknowledge": "Dismiss",
         "close": "Close",
+        "copyError": "Copy error",
+        "errorCopied": "Error copied",
         "startedAgo": "started {{time}}",
         "title": "Details — {{label}}"
       },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1864,6 +1864,8 @@
       "popover": {
         "acknowledge": "Ignorer",
         "close": "Fermer",
+        "copyError": "Copier l'erreur",
+        "errorCopied": "Erreur copiée",
         "startedAgo": "démarré {{time}}",
         "title": "Détails — {{label}}"
       },

--- a/apps/frontend/src/rework/components/pages/HelpCenterPage/HelpArticle.tsx
+++ b/apps/frontend/src/rework/components/pages/HelpCenterPage/HelpArticle.tsx
@@ -21,6 +21,7 @@ import { Breadcrumb, type BreadcrumbSegment } from "@shared/molecules/Breadcrumb
 import { MarkdownRenderer } from "@shared/molecules/MarkdownRenderer/MarkdownRenderer";
 import { helpPagePath, type HelpPage, type HelpSectionTree } from "@rework/features/helpCenter/content";
 import type { HelpLang } from "@rework/features/helpCenter/manifest";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import styles from "./HelpArticle.module.scss";
 
 interface HelpArticleProps {
@@ -55,9 +56,11 @@ export default function HelpArticle({ lang, section, page }: HelpArticleProps) {
   ];
 
   const copyPageLink = () => {
-    void navigator.clipboard.writeText(`${window.location.origin}${pageHref}`).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
+    writeRichClipboard("", `${window.location.origin}${pageHref}`).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      }
     });
   };
 

--- a/apps/frontend/src/rework/components/pages/PromptsPage/PromptViewDialog/PromptViewDialog.tsx
+++ b/apps/frontend/src/rework/components/pages/PromptsPage/PromptViewDialog/PromptViewDialog.tsx
@@ -16,6 +16,7 @@ import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import { Spinner } from "@shared/atoms/Spinner/Spinner.tsx";
 import { FullPageModal } from "@shared/molecules/FullPageModal/FullPageModal.tsx";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -58,10 +59,12 @@ export default function PromptViewDialog({ open, teamId, promptId, categories, o
 
   const handleCopy = () => {
     if (!detail) return;
-    navigator.clipboard.writeText(detail.text).then(() => {
-      setCopied(true);
-      showSuccess({ summary: t("rework.teams.prompts.view.copiedToast"), duration: 2000 });
-      setTimeout(() => setCopied(false), 2000);
+    writeRichClipboard("", detail.text).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        showSuccess({ summary: t("rework.teams.prompts.view.copiedToast"), duration: 2000 });
+        setTimeout(() => setCopied(false), 2000);
+      }
     });
   };
 

--- a/apps/frontend/src/rework/components/pages/ReleaseNotesPage/ReleaseNotesContent.tsx
+++ b/apps/frontend/src/rework/components/pages/ReleaseNotesPage/ReleaseNotesContent.tsx
@@ -20,6 +20,7 @@ import type { ButtonGroupItemProps } from "@shared/atoms/ButtonGroup/ButtonGroup
 import CodenameModal from "@shared/molecules/CodenameModal/CodenameModal";
 import { MarkdownRenderer } from "@shared/molecules/MarkdownRenderer/MarkdownRenderer";
 import { getProperty } from "../../../../common/config";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import CODENAME from "../../../../releases/swift.json";
 import styles from "./ReleaseNotesContent.module.css";
 
@@ -108,12 +109,10 @@ export default function ReleaseNotesContent() {
 
   const handleCopy = async () => {
     if (!selectedContent) return;
-    try {
-      await navigator.clipboard.writeText(selectedContent);
+    const ok = await writeRichClipboard("", selectedContent);
+    if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // clipboard unavailable — silent fallback
     }
   };
 

--- a/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/KeaMigrationPage/KeaMigrationPage.tsx
@@ -30,6 +30,7 @@ import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
 import { ConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialog";
 import PageHeader from "@shared/molecules/PageHeader/PageHeader.tsx";
 import { personalTeamId } from "@shared/utils/teamId";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import { launchPlatformImport } from "../../../../features/migration/launchPlatformImport";
 import { runKeaDryRun } from "../../../../features/migration/runKeaDryRun";
 import { taskRegistered } from "../../../../features/tasks/taskSlice";
@@ -130,9 +131,11 @@ export default function KeaMigrationPage() {
   // just the truncated display text), not a human-readable digest.
   const handleCopyReport = async () => {
     if (!report) return;
-    await navigator.clipboard.writeText(JSON.stringify(report, null, 2));
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    const ok = await writeRichClipboard("", JSON.stringify(report, null, 2));
+    if (ok) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }
   };
 
   const handleDryRun = async () => {

--- a/apps/frontend/src/rework/components/pages/admin/MigrationPage/MigrationPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/MigrationPage/MigrationPage.tsx
@@ -259,7 +259,7 @@ export default function MigrationPage() {
               <TaskCard
                 key={task.taskId}
                 task={task}
-                onAcknowledge={() => acknowledge(task.taskId, task.kind)}
+                onAcknowledge={() => acknowledge(task.taskId, task.kind, task.localOnly)}
                 acknowledging={isAcknowledging(task.taskId)}
               />
             ))}
@@ -275,7 +275,7 @@ export default function MigrationPage() {
               <TaskCard
                 key={task.taskId}
                 task={task}
-                onAcknowledge={() => acknowledge(task.taskId, task.kind)}
+                onAcknowledge={() => acknowledge(task.taskId, task.kind, task.localOnly)}
                 acknowledging={isAcknowledging(task.taskId)}
               />
             ))}

--- a/apps/frontend/src/rework/components/pages/admin/SelfTestPage/StepReportPanel.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/SelfTestPage/StepReportPanel.tsx
@@ -19,6 +19,7 @@ import { TaskStateBadge } from "@shared/atoms/TaskStateBadge/TaskStateBadge.tsx"
 import { TaskProgressBar } from "@shared/atoms/TaskProgressBar/TaskProgressBar.tsx";
 import type { TaskState } from "../../../../features/tasks/taskTypes";
 import type { StepReport, StepStatus } from "../../../../features/pipeline/types";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import styles from "./SelfTestPage.module.css";
 
 // The Task atoms speak the fred-core TaskState vocabulary; map the pipeline
@@ -82,9 +83,11 @@ export function StepReportPanel({ steps, isRunning, emptyLabel }: StepReportPane
   const progress = total > 0 ? completed / total : null;
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(buildReport(steps));
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    const ok = await writeRichClipboard("", buildReport(steps));
+    if (ok) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }
   };
 
   if (total === 0) {

--- a/apps/frontend/src/rework/components/shared/molecules/CodeBlock/CodeBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/CodeBlock/CodeBlock.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { useIsDark } from "../../../../core/hooks/useIsDark";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import styles from "./CodeBlock.module.css";
 
 interface CodeBlockProps {
@@ -44,9 +45,11 @@ export function CodeBlock({
   }
 
   function handleCopy() {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+    writeRichClipboard("", code).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     });
   }
 

--- a/apps/frontend/src/rework/components/shared/molecules/DebugRawDrawer/DebugRawDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DebugRawDrawer/DebugRawDrawer.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next";
 import { InlineDrawer } from "../InlineDrawer/InlineDrawer";
 import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup";
 import IconButton from "@shared/atoms/IconButton/IconButton";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import type { ChatMessage } from "../../../../../slices/runtime/runtimeOpenApi";
 import styles from "./DebugRawDrawer.module.css";
 
@@ -38,13 +39,12 @@ export function DebugRawDrawer({ open, onClose, messages }: DebugRawDrawerProps)
   const json = JSON.stringify(displayed, null, 2);
 
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(json)
-      .then(() => {
+    writeRichClipboard("", json).then((ok) => {
+      if (ok) {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
-      })
-      .catch(() => {});
+      }
+    });
   };
 
   return (

--- a/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/HeadingWithAnchor.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/HeadingWithAnchor.tsx
@@ -16,6 +16,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import styles from "./MarkdownRenderer.module.css";
 
 /**
@@ -59,9 +60,11 @@ export function HeadingWithAnchor({ level, children }: HeadingWithAnchorProps) {
 
   const copyLink = () => {
     const url = `${window.location.origin}${window.location.pathname}#${slug}`;
-    void navigator.clipboard.writeText(url).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
+    writeRichClipboard("", url).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      }
     });
   };
 

--- a/apps/frontend/src/rework/components/shared/molecules/MermaidBlock/MermaidBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MermaidBlock/MermaidBlock.tsx
@@ -16,6 +16,7 @@ import { useEffect, useId, useState } from "react";
 import mermaid from "mermaid";
 import { useIsDark } from "../../../../core/hooks/useIsDark";
 import { sanitizeMermaidForParsing } from "./mermaidSanitizer";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { FullPageModal } from "../FullPageModal/FullPageModal";
 import styles from "./MermaidBlock.module.css";
@@ -32,9 +33,11 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   const isDark = useIsDark();
 
   function handleCopy() {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+    writeRichClipboard("", code).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     });
   }
 

--- a/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MindMapBlock/MindMapBlock.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import ReactECharts from "echarts-for-react";
 import { useIsDark } from "../../../../core/hooks/useIsDark";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import styles from "./MindMapBlock.module.css";
 import {
   escapeHtml,
@@ -288,9 +289,11 @@ export function MindMapBlock({ code, language = "mindmap-json" }: MindMapBlockPr
   }, [chartReady, parsed, selectedNodeId]);
 
   function handleCopy() {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+    writeRichClipboard("", code).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
     });
   }
 

--- a/apps/frontend/src/rework/components/shared/molecules/TaskCard/TaskCard.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TaskCard/TaskCard.tsx
@@ -19,6 +19,7 @@ import { TERMINAL_STATES } from "../../../../features/tasks/taskTypes";
 import { relativeTime } from "../../../../features/tasks/taskLabels";
 import IconButton from "../../atoms/IconButton/IconButton.tsx";
 import { Tooltip } from "../../atoms/Tooltip/Tooltip.tsx";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import { TaskProgressBar } from "../../atoms/TaskProgressBar/TaskProgressBar";
 import { TaskStateBadge } from "../../atoms/TaskStateBadge/TaskStateBadge";
 import styles from "./TaskCard.module.css";
@@ -47,9 +48,11 @@ export function TaskCard({ task, onAcknowledge, acknowledging }: TaskCardProps) 
 
   const handleCopyWarnings = async () => {
     if (!task.warnings || task.warnings.length === 0) return;
-    await navigator.clipboard.writeText(task.warnings.join("\n"));
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    const ok = await writeRichClipboard("", task.warnings.join("\n"));
+    if (ok) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }
   };
 
   return (

--- a/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.module.css
@@ -27,8 +27,11 @@
   width: 280px;
   /* A long backend error (e.g. a raw DuckDB sniffer dump) can be taller than
      the viewport space below the anchor. Cap and scroll internally instead of
-     overflowing past the viewport edge with no way to reach the rest. */
-  max-height: 400px;
+     overflowing past the viewport edge with no way to reach the rest. Capped
+     to the viewport itself too (16px = 2x MARGIN in the positioning math
+     below) so a short viewport (mobile landscape, a squeezed split window)
+     can't still clip the box past its own bottom edge. */
+  max-height: min(400px, calc(100vh - 16px));
   overflow-y: auto;
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.module.css
@@ -25,6 +25,11 @@
   background: var(--surface-container-high);
   padding: var(--spacing-s);
   width: 280px;
+  /* A long backend error (e.g. a raw DuckDB sniffer dump) can be taller than
+     the viewport space below the anchor. Cap and scroll internally instead of
+     overflowing past the viewport edge with no way to reach the rest. */
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 /* Header */
@@ -102,7 +107,7 @@
 /* Error row */
 .errorRow {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--spacing-xs);
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx
@@ -23,7 +23,9 @@ import { TaskProgressBar } from "../../atoms/TaskProgressBar/TaskProgressBar";
 import { TaskStateBadge } from "../../atoms/TaskStateBadge/TaskStateBadge";
 import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
-import { viewportWidth } from "@shared/utils/viewport.ts";
+import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
+import { useCopyConfirmation } from "../../../../core/hooks/useCopyConfirmation";
+import { viewportHeight, viewportWidth } from "@shared/utils/viewport.ts";
 import styles from "./TaskDetailPopover.module.css";
 
 interface TaskDetailPopoverProps {
@@ -37,6 +39,7 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
   const { t } = useTranslation();
   const task = useSelector(selectTask(taskId));
   const { acknowledge, isAcknowledging } = useTaskAcknowledgement();
+  const { copied: errorCopied, confirmCopied: confirmErrorCopied } = useCopyConfirmation();
   const popoverRef = React.useRef<HTMLDivElement>(null);
 
   // Position the popover below the anchor element
@@ -49,8 +52,14 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
     }
     const rect = anchorEl.getBoundingClientRect();
     const POPOVER_WIDTH = 280;
+    // Matches .popover's max-height (TaskDetailPopover.module.css) — used here
+    // to keep the popover's bottom edge on-screen without measuring the real
+    // DOM height (the CSS cap is the worst case; content scrolls internally).
+    const POPOVER_MAX_HEIGHT = 400;
     const MARGIN = 8;
-    const top = rect.bottom + 6;
+    // Prefer opening below the anchor; clamp upward when a long error would
+    // otherwise push the popover's bottom edge past the viewport.
+    const top = Math.max(MARGIN, Math.min(rect.bottom + 6, viewportHeight() - MARGIN - POPOVER_MAX_HEIGHT));
     // Prefer left-aligned; flip to right-aligned when it would overflow the viewport.
     const left =
       rect.left + POPOVER_WIDTH + MARGIN > viewportWidth() ? Math.max(MARGIN, rect.right - POPOVER_WIDTH) : rect.left;
@@ -80,6 +89,14 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
   }, [open, onClose]);
 
   if (!open || !task || !pos) return null;
+
+  const handleCopyError = () => {
+    if (!task.error) return;
+    navigator.clipboard
+      .writeText(task.error)
+      .then(confirmErrorCopied)
+      .catch(() => {});
+  };
 
   const progressPct = task.progress !== null ? `${Math.round(task.progress * 100)}%` : null;
   const elapsedLabel = t("rework.tasks.popover.startedAgo", { time: relativeTime(task.registeredAt, t) });
@@ -133,6 +150,13 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
       {task.error && (
         <div className={styles.errorRow}>
           <span className={styles.errorText}>{task.error}</span>
+          <IconButton
+            variant="icon"
+            size="small"
+            icon={{ category: "outlined", type: errorCopied ? "check_circle" : "content_copy" }}
+            aria-label={errorCopied ? t("rework.tasks.popover.errorCopied") : t("rework.tasks.popover.copyError")}
+            onClick={handleCopyError}
+          />
         </div>
       )}
 
@@ -142,7 +166,7 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
             color="on-surface"
             variant="text"
             size="small"
-            onClick={() => acknowledge(task.taskId, task.kind)}
+            onClick={() => acknowledge(task.taskId, task.kind, task.localOnly)}
             disabled={isAcknowledging(task.taskId)}
           >
             {t("rework.tasks.popover.acknowledge")}

--- a/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx
@@ -25,6 +25,7 @@ import Button from "@shared/atoms/Button/Button.tsx";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import { useCopyConfirmation } from "../../../../core/hooks/useCopyConfirmation";
+import { writeRichClipboard } from "../../../../utils/clipboardUtils";
 import { viewportHeight, viewportWidth } from "@shared/utils/viewport.ts";
 import styles from "./TaskDetailPopover.module.css";
 
@@ -52,11 +53,15 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
     }
     const rect = anchorEl.getBoundingClientRect();
     const POPOVER_WIDTH = 280;
-    // Matches .popover's max-height (TaskDetailPopover.module.css) — used here
-    // to keep the popover's bottom edge on-screen without measuring the real
-    // DOM height (the CSS cap is the worst case; content scrolls internally).
-    const POPOVER_MAX_HEIGHT = 400;
     const MARGIN = 8;
+    // Matches .popover's max-height (`min(400px, 100vh - 16px)` in
+    // TaskDetailPopover.module.css) — used here to keep the popover's bottom
+    // edge on-screen without measuring the real DOM height (the CSS cap is
+    // the worst case; content scrolls internally). Capped to the viewport
+    // itself too: on a short viewport (mobile landscape, a squeezed split
+    // window) the fixed 400px alone would still get clipped past the bottom
+    // even with internal scroll.
+    const POPOVER_MAX_HEIGHT = Math.min(400, viewportHeight() - 2 * MARGIN);
     // Prefer opening below the anchor; clamp upward when a long error would
     // otherwise push the popover's bottom edge past the viewport.
     const top = Math.max(MARGIN, Math.min(rect.bottom + 6, viewportHeight() - MARGIN - POPOVER_MAX_HEIGHT));
@@ -92,10 +97,9 @@ export function TaskDetailPopover({ taskId, anchorEl, open, onClose }: TaskDetai
 
   const handleCopyError = () => {
     if (!task.error) return;
-    navigator.clipboard
-      .writeText(task.error)
-      .then(confirmErrorCopied)
-      .catch(() => {});
+    writeRichClipboard("", task.error).then((ok) => {
+      if (ok) confirmErrorCopied();
+    });
   };
 
   const progressPct = task.progress !== null ? `${Math.round(task.progress * 100)}%` : null;

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceDetailDrawer/TraceDetailDrawer.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { useToast, type ToastInput } from "@shared/molecules/Toast/ToastProvider";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import { CodeBlock } from "../../CodeBlock/CodeBlock";
 import { SourcesPanel } from "../../SourcesPanel/SourcesPanel";
 import { InlineDrawer } from "../../InlineDrawer/InlineDrawer";
@@ -210,14 +211,13 @@ function CopyHeaderAction({ text, toast }: { text: string; toast?: ToastInput })
   const { showSuccess } = useToast();
 
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
+    writeRichClipboard("", text).then((ok) => {
+      if (ok) {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
         if (toast) showSuccess(toast);
-      })
-      .catch(() => {});
+      }
+    });
   };
 
   return (

--- a/apps/frontend/src/rework/components/shared/molecules/Toast/Toast.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Toast/Toast.tsx
@@ -14,6 +14,7 @@
 
 import React, { useEffect } from "react";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import styles from "./Toast.module.css";
 
 export type ToastSeverity = "success" | "error" | "warning" | "info";
@@ -67,9 +68,7 @@ export function Toast({ id, severity, summary, detail, duration, exiting, onClos
   };
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText([summary, detail].filter(Boolean).join("\n"));
-    } catch {}
+    await writeRichClipboard("", [summary, detail].filter(Boolean).join("\n"));
   };
 
   return (

--- a/apps/frontend/src/rework/components/shared/organisms/TaskTray/TaskTray.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TaskTray/TaskTray.tsx
@@ -124,7 +124,7 @@ export function TaskTray() {
                   <TaskCard
                     key={task.taskId}
                     task={task}
-                    onAcknowledge={() => acknowledge(task.taskId, task.kind)}
+                    onAcknowledge={() => acknowledge(task.taskId, task.kind, task.localOnly)}
                     acknowledging={isAcknowledging(task.taskId)}
                   />
                 ))

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsEvaluations/views/EvaluationRunDetail.tsx
@@ -24,6 +24,7 @@ import { Breadcrumb } from "@shared/molecules/Breadcrumb/Breadcrumb";
 import { InlineDrawer } from "@shared/molecules/InlineDrawer/InlineDrawer";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice";
 import type { ColorTheme } from "@shared/utils/Type";
+import { writeRichClipboard } from "@rework/utils/clipboardUtils";
 import {
   StatusPill,
   FieldBlock,
@@ -569,18 +570,13 @@ function CaseDetail({ caseData, t }: { caseData: EvaluationCaseResponse; t: Retu
   }, []);
 
   const handleCopy = () => {
-    // navigator.clipboard is undefined in non-secure contexts (plain HTTP,
-    // except localhost), older browsers, and some test DOM environments —
-    // accessing .writeText on it would throw synchronously.
-    if (!navigator.clipboard) return;
-    navigator.clipboard
-      .writeText(JSON.stringify(caseData, null, 2))
-      .then(() => {
+    writeRichClipboard("", JSON.stringify(caseData, null, 2)).then((ok) => {
+      if (ok) {
         setCopied(true);
         if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
         copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
-      })
-      .catch(() => {});
+      }
+    });
   };
 
   return (

--- a/apps/frontend/src/rework/features/tasks/useTaskAcknowledgement.ts
+++ b/apps/frontend/src/rework/features/tasks/useTaskAcknowledgement.ts
@@ -31,6 +31,14 @@ import { taskAcknowledged } from "./taskSlice";
  * stream) — this used to always call control-plane regardless of which
  * backend actually owns the task, so a failed ingestion task's ack 404'd
  * and silently left the button visible (#2123 review).
+ *
+ * `localOnly` tasks (e.g. a chat-attachment fast-ingest failure — see
+ * `useChatAttachments.addFiles`) never had a server-side task record created
+ * for them in the first place (the fast-ingest route is synchronous and
+ * registers no task), so POSTing an ack for one always 404s. Acknowledging
+ * one is a purely local Redux update instead of a network call — same as
+ * `useTaskSseManager` already excludes `localOnly` tasks from its SSE
+ * subscription for the same underlying reason.
  */
 export function useTaskAcknowledgement() {
   const dispatch = useDispatch();
@@ -38,7 +46,11 @@ export function useTaskAcknowledgement() {
   const [ackKnowledgeFlow] = useAcknowledgeTaskKnowledgeFlowV1TasksTaskIdAckPostMutation();
   const [pendingTaskId, setPendingTaskId] = useState<string | null>(null);
 
-  const acknowledge = async (taskId: string, kind: string | null) => {
+  const acknowledge = async (taskId: string, kind: string | null, localOnly?: boolean) => {
+    if (localOnly) {
+      dispatch(taskAcknowledged({ taskId, acknowledgedAt: new Date().toISOString() }));
+      return;
+    }
     const backend = taskBackendFor(kind);
     if (backend === "evaluation") {
       // No acknowledgement endpoint exists on the evaluation backend yet

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/csv_tabular_processor/csv_tabular_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/csv_tabular_processor/csv_tabular_processor.py
@@ -50,7 +50,7 @@ class CsvReadOptions:
     - `options = processor.inspect_read_options(Path("/tmp/data.csv"))`
     """
 
-    delimiter: str
+    delimiter: str | None
     encoding: str
     header: bool = True
     source_path: Path | None = None
@@ -109,7 +109,7 @@ class CsvTabularProcessor(BaseTabularProcessor):
         """
         return file_path.suffix.lower() == ".csv" and file_path.is_file()
 
-    def detect_delimiter(self, file_path: Path, encodings: list[str]) -> str:
+    def detect_delimiter(self, file_path: Path, encodings: list[str]) -> str | None:
         """
         Detect the CSV delimiter from a small file sample.
 
@@ -119,6 +119,16 @@ class CsvTabularProcessor(BaseTabularProcessor):
 
         How to use:
         - Pass the candidate encodings that should be tried while sniffing.
+        - Returns `None` when no candidate encoding yields a confident
+          sniff — e.g. a quoted field with an embedded raw newline can throw
+          off `csv.Sniffer` well before it sees enough consistent rows to
+          settle on a delimiter. `None` must NOT be defaulted to `,` here:
+          that silently forces the wrong delimiter on every non-comma export
+          (semicolon is the common case for French/European exports, since
+          `,` is the decimal separator) and dooms the DuckDB read that
+          follows. Let the caller pass `None` through to DuckDB's own
+          `read_csv_auto`, whose built-in auto-detection tries multiple
+          delimiter candidates instead of being constrained to one guess.
         """
         for enc in encodings:
             try:
@@ -128,7 +138,7 @@ class CsvTabularProcessor(BaseTabularProcessor):
                 return dialect.delimiter
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Failed to detect delimiter for %s with encoding '%s': %s", file_path, enc, exc)
-        return ","
+        return None
 
     def detect_source_encoding(self, path: Path, encodings: list[str]) -> str:
         """
@@ -200,7 +210,16 @@ class CsvTabularProcessor(BaseTabularProcessor):
                 exc,
             )
             utf8_path = self.transcode_csv_to_utf8(path, source_encoding)
-            self._validate_duckdb_read(utf8_path, delimiter=delimiter, encoding="utf-8")
+            try:
+                self._validate_duckdb_read(utf8_path, delimiter=delimiter, encoding="utf-8")
+            except Exception as utf8_exc:  # noqa: BLE001
+                logger.error(
+                    "DuckDB could not read %s after transcoding to UTF-8 (delimiter '%s'): %s",
+                    utf8_path,
+                    delimiter,
+                    utf8_exc,
+                )
+                raise
             return CsvReadOptions(delimiter=delimiter, encoding="utf-8", header=True, source_path=utf8_path)
 
     def extract_file_metadata(self, file_path: Path) -> dict:
@@ -256,7 +275,7 @@ class CsvTabularProcessor(BaseTabularProcessor):
             sample_size=sample_size,
         )
 
-    def _validate_duckdb_read(self, path: Path, *, delimiter: str, encoding: str) -> None:
+    def _validate_duckdb_read(self, path: Path, *, delimiter: str | None, encoding: str) -> None:
         """
         Probe one CSV/encoding pair with DuckDB.
 
@@ -298,16 +317,25 @@ class CsvTabularProcessor(BaseTabularProcessor):
           files outright, whereas here we skip only the offending rows. The
           encoding is validated separately in `detect_source_encoding`, so this
           tolerance cannot silently swallow a wrong-encoding read.
+        - `options.delimiter` is omitted from the SQL entirely when `None`
+          (our own sniff failed to settle on one) instead of falling back to a
+          guessed value: forcing a wrong `delim=` constrains DuckDB's own
+          `read_csv_auto` to that single candidate and dooms the read, whereas
+          leaving it unset lets DuckDB's built-in auto-detection try its full
+          candidate set.
         """
         effective_path = options.source_path or file_path
 
         quoted_path = str(effective_path).replace("'", "''")
-        quoted_delimiter = options.delimiter.replace("'", "''")
         quoted_encoding = options.encoding.replace("'", "''")
         header_literal = "true" if options.header else "false"
         sample_size_sql = f", sample_size={sample_size}" if sample_size is not None else ""
+        delim_sql = ""
+        if options.delimiter is not None:
+            quoted_delimiter = options.delimiter.replace("'", "''")
+            delim_sql = f", delim='{quoted_delimiter}'"
 
-        return f"read_csv_auto('{quoted_path}', delim='{quoted_delimiter}', header={header_literal}, encoding='{quoted_encoding}', ignore_errors=true{sample_size_sql})"
+        return f"read_csv_auto('{quoted_path}', header={header_literal}, encoding='{quoted_encoding}', ignore_errors=true{delim_sql}{sample_size_sql})"
 
     def normalize_duckdb_encoding_name(self, encoding: str) -> str:
         """

--- a/apps/knowledge-flow-backend/tests/processors/input/csv_tabular_processor/test_sample_tabular_processor.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/csv_tabular_processor/test_sample_tabular_processor.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 
 
+import logging
 import tempfile
 from pathlib import Path
 
+import duckdb
 import pytest
 
-from knowledge_flow_backend.core.processors.input.csv_tabular_processor.csv_tabular_processor import CsvTabularProcessor
+from knowledge_flow_backend.core.processors.input.csv_tabular_processor.csv_tabular_processor import (
+    CsvReadOptions,
+    CsvTabularProcessor,
+)
 
 
 def test_valid_csv():
@@ -86,6 +91,77 @@ def test_inspect_read_options_rejects_invalid_csv_path(tmp_path):
 
     with pytest.raises(ValueError, match="File invalid or not found"):
         processor.inspect_read_options(tmp_path / "missing.csv")
+
+
+def test_inspect_read_options_logs_when_utf8_fallback_also_fails(tmp_path, caplog, monkeypatch):
+    """The UTF-8-transcode fallback is the terminal attempt: when it also fails,
+    the failure must be logged, not just re-raised. Otherwise an operator watching
+    stdout only sees the two earlier warnings and a bare error propagating out —
+    the actual root cause is only visible in the HTTP error response reaching the
+    end user, never in the backend's own logs."""
+    processor = CsvTabularProcessor()
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    def always_fail(self, path, *, delimiter, encoding):
+        raise duckdb.Error("boom")
+
+    monkeypatch.setattr(CsvTabularProcessor, "_validate_duckdb_read", always_fail)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(duckdb.Error, match="boom"):
+            processor.inspect_read_options(csv_path)
+
+    assert any("after transcoding to UTF-8" in record.message for record in caplog.records)
+
+
+# Verbatim excerpt from a real semicolon-delimited export (issue #2366's
+# export-exigences.csv) — bisected down to the shortest prefix that reliably
+# breaks csv.Sniffer, then closed into a syntactically complete CSV. The
+# embedded raw '\n' inside the first quoted field (before its closing quote)
+# is what throws the sniffer off, well before it sees enough consistent rows
+# to settle on ';'.
+_UNSNIFFABLE_SEMICOLON_EXPORT = (
+    "REQ_ID;REQ_VERSION_NAME;REQ_VERSION_DESCRIPTION\n"
+    '1943;Ajout .zip dans les upload de fichier;"les fichier de types ZIP sont autorisés\xa0\n"\n'
+    '1106;Comportement de recherche dans un champ liste;"A partir du moment ou un champ de type liste '
+    "(donc liste à choix unique ou à selection multiple) contient 5 éléments, une barre de recherche "
+    "permettant à l'utilisateur de rechercher les éléments de la liste apparaît.\n\"\n"
+    "1847;Conditionner l'affichage de l'éditeur de texte par champs;\"Composant permetant de :d'écrire"
+    "\xa0de long texte sans pour autant avoir un éditeur de texte dans le champ.de visualiser de long texte "
+    'sans pour autant avoir un éditeur de texte dans le champ.\n"\n'
+    "1549;Emplacement de defaut_value dans FORMULAIRE;\"Quand\xa0 l'administrateur est dans le menu "
+    '""Gére les champs""\xa0\n"\n'
+    "99;ok;fin\n"
+)
+
+
+def test_detect_delimiter_returns_none_when_sniffing_fails(tmp_path):
+    """A quoted field with an embedded raw newline (real-world export
+    artifact, e.g. issue #2366's export-exigences.csv) can throw off
+    csv.Sniffer before it sees enough consistent rows to settle on a
+    delimiter. detect_delimiter must return None rather than silently
+    defaulting to ',' — a wrong guess forces DuckDB to look for a delimiter
+    that isn't actually there."""
+    processor = CsvTabularProcessor()
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text(_UNSNIFFABLE_SEMICOLON_EXPORT, encoding="utf-8")
+
+    assert processor.detect_delimiter(csv_path, ["utf-8"]) is None
+
+
+def test_build_duckdb_read_relation_sql_omits_delim_when_unset():
+    """When our own sniff couldn't settle on a delimiter (CsvReadOptions.delimiter
+    is None), the generated SQL must not pass `delim=` at all — DuckDB's own
+    read_csv_auto then runs its full built-in auto-detection instead of being
+    constrained to a forced (and possibly wrong) single candidate."""
+    processor = CsvTabularProcessor()
+    options = CsvReadOptions(delimiter=None, encoding="utf-8", header=True)
+
+    sql = processor.build_duckdb_read_relation_sql(Path("/tmp/input.csv"), options)
+
+    assert "delim=" not in sql
+    assert "encoding='utf-8'" in sql
 
 
 def test_ragged_semicolon_export_is_tolerated(tmp_path):

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -2536,6 +2536,37 @@ _(none yet)_
 
 ---
 
+### `TaskCard` / `TaskDetailPopover`
+
+**Location:** `src/rework/components/shared/molecules/TaskCard/TaskCard.tsx`,
+`src/rework/components/shared/molecules/TaskDetailPopover/TaskDetailPopover.tsx`
+**Status:** `Functional`
+
+The personal-tray task surface (`TaskTray`, `MigrationPage`'s active/terminal grids) —
+`TaskCard` renders one row per task with the ack/dismiss affordance referenced above; clicking
+its status indicator opens `TaskDetailPopover`, a floating detail panel showing state,
+progress %, step, elapsed time, and the raw `task.error` on failure.
+
+#### Open UX issues
+
+_(none yet)_
+
+#### Resolved
+
+- **Error text unreachable/uncopyable on failure, "Ignorer" a no-op for attachment tasks
+  (2026-08-13, #2366)** — three gaps found live-testing a real ingest failure. The popover
+  positioned itself purely from the anchor's rect with no vertical bound, so a long raw
+  backend error (e.g. a DuckDB sniffer dump) could render past the bottom of the viewport with
+  no way to reach the rest — now capped at `min(400px, 100vh - 16px)` with internal scroll, and
+  the vertical position clamps against that same cap. The error text had no copy affordance
+  short of a screenshot — added, reusing the existing `IconButton` + `useCopyConfirmation` +
+  `writeRichClipboard` pattern. And "Ignorer" silently did nothing for a chat-attachment task:
+  `fast/ingest` is synchronous and never creates a server-side task record, so the task is a
+  client-only Redux entry and acknowledging it always 404'd — it now acknowledges locally for
+  these `localOnly` tasks instead of calling an endpoint that never heard of them.
+
+---
+
 ### `WritableDocumentPane` (writable_document capability)
 
 **Location:** `src/rework/features/capabilities/writable_document/WritableDocumentPane.tsx`

--- a/libs/fred-core/fred_core/tests/integration/test_postgres_document_store_sql.py
+++ b/libs/fred-core/fred_core/tests/integration/test_postgres_document_store_sql.py
@@ -43,6 +43,9 @@ from typing import AsyncIterator
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
 from fred_core.documents.document_models import DocumentMetadataRow
 from fred_core.documents.document_structures import (
     DocumentMetadata,
@@ -55,8 +58,6 @@ from fred_core.documents.document_structures import (
 from fred_core.documents.label_models import DocumentLabelRow
 from fred_core.documents.postgres_document_store import PostgresDocumentMetadataStore
 from fred_core.models.base import Base
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
 
 pytestmark = pytest.mark.integration
 

--- a/libs/fred-core/fred_core/tests/integration/test_postgres_document_store_sql.py
+++ b/libs/fred-core/fred_core/tests/integration/test_postgres_document_store_sql.py
@@ -59,7 +59,7 @@ from fred_core.documents.label_models import DocumentLabelRow
 from fred_core.documents.postgres_document_store import PostgresDocumentMetadataStore
 from fred_core.models.base import Base
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.integration_postgres]
 
 _PG_DSN_ENV = "FRED_PG_DSN"
 _DEFAULT_DSN = "postgresql+asyncpg://fred:Azerty123_@localhost:5432/fred"  # pragma: allowlist secret

--- a/libs/fred-core/pyproject.toml
+++ b/libs/fred-core/pyproject.toml
@@ -127,5 +127,8 @@ exclude_lines = [
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra"
-markers = ["integration: marks tests that require external services"]
+markers = [
+  "integration: marks tests that require external services",
+  "integration_postgres: integration tests that specifically need a real PostgreSQL — docker-compose.integration.yml only provisions OpenFGA, so `make test-integration` excludes this subset by default",
+]
 testpaths = ["fred_core/tests"]

--- a/scripts/makefiles/python-test.mk
+++ b/scripts/makefiles/python-test.mk
@@ -42,11 +42,15 @@ integration-down: ## Stop integration test dependencies
 	docker compose -f $(INTEGRATION_COMPOSE) down -v
 
 .PHONY: test-integration-only
-test-integration-only: dev ## Run integration tests that rely on external services
-	${UV} run pytest -m integration
+test-integration-only: dev ## Run integration tests that rely on external services already running
+	${UV} run pytest -m "integration and not integration_postgres"
 
 .PHONY: test-integration
 test-integration: dev ## Run integration tests that rely on external services and start/stop those services automatically
 	@set -e; trap 'docker compose -f $(INTEGRATION_COMPOSE) down -v' EXIT; \
 		docker compose -f $(INTEGRATION_COMPOSE) up -d; \
-		${UV} run pytest -m integration
+		${UV} run pytest -m "integration and not integration_postgres"
+
+.PHONY: test-integration-postgres
+test-integration-postgres: dev ## Run the integration tests that need a real PostgreSQL — not provisioned by docker-compose.integration.yml (OpenFGA only), so these are excluded from test-integration/test-integration-only until that's addressed. Point FRED_PG_DSN at a running Postgres first (see the test file's own docstring for the default dev-stack DSN).
+	${UV} run pytest -m integration_postgres


### PR DESCRIPTION
## Summary
Found live-testing a CSV file that crashed ingestion the day before. Root cause and two related UI bugs surfaced along the way in the same session.

- **Root cause**: `CsvTabularProcessor.detect_delimiter` silently defaulted to `,` whenever Python's `csv.Sniffer` failed to settle on a delimiter (a quoted field with an embedded raw newline — common in real Excel/Windows exports — throws the sniffer off). That wrong guess then forced DuckDB to look for a delimiter that wasn't actually in the file, failing identically before and after the UTF-8 transcode fallback. Now returns `None` on genuine sniff failure and lets DuckDB's own multi-candidate auto-detection run instead. Verified against the actual file that crashed: it now ingests on the first attempt.
- **Logging gap**: the terminal UTF-8-fallback attempt was the only one of three read attempts with no logging — its exception reached the HTTP 400 body but never stdout, so an operator watching logs never saw the real failure.
- **Task error popover**: found while reproducing the crash live —
  - popover had no vertical bound and could render past the viewport with the rest of the error unreachable — now capped with internal scroll and clamped positioning
  - no way to copy the raw error text out (added, reusing the existing `IconButton` + `useCopyConfirmation` pattern)
  - "Ignorer" silently no-op'd for chat-attachment failures — `fast/ingest` is synchronous and never creates a server-side task record, so the task is a client-only Redux entry; acknowledging it was POSTing to an ack endpoint that 404'd. Now acknowledges locally for `localOnly` tasks.

## Test plan
- [x] `make code-quality` clean (backend + frontend)
- [x] Backend: 9/9 tests pass in `csv_tabular_processor` suite (2 new: delimiter-sniff-failure → `None`, SQL builder omits `delim=` when unset)
- [x] Frontend: full `make test` — 1252/1254 pass (2 pre-existing skips), no regressions
- [x] Live-verified against the real crashing file: ingest succeeds (200, vectors stored), and the file is retrieved correctly in a subsequent RAG search (`export-exigences.csv` top result, score 1.0)
- [x] Live-verified copy button, popover scroll/positioning, and "Ignorer" dismiss on a failed attachment

Closes #2366