### PR TITLE
fix(#2369): Save current chat composer options even for the first message sent (resoning effort etc.)

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// #2369: the composer's defaults-hydration effect (chat_controls arrives async
+// after mount, RFC §3.7) must never overwrite a pick the user made themselves.
+// It could, in exactly one window: a brand-new conversation, where `sessionId`
+// is still null so nothing is written to sessionStorage, and prepare-execution
+// hands back a fresh `chat_controls` ARRAY IDENTITY on every send() — which is
+// what re-runs the effect. Reasoning turned on before the first question was
+// reverted to the widget default the moment that first question was sent (the
+// turn itself ran with reasoning; only the composer forgot).
+//
+// Driven through a minimal host component — there is no
+// @testing-library/react in this repo, same as useManagedChat.test.tsx.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ChatControlDescriptor } from "../../../../slices/controlPlane/controlPlaneOpenApi";
+import { useComposerSettings } from "./useComposerSettings";
+
+/** A reasoning_toggle descriptor, `params.default` being the agent author's
+ *  preselection (#2175). Each call returns a NEW array — the point of the
+ *  regression below is that identity, not content, is what wakes the effect. */
+function controls(defaultOn: boolean): ChatControlDescriptor[] {
+  return [{ capability_id: "platform", widget: "reasoning_toggle", params: { default: defaultOn, effort: "high" } }];
+}
+
+type Hook = ReturnType<typeof useComposerSettings>;
+
+function TestHost({
+  sessionId,
+  chatControls,
+  onRender,
+}: {
+  sessionId: string | null;
+  chatControls: readonly ChatControlDescriptor[];
+  onRender: (hook: Hook) => void;
+}) {
+  onRender(useComposerSettings(sessionId, chatControls));
+  return null;
+}
+
+describe("useComposerSettings — defaults never clobber an explicit pick", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: Hook;
+
+  const render = (sessionId: string | null, chatControls: readonly ChatControlDescriptor[]) => {
+    act(() => {
+      root.render(<TestHost sessionId={sessionId} chatControls={chatControls} onRender={(h) => (latest = h)} />);
+    });
+  };
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    sessionStorage.clear();
+  });
+
+  it("keeps a reasoning pick made before the first message, once that message binds a session", () => {
+    // New conversation: no session id yet, so nothing this hook writes reaches
+    // sessionStorage.
+    render(null, controls(false));
+    expect(latest.reasoning).toBe(false);
+
+    act(() => latest.setReasoning(true));
+    expect(latest.reasoning).toBe(true);
+
+    // handleSend mints the session id (suppressing the session-change reset)
+    // and send() re-runs prepare-execution, whose response replaces
+    // `chatControls` with an equal-but-new array.
+    render("sid-1", controls(false));
+
+    expect(latest.reasoning).toBe(true);
+  });
+
+  it("keeps a search policy / library pick across the same first-send refresh", () => {
+    render(null, controls(false));
+
+    act(() => latest.setSearchPolicy("semantic"));
+    act(() => latest.setSelectedLibraryIds(["lib-a"]));
+
+    render("sid-1", controls(false));
+
+    expect(latest.searchPolicy).toBe("semantic");
+    expect(latest.selectedLibraryIds).toEqual(["lib-a"]);
+  });
+
+  it("still applies the author's defaults when chat_controls lands after mount and nothing was picked", () => {
+    // The effect's original job: the eager prepare-execution call has not
+    // resolved yet at mount, so the composer starts on the `?? false` fallback.
+    render(null, []);
+    expect(latest.reasoning).toBe(false);
+
+    render(null, controls(true));
+
+    expect(latest.reasoning).toBe(true);
+  });
+
+  it("re-enables default hydration after reset() — a genuine session entry", () => {
+    render(null, controls(false));
+    act(() => latest.setReasoning(true));
+
+    // Entering another session: state is rebuilt from that session's storage
+    // (empty here) with no chat_controls resolved for it yet.
+    act(() => latest.reset("sid-2", []));
+    expect(latest.reasoning).toBe(false);
+
+    // …and that session's own controls, arriving after, are applied normally.
+    render("sid-2", controls(true));
+
+    expect(latest.reasoning).toBe(true);
+  });
+
+  it("lets a stored session pick outrank the author's default", () => {
+    sessionStorage.setItem("chat.composer.sid-3", JSON.stringify({ reasoning: false }));
+
+    render("sid-3", []);
+    render("sid-3", controls(true));
+
+    expect(latest.reasoning).toBe(false);
+  });
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.test.tsx
@@ -64,6 +64,14 @@ describe("useComposerSettings — defaults never clobber an explicit pick", () =
     });
   };
 
+  /** A reload (or leaving the conversation and coming back): nothing survives
+   *  but sessionStorage. */
+  const remount = (sessionId: string | null, chatControls: readonly ChatControlDescriptor[]) => {
+    act(() => root.unmount());
+    root = createRoot(container);
+    render(sessionId, chatControls);
+  };
+
   beforeEach(() => {
     sessionStorage.clear();
     container = document.createElement("div");
@@ -104,6 +112,28 @@ describe("useComposerSettings — defaults never clobber an explicit pick", () =
 
     expect(latest.searchPolicy).toBe("semantic");
     expect(latest.selectedLibraryIds).toEqual(["lib-a"]);
+  });
+
+  it("makes that pick durable: bindSession() persists it under the freshly minted session id", () => {
+    render(null, controls(false));
+    act(() => latest.setReasoning(true));
+
+    // What useManagedChat does the moment it mints a session id for a
+    // conversation that had none.
+    act(() => latest.bindSession("sid-1"));
+    remount("sid-1", controls(false));
+
+    expect(latest.reasoning).toBe(true);
+  });
+
+  it("does not seed storage on bind when the user picked nothing — defaults keep applying", () => {
+    render(null, []);
+
+    act(() => latest.bindSession("sid-1"));
+
+    expect(sessionStorage.getItem("chat.composer.sid-1")).toBeNull();
+    render("sid-1", controls(true));
+    expect(latest.reasoning).toBe(true);
   });
 
   it("still applies the author's defaults when chat_controls lands after mount and nothing was picked", () => {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.ts
@@ -101,17 +101,30 @@ export function useComposerSettings(sessionId: string | null, chatControls: read
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
 
+  // True as soon as the user picks anything; cleared by reset() (a genuine
+  // entry into a new or different session). #2369: sessionStorage alone cannot
+  // stand in for it. A pick made in a brand-new conversation happens while
+  // `sessionId` is still null, so update() below writes nothing — and
+  // prepare-execution hands back a FRESH chat_controls array on every send(),
+  // which re-runs the effect below. Without this flag the first send reverted
+  // the user's own reasoning pick (and search policy, RAG scope, library and
+  // document selection) to the widget defaults, mid-conversation.
+  const userEditedRef = useRef(false);
+
   // chatControls arrives async (an eager prepare-execution call, RFC §3.7). If
   // it was empty at mount and no sessionStorage data exists for this session,
-  // apply the resolved defaults now.
+  // apply the resolved defaults now. Defaults only ever fill a gap: a resolved
+  // value the user chose themselves outranks them.
   useEffect(() => {
     if (chatControls.length === 0) return;
+    if (userEditedRef.current) return;
     if (Object.keys(readStorage(sessionIdRef.current)).length > 0) return;
     setState(buildInitial(sessionIdRef.current, chatControls));
   }, [chatControls]);
 
   const update = useCallback(
     (patch: Partial<ComposerState>) => {
+      userEditedRef.current = true;
       setState((prev) => {
         const next = { ...prev, ...patch };
         if (sessionId) writeStorage(sessionId, next);
@@ -122,6 +135,7 @@ export function useComposerSettings(sessionId: string | null, chatControls: read
   );
 
   const reset = useCallback((nextSessionId: string | null, nextChatControls: readonly ChatControlDescriptor[]) => {
+    userEditedRef.current = false;
     setState(buildInitial(nextSessionId, nextChatControls));
   }, []);
 

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useComposerSettings.ts
@@ -93,13 +93,21 @@ function buildInitial(sessionId: string | null, chatControls: readonly ChatContr
  * Writes through to sessionStorage on every change so state survives
  * navigation within the same browser tab.
  *
- * Call reset() when the session changes to reinitialise from storage/defaults.
+ * Call reset() when the session changes to reinitialise from storage/defaults,
+ * and bindSession() when a session id is minted for a conversation that had
+ * none — that is the moment a pick made before the first message becomes
+ * durable (#2369).
  */
 export function useComposerSettings(sessionId: string | null, chatControls: readonly ChatControlDescriptor[]) {
   const [state, setState] = useState<ComposerState>(() => buildInitial(sessionId, chatControls));
 
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+
+  // Read by bindSession() below, which fires from a callback and so cannot
+  // close over the render-time state.
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   // True as soon as the user picks anything; cleared by reset() (a genuine
   // entry into a new or different session). #2369: sessionStorage alone cannot
@@ -139,6 +147,20 @@ export function useComposerSettings(sessionId: string | null, chatControls: read
     setState(buildInitial(nextSessionId, nextChatControls));
   }, []);
 
+  // Called by the caller that MINTS a session id for a conversation that had
+  // none (#2369) — the flag above keeps the pick alive for the rest of the
+  // mount, this is what makes it durable. Until the id exists update() has
+  // nowhere to write, so without this a reasoning pick made before the first
+  // message was gone the next time the user entered that very session (reload,
+  // or leaving and coming back), reverting to the widget default one
+  // navigation later. Only a real pick is written: seeding storage with
+  // untouched defaults would freeze them against a later chat_controls
+  // refresh, which is exactly what the storage guard above is there to allow.
+  const bindSession = useCallback((nextSessionId: string) => {
+    if (!userEditedRef.current) return;
+    writeStorage(nextSessionId, stateRef.current);
+  }, []);
+
   const setSearchPolicy = useCallback((p: SearchPolicyName) => update({ searchPolicy: p }), [update]);
 
   const setRagScope = useCallback((s: RagScope) => update({ ragScope: s }), [update]);
@@ -161,5 +183,6 @@ export function useComposerSettings(sessionId: string | null, chatControls: read
     setSelectedLibraryIds,
     setSelectedDocumentUids,
     reset,
+    bindSession,
   };
 }

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
@@ -138,6 +138,7 @@ vi.mock("@hooks/useChatSse", () => ({
 }));
 
 const composerResetMock = vi.fn();
+const composerBindSessionMock = vi.fn();
 const composerValue = {
   searchPolicy: "corpus" as const,
   ragScope: "general" as const,
@@ -148,6 +149,7 @@ const composerValue = {
   setSelectedLibraryIds: vi.fn(),
   setSelectedDocumentUids: vi.fn(),
   reset: composerResetMock,
+  bindSession: composerBindSessionMock,
 };
 vi.mock("./useComposerSettings", () => ({
   useComposerSettings: () => composerValue,
@@ -311,6 +313,7 @@ describe("useManagedChat — session write reliability", () => {
       abortMock,
       replaceAllMessagesMock,
       composerResetMock,
+      composerBindSessionMock,
       showErrorMock,
       notifyApiErrorMock,
       chatAttachmentsValue.clearReadyAttachments,
@@ -401,6 +404,34 @@ describe("useManagedChat — session write reliability", () => {
 
     expect(latest.inputTooLong).toBe(false);
     expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  // #2369: a brand-new conversation's composer settings live only in memory —
+  // there is no session id to key sessionStorage on until handleSend mints
+  // one. So the mint must both hand that id to the composer (making the pick
+  // durable) and NOT trigger the sessionId-change reset(), which would rebuild
+  // the composer from that session's still-empty storage and revert the pick.
+  // Both halves are this hook's job and invisible from useComposerSettings'
+  // own tests, which can only simulate the bind.
+  it("hands a handleSend-minted session id to the composer instead of resetting it", async () => {
+    mount();
+    act(() => {
+      latest.setInput("first question");
+    });
+    rerender();
+    // The mount itself legitimately resets (entering a session, here the empty
+    // one) — only what the send adds on top is under test.
+    const resetsBeforeSend = composerResetMock.mock.calls.length;
+
+    await act(async () => {
+      await latest.handleSend();
+    });
+    rerender();
+
+    const sid = (registerSessionCalls[0] as { createSessionRequest: { session_id: string } }).createSessionRequest
+      .session_id;
+    expect(composerBindSessionMock).toHaveBeenCalledWith(sid);
+    expect(composerResetMock.mock.calls.length).toBe(resetsBeforeSend);
   });
 
   it("restores the complete ordinary draft after a backend length rejection", async () => {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
@@ -455,13 +455,17 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     if (!sid) {
       sid = uuidv4();
       skipResetOnSessionBindRef.current = true;
+      // Before bindSessionId: the composer settings the user picked while this
+      // conversation had no id are only in memory until they are written under
+      // one (#2369).
+      composer.bindSession(sid);
       bindSessionId(sid);
     }
     if (needsCreate) {
       createSessionRow(sid, "New conversation");
     }
     return sid;
-  }, [bindSessionId, createSessionRow, sessionId]);
+  }, [bindSessionId, composer.bindSession, createSessionRow, sessionId]);
 
   const handleAddAttachments = useCallback(
     (files: File[], source: "picker" | "drop") => {
@@ -498,6 +502,9 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
         sid = uuidv4();
         console.debug(`[useManagedChat] handleSend() — no session, creating new sid=${sid}, calling bindSessionId`);
         skipResetOnSessionBindRef.current = true;
+        // See ensureSessionForAttachments: makes this turn's composer settings
+        // durable under the id they were picked for (#2369).
+        composer.bindSession(sid);
         bindSessionId(sid);
       }
       if (needsCreate) {
@@ -587,6 +594,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     waitResponse,
     sessionId,
     chatControls,
+    composer.bindSession,
     composer.selectedLibraryIds,
     composer.selectedDocumentUids,
     composer.searchPolicy,

--- a/docs/swift/backlog/CHAT-UI-BACKLOG.md
+++ b/docs/swift/backlog/CHAT-UI-BACKLOG.md
@@ -1270,6 +1270,7 @@ defaults after navigation, and half-streaming state on session switch.
 - [x] Reads initial state from `sessionStorage` key `chat.composer.{sessionId}` if present; otherwise from `agentDefaults` (2026-05-24)
 - [x] Writes through to `sessionStorage` on every setter call (2026-05-24)
 - [x] `useManagedChat` delegates `searchPolicy`, `ragScope`, `selectedLibraryIds` to this hook (2026-05-24)
+- [x] A pick the user made themselves outranks both tiers above: it survives the `chat_controls` refresh every send triggers, and `bindSession()` persists it under the session id the first message mints — until that id exists there is no key to write to (#2369, 2026-08-13)
 
 ---
 


### PR DESCRIPTION
Closes #2369.

## Symptom

Start a new conversation, turn reasoning ON, ask the first question: the answer
*does* run with reasoning, but the composer chip flips back to `Off` on its own
— so the second question silently runs without it. Only on the first question
of a new conversation.

## Root cause

`useComposerSettings` never persists a pick made while `sessionId` is still
`null`: `update()` writes through only `if (sessionId)`. Its defaults-hydration
effect (which exists because `chat_controls` arrives async, RFC §3.7) keyed its
"don't clobber" guard on sessionStorage alone.

The first send mints the sid and correctly suppresses the session-change reset,
but `send()` then runs prepare-execution, and `setChatControls(prep.chat_controls)`
hands back a **fresh array identity** — waking the effect. Nothing in storage
for the brand-new sid, so the state was rebuilt from `params.default`. The turn
itself was unaffected: `handleSend` had already built the `RuntimeContext`,
hence "reasoning ran, chip says off".

Search policy, RAG scope and the library/document selection were reverted the
same way.

## Fix

1. An explicit-pick flag guards the effect: defaults only ever fill a gap, and
   a value the user chose outranks them (cleared by `reset()` — a genuine
   session entry).
2. `bindSession()`, called by the two places that mint a session id for a
   conversation that had none, persists the pick under it. Without this the
   loss just moved one navigation later (reload, or leave and come back), which
   is what the review of commit 1 caught. It writes only when the user actually
   picked something — seeding storage with untouched defaults would freeze them
   against a later `chat_controls` refresh.

## Tests

`useComposerSettings.test.tsx` (new, 7 cases): the pick survives the first
send's `chat_controls` refresh, `bindSession()` makes it survive a remount,
defaults still hydrate when nothing was picked and after `reset()`, stored
state still outranks defaults. Verified red without the fix (2 of them fail on
the old code), green with it.

`useManagedChat.test.tsx`: pins the cross-hook contract the fix rests on — a
handleSend-minted sid reaches the composer and does **not** trigger the
session-change `reset()`.

Full frontend suite: 1271 passed. Root `make code-quality`: green on all
modules.

## Notes for the reviewer

Considered and deliberately not done, all pre-existing and unchanged in kind
by this PR:

- **Per-field dirty tracking.** The flag is all-or-nothing, so one pick
  suppresses a *later* author default for untouched fields. That window is
  the pre-first-message phase only: once a pick is stored, the pre-existing
  sessionStorage guard blocks hydration exactly the same way. Same behaviour,
  no new mechanism.
- **No-op click marks the composer dirty.** Re-picking the already-selected
  row calls `update()`. It already wrote a full storage blob before this PR,
  with the same consequence.
- **Double `readStorage` in the effect.** One extra parse of a small blob per
  send; hoisting it means threading the parsed value through `buildInitial`.
