### PR TITLE
fix(#2373): bring the writable-document Alembic tree under the combined migration checks

### DIFF
--- a/.github/workflows/Check-migrations.yml
+++ b/.github/workflows/Check-migrations.yml
@@ -45,7 +45,11 @@ jobs:
         run: uv sync
         working-directory: libs/fred-runtime
 
-      - name: Check single Alembic head per backend
+      - name: Install dependencies (fred-capability-writable-document)
+        run: uv sync
+        working-directory: libs/fred-capability-writable-document
+
+      - name: Check single Alembic head per tree
         run: make db-check-combined-heads
 
   check-migrations-sqlite:
@@ -74,6 +78,10 @@ jobs:
       - name: Install dependencies (fred-runtime)
         run: uv sync
         working-directory: libs/fred-runtime
+
+      - name: Install dependencies (fred-capability-writable-document)
+        run: uv sync
+        working-directory: libs/fred-capability-writable-document
 
       - name: Run combined SQLite migration checks
         run: make db-check-combined-sqlite
@@ -104,6 +112,10 @@ jobs:
       - name: Install dependencies (fred-runtime)
         run: uv sync
         working-directory: libs/fred-runtime
+
+      - name: Install dependencies (fred-capability-writable-document)
+        run: uv sync
+        working-directory: libs/fred-capability-writable-document
 
       - name: Run combined PostgreSQL migration checks
         run: make db-check-combined-postgres

--- a/Makefile
+++ b/Makefile
@@ -217,15 +217,23 @@ db-snapshots: ## Dump schema after each migration for migratable backends into t
 MIGRATION_COMPOSE    := scripts/docker-compose.postgres.yml
 PG_COMBINED_URL      := postgresql+asyncpg://test:test@localhost:5433/test_migrations
 SQLITE_COMBINED_DB   := /tmp/fred_combined_migrations.db
-CP_UV                := apps/control-plane-backend/.venv/bin/uv
-KF_UV                := apps/knowledge-flow-backend/.venv/bin/uv
-RT_UV                := libs/fred-runtime/.venv/bin/uv
+# One entry per Alembic tree. These lists are hardcoded, not discovery: a new
+# tree is exercised by nothing until it is added to all three targets below.
+CP_DIR               := apps/control-plane-backend
+KF_DIR               := apps/knowledge-flow-backend
+RT_DIR               := libs/fred-runtime
+WD_DIR               := libs/fred-capability-writable-document
+CP_UV                := $(CP_DIR)/.venv/bin/uv
+KF_UV                := $(KF_DIR)/.venv/bin/uv
+RT_UV                := $(RT_DIR)/.venv/bin/uv
+WD_UV                := $(WD_DIR)/.venv/bin/uv
 
 .PHONY: db-check-combined-heads
-db-check-combined-heads: ## assert each migratable backend has exactly one Alembic head (no branch conflicts)
-	$(MAKE) -C apps/control-plane-backend db-check-heads
-	$(MAKE) -C apps/knowledge-flow-backend db-check-heads
-	$(MAKE) -C libs/fred-runtime db-check-heads
+db-check-combined-heads: ## assert each Alembic tree has exactly one head (no branch conflicts)
+	$(MAKE) -C $(CP_DIR) db-check-heads
+	$(MAKE) -C $(KF_DIR) db-check-heads
+	$(MAKE) -C $(RT_DIR) db-check-heads
+	$(MAKE) -C $(WD_DIR) db-check-heads
 
 .PHONY: db-check-combined-postgres-up
 db-check-combined-postgres-up: ## start the PostgreSQL container for combined migration checks
@@ -236,37 +244,43 @@ db-check-combined-postgres-down: ## stop and wipe the PostgreSQL container for c
 	docker compose -f $(MIGRATION_COMPOSE) down -v
 
 .PHONY: db-check-combined-sqlite
-db-check-combined-sqlite: ## upgrade control-plane, knowledge-flow, and fred-runtime against the same SQLite DB, check for drift, then downgrade
+db-check-combined-sqlite: ## upgrade every Alembic tree against the same SQLite DB, check for drift, then downgrade
 	@echo "=== Combined SQLite migration check: upgrade ==="
 	@rm -f $(SQLITE_COMBINED_DB)
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(CP_UV) run --directory apps/control-plane-backend alembic upgrade head
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(KF_UV) run --directory apps/knowledge-flow-backend alembic upgrade head
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory libs/fred-runtime alembic upgrade head
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(CP_UV) run --directory $(CP_DIR) alembic upgrade head
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(KF_UV) run --directory $(KF_DIR) alembic upgrade head
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory $(RT_DIR) alembic upgrade head
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(WD_UV) run --directory $(WD_DIR) alembic upgrade head
 	@echo "=== Combined SQLite migration check: drift check ==="
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(CP_UV) run --directory apps/control-plane-backend alembic check
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(KF_UV) run --directory apps/knowledge-flow-backend alembic check
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory libs/fred-runtime alembic check
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(CP_UV) run --directory $(CP_DIR) alembic check
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(KF_UV) run --directory $(KF_DIR) alembic check
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory $(RT_DIR) alembic check
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(WD_UV) run --directory $(WD_DIR) alembic check
 	@echo "=== Combined SQLite migration check: downgrade ==="
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(KF_UV) run --directory apps/knowledge-flow-backend alembic downgrade base
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(CP_UV) run --directory apps/control-plane-backend alembic downgrade base
-	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory libs/fred-runtime alembic downgrade base
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(WD_UV) run --directory $(WD_DIR) alembic downgrade base
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(KF_UV) run --directory $(KF_DIR) alembic downgrade base
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(CP_UV) run --directory $(CP_DIR) alembic downgrade base
+	DATABASE_URL="sqlite+aiosqlite:///$(SQLITE_COMBINED_DB)" $(RT_UV) run --directory $(RT_DIR) alembic downgrade base
 	@rm -f $(SQLITE_COMBINED_DB)
 	@echo "=== Combined SQLite migration check passed ==="
 
 .PHONY: db-check-combined-postgres
-db-check-combined-postgres: db-check-combined-postgres-down db-check-combined-postgres-up ## upgrade control-plane, knowledge-flow, and fred-runtime against the same DB, check for drift, then downgrade
+db-check-combined-postgres: db-check-combined-postgres-down db-check-combined-postgres-up ## upgrade every Alembic tree against the same DB, check for drift, then downgrade
 	@echo "=== Combined migration check: upgrade ==="
-	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory apps/control-plane-backend alembic upgrade head
-	DATABASE_URL="$(PG_COMBINED_URL)" $(KF_UV) run --directory apps/knowledge-flow-backend alembic upgrade head
-	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory libs/fred-runtime alembic upgrade head
+	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory $(CP_DIR) alembic upgrade head
+	DATABASE_URL="$(PG_COMBINED_URL)" $(KF_UV) run --directory $(KF_DIR) alembic upgrade head
+	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory $(RT_DIR) alembic upgrade head
+	DATABASE_URL="$(PG_COMBINED_URL)" $(WD_UV) run --directory $(WD_DIR) alembic upgrade head
 	@echo "=== Combined migration check: drift check ==="
-	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory apps/control-plane-backend alembic check
-	DATABASE_URL="$(PG_COMBINED_URL)" $(KF_UV) run --directory apps/knowledge-flow-backend alembic check
-	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory libs/fred-runtime alembic check
+	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory $(CP_DIR) alembic check
+	DATABASE_URL="$(PG_COMBINED_URL)" $(KF_UV) run --directory $(KF_DIR) alembic check
+	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory $(RT_DIR) alembic check
+	DATABASE_URL="$(PG_COMBINED_URL)" $(WD_UV) run --directory $(WD_DIR) alembic check
 	@echo "=== Combined migration check: downgrade ==="
-	DATABASE_URL="$(PG_COMBINED_URL)" $(KF_UV) run --directory apps/knowledge-flow-backend alembic downgrade base
-	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory apps/control-plane-backend alembic downgrade base
-	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory libs/fred-runtime alembic downgrade base
+	DATABASE_URL="$(PG_COMBINED_URL)" $(WD_UV) run --directory $(WD_DIR) alembic downgrade base
+	DATABASE_URL="$(PG_COMBINED_URL)" $(KF_UV) run --directory $(KF_DIR) alembic downgrade base
+	DATABASE_URL="$(PG_COMBINED_URL)" $(CP_UV) run --directory $(CP_DIR) alembic downgrade base
+	DATABASE_URL="$(PG_COMBINED_URL)" $(RT_UV) run --directory $(RT_DIR) alembic downgrade base
 	@echo "=== Combined migration check passed ==="
 	$(MAKE) db-check-combined-postgres-down
 

--- a/docs/swift/ops/DATABASE_MIGRATIONS.md
+++ b/docs/swift/ops/DATABASE_MIGRATIONS.md
@@ -11,9 +11,22 @@ order. The current position is tracked in an `alembic_version` table in the data
 The `--autogenerate` flag compares the current ORM models against the live database and
 drafts the `upgrade()`/`downgrade()` functions automatically.
 
-Each backend that owns database tables has its own Alembic setup under `<backend>/alembic/`.
-ORM models are registered in each backend's `alembic/env.py` so that autogenerate can
-detect differences between the code and the live database.
+Each component that owns database tables has its own tree, its own version table, and its
+own single head — never rebased against another's. ORM models are registered in each tree's
+`env.py` so that autogenerate can detect differences between the code and the live database.
+
+| Tree | Location | Version table |
+| --- | --- | --- |
+| control-plane | `apps/control-plane-backend/alembic/` | `alembic_version_control_plane` |
+| knowledge-flow | `apps/knowledge-flow-backend/alembic/` | `alembic_version_knowledge_flow` |
+| fred-runtime | `libs/fred-runtime/alembic/` | `alembic_version_runtime` |
+| writable-document capability | `libs/fred-capability-writable-document/fred_capability_writable_document/writable_document_migrations/` | `cap_writable_document_alembic_version` |
+
+A capability's tree sits inside its package rather than under `alembic/`, because
+`python -m fred_runtime migrate` discovers it by entry point (`fred.capabilities`) and runs
+it after fred-runtime's own. Every tree resolves its `script_location` from a
+`[tool.alembic]` block in the owning package's `pyproject.toml`, which is also what lets the
+`alembic` CLI and the CI checks below reach it.
 
 ## Configuration
 
@@ -236,6 +249,19 @@ make db-check-postgres       # PostgreSQL checks only (assumes container is runn
 make db-check-postgres-down  # stop the PostgreSQL container
 make db-check-postgres-full  # start container, run checks, stop container
 ```
+
+The targets above cover one tree — the one in the directory you run them from. From the
+repo root, the `db-check-combined-*` targets run every tree in the table above against a
+single shared database, which is what `Check-migrations.yml` invokes:
+
+```bash
+make db-check-combined-heads     # one head per tree
+make db-check-combined-sqlite    # all trees: upgrade, check, downgrade
+make db-check-combined-postgres  # same, against a PostgreSQL container
+```
+
+These aggregators are hardcoded lists, not discovery: **a new tree is exercised by nothing
+until it is added to all three by hand** (and given its `uv sync` step in the workflow).
 
 ## How to stamp DB created before Alembic
 

--- a/libs/fred-capability-writable-document/Makefile
+++ b/libs/fred-capability-writable-document/Makefile
@@ -8,4 +8,7 @@ include ../../scripts/makefiles/python-code-quality.mk
 include ../../scripts/makefiles/python-test.mk
 include ../../scripts/makefiles/python-clean.mk
 include ../../scripts/makefiles/python-publish.mk
+# This capability ships its own Alembic tree, so it gets the same db-* targets
+# and the same single-head check as the three backend trees (#2373).
+include ../../scripts/makefiles/alembic.mk
 include ../../scripts/makefiles/help.mk

--- a/libs/fred-capability-writable-document/pyproject.toml
+++ b/libs/fred-capability-writable-document/pyproject.toml
@@ -66,6 +66,14 @@ fred-core = { path = "../fred-core", editable = true }
 fred-sdk = { path = "../fred-sdk", editable = true }
 fred-runtime = { path = "../fred-runtime", editable = true }
 
+[tool.alembic]
+# This capability owns its own migration tree (#1905, RFC §7.1). At deploy time
+# `python -m fred_runtime migrate` finds it by entry point and sets
+# script_location itself; this block is what lets the `alembic` CLI — and
+# therefore the combined migration checks — reach the same tree (#2373).
+script_location = "%(here)s/fred_capability_writable_document/writable_document_migrations"
+prepend_sys_path = ["."]
+
 [dependency-groups]
 dev = [
   "bandit>=1.8.6",


### PR DESCRIPTION
Closes #2373. Closes P5's CI half of #2137 — the duplicated Helm migration job in the deployment factory stays out of scope.

## What was wrong

`libs/fred-capability-writable-document` owns a fourth Alembic tree (`writable_document_migrations/`, version table `cap_writable_document_alembic_version`). It was exercised by **nothing** in CI: the root aggregators were hardcoded to three trees, so the workflow never touched it, and the tree only ever ran at deploy time via `python -m fred_runtime migrate`.

The `alembic` CLI could not reach it at all. The other three trees resolve `script_location` from a `[tool.alembic]` block in their own `pyproject.toml`; the capability package had none, so only `migrations.py` could find the tree — it sets `script_location` programmatically.

Harmless at one revision. At two, a branch conflict or a model/migration drift ships with a green build and is discovered in production.

## What changed

- `[tool.alembic]` in the capability's `pyproject.toml`, matching the three existing trees.
- `include alembic.mk` in its `Makefile` — reuses the existing `db-check-heads` rather than adding a second copy of the check, and gives the capability the same `db-upgrade` / `db-check-sqlite` dev targets as the other trees.
- The tree added to `db-check-combined-heads`, `-sqlite` and `-postgres`, plus its `uv sync` step in all three CI jobs.
- Each tree's directory now lives in a variable (`CP_DIR`/`KF_DIR`/`RT_DIR`/`WD_DIR`) so the aggregators stop repeating literal paths.

No change to `migrations.py` or the deploy path.

## Verification

- `make db-check-combined-heads` — 4/4 trees single head.
- `make db-check-combined-sqlite` — exit 0, "Combined SQLite migration check passed".
- `make db-check-combined-postgres` — exit 0, run twice (before and after the variable refactor). Log confirms the capability's three steps really execute: `upgrade head`, `check`, `downgrade base` against the shared PG container.
- `alembic check` on the capability tree is clean — no drift between `WritableDocumentDoc` and its single revision.
- **Bite-verified**: dropping a second revision with `down_revision = None` into the tree makes the guard fail with `Expected 1 head, found 2` → exit 1; removing it returns to green. The check is not vacuous.
- `make -C libs/fred-capability-writable-document db-check-sqlite` — passes standalone, which is what validates the `alembic.mk` include.
- `make code-quality` from the repo root — exit 0, all 9 modules.
- `make -C libs/fred-capability-writable-document test` — 50 passed.
