### PR TITLE
fix(#2170): give each backend its own task tables instead of a shared pair

### DIFF
--- a/apps/control-plane-backend/alembic/env.py
+++ b/apps/control-plane-backend/alembic/env.py
@@ -11,8 +11,8 @@ import control_plane_backend.models.purge_queue_models  # noqa: F401
 import control_plane_backend.models.routing_policy_models  # noqa: F401
 import control_plane_backend.models.session_attachment_models  # noqa: F401
 import control_plane_backend.models.session_metadata_models  # noqa: F401
+import control_plane_backend.models.task_models  # noqa: F401 — registers cp_task_run / cp_task_event_log with Base
 import fred_core.documents.document_models  # noqa: F401 — registers metadata table with CoreBase
-import fred_core.tasks.orm_models  # noqa: F401 — registers task_run / task_event_log with CoreBase
 import fred_core.teams.team_metatada_models  # noqa: F401
 from alembic import context
 from control_plane_backend.config.loader import load_configuration
@@ -33,7 +33,8 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 run_migrations_offline, run_migrations_online = make_alembic_env(
-    # Both metadata objects so autogenerate sees CPB tables and shared task tables.
+    # Both metadata objects so autogenerate sees CPB tables (incl. its own
+    # cp_task_* pair, #2170) and the shared fred-core tables.
     target_metadata=[Base.metadata, CoreBase.metadata],
     get_postgres_config=lambda: load_configuration().storage.postgres,
     version_table="alembic_version_control_plane",

--- a/apps/control-plane-backend/alembic/versions/b7e1c4a09d52_split_task_tables_per_backend.py
+++ b/apps/control-plane-backend/alembic/versions/b7e1c4a09d52_split_task_tables_per_backend.py
@@ -1,0 +1,148 @@
+"""split task tables per backend: task_run/task_event_log -> cp_task_run/cp_task_event_log
+
+Revision ID: b7e1c4a09d52
+Revises: a7d2e9c41f38
+Create Date: 2026-08-14 00:00:00.000000
+
+control-plane and knowledge-flow both migrate the same `fred` database, and both
+mapped the *same* shared `task_run`/`task_event_log` (registered on fred-core's
+`CoreBase`). Neither backend scoped `GET /tasks` to the rows it created, so each
+returned the other's tasks and the Activity page listed every task twice (#2170).
+
+Each backend now owns a prefixed pair declared on its own `Base`
+(`control_plane_backend.models.task_models`). Postgres scopes index names per
+schema, so the indexes are renamed with the tables.
+
+Create-only: the shared `task_run`/`task_event_log` are deliberately LEFT IN
+PLACE, orphaned, to be dropped by a later release. #2170 is fixed the moment each
+backend maps its own pair — the old table's continued existence changes nothing
+about which rows a backend returns. There is no backfill either; task rows are
+progress bookkeeping and #2170 chose not to carry them over.
+
+Why not drop it here, which was the original plan: the two Temporal workers have
+no `migration:` block in `deploy/charts/fred/values.yaml`, so unlike the API
+Deployments they get no `hook-scale-down` Job and keep running OLD code through
+the entire hook phase and the rolling update that follows. Old knowledge-flow
+worker code writes to the shared `task_run` via `emit_ingestion_task_event`
+(`features/scheduler/activities.py`), which is an unguarded `@activity.defn`
+invoked as the FIRST step of `ProcessPushFile` with `maximum_attempts=1`
+(`features/scheduler/workflow.py`). Dropping the table mid-deploy therefore does
+not merely lose task bookkeeping — it fails the workflow before any extraction
+runs, and the document is never ingested, with no retry. Leaving one dead table
+pair behind for a release is the cheaper side of that trade.
+
+This also keeps the revision symmetric with knowledge-flow's `c8f2d5b13ea6`:
+create on upgrade, drop on downgrade, nothing conditional.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e1c4a09d52"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = (
+    "a7d2e9c41f38"  # pragma: allowlist secret
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_JSONB = postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite")
+_BIGINT_PK = sa.BigInteger().with_variant(sa.INTEGER(), "sqlite")
+
+_RUN = "cp_task_run"
+_LOG = "cp_task_event_log"
+
+# Mirrors `fred_core.tasks.orm_models.task_run_table_args`.
+_NON_TERMINAL_MIGRATION = (
+    "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        _RUN,
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("progress", sa.Float(), nullable=True),
+        sa.Column("step", sa.Text(), nullable=True),
+        sa.Column("detail", _JSONB, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("target", _JSONB, nullable=True),
+        sa.Column("execution_id", sa.String(length=255), nullable=True),
+        sa.Column("created_by", sa.String(length=36), nullable=True),
+        sa.Column("team_id", sa.String(length=255), nullable=True),
+        sa.Column("scheduled_for", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("acknowledged_by", sa.String(length=36), nullable=True),
+        sa.PrimaryKeyConstraint("task_id"),
+    )
+    op.create_index(op.f(f"ix_{_RUN}_kind"), _RUN, ["kind"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_state"), _RUN, ["state"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_created_by"), _RUN, ["created_by"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_team_id"), _RUN, ["team_id"], unique=False)
+    op.create_index(
+        op.f(f"ix_{_RUN}_scheduled_for"), _RUN, ["scheduled_for"], unique=False
+    )
+    # Reconciliation sweeper: scans non-terminal tasks ordered by age.
+    op.create_index(f"ix_{_RUN}_state_updated", _RUN, ["state", "updated_at"])
+    # At most one non-terminal kind='migration' row (import/reset exclusion).
+    op.create_index(
+        f"uq_{_RUN}_single_active_migration",
+        _RUN,
+        ["kind"],
+        unique=True,
+        sqlite_where=sa.text(_NON_TERMINAL_MIGRATION),
+        postgresql_where=sa.text(_NON_TERMINAL_MIGRATION),
+    )
+
+    op.create_table(
+        _LOG,
+        sa.Column("id", _BIGINT_PK, autoincrement=True, nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("progress", sa.Float(), nullable=True),
+        sa.Column("step", sa.Text(), nullable=True),
+        sa.Column("detail", _JSONB, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("target", _JSONB, nullable=True),
+        sa.Column("owner", sa.String(length=255), nullable=True),
+        sa.Column(
+            "emitted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("task_id", "seq", name=f"uq_{_LOG}_task_seq"),
+    )
+    op.create_index(op.f(f"ix_{_LOG}_task_id"), _LOG, ["task_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema. Indexes are dropped with their table on both backends.
+
+    Unguarded, like `c8f2d5b13ea6`'s: the pair can only exist if this revision
+    created it. The shared `task_run` is untouched in both directions.
+    """
+    op.drop_table(_LOG)
+    op.drop_table(_RUN)

--- a/apps/control-plane-backend/alembic/versions/c1d2e3f4a5b6_add_task_run_single_active_migration_index.py
+++ b/apps/control-plane-backend/alembic/versions/c1d2e3f4a5b6_add_task_run_single_active_migration_index.py
@@ -50,10 +50,14 @@ _WHERE_CLAUSE = (
 )
 
 
+def _task_run_exists() -> bool:
+    return "task_run" in sa.inspect(op.get_bind()).get_table_names()
+
+
 def _task_run_indexes() -> set[str]:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-    if "task_run" not in inspector.get_table_names():
+    if not _task_run_exists():
         return {_INDEX_NAME}  # table absent (fresh create_all) → treat as present
     return {
         ix["name"] for ix in inspector.get_indexes("task_run") if ix["name"] is not None
@@ -73,6 +77,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    if _INDEX_NAME in _task_run_indexes():
+    """Downgrade schema.
+
+    `_task_run_indexes`'s "table absent → treat as present" sentinel is written
+    for `upgrade` (skip the create). Downgrade needs the opposite reading: since
+    #2170 split the task tables per backend, the shared `task_run` is genuinely
+    gone by the time this unwinds, and DROP INDEX would fail on a missing table.
+    """
+    if _task_run_exists() and _INDEX_NAME in _task_run_indexes():
         op.drop_index(_INDEX_NAME, table_name="task_run")

--- a/apps/control-plane-backend/control_plane_backend/app/context.py
+++ b/apps/control-plane-backend/control_plane_backend/app/context.py
@@ -47,6 +47,7 @@ from control_plane_backend.config.models import (
     MinioContentStorageConfig,
 )
 from control_plane_backend.evaluations.store import EvaluationStore
+from control_plane_backend.models.task_models import TASK_TABLES
 from control_plane_backend.prompts.category_store import PromptCategoryStore
 from control_plane_backend.prompts.store import PromptStore
 from control_plane_backend.routing_policy.store import TeamRoutingPolicyStore
@@ -382,6 +383,7 @@ class ApplicationContext:
             )
             self._task_service = TaskService.build(
                 engine=self.get_pg_async_engine(),
+                tables=TASK_TABLES,
                 backend=backend,
                 temporal_client_provider=temporal_provider,
                 postgres_dsn=self.configuration.storage.postgres.dsn()

--- a/apps/control-plane-backend/control_plane_backend/import_export/api.py
+++ b/apps/control-plane-backend/control_plane_backend/import_export/api.py
@@ -47,6 +47,7 @@ from fred_core.tasks.models import (
     TaskState,
     TaskTarget,
 )
+from fred_core.tasks.orm_models import single_active_migration_index_name
 from fred_core.tasks.service import TaskService
 from pydantic import BaseModel
 from sqlalchemy import delete
@@ -64,6 +65,7 @@ from control_plane_backend.import_export.stats import (
 )
 from control_plane_backend.import_export.teardown import run_teardown
 from control_plane_backend.models.agent_instance_models import AgentInstanceRow
+from control_plane_backend.models.task_models import TASK_RUN_TABLE
 from control_plane_backend.product.dependencies import (
     ProductServiceDependencies,
     get_product_service_dependencies,
@@ -142,8 +144,8 @@ async def _reject_if_migration_task_active(task_service: TaskService) -> None:
     This is a fast-path optimization ONLY — it avoids doing upload/parsing work
     before failing, but it is a plain list-then-check and does not, by itself,
     prevent two concurrent callers from both passing it and both starting a
-    task. The actual correctness guarantee is `uq_task_run_single_active_migration`
-    (a DB-level partial unique index, `fred_core.tasks.orm_models.TaskRunRow`),
+    task. The actual correctness guarantee is the single-active-migration
+    partial unique index on `cp_task_run` (`fred_core.tasks.orm_models`),
     enforced by `_start_migration_task_or_409` below.
     """
     active = await task_service.list_tasks(kind="migration", exclude_terminal=True)
@@ -157,8 +159,8 @@ async def _reject_if_migration_task_active(task_service: TaskService) -> None:
         )
 
 
-# Must match the index name in `fred_core.tasks.orm_models.TaskRunRow.__table_args__`.
-_MIGRATION_EXCLUSION_INDEX_NAME = "uq_task_run_single_active_migration"
+# Derived from the same helper that names the index, so the two cannot drift.
+_MIGRATION_EXCLUSION_INDEX_NAME = single_active_migration_index_name(TASK_RUN_TABLE)
 
 
 def _is_concurrent_migration_violation(exc: IntegrityError) -> bool:
@@ -183,7 +185,7 @@ async def _start_migration_task_or_409(
     This — not `_reject_if_migration_task_active` above — is what actually
     guarantees at most one active migration task: two callers can both pass
     that pre-check and both reach here concurrently, but the partial unique
-    index on `task_run` (`kind='migration'` AND non-terminal state) lets only
+    index on `cp_task_run` (`kind='migration'` AND non-terminal state) lets only
     one insert succeed; the other's `IntegrityError` is translated here.
     """
     try:

--- a/apps/control-plane-backend/control_plane_backend/models/task_models.py
+++ b/apps/control-plane-backend/control_plane_backend/models/task_models.py
@@ -1,0 +1,53 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Control-plane's own task tables (#2170, TASK-EVENT-STREAM-RFC §2.6).
+
+Declared on control-plane's `Base`, not the shared `CoreBase`: these two tables
+belong to this backend alone. knowledge-flow owns the `kf_`-prefixed pair in the
+same `fred` database (`knowledge_flow_backend.models.task_models`). Before the
+split both backends mapped one shared `task_run`, so each one's `GET /tasks`
+returned the other's rows and the Activity page listed every task twice.
+
+Column definitions live once, in `fred_core.tasks.orm_models` — only the names
+differ between the two owners.
+"""
+
+from __future__ import annotations
+
+from fred_core.tasks.orm_models import (
+    TaskEventLogColumns,
+    TaskRunColumns,
+    TaskTables,
+    task_event_log_table_args,
+    task_run_table_args,
+)
+
+from control_plane_backend.models.base import Base
+
+TASK_RUN_TABLE = "cp_task_run"
+TASK_EVENT_LOG_TABLE = "cp_task_event_log"
+
+
+class CpTaskRunRow(TaskRunColumns, Base):
+    __tablename__ = TASK_RUN_TABLE
+    __table_args__ = task_run_table_args(TASK_RUN_TABLE)
+
+
+class CpTaskEventLogRow(TaskEventLogColumns, Base):
+    __tablename__ = TASK_EVENT_LOG_TABLE
+    __table_args__ = task_event_log_table_args(TASK_EVENT_LOG_TABLE)
+
+
+TASK_TABLES = TaskTables(run=CpTaskRunRow, event_log=CpTaskEventLogRow)

--- a/apps/control-plane-backend/tests/conftest.py
+++ b/apps/control-plane-backend/tests/conftest.py
@@ -20,7 +20,7 @@ def _setup_test_schema() -> None:
     import control_plane_backend.models.prompt_models  # noqa: F401
     import control_plane_backend.models.purge_queue_models  # noqa: F401
     import control_plane_backend.models.session_metadata_models  # noqa: F401
-    import fred_core.tasks.orm_models  # noqa: F401
+    import control_plane_backend.models.task_models  # noqa: F401
     from control_plane_backend.models.base import Base as CPBase
     from fred_core.models.base import Base as FredCoreBase
     from fred_core.teams import TeamMetadataRow  # noqa: F401

--- a/apps/control-plane-backend/tests/test_import_capability_sweeps_2004.py
+++ b/apps/control-plane-backend/tests/test_import_capability_sweeps_2004.py
@@ -86,7 +86,6 @@ class _FakeBundle:
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import control_plane_backend.models.task_models  # noqa: F401
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / name}")
     async with engine.begin() as conn:

--- a/apps/control-plane-backend/tests/test_import_capability_sweeps_2004.py
+++ b/apps/control-plane-backend/tests/test_import_capability_sweeps_2004.py
@@ -37,6 +37,7 @@ from control_plane_backend.import_export import importer as importer_module
 from control_plane_backend.import_export.bundle import KBundle
 from control_plane_backend.import_export.importer import run_import
 from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.models.task_models import TASK_TABLES
 from fred_core.models import Base as CoreBase
 from fred_core.scheduler import SchedulerBackend
 from fred_core.tasks.models import MigrationTaskEvent, StartMigrationRequest, TaskState
@@ -85,7 +86,7 @@ class _FakeBundle:
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import fred_core.tasks.orm_models  # noqa: F401
+    import control_plane_backend.models.task_models  # noqa: F401
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / name}")
     async with engine.begin() as conn:
@@ -101,7 +102,9 @@ async def _run(
     product_deps: Any = None,
     import_id: str = "imp-2004",
 ) -> None:
-    task_service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+    task_service = TaskService.build(
+        engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+    )
     start = await task_service.start(StartMigrationRequest(), created_by="tester")
     await run_import(
         bundle=cast(KBundle, bundle),

--- a/apps/control-plane-backend/tests/test_import_export_kea_bundle.py
+++ b/apps/control-plane-backend/tests/test_import_export_kea_bundle.py
@@ -256,10 +256,10 @@ class FakeRebac:
 
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
-    # prompt_models is already imported above (PromptRow) — only agent_instance_models
-    # and the task models still need a registration-only import here.
+    # prompt_models is already imported above (PromptRow) and the task models come
+    # with the module-level TASK_TABLES import — only agent_instance_models still
+    # needs a registration-only import here.
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import control_plane_backend.models.task_models  # noqa: F401
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / name}")
     async with engine.begin() as conn:

--- a/apps/control-plane-backend/tests/test_import_export_kea_bundle.py
+++ b/apps/control-plane-backend/tests/test_import_export_kea_bundle.py
@@ -33,6 +33,7 @@ from control_plane_backend.import_export.kea_reconciliation import (
 )
 from control_plane_backend.models.base import Base as CPBase
 from control_plane_backend.models.prompt_models import PromptRow
+from control_plane_backend.models.task_models import TASK_TABLES
 from fred_core import Relation, RelationType, team_organization_relation
 from fred_core.documents.tag_models import TagRow
 from fred_core.models import Base as CoreBase
@@ -256,9 +257,9 @@ class FakeRebac:
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     # prompt_models is already imported above (PromptRow) — only agent_instance_models
-    # and orm_models still need a registration-only import here.
+    # and the task models still need a registration-only import here.
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import fred_core.tasks.orm_models  # noqa: F401
+    import control_plane_backend.models.task_models  # noqa: F401
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / name}")
     async with engine.begin() as conn:
@@ -283,8 +284,9 @@ async def _import(
     try:
         async with tasks_engine.begin() as conn:
             await conn.run_sync(CoreBase.metadata.create_all)
+            await conn.run_sync(CPBase.metadata.create_all)
         task_service = TaskService.build(
-            engine=tasks_engine, backend=SchedulerBackend.MEMORY
+            engine=tasks_engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
         )
         start = await task_service.start(StartMigrationRequest(), created_by="tester")
         report = await run_import(

--- a/apps/control-plane-backend/tests/test_import_export_manifest.py
+++ b/apps/control-plane-backend/tests/test_import_export_manifest.py
@@ -27,6 +27,7 @@ from control_plane_backend.import_export.bundle import (
 from control_plane_backend.import_export.exporter import run_export
 from control_plane_backend.import_export.importer import MigrationReport, run_import
 from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.models.task_models import TASK_TABLES
 from fred_core.documents.document_models import DocumentMetadataRow
 from fred_core.models import Base as CoreBase
 from fred_core.scheduler import SchedulerBackend
@@ -102,7 +103,7 @@ async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     # import chain (imported above), so it is present on CoreBase.metadata by
     # the time create_all runs below.
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import fred_core.tasks.orm_models  # noqa: F401
+    import control_plane_backend.models.task_models  # noqa: F401
 
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
@@ -120,7 +121,9 @@ async def _seed_metadata(engine: AsyncEngine, row: DocumentMetadataRow) -> None:
 
 
 async def _import(bundle_bytes: bytes, engine: AsyncEngine) -> MigrationReport:
-    task_service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+    task_service = TaskService.build(
+        engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+    )
     start = await task_service.start(StartMigrationRequest(), created_by="tester")
     bundle = open_bundle(bundle_bytes)
     return await run_import(

--- a/apps/control-plane-backend/tests/test_import_export_manifest.py
+++ b/apps/control-plane-backend/tests/test_import_export_manifest.py
@@ -103,7 +103,6 @@ async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     # import chain (imported above), so it is present on CoreBase.metadata by
     # the time create_all runs below.
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import control_plane_backend.models.task_models  # noqa: F401
 
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")

--- a/apps/control-plane-backend/tests/test_import_export_team_metadata.py
+++ b/apps/control-plane-backend/tests/test_import_export_team_metadata.py
@@ -51,7 +51,6 @@ async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     # Import the ORM modules so every table is registered on the two metadatas
     # before create_all runs.
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import control_plane_backend.models.task_models  # noqa: F401
 
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")

--- a/apps/control-plane-backend/tests/test_import_export_team_metadata.py
+++ b/apps/control-plane-backend/tests/test_import_export_team_metadata.py
@@ -19,6 +19,7 @@ from control_plane_backend.import_export.bundle import open_bundle
 from control_plane_backend.import_export.exporter import run_export
 from control_plane_backend.import_export.importer import MigrationReport, run_import
 from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.models.task_models import TASK_TABLES
 from fred_core.models import Base as CoreBase
 from fred_core.scheduler import SchedulerBackend
 from fred_core.tasks.models import StartMigrationRequest
@@ -50,7 +51,7 @@ async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     # Import the ORM modules so every table is registered on the two metadatas
     # before create_all runs.
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import fred_core.tasks.orm_models  # noqa: F401
+    import control_plane_backend.models.task_models  # noqa: F401
 
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
@@ -72,7 +73,9 @@ async def _seed_team(engine: AsyncEngine, row: TeamMetadataRow) -> None:
 async def _import(
     bundle_bytes: bytes, engine: AsyncEngine, *, rebac: Any | None = None
 ) -> MigrationReport:
-    task_service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+    task_service = TaskService.build(
+        engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+    )
     start = await task_service.start(StartMigrationRequest(), created_by="tester")
     bundle = open_bundle(bundle_bytes)
     return await run_import(

--- a/apps/control-plane-backend/tests/test_import_export_teardown.py
+++ b/apps/control-plane-backend/tests/test_import_export_teardown.py
@@ -76,8 +76,8 @@ def _user_deps() -> UserServiceDependencies:
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     # agent_instance_models (AgentInstanceRow) and prompt_models (PromptRow) are
-    # already imported above — only orm_models still needs a registration-only import.
-    import fred_core.tasks.orm_models  # noqa: F401
+    # already imported above — only the task models still need a registration-only import.
+    import control_plane_backend.models.task_models  # noqa: F401
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / name}")
     async with engine.begin() as conn:

--- a/apps/control-plane-backend/tests/test_import_export_users.py
+++ b/apps/control-plane-backend/tests/test_import_export_users.py
@@ -73,6 +73,7 @@ from control_plane_backend.import_export.importer import (
 from control_plane_backend.import_export.kea_reconciliation import KeaUserResolver
 from control_plane_backend.import_export.schemas import BundleUserEntry
 from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.models.task_models import TASK_TABLES
 from control_plane_backend.scheduler.policies.policy_models import (
     ConversationPolicyCatalog,
 )
@@ -120,7 +121,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     """One file-backed SQLite async engine carrying the full control-plane schema."""
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import fred_core.tasks.orm_models  # noqa: F401
+    import control_plane_backend.models.task_models  # noqa: F401
 
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
@@ -495,7 +496,9 @@ async def _run(
     user_deps: UserServiceDependencies,
     team_deps: TeamServiceDependencies,
 ) -> MigrationReport:
-    task_service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+    task_service = TaskService.build(
+        engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+    )
     start = await task_service.start(
         StartMigrationRequest(), created_by=platform_admin.uid
     )
@@ -959,7 +962,9 @@ async def test_run_users_phase_rebac_disabled_guard_precedes_every_counter_incre
         team_deps = _team_deps(engine, cast(Any, spy_rebac))
         user_deps, admin = _writable_user_deps({})
         platform_admin = _admin_user()
-        task_service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+        task_service = TaskService.build(
+            engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+        )
         start = await task_service.start(
             StartMigrationRequest(), created_by=platform_admin.uid
         )

--- a/apps/control-plane-backend/tests/test_import_export_users.py
+++ b/apps/control-plane-backend/tests/test_import_export_users.py
@@ -121,7 +121,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
     """One file-backed SQLite async engine carrying the full control-plane schema."""
     import control_plane_backend.models.agent_instance_models  # noqa: F401
-    import control_plane_backend.models.task_models  # noqa: F401
 
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")

--- a/apps/control-plane-backend/tests/test_lifecycle_actions.py
+++ b/apps/control-plane-backend/tests/test_lifecycle_actions.py
@@ -219,6 +219,8 @@ async def test_worker_moves_scheduled_erasure_task_to_succeeded(tmp_path) -> Non
     running → succeeded as it erases, so the schedule item completes for admins."""
     from datetime import timedelta
 
+    from control_plane_backend.models.base import Base as CPBase
+    from control_plane_backend.models.task_models import TASK_TABLES
     from control_plane_backend.sessions.erasure_tasks import schedule_erasure_task
     from fred_core.common import PostgresStoreConfig
     from fred_core.models.base import Base as CoreBase
@@ -234,8 +236,11 @@ async def test_worker_moves_scheduled_erasure_task_to_succeeded(tmp_path) -> Non
     )
     async with engine.begin() as conn:
         await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(CPBase.metadata.create_all)
     task_service = TaskService(
-        store=TaskStore(engine), bus=MemoryEventBus(), control=NoopWorkflowControl()
+        store=TaskStore(engine, TASK_TABLES),
+        bus=MemoryEventBus(),
+        control=NoopWorkflowControl(),
     )
 
     # A conversation was deferred-deleted: its erasure task is scheduled.
@@ -277,6 +282,8 @@ async def test_repeatedly_failing_erasure_flags_stalled_but_keeps_retrying(
     still closes it succeeded (the retry is never abandoned)."""
     from datetime import timedelta
 
+    from control_plane_backend.models.base import Base as CPBase
+    from control_plane_backend.models.task_models import TASK_TABLES
     from control_plane_backend.sessions.erasure_tasks import (
         ERASURE_STALL_AFTER_ATTEMPTS,
         ERASURE_STEP_STALLED,
@@ -296,8 +303,11 @@ async def test_repeatedly_failing_erasure_flags_stalled_but_keeps_retrying(
     )
     async with engine.begin() as conn:
         await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(CPBase.metadata.create_all)
     task_service = TaskService(
-        store=TaskStore(engine), bus=MemoryEventBus(), control=NoopWorkflowControl()
+        store=TaskStore(engine, TASK_TABLES),
+        bus=MemoryEventBus(),
+        control=NoopWorkflowControl(),
     )
 
     await schedule_erasure_task(

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -8840,6 +8840,8 @@ async def test_deferred_delete_creates_scheduled_erasure_task(tmp_path) -> None:
     """CTRLP-12: a deferred delete creates a future-dated `erasure` task, so a
     platform/team admin sees the scheduled erasure — with its due date, target and
     team — immediately via GET /tasks, before any worker runs."""
+    from control_plane_backend.models.base import Base as CPBase
+    from control_plane_backend.models.task_models import TASK_TABLES
     from control_plane_backend.product.service import delete_or_defer_session
     from fred_core.common import PostgresStoreConfig
     from fred_core.models.base import Base as CoreBase
@@ -8854,8 +8856,11 @@ async def test_deferred_delete_creates_scheduled_erasure_task(tmp_path) -> None:
     )
     async with engine.begin() as conn:
         await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(CPBase.metadata.create_all)
     task_service = TaskService(
-        store=TaskStore(engine), bus=MemoryEventBus(), control=NoopWorkflowControl()
+        store=TaskStore(engine, TASK_TABLES),
+        bus=MemoryEventBus(),
+        control=NoopWorkflowControl(),
     )
 
     session_store = _FakeSessionMetadataStore(

--- a/apps/control-plane-backend/tests/test_task_service.py
+++ b/apps/control-plane-backend/tests/test_task_service.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from fred_core.models import Base as CoreBase
+from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.models.task_models import TASK_TABLES
 from fred_core.scheduler import SchedulerBackend
 from fred_core.tasks.models import (
     StartIngestionParams,
@@ -16,12 +17,10 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
-    import fred_core.tasks.orm_models  # noqa: F401
-
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     async with engine.begin() as conn:
-        await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(CPBase.metadata.create_all)
     return engine
 
 
@@ -32,7 +31,9 @@ async def test_task_service_start_creates_task_run(
 ) -> None:
     engine = await _make_engine(tmp_path, f"svc_start_{created_by}.sqlite3")
     try:
-        service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+        service = TaskService.build(
+            engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+        )
         req = StartIngestionRequest(params=StartIngestionParams(resource_ids=["doc1"]))
         response = await service.start(req, created_by=created_by)
 
@@ -50,7 +51,9 @@ async def test_task_service_start_creates_task_run(
 async def test_task_service_cancel_unknown_task_raises(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "svc_cancel.sqlite3")
     try:
-        service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+        service = TaskService.build(
+            engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+        )
         with pytest.raises(TaskNotFoundError):
             await service.cancel("nonexistent-id")
     finally:
@@ -61,7 +64,9 @@ async def test_task_service_cancel_unknown_task_raises(tmp_path: Path) -> None:
 async def test_task_service_replay_empty_before_any_events(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "svc_replay.sqlite3")
     try:
-        service = TaskService.build(engine=engine, backend=SchedulerBackend.MEMORY)
+        service = TaskService.build(
+            engine=engine, tables=TASK_TABLES, backend=SchedulerBackend.MEMORY
+        )
         req = StartIngestionRequest(params=StartIngestionParams(resource_ids=["doc1"]))
         response = await service.start(req, created_by=None)
 

--- a/apps/control-plane-backend/tests/test_task_store.py
+++ b/apps/control-plane-backend/tests/test_task_store.py
@@ -4,7 +4,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-from fred_core.models import Base as CoreBase
+from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.models.task_models import TASK_TABLES
 from fred_core.tasks.models import (
     ErasureDetail,
     IngestionDetail,
@@ -22,12 +23,10 @@ _NOW = datetime(2026, 6, 4, tzinfo=timezone.utc)
 
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
-    import fred_core.tasks.orm_models  # noqa: F401 — registers ORM models with CoreBase
-
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     async with engine.begin() as conn:
-        await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(CPBase.metadata.create_all)
     return engine
 
 
@@ -35,7 +34,7 @@ async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
 async def test_task_store_create_and_get_run(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_create.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="t1", kind="ingestion", created_by="user-1")
         row = await store.get_run("t1")
         assert row is not None
@@ -51,7 +50,7 @@ async def test_task_store_create_and_get_run(tmp_path: Path) -> None:
 async def test_task_store_get_run_returns_none_for_missing(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_missing.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         assert await store.get_run("no-such-id") is None
     finally:
         await engine.dispose()
@@ -63,7 +62,7 @@ async def test_task_store_record_event_updates_run_and_appends_log(
 ) -> None:
     engine = await _make_engine(tmp_path, "store_record.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="t2", kind="ingestion", created_by=None)
 
         # seq is a placeholder — store auto-assigns monotonically from run.seq
@@ -92,7 +91,7 @@ async def test_task_store_record_event_updates_run_and_appends_log(
 async def test_task_store_record_event_raises_for_unknown_task(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_unknown.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         event = IngestionTaskEvent(
             task_id="ghost", state=TaskState.running, seq=1, timestamp=_NOW
         )
@@ -106,7 +105,7 @@ async def test_task_store_record_event_raises_for_unknown_task(tmp_path: Path) -
 async def test_task_store_replay_events_returns_ordered_subset(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_replay.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="t3", kind="ingestion", created_by=None)
 
         # All events carry seq=0 (placeholder); store assigns 1, 2, 3 monotonically.
@@ -132,7 +131,7 @@ async def test_task_store_replay_events_returns_ordered_subset(tmp_path: Path) -
 async def test_task_store_list_tasks_filters_by_team_and_state(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_list.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(
             task_id="a1", kind="ingestion", created_by="u1", team_id="team-x"
         )
@@ -168,7 +167,7 @@ async def test_task_store_list_tasks_filters_by_team_and_state(tmp_path: Path) -
 async def test_task_store_replay_preserves_target_and_owner(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_target.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="t4", kind="ingestion", created_by="user-42")
 
         event = IngestionTaskEvent(
@@ -202,7 +201,7 @@ async def test_task_store_list_tasks_projects_typed_migration_detail_with_result
     reload."""
     engine = await _make_engine(tmp_path, "store_migration_detail.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(
             task_id="m1",
             kind="migration",
@@ -253,7 +252,7 @@ async def test_task_store_list_tasks_detail_is_none_for_legacy_task(
     the addition is backward compatible (AUTHZ-07 Step 3)."""
     engine = await _make_engine(tmp_path, "store_legacy_detail.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="legacy1", kind="ingestion", created_by="u1")
         await store.record_event(
             IngestionTaskEvent(
@@ -276,7 +275,7 @@ async def test_task_store_list_tasks_projects_other_kinds_without_regression(
     correctly after the union field was added (AUTHZ-07 Step 3)."""
     engine = await _make_engine(tmp_path, "store_other_kinds_detail.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="i1", kind="ingestion", created_by="u1")
         await store.record_event(
             IngestionTaskEvent(

--- a/apps/knowledge-flow-backend/alembic/env.py
+++ b/apps/knowledge-flow-backend/alembic/env.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 from logging.config import fileConfig
 
 import fred_core.documents.document_models  # noqa: F401 — registers metadata + tag tables with CoreBase (via fred_core.documents.__init__)
-import fred_core.tasks.orm_models  # noqa: F401 — registers task_run / task_event_log with CoreBase
 from fred_core.models.base import Base as CoreBase
 from fred_core.sql import make_alembic_env
 
 import knowledge_flow_backend.core.stores.resources.resource_models  # noqa: F401
+import knowledge_flow_backend.models.task_models  # noqa: F401 — registers kf_task_run / kf_task_event_log with Base
 from alembic import context
 from knowledge_flow_backend.common.config_loader import load_configuration
 
@@ -38,7 +38,8 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 run_migrations_offline, run_migrations_online = make_alembic_env(
-    # Both metadata objects so autogenerate sees KFB tables and shared task tables.
+    # Both metadata objects so autogenerate sees KFB tables (incl. its own
+    # kf_task_* pair, #2170) and the shared fred-core tables.
     target_metadata=[Base.metadata, CoreBase.metadata],
     get_postgres_config=lambda: load_configuration().storage.postgres,
     version_table="alembic_version_knowledge_flow",

--- a/apps/knowledge-flow-backend/alembic/versions/c8f2d5b13ea6_create_knowledge_flow_task_tables.py
+++ b/apps/knowledge-flow-backend/alembic/versions/c8f2d5b13ea6_create_knowledge_flow_task_tables.py
@@ -1,0 +1,117 @@
+"""create knowledge-flow's own task tables (kf_task_run / kf_task_event_log)
+
+Revision ID: c8f2d5b13ea6
+Revises: bcd7cbdbedca
+Create Date: 2026-08-14 00:00:00.000000
+
+Knowledge-flow's first real `CREATE TABLE` for its task pair (#2170). Until now
+this tree only carried defensive `ALTER`s (`1c9a54674ebf`, `d96d9ae21375`,
+`e2f3a4b5c6d7`) against a `task_run` it never created: the table came either
+from control-plane's `a3b4c5d6e7f8` — both backends migrate the same `fred`
+database — or from the unfiltered `CoreBase.metadata.create_all` at startup
+(#2313, tracked under #2314). Sharing one physical table meant each backend's
+`GET /tasks` returned the other's rows, so the Activity page listed every task
+twice.
+
+`control-plane` keeps the `cp_`-prefixed pair (its `b7e1c4a09d52` drops the
+shared one). Postgres scopes index names per schema, so both pairs carry their
+table name in every index name.
+
+No backfill: task rows are operational telemetry, not records of record, so the
+history that lived in the shared table is deliberately not carried over (#2170).
+
+The DDL below is intentionally a self-contained copy of the shape
+`control_plane_backend/alembic/versions/b7e1c4a09d52` creates, not a shared
+helper import: a migration is a frozen snapshot, and importing living code into
+it would let a later refactor silently rewrite history.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f2d5b13ea6"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "bcd7cbdbedca"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_JSONB = postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite")
+_BIGINT_PK = sa.BigInteger().with_variant(sa.INTEGER(), "sqlite")
+
+_RUN = "kf_task_run"
+_LOG = "kf_task_event_log"
+
+# Mirrors `fred_core.tasks.orm_models.task_run_table_args`.
+_NON_TERMINAL_MIGRATION = "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        _RUN,
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("progress", sa.Float(), nullable=True),
+        sa.Column("step", sa.Text(), nullable=True),
+        sa.Column("detail", _JSONB, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("target", _JSONB, nullable=True),
+        sa.Column("execution_id", sa.String(length=255), nullable=True),
+        sa.Column("created_by", sa.String(length=36), nullable=True),
+        sa.Column("team_id", sa.String(length=255), nullable=True),
+        sa.Column("scheduled_for", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("acknowledged_by", sa.String(length=36), nullable=True),
+        sa.PrimaryKeyConstraint("task_id"),
+    )
+    op.create_index(op.f(f"ix_{_RUN}_kind"), _RUN, ["kind"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_state"), _RUN, ["state"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_created_by"), _RUN, ["created_by"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_team_id"), _RUN, ["team_id"], unique=False)
+    op.create_index(op.f(f"ix_{_RUN}_scheduled_for"), _RUN, ["scheduled_for"], unique=False)
+    # Reconciliation sweeper: scans non-terminal tasks ordered by age.
+    op.create_index(f"ix_{_RUN}_state_updated", _RUN, ["state", "updated_at"], unique=False)
+    # At most one non-terminal kind='migration' row. Knowledge-flow never creates
+    # migration-kind tasks today, but the table shape is shared with control-plane
+    # and `alembic check` compares it against the same ORM mixin.
+    op.create_index(
+        f"uq_{_RUN}_single_active_migration",
+        _RUN,
+        ["kind"],
+        unique=True,
+        sqlite_where=sa.text(_NON_TERMINAL_MIGRATION),
+        postgresql_where=sa.text(_NON_TERMINAL_MIGRATION),
+    )
+
+    op.create_table(
+        _LOG,
+        sa.Column("id", _BIGINT_PK, nullable=False, autoincrement=True),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("progress", sa.Float(), nullable=True),
+        sa.Column("step", sa.Text(), nullable=True),
+        sa.Column("detail", _JSONB, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("target", _JSONB, nullable=True),
+        sa.Column("owner", sa.String(length=255), nullable=True),
+        sa.Column("emitted_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("task_id", "seq", name=f"uq_{_LOG}_task_seq"),
+    )
+    op.create_index(op.f(f"ix_{_LOG}_task_id"), _LOG, ["task_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema. Indexes are dropped with their table on both backends."""
+    op.drop_table(_LOG)
+    op.drop_table(_RUN)

--- a/apps/knowledge-flow-backend/alembic/versions/e2f3a4b5c6d7_add_task_run_single_active_migration_index.py
+++ b/apps/knowledge-flow-backend/alembic/versions/e2f3a4b5c6d7_add_task_run_single_active_migration_index.py
@@ -46,10 +46,14 @@ _INDEX_NAME = "uq_task_run_single_active_migration"
 _WHERE_CLAUSE = "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
 
 
+def _task_run_exists() -> bool:
+    return "task_run" in sa.inspect(op.get_bind()).get_table_names()
+
+
 def _task_run_indexes() -> set[str]:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-    if "task_run" not in inspector.get_table_names():
+    if not _task_run_exists():
         return {_INDEX_NAME}
     return {ix["name"] for ix in inspector.get_indexes("task_run") if ix["name"] is not None}
 
@@ -67,6 +71,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    if _INDEX_NAME in _task_run_indexes():
+    """Downgrade schema.
+
+    `_task_run_indexes`'s "table absent → treat as present" sentinel is written
+    for `upgrade` (skip the create). Downgrade needs the opposite reading: since
+    #2170 split the task tables per backend, the shared `task_run` is genuinely
+    gone by the time this unwinds, and DROP INDEX would fail on a missing table.
+    """
+    if _task_run_exists() and _INDEX_NAME in _task_run_indexes():
         op.drop_index(_INDEX_NAME, table_name="task_run")

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/application_context.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/application_context.py
@@ -839,12 +839,14 @@ class ApplicationContext:
         from fred_core.tasks.service import TaskService
 
         from knowledge_flow_backend.features.scheduler.document_failure import on_reconciled_terminal
+        from knowledge_flow_backend.models.task_models import TASK_TABLES
 
         backend = self.get_scheduler_backend()
         config = self.get_config()
         temporal_provider = TemporalClientProvider(config.scheduler.temporal) if backend == SchedulerBackend.TEMPORAL else None
         self._task_service_instance = TaskService.build(
             engine=self.get_pg_async_engine(),
+            tables=TASK_TABLES,
             backend=backend,
             temporal_client_provider=temporal_provider,
             postgres_dsn=config.storage.postgres.dsn() if backend == SchedulerBackend.TEMPORAL else None,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/document_failure.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/scheduler/document_failure.py
@@ -50,7 +50,7 @@ from fred_core.tasks.models import TaskState
 
 if TYPE_CHECKING:
     from fred_core.documents.document_store import BaseDocumentMetadataStore
-    from fred_core.tasks.orm_models import TaskRunRow
+    from fred_core.tasks.orm_models import TaskRunColumns
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +179,7 @@ async def repair_document_after_terminal(document_uid: str, state: TaskState, me
         await delete_cancelled_document(document_uid, created_by)
 
 
-async def on_reconciled_terminal(run: "TaskRunRow", state: TaskState, message: str) -> None:
+async def on_reconciled_terminal(run: "TaskRunColumns", state: TaskState, message: str) -> None:
     """`TaskService.on_reconciled_terminal` hook — the reconciliation-side entry
     into `repair_document_after_terminal`; unwraps the run's document target."""
     target = run.target or {}

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/main.py
@@ -132,9 +132,15 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
-        import fred_core.tasks.orm_models  # noqa: F401 — registers ORM models with CoreBase
         from fred_core.models.base import Base as CoreBase
 
+        # #2170: the task tables are no longer among these. They are
+        # `kf_task_run`/`kf_task_event_log` on knowledge-flow's own `Base`, created
+        # by Alembic (`c8f2d5b13ea6`) and by nothing else — so the registration
+        # import that used to sit here would now be a no-op.
+        # This unfiltered `create_all` over the *shared* CoreBase is itself the
+        # defect tracked in #2313, consolidated into #2314; removing it is that
+        # issue's acceptance criterion, deliberately not bundled here.
         async with application_context.get_pg_async_engine().begin() as conn:
             await conn.run_sync(CoreBase.metadata.create_all)
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/models/task_models.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/models/task_models.py
@@ -1,0 +1,53 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Knowledge-flow's own task tables (#2170, TASK-EVENT-STREAM-RFC §2.6).
+
+Declared on knowledge-flow's `Base`, not the shared `CoreBase`: these two tables
+belong to this backend alone. control-plane owns the `cp_`-prefixed pair in the
+same `fred` database (`control_plane_backend.models.task_models`). Before the
+split both backends mapped one shared `task_run`, so each one's `GET /tasks`
+returned the other's rows and the Activity page listed every task twice.
+
+Column definitions live once, in `fred_core.tasks.orm_models` — only the names
+differ between the two owners.
+"""
+
+from __future__ import annotations
+
+from fred_core.tasks.orm_models import (
+    TaskEventLogColumns,
+    TaskRunColumns,
+    TaskTables,
+    task_event_log_table_args,
+    task_run_table_args,
+)
+
+from knowledge_flow_backend.models.base import Base
+
+TASK_RUN_TABLE = "kf_task_run"
+TASK_EVENT_LOG_TABLE = "kf_task_event_log"
+
+
+class KfTaskRunRow(TaskRunColumns, Base):
+    __tablename__ = TASK_RUN_TABLE
+    __table_args__ = task_run_table_args(TASK_RUN_TABLE)
+
+
+class KfTaskEventLogRow(TaskEventLogColumns, Base):
+    __tablename__ = TASK_EVENT_LOG_TABLE
+    __table_args__ = task_event_log_table_args(TASK_EVENT_LOG_TABLE)
+
+
+TASK_TABLES = TaskTables(run=KfTaskRunRow, event_log=KfTaskEventLogRow)

--- a/apps/knowledge-flow-backend/tests/features/test_task_store.py
+++ b/apps/knowledge-flow-backend/tests/features/test_task_store.py
@@ -20,21 +20,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-from fred_core.models import Base as CoreBase
 from fred_core.tasks.models import IngestionTaskEvent, TaskState, TaskTarget
 from fred_core.tasks.store import TaskNotFoundError, TaskStore
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from knowledge_flow_backend.models.base import Base as KFBase
+from knowledge_flow_backend.models.task_models import TASK_TABLES
 
 _NOW = datetime(2026, 6, 4, tzinfo=timezone.utc)
 
 
 async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
-    import fred_core.tasks.orm_models  # noqa: F401 — registers ORM models with CoreBase
-
     db_path = tmp_path / name
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     async with engine.begin() as conn:
-        await conn.run_sync(CoreBase.metadata.create_all)
+        await conn.run_sync(KFBase.metadata.create_all)
     return engine
 
 
@@ -42,7 +42,7 @@ async def _make_engine(tmp_path: Path, name: str) -> AsyncEngine:
 async def test_task_store_replay_preserves_target_and_owner(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_target.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="t1", kind="ingestion", created_by="user-42")
 
         event = IngestionTaskEvent(
@@ -70,7 +70,7 @@ async def test_task_store_replay_preserves_target_and_owner(tmp_path: Path) -> N
 async def test_task_store_replay_target_none_when_not_set(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_no_target.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(task_id="t2", kind="ingestion", created_by=None)
 
         event = IngestionTaskEvent(
@@ -96,7 +96,7 @@ async def test_task_store_create_persists_target_without_any_event(tmp_path: Pat
     (e.g. a document) alive across a reload when no worker is running."""
     engine = await _make_engine(tmp_path, "store_create_target.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         await store.create(
             task_id="t3",
             kind="ingestion",
@@ -120,7 +120,7 @@ async def test_task_store_create_persists_target_without_any_event(tmp_path: Pat
 async def test_task_store_record_event_raises_for_unknown_task(tmp_path: Path) -> None:
     engine = await _make_engine(tmp_path, "store_unknown.sqlite3")
     try:
-        store = TaskStore(engine)
+        store = TaskStore(engine, TASK_TABLES)
         event = IngestionTaskEvent(task_id="ghost", state=TaskState.running, seq=0, timestamp=_NOW)
         with pytest.raises(TaskNotFoundError):
             await store.record_event(event)

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -927,10 +927,49 @@ task kinds that support cooperative cancellation.
 
 ### Persistence
 
-Two new tables in `fred_swift` (Alembic-managed, both mandatory):
+**One pair of tables per task-producing backend, prefixed by its owner** (settled
+2026-08-14, issue #2170 — supersedes the "dedicated database per backend" design
+in `TASK-EVENT-STREAM-RFC.md` rev. 4 §2.9, which was confirmed but never built):
 
-- `task_run` — current-state summary (one row per task, updated in place)
-- `task_event_log` — append-only event journal (one row per `TaskEvent`, source of truth for SSE replay)
+| Owner           | Tables                              | Alembic tree           |
+| --------------- | ----------------------------------- | ---------------------- |
+| control-plane   | `cp_task_run`, `cp_task_event_log`  | `alembic_version_control_plane` |
+| knowledge-flow  | `kf_task_run`, `kf_task_event_log`  | `alembic_version_knowledge_flow` |
+| evaluation      | `task_run`, `task_event_log`        | its own database (provisioned 2026-07-07) |
+
+- `<prefix>task_run` — current-state summary (one row per task, updated in place)
+- `<prefix>task_event_log` — append-only event journal (one row per `TaskEvent`, source of truth for SSE replay)
+
+Column definitions live once, in `fred_core.tasks.orm_models`, as declarative
+mixins (`TaskRunColumns` / `TaskEventLogColumns`); each backend declares the
+concrete pair on **its own** `Base` and hands the pair to `TaskStore` /
+`TaskService.build` as a `TaskTables`. fred-core maps nothing itself.
+
+**Why prefixes rather than a database per backend.** control-plane and
+knowledge-flow share the `fred` database, and both mapped the *same* `task_run`
+on the shared `CoreBase`. Nothing scoped either backend's `GET /tasks` to the
+rows it created, so each returned the other's and the Activity page — which
+queries every backend and merges client-side, by design — listed every task
+twice. Distinct names per owner fix that at the schema layer with no new
+infrastructure, no second engine, and no `RemoteTaskClient`-style coupling. They
+also take these two tables out of the shared-`CoreBase` ownership ambiguity of
+issue #2314: each pair now appears in exactly one backend's metadata, which is
+what `make_alembic_env`'s `include_name` filter reads to decide what a tree owns.
+
+Postgres scopes index names per schema, so **every** index and constraint name
+embeds its table name (`ix_cp_task_run_kind`, `uq_kf_task_event_log_task_seq`, …)
+— built by `task_run_table_args` / `task_event_log_table_args`, never hand-written.
+`import_export/api.py` derives the single-active-migration index name it matches
+in an `IntegrityError` from `single_active_migration_index_name` for the same reason.
+
+Task rows are progress bookkeeping, so the split ships with **no backfill**. It
+also does **not drop** the old shared `task_run`/`task_event_log`: they are left
+orphaned for a later release. The two Temporal workers have no `migration:` block
+in `deploy/charts/fred/values.yaml`, so they get no scale-down hook and keep
+running old code — which writes the shared table through an unguarded activity
+that is the first step of every push-file ingestion. Dropping it mid-deploy would
+fail those workflows outright and lose the document, not just its task row.
+Expand now, contract in a later release.
 
 ### Ownership boundary
 

--- a/docs/swift/rfc/TASK-EVENT-STREAM-RFC.md
+++ b/docs/swift/rfc/TASK-EVENT-STREAM-RFC.md
@@ -1,7 +1,7 @@
 # RFC OPS-04 — Unified Task Event Stream & Worker-Action Audit
 
 **ID:** OPS-04  
-**Status:** confirmed (core: §1–§2, §4–§7) — 2026-06-16 · rev. 2 (2026-07-07): worker-action audit + shared Activity surface — proposed · rev. 3 (2026-07-25): persisted acknowledgement — proposed, driven by OBSERV-02's role-based dashboard finalization (§2.10) · **rev. 4 (2026-07-27): per-service task persistence, rejects rev. 2's central-ownership/`RemoteTaskClient` design (§2.6/§2.9) — confirmed**  
+**Status:** confirmed (core: §1–§2, §4–§7) — 2026-06-16 · rev. 2 (2026-07-07): worker-action audit + shared Activity surface — proposed · rev. 3 (2026-07-25): persisted acknowledgement — proposed, driven by OBSERV-02's role-based dashboard finalization (§2.10) · **rev. 4 (2026-07-27): per-service task persistence, rejects rev. 2's central-ownership/`RemoteTaskClient` design (§2.6/§2.9) — confirmed** · **rev. 5 (2026-08-14): per-service task persistence SHIPPED as prefixed tables in the shared database, not a dedicated one (#2170) — settled, see [`CONTROL-PLANE-PRODUCT-CONTRACT.md` § Persistence](../design/CONTROL-PLANE-PRODUCT-CONTRACT.md)**  
 **Author:** Dimitri Tombroff  
 **Date:** 2026-06-04  
 
@@ -40,6 +40,26 @@
 > change adds a table, an endpoint, or a parallel model — see
 > `CONTROL-PLANE-PRODUCT-CONTRACT.md §27` for
 > the full rationale and the producer-side wiring (`import_export/api.py`).
+
+> **Amendment (2026-08-14) — rev. 5, shipped: prefixed tables, not a dedicated database (#2170).**
+> Rev. 4's diagnosis below is confirmed and unchanged — two backends, one shared `task_run`, no
+> per-backend scoping, duplicate rows on the Activity page. Its **remedy** is superseded: isolating
+> knowledge-flow needed no second database, no `POSTGRES_KNOWLEDGE_FLOW_DB`, and no second engine in
+> `ApplicationContext`. Each backend now declares its own prefixed pair (`cp_task_run`/
+> `cp_task_event_log`, `kf_task_run`/`kf_task_event_log`) on its **own** declarative `Base`, from
+> shared column mixins in `fred_core.tasks.orm_models`; fred-core maps nothing itself.
+>
+> Prefixes beat a dedicated database on the axis rev. 4 could not address: issue #2314 shows the
+> Alembic ownership filter is inert because `_owned_tables` is derived from the shared `CoreBase`,
+> and notes that "a dedicated knowledge-flow database would sidestep cross-service collision, but
+> would not fix autogenerate proposing foreign tables within a tree." Moving these two tables onto
+> per-backend `Base`es does fix it for them — each pair is now in exactly one tree's metadata.
+>
+> **This decision is settled and shipped, so it does not live here.** §2.6 and §2.9 below are
+> trimmed to pointers per CLAUDE.md's RFC-vs-doc rule; the durable what/why is in
+> [`CONTROL-PLANE-PRODUCT-CONTRACT.md` § Persistence](../design/CONTROL-PLANE-PRODUCT-CONTRACT.md).
+> Out of scope and still open: #2314 (ownership filter, incl. removing knowledge-flow's startup
+> `CoreBase.metadata.create_all` — #2313, closed as consolidated into it).
 
 > **Amendment (2026-07-27) — rev. 4, per-service task persistence, rejects central ownership.**
 > Rev. 2's §2.6/§2.9 (one `task_run`/`task_event_log` pair owned by control-plane, every other
@@ -277,13 +297,13 @@ All detail/event/params models live in `fred_core/tasks/models.py`; backends imp
 
 ### 2.6 Persistence — two tables (both mandatory)
 
-**One pair per backend, each in that backend's own database** (rev. 4; see §2.9 — corrects rev. 2's
-"one pair, owned by control-plane" design below, which was proposed but never confirmed or
-implemented). Each backend runs its own Alembic migrations for `task_run`/`task_event_log`
-against its own database — control-plane's is the `fred` database it already owns; knowledge-flow
-needs a dedicated database of its own (its `tag`/`document_metadata` tables stay in the shared
-`fred` database for the import/export atomic-transaction reason in §2.9); `evaluation` already has
-one. ~~Rev. 2 text (superseded, kept for history): "owned by control-plane (`fred_swift`) — the
+**One pair per backend, prefixed by its owner** (rev. 5, shipped #2170; corrects both rev. 2's
+"one pair, owned by control-plane" — proposed, never built — and rev. 4's "each in its own
+database" — confirmed, never built). control-plane owns `cp_task_run`/`cp_task_event_log` and
+knowledge-flow owns `kf_task_run`/`kf_task_event_log`, both migrated by their own Alembic tree
+against the shared `fred` database; `evaluation` keeps the unprefixed pair in the separate
+database it already has. Table list and rationale:
+[`CONTROL-PLANE-PRODUCT-CONTRACT.md` § Persistence](../design/CONTROL-PLANE-PRODUCT-CONTRACT.md). ~~Rev. 2 text (superseded, kept for history): "owned by control-plane (`fred_swift`) — the
 single, central home for every task/audit record. The Alembic migrations for `task_run` /
 `task_event_log` run only in control-plane; no other backend creates these tables."~~ (Rev. 1
 placed a pair in each backend's database and treated the audit log as a query-time union — the
@@ -405,29 +425,13 @@ The correction is emitted as a normal `TaskEvent` via `TaskService.record(...)`,
 
 **Principle.** Reconciliation only *reflects the executor's verdict* — it never invents fred-side timeouts or retries. Temporal owns liveness and timeouts; this layer makes the durable task mirror that truth.
 
-### 2.9 Per-service task persistence (rev. 4, 2026-07-27 — replaces rev. 2's centralisation below)
+### 2.9 Per-service task persistence (rev. 5, 2026-08-14 — shipped; replaces rev. 2's centralisation below)
 
-**Each backend persists its own `task_run`/`task_event_log`, in its own database, and serves its
-own `GET /tasks`/SSE.** No new machinery: this is exactly `TaskStore`/`TaskService` as they exist
-today (`libs/fred-core/fred_core/tasks/store.py`) — the fix is entirely at the infrastructure
-layer, not the application layer. control-plane already correctly owns its copy (the `fred`
-database it was created in). knowledge-flow needs its **own dedicated database**, mirroring the
-one `evaluation` already has: provision `POSTGRES_KNOWLEDGE_FLOW_DB`/`_USER`/`_PASSWORD` the same
-way `86f2c3b` (`fred-deployment-factory`) provisioned `POSTGRES_EVALUATION_DB`, wire a second
-engine in knowledge-flow's `ApplicationContext` (its `metadata_store`/`tag_store`/`resource_store`
-keep using the existing shared engine — only `get_task_service()` moves), and give knowledge-flow's
-Alembic chain a real `CREATE TABLE` for `task_run`/`task_event_log` on that new database (today it
-only carries `ALTER` migrations, because it has always silently ridden on control-plane's copy —
-see the rev. 4 amendment above).
-
-**Why not co-locate knowledge-flow's task tables with its `tag`/`document_metadata` tables in the
-shared database instead of a second dedicated one?** Because nothing requires it: unlike
-`tag`/`document_metadata` (which control-plane's platform import/export/reset genuinely writes in
-the *same atomic transaction* as its own `agent_instance`/`team_metadata`/`prompt` rows — see the
-rev. 4 amendment above), `task_run` writes always go through `TaskService.record(...)` **outside**
-any such transaction, in every producer, today. There is no atomicity requirement pulling task
-rows into the shared database — keeping them there was simply an infrastructure default nobody
-had reconsidered.
+**Each backend persists its own task pair, in its own prefixed tables, and serves its own
+`GET /tasks`/SSE.** Shipped in #2170. The schema, the naming rule and the reasoning are in
+[`CONTROL-PLANE-PRODUCT-CONTRACT.md` § Persistence](../design/CONTROL-PLANE-PRODUCT-CONTRACT.md)
+— not restated here. Rev. 4's dedicated-database remedy (`POSTGRES_KNOWLEDGE_FLOW_DB`, a second
+engine in `ApplicationContext`) was **not** built; see the rev. 5 amendment at the top for why.
 
 **The Activity page stays multi-source, by design, not as a stopgap** (corrects §3.4's "Rev. 2:
 single-source" text below): the frontend already queries each backend's own `GET /tasks`
@@ -655,7 +659,7 @@ function useTaskStream(taskId: string | null): {
 
 ## 5. Consumers
 
-- **Ingestion** (`kind = "ingestion"`, knowledge-flow). The `POST /upload-process-documents` NDJSON stream co-emits `task_id` and `document_uid` on the same line (the metadata row is created before the workflow is submitted), making the task linkable to its document row immediately. Ingestion panels consume `useTaskStream`; per-document live progress replaces polling. **Rev. 4 (corrects rev. 2 below):** knowledge-flow (API and worker) keeps owning its `task_run`/`task_event_log` tables and its own task SSE, in its own dedicated database (§2.9) — the frontend's ingestion panels subscribe to knowledge-flow directly, same as today. ~~Rev. 2 text (superseded, never built): "knowledge-flow (API and worker) records through `RemoteTaskClient` to control-plane; it no longer owns task tables or serves task SSE — the frontend subscribes to control-plane for ingestion progress."~~
+- **Ingestion** (`kind = "ingestion"`, knowledge-flow). The `POST /upload-process-documents` NDJSON stream co-emits `task_id` and `document_uid` on the same line (the metadata row is created before the workflow is submitted), making the task linkable to its document row immediately. Ingestion panels consume `useTaskStream`; per-document live progress replaces polling. **Rev. 5 (shipped #2170; corrects rev. 4 and rev. 2 below):** knowledge-flow (API and worker) keeps owning its task tables and its own task SSE, as `kf_task_run`/`kf_task_event_log` in the shared `fred` database (§2.9) — not the dedicated database rev. 4 called for. The frontend's ingestion panels subscribe to knowledge-flow directly, same as today. ~~Rev. 2 text (superseded, never built): "knowledge-flow (API and worker) records through `RemoteTaskClient` to control-plane; it no longer owns task tables or serves task SSE — the frontend subscribes to control-plane for ingestion progress."~~
 - **Migration / platform import** (`kind = "migration"`, control-plane, platform-owner only). The task/event contract supplies durable task registration, replayable SSE, typed `MigrationDetail`, and UI rendering. The current Kea-to-Swift business order is governed by [`KEA_SWIFT_CUTOVER.md`](../ops/KEA_SWIFT_CUTOVER.md); the MIGR-05 backend workflow is governed by `CONTROL-PLANE-PRODUCT-CONTRACT.md §27`. Keep migration-specific step names in those documents, not in this shared task/event RFC.
 - **Evaluation** (`kind = "evaluation"`, standalone `fred-agent-evaluator`). Campaign progress counters only; target `{ type: "evaluation_campaign", id, label }`; team-scoped and readable by authorized team members (§3.2). Detail per `EvaluationDetail`. **Adoption (folded from EVAL-02; rev. 4 corrects the text below):** the evaluator owns its own `task_run`/`task_event_log` in its own already-dedicated database (provisioned 2026-07-07, `fred-deployment-factory` commit `86f2c3b`) and serves its own `/tasks` — the frontend queries it directly (`useListTasksEvaluationV1TasksGetQuery`, §2.9), exactly the pattern rev. 4 extends to knowledge-flow. This is, and was always, correct — the evaluator never needed `RemoteTaskClient` to avoid duplication, because it never shared a database with anyone. Task `succeeded` ≠ evaluation verdict — the task plane stays distinct from the evaluation-domain plane. See `AGENT-EVALUATION-RFC.md` (EVAL-01) §5. ~~Rev. 2 text (superseded, never built): "the evaluator records through `RemoteTaskClient` to control-plane and drops its bespoke `/campaigns/{id}/events` SSE — it does not mount its own `/tasks` surface; the frontend reads control-plane (single-source)."~~
 - **Erasure** (`kind = "erasure"`, control-plane; shipped CTRLP-12). Deferred conversation delete emits a future-dated `erasure` task (`scheduled_for = due_at`), advanced `pending → running → succeeded` by the lifecycle worker; a partial receipt stays `running` for retry, never `failed`. `ErasureDetail` carries `reason` + per-store counts, no content (§3.3). **CTRLP-13** extends the producer so member-removal and idle-expiry enqueues each emit a paired task (§3.5); the enforcement mechanics live in the RGPD RFC, the surfacing here.
@@ -666,7 +670,7 @@ function useTaskStream(taskId: string | null): {
 ## 6. Impact on existing code
 
 - **`libs/fred-core`** — add `fred_core/tasks/` (`models.py`, `bus.py`, `scheduler.py`, store/service, reconciliation); incorporate the existing `SchedulerBackend` enum and `TemporalClientProvider`.
-- **`apps/knowledge-flow-backend`** — `BaseScheduler`'s public API is unchanged; its internal asyncio/Temporal dispatch delegates to `IScheduler`. `record_workflow_status` / `record_current_document` activities emit `TaskEvent`; `get_progress()` and `ProcessDocumentsProgressResponse` remain until UI callers move to `useTaskStream`. **Rev. 4 (corrects rev. 2 below, tracked as a `swift ga` GitHub issue):** knowledge-flow keeps owning `task_run`/`task_event_log` and its task SSE endpoint (§2.9) — the only change is that they move to a **dedicated Postgres database** of knowledge-flow's own (provisioned like `evaluation`'s, `fred-deployment-factory` commit `86f2c3b`), instead of accidentally sharing control-plane's `fred` database; `ApplicationContext` gains a second engine, used only by `get_task_service()`; `metadata_store`/`tag_store`/`resource_store` are unaffected. ~~Rev. 2 text (superseded, never built): "knowledge-flow (API + worker) records via `RemoteTaskClient` — it no longer owns `task_run`/`task_event_log` tables or a task SSE endpoint. Configure `tasks.persistence: remote` + `control_plane_base_url` + a client-credentials `service_identity` on both the API and worker deployments."~~
+- **`apps/knowledge-flow-backend`** — `BaseScheduler`'s public API is unchanged; its internal asyncio/Temporal dispatch delegates to `IScheduler`. `record_workflow_status` / `record_current_document` activities emit `TaskEvent`; `get_progress()` and `ProcessDocumentsProgressResponse` remain until UI callers move to `useTaskStream`. **Rev. 5 (shipped #2170; corrects rev. 4 and rev. 2 below):** knowledge-flow keeps owning its task tables and its task SSE endpoint (§2.9) — the only change is that they are renamed `kf_task_run`/`kf_task_event_log` and declared on knowledge-flow's own `Base`, so they stop colliding with control-plane's copy in the shared `fred` database. `ApplicationContext` gains **no** second engine and no new database: rev. 4's `POSTGRES_KNOWLEDGE_FLOW_DB` remedy was confirmed but never built. `metadata_store`/`tag_store`/`resource_store` are unaffected. ~~Rev. 2 text (superseded, never built): "knowledge-flow (API + worker) records via `RemoteTaskClient` — it no longer owns `task_run`/`task_event_log` tables or a task SSE endpoint. Configure `tasks.persistence: remote` + `control_plane_base_url` + a client-credentials `service_identity` on both the API and worker deployments."~~
 - **`apps/control-plane-backend`** — add `tasks/` wiring + `migration/` step activities (using `IScheduler` directly); `PurgeQueueStore` untouched; own its own `task_run` + `task_event_log` migrations (in the `fred` database it already has); serve its own task SSE; host the Activity page. ~~Rev. 2 text (superseded): "own the central `task_run` + `task_event_log` migrations and the `POST /tasks/ingest` endpoint; serve all task SSE."~~ There is no `POST /tasks/ingest` endpoint under rev. 4 — nothing records remotely.
 - **Frozen contracts** — `RUNTIME-EXECUTION-CONTRACT.md` unchanged (task endpoints are product/admin surface). `CONTROL-PLANE-PRODUCT-CONTRACT.md` documents control-plane's own `/api/v1/tasks*` endpoints and the `erasure`/`deletion` kinds — no `POST /tasks/ingest`, no cross-backend table (rev. 4).
 

--- a/libs/fred-core/fred_core/tasks/__init__.py
+++ b/libs/fred-core/fred_core/tasks/__init__.py
@@ -42,7 +42,14 @@ from fred_core.tasks.models import (
     TaskTarget,
     needs_attention,
 )
-from fred_core.tasks.orm_models import TaskEventLogRow, TaskRunRow
+from fred_core.tasks.orm_models import (
+    TaskEventLogColumns,
+    TaskRunColumns,
+    TaskTables,
+    single_active_migration_index_name,
+    task_event_log_table_args,
+    task_run_table_args,
+)
 from fred_core.tasks.service import (
     TaskNotAcknowledgeableError,
     TaskService,
@@ -87,8 +94,12 @@ __all__ = [
     "AcknowledgeTaskResponse",
     "needs_attention",
     # orm models
-    "TaskRunRow",
-    "TaskEventLogRow",
+    "TaskRunColumns",
+    "TaskEventLogColumns",
+    "TaskTables",
+    "task_run_table_args",
+    "task_event_log_table_args",
+    "single_active_migration_index_name",
     # bus
     "IEventBus",
     "MemoryEventBus",

--- a/libs/fred-core/fred_core/tasks/authz.py
+++ b/libs/fred-core/fred_core/tasks/authz.py
@@ -42,12 +42,12 @@ from fred_core.security.rebac.rebac_engine import (
 )
 from fred_core.security.structure import KeycloakUser
 from fred_core.tasks.models import TaskListResponse
-from fred_core.tasks.orm_models import TaskRunRow
+from fred_core.tasks.orm_models import TaskRunColumns
 from fred_core.tasks.service import TaskService
 
 
 async def authorize_task_access(
-    user: KeycloakUser, run: TaskRunRow, rebac: RebacEngine
+    user: KeycloakUser, run: TaskRunColumns, rebac: RebacEngine
 ) -> None:
     """Authorize *viewing* a task (list detail / stream) by one rule: its creator,
     a platform admin, or a member with CAN_READ_MEMBERS on the task's team. Tasks
@@ -76,7 +76,7 @@ authorize_task_stream = authorize_task_access
 
 
 async def authorize_task_mutation(
-    user: KeycloakUser, run: TaskRunRow, rebac: RebacEngine
+    user: KeycloakUser, run: TaskRunColumns, rebac: RebacEngine
 ) -> None:
     """Authorize *mutating* a task (cancel). Deliberately a stricter subset of the
     view rule: the creator or a platform admin only — NOT a team reader. Canceling

--- a/libs/fred-core/fred_core/tasks/orm_models.py
+++ b/libs/fred-core/fred_core/tasks/orm_models.py
@@ -12,9 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Per-service task persistence schema (TASK-EVENT-STREAM-RFC §2.6).
+
+This module deliberately exposes **no mapped class**. Every backend that
+records tasks declares its own concrete pair on its own declarative ``Base``,
+under its own table prefix — `control_plane_backend.models.task_models`
+(``cp_``) and `knowledge_flow_backend.models.task_models` (``kf_``):
+
+    class CpTaskRunRow(TaskRunColumns, Base):
+        __tablename__ = "cp_task_run"
+        __table_args__ = task_run_table_args("cp_task_run")
+
+Why not one shared mapped class (#2170): control-plane and knowledge-flow run
+their Alembic trees against the *same* `fred` database. A single `task_run`
+registered on the shared `CoreBase` therefore gave both backends one physical
+table — so each backend's `GET /tasks` returned the other's rows and the
+Activity page showed every task twice. Distinct table names per owner fix that
+without a second database, and take these two tables out of the shared-`CoreBase`
+ownership ambiguity tracked in #2314: each pair now lives in exactly one
+backend's metadata, which is what `make_alembic_env`'s `include_name` filter
+reads to decide what a tree owns.
+
+The columns themselves stay here, once: the two tables are the same schema with
+two owners, not two schemas.
+"""
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     JSON,
@@ -32,47 +59,35 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.sqlite import INTEGER as SQLITE_INTEGER
 from sqlalchemy.orm import Mapped, mapped_column
 
-from fred_core.models.base import Base
-
 # BigInteger PK that autorements correctly on SQLite (INTEGER rowid alias).
 _PK_BIG = BigInteger().with_variant(SQLITE_INTEGER(), "sqlite")
 _JSONB = JSONB().with_variant(JSON(), "sqlite")
+
+_NON_TERMINAL_MIGRATION = (
+    "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
+)
 
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-class TaskRunRow(Base):
-    """Current-state summary for a task. One row per task, updated in place."""
+class TaskRunColumns:
+    """Current-state summary for a task. One row per task, updated in place.
 
-    __tablename__ = "task_run"
-    __table_args__ = (
-        # Index for the reconciliation sweeper, which scans non-terminal tasks by age.
-        Index("ix_task_run_state_updated", "state", "updated_at"),
-        # Atomic exclusion for concurrent migration-task launches (import/reset/
-        # reset-full, `import_export/api.py`, all created with kind="migration").
-        # Every row this partial index covers already has kind='migration' (the
-        # predicate says so) — a unique index on `kind` among only those rows
-        # therefore enforces "at most one non-terminal migration-kind row can
-        # exist at any time", without constraining any other task kind
-        # (ingestion/evaluation/erasure/log never appear in the filtered set).
-        # This replaces a check-then-act race (list active tasks, then insert)
-        # with a real DB-level guarantee: two concurrent inserts can't both
-        # succeed, the loser gets an IntegrityError translated to a 409
-        # (`import_export/api.py::_is_concurrent_migration_violation`).
-        Index(
-            "uq_task_run_single_active_migration",
-            "kind",
-            unique=True,
-            sqlite_where=text(
-                "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
-            ),
-            postgresql_where=text(
-                "kind = 'migration' AND state NOT IN ('succeeded', 'failed', 'cancelled')"
-            ),
-        ),
-    )
+    A declarative mixin, not a mapped class — SQLAlchemy copies these columns
+    into each concrete subclass, so `cp_task_run` and `kf_task_run` cannot
+    drift apart. Single-column indexes (`index=True`) are named after the
+    concrete table by SQLAlchemy itself (`ix_cp_task_run_kind`, …); the
+    composite and partial ones need `task_run_table_args` below.
+    """
+
+    if TYPE_CHECKING:
+        # A mixin is not itself mapped, so type checkers only see
+        # `object.__init__` and reject the keyword construction `TaskStore` does.
+        # The concrete subclass really does get SQLAlchemy's kwargs constructor —
+        # declaring it outside `TYPE_CHECKING` would shadow it at runtime.
+        def __init__(self, **kw: Any) -> None: ...
 
     task_id: Mapped[str] = mapped_column(String(36), primary_key=True)
     kind: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
@@ -116,13 +131,12 @@ class TaskRunRow(Base):
     acknowledged_by: Mapped[str | None] = mapped_column(String(36), nullable=True)
 
 
-class TaskEventLogRow(Base):
+class TaskEventLogColumns:
     """Append-only event journal. Source of truth for SSE replay."""
 
-    __tablename__ = "task_event_log"
-    __table_args__ = (
-        UniqueConstraint("task_id", "seq", name="uq_task_event_log_task_seq"),
-    )
+    if TYPE_CHECKING:
+        # See `TaskRunColumns.__init__`.
+        def __init__(self, **kw: Any) -> None: ...
 
     id: Mapped[int] = mapped_column(_PK_BIG, primary_key=True, autoincrement=True)
     task_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
@@ -138,3 +152,59 @@ class TaskEventLogRow(Base):
     emitted_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utcnow
     )
+
+
+def single_active_migration_index_name(table: str) -> str:
+    """Name of the partial unique index built by `task_run_table_args`.
+
+    Exported so `import_export/api.py` can recognise the constraint in an
+    `IntegrityError` string without restating the naming rule — the two used to
+    be kept in sync by a "must match" comment.
+    """
+    return f"uq_{table}_single_active_migration"
+
+
+def task_run_table_args(table: str) -> tuple[Index, ...]:
+    """`__table_args__` for a concrete `<prefix>task_run`.
+
+    Index names are derived from *table* because Postgres scopes index names
+    per schema: `cp_task_run` and `kf_task_run` live side by side in the same
+    database and cannot both own an index called `ix_task_run_state_updated`.
+    """
+    return (
+        # Index for the reconciliation sweeper, which scans non-terminal tasks by age.
+        Index(f"ix_{table}_state_updated", "state", "updated_at"),
+        # Atomic exclusion for concurrent migration-task launches (import/reset/
+        # reset-full, `import_export/api.py`, all created with kind="migration").
+        # Every row this partial index covers already has kind='migration' (the
+        # predicate says so) — a unique index on `kind` among only those rows
+        # therefore enforces "at most one non-terminal migration-kind row can
+        # exist at any time", without constraining any other task kind
+        # (ingestion/evaluation/erasure/log never appear in the filtered set).
+        # This replaces a check-then-act race (list active tasks, then insert)
+        # with a real DB-level guarantee: two concurrent inserts can't both
+        # succeed, the loser gets an IntegrityError translated to a 409
+        # (`import_export/api.py::_is_concurrent_migration_violation`).
+        Index(
+            single_active_migration_index_name(table),
+            "kind",
+            unique=True,
+            sqlite_where=text(_NON_TERMINAL_MIGRATION),
+            postgresql_where=text(_NON_TERMINAL_MIGRATION),
+        ),
+    )
+
+
+def task_event_log_table_args(table: str) -> tuple[UniqueConstraint, ...]:
+    """`__table_args__` for a concrete `<prefix>task_event_log`. Same
+    per-database uniqueness reason as `task_run_table_args`."""
+    return (UniqueConstraint("task_id", "seq", name=f"uq_{table}_task_seq"),)
+
+
+@dataclass(frozen=True)
+class TaskTables:
+    """The concrete pair a backend owns, handed to `TaskStore`/`TaskService.build`
+    so fred-core's persistence code stays table-name agnostic."""
+
+    run: type[TaskRunColumns]
+    event_log: type[TaskEventLogColumns]

--- a/libs/fred-core/fred_core/tasks/service.py
+++ b/libs/fred-core/fred_core/tasks/service.py
@@ -39,7 +39,7 @@ from fred_core.tasks.models import (
     TaskTarget,
     needs_attention,
 )
-from fred_core.tasks.orm_models import TaskRunRow
+from fred_core.tasks.orm_models import TaskRunColumns, TaskTables
 from fred_core.tasks.store import TaskNotFoundError, TaskStore
 from fred_core.tasks.workflow_control import (
     ExecutionStatus,
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 # Invoked only on a terminal executor verdict, never when the status is unknown,
 # so the never-false-fail rule in `_reconciled_terminal` extends to whatever the
 # hook writes. Failures inside the hook are swallowed by the caller.
-ReconciledTerminalHook = Callable[["TaskRunRow", TaskState, str], Awaitable[None]]
+ReconciledTerminalHook = Callable[["TaskRunColumns", TaskState, str], Awaitable[None]]
 
 
 def _utcnow() -> datetime:
@@ -93,12 +93,13 @@ class TaskService:
     def build(
         cls,
         engine: AsyncEngine,
+        tables: TaskTables,
         backend: SchedulerBackend,
         temporal_client_provider: TemporalClientProvider | None = None,
         postgres_dsn: str | None = None,
         on_reconciled_terminal: ReconciledTerminalHook | None = None,
     ) -> "TaskService":
-        store = TaskStore(engine)
+        store = TaskStore(engine, tables)
         if backend == SchedulerBackend.TEMPORAL:
             if temporal_client_provider is None:
                 raise ValueError(
@@ -166,7 +167,7 @@ class TaskService:
             acknowledged_by=acknowledged.acknowledged_by,
         )
 
-    async def get_run(self, task_id: str) -> TaskRunRow | None:
+    async def get_run(self, task_id: str) -> TaskRunColumns | None:
         return await self.store.get_run(task_id)
 
     async def replay(self, task_id: str, after_seq: int) -> list[TaskEvent]:
@@ -237,7 +238,7 @@ class TaskService:
         return None
 
     def _build_terminal_event(
-        self, run: TaskRunRow, state: TaskState, message: str
+        self, run: TaskRunColumns, state: TaskState, message: str
     ) -> TaskEvent:
         """Build a terminal event whose ``kind`` MATCHES the run's kind.
 
@@ -312,7 +313,7 @@ class TaskService:
             detail=TaskLogDetail(level=level, message=message),
         )
 
-    def _build_failed_event(self, run: TaskRunRow, message: str) -> TaskEvent:
+    def _build_failed_event(self, run: TaskRunColumns, message: str) -> TaskEvent:
         """Build a ``failed`` terminal event (thin wrapper over the general builder)."""
         return self._build_terminal_event(run, TaskState.failed, message)
 

--- a/libs/fred-core/fred_core/tasks/store.py
+++ b/libs/fred-core/fred_core/tasks/store.py
@@ -34,7 +34,7 @@ from fred_core.tasks.models import (
     TaskSummary,
     TaskTarget,
 )
-from fred_core.tasks.orm_models import TaskEventLogRow, TaskRunRow
+from fred_core.tasks.orm_models import TaskRunColumns, TaskTables
 
 _EVENT_ADAPTER: TypeAdapter[TaskEvent] = TypeAdapter(TaskEvent)
 
@@ -78,8 +78,18 @@ class TaskNotFoundError(Exception):
 
 
 class TaskStore:
-    def __init__(self, engine: AsyncEngine) -> None:
+    """Persistence for one backend's task pair.
+
+    *tables* names the concrete `<prefix>task_run`/`<prefix>task_event_log` the
+    calling backend owns (#2170) — control-plane and knowledge-flow share the
+    `fred` database, so the table names, not the connection, are what keeps one
+    backend's `GET /tasks` from returning the other's rows.
+    """
+
+    def __init__(self, engine: AsyncEngine, tables: TaskTables) -> None:
         self._sessions = make_session_factory(engine)
+        self._run = tables.run
+        self._event_log = tables.event_log
 
     def new_task_id(self) -> str:
         return str(uuid.uuid4())
@@ -100,7 +110,7 @@ class TaskStore:
         # row (e.g. a document) would vanish on reload whenever no worker is running.
         # `scheduled_for` makes a future-dated task (erasure at expiry) show up in
         # the schedule immediately, before any worker touches it.
-        row = TaskRunRow(
+        row = self._run(
             task_id=task_id,
             kind=kind,
             state=TaskState.pending,
@@ -122,7 +132,7 @@ class TaskStore:
     ) -> int:
         detail = event.detail.model_dump() if event.detail is not None else None
         async with use_session(self._sessions, session) as s:
-            run = await s.get(TaskRunRow, event.task_id)
+            run = await s.get(self._run, event.task_id)
             if run is None:
                 raise TaskNotFoundError(event.task_id)
             next_seq = run.seq + 1
@@ -146,7 +156,7 @@ class TaskStore:
             target = event.target.model_dump() if event.target is not None else None
             if target is not None:
                 run.target = target
-            log_row = TaskEventLogRow(
+            log_row = self._event_log(
                 task_id=event.task_id,
                 kind=event.kind,
                 seq=next_seq,
@@ -166,9 +176,9 @@ class TaskStore:
         self,
         task_id: str,
         session: AsyncSession | None = None,
-    ) -> TaskRunRow | None:
+    ) -> TaskRunColumns | None:
         async with use_session(self._sessions, session) as s:
-            return await s.get(TaskRunRow, task_id)
+            return await s.get(self._run, task_id)
 
     async def set_execution(
         self,
@@ -183,7 +193,7 @@ class TaskStore:
         cannot clobber a concurrent ``record_event`` from the worker.
         """
         async with use_session(self._sessions, session) as s:
-            run = await s.get(TaskRunRow, task_id)
+            run = await s.get(self._run, task_id)
             if run is None:
                 raise TaskNotFoundError(task_id)
             run.execution_id = execution_id
@@ -194,7 +204,7 @@ class TaskStore:
         older_than: datetime,
         limit: int,
         session: AsyncSession | None = None,
-    ) -> list[TaskRunRow]:
+    ) -> list[TaskRunColumns]:
         """Non-terminal tasks that carry an execution binding and have not been
         updated since ``older_than`` — the reconciliation sweeper's work-list."""
         terminal = [
@@ -203,11 +213,11 @@ class TaskStore:
             TaskState.cancelled.value,
         ]
         q = (
-            select(TaskRunRow)
-            .where(TaskRunRow.state.notin_(terminal))
-            .where(TaskRunRow.execution_id.is_not(None))
-            .where(TaskRunRow.updated_at < older_than)
-            .order_by(TaskRunRow.updated_at)
+            select(self._run)
+            .where(self._run.state.notin_(terminal))
+            .where(self._run.execution_id.is_not(None))
+            .where(self._run.updated_at < older_than)
+            .order_by(self._run.updated_at)
             .limit(limit)
         )
         async with use_session(self._sessions, session) as s:
@@ -222,10 +232,10 @@ class TaskStore:
     ) -> list[TaskEvent]:
         async with use_session(self._sessions, session) as s:
             result = await s.execute(
-                select(TaskEventLogRow)
-                .where(TaskEventLogRow.task_id == task_id)
-                .where(TaskEventLogRow.seq > after_seq)
-                .order_by(TaskEventLogRow.seq)
+                select(self._event_log)
+                .where(self._event_log.task_id == task_id)
+                .where(self._event_log.seq > after_seq)
+                .order_by(self._event_log.seq)
             )
             rows = result.scalars().all()
 
@@ -258,18 +268,18 @@ class TaskStore:
         session: AsyncSession | None = None,
     ) -> list[TaskSummary]:
         _TERMINAL = {TaskState.succeeded, TaskState.failed, TaskState.cancelled}
-        q = select(TaskRunRow)
+        q = select(self._run)
         if team_id is not None:
-            q = q.where(TaskRunRow.team_id == team_id)
+            q = q.where(self._run.team_id == team_id)
         if kind is not None:
-            q = q.where(TaskRunRow.kind == kind)
+            q = q.where(self._run.kind == kind)
         if state is not None:
-            q = q.where(TaskRunRow.state == state)
+            q = q.where(self._run.state == state)
         if created_by is not None:
-            q = q.where(TaskRunRow.created_by == created_by)
+            q = q.where(self._run.created_by == created_by)
         if exclude_terminal:
-            q = q.where(TaskRunRow.state.notin_([s.value for s in _TERMINAL]))
-        q = q.order_by(TaskRunRow.created_at.desc())
+            q = q.where(self._run.state.notin_([s.value for s in _TERMINAL]))
+        q = q.order_by(self._run.created_at.desc())
         async with use_session(self._sessions, session) as s:
             result = await s.execute(q)
             rows = result.scalars().all()
@@ -300,7 +310,7 @@ class TaskStore:
         *,
         by: str,
         session: AsyncSession | None = None,
-    ) -> TaskRunRow:
+    ) -> TaskRunColumns:
         """Stamp `acknowledged_at`/`acknowledged_by` on a task (rev. 3 §2.10).
 
         The "needs attention" gate is the CALLER's responsibility
@@ -309,7 +319,7 @@ class TaskStore:
         persistence primitive with no business rule duplicated here.
         """
         async with use_session(self._sessions, session) as s:
-            run = await s.get(TaskRunRow, task_id)
+            run = await s.get(self._run, task_id)
             if run is None:
                 raise TaskNotFoundError(task_id)
             run.acknowledged_at = _utcnow()

--- a/libs/fred-core/fred_core/tests/tasks/task_tables.py
+++ b/libs/fred-core/fred_core/tests/tasks/task_tables.py
@@ -1,0 +1,61 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A concrete task pair for fred-core's own tests (#2170).
+
+`fred_core.tasks.orm_models` deliberately maps nothing: each backend declares
+its own `cp_`/`kf_`-prefixed pair. fred-core's tests exercise `TaskStore` and
+`TaskService` without either backend installed, so they need a pair of their
+own — declared here once rather than in every test module.
+
+Declared on a test-local `DeclarativeBase`, never on the shared `CoreBase` —
+`fred_core.tests` ships in the wheel, and anything mapped on `CoreBase` is
+created by knowledge-flow's unfiltered startup `create_all` and proposed by both
+alembic trees' autogenerate. That is the exact hazard #2170 removes for the real
+task tables; re-introducing it for a test fixture would be perverse. Same shape
+as `test_table_isolation.py`.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+from fred_core.tasks.orm_models import (
+    TaskEventLogColumns,
+    TaskRunColumns,
+    TaskTables,
+    task_event_log_table_args,
+    task_run_table_args,
+)
+
+
+class Base(DeclarativeBase):
+    """Isolated from `fred_core.models.base.Base` on purpose — see the module docstring."""
+
+
+_RUN = "test_task_run"
+_LOG = "test_task_event_log"
+
+
+class TaskRunRow(TaskRunColumns, Base):
+    __tablename__ = _RUN
+    __table_args__ = task_run_table_args(_RUN)
+
+
+class TaskEventLogRow(TaskEventLogColumns, Base):
+    __tablename__ = _LOG
+    __table_args__ = task_event_log_table_args(_LOG)
+
+
+TASK_TABLES = TaskTables(run=TaskRunRow, event_log=TaskEventLogRow)

--- a/libs/fred-core/fred_core/tests/tasks/test_acknowledge.py
+++ b/libs/fred-core/fred_core/tests/tasks/test_acknowledge.py
@@ -25,7 +25,6 @@ import pytest
 import pytest_asyncio
 
 from fred_core.common import PostgresStoreConfig
-from fred_core.models.base import Base
 from fred_core.sql import create_async_engine_from_config
 from fred_core.tasks.bus import MemoryEventBus
 from fred_core.tasks.models import (
@@ -40,6 +39,7 @@ from fred_core.tasks.service import (
 )
 from fred_core.tasks.store import TaskNotFoundError, TaskStore
 from fred_core.tasks.workflow_control import NoopWorkflowControl
+from fred_core.tests.tasks.task_tables import TASK_TABLES, Base
 
 # ── 1. needs_attention — pure predicate ──────────────────────────────────────
 
@@ -84,7 +84,9 @@ async def build_service():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
         return TaskService(
-            store=TaskStore(engine), bus=MemoryEventBus(), control=NoopWorkflowControl()
+            store=TaskStore(engine, TASK_TABLES),
+            bus=MemoryEventBus(),
+            control=NoopWorkflowControl(),
         )
 
     yield _build

--- a/libs/fred-core/fred_core/tests/tasks/test_reconcile.py
+++ b/libs/fred-core/fred_core/tests/tasks/test_reconcile.py
@@ -23,7 +23,6 @@ import pytest
 import pytest_asyncio
 
 from fred_core.common import PostgresStoreConfig
-from fred_core.models.base import Base
 from fred_core.sql import create_async_engine_from_config
 from fred_core.tasks.bus import MemoryEventBus
 from fred_core.tasks.models import (
@@ -31,7 +30,6 @@ from fred_core.tasks.models import (
     StartIngestionRequest,
     TaskState,
 )
-from fred_core.tasks.orm_models import TaskRunRow
 from fred_core.tasks.service import TaskService
 from fred_core.tasks.sse import task_event_stream
 from fred_core.tasks.store import TaskStore
@@ -40,6 +38,7 @@ from fred_core.tasks.workflow_control import (
     NoopWorkflowControl,
     TemporalWorkflowControl,
 )
+from fred_core.tests.tasks.task_tables import TASK_TABLES, Base, TaskRunRow
 
 _NOW = datetime(2026, 6, 17, tzinfo=timezone.utc)
 
@@ -149,7 +148,7 @@ async def build_service():
             await conn.run_sync(Base.metadata.create_all)
         control = _StubControl(status_by_eid)
         service = TaskService(
-            store=TaskStore(engine),
+            store=TaskStore(engine, TASK_TABLES),
             bus=MemoryEventBus(),
             control=control,
             on_reconciled_terminal=on_reconciled_terminal,

--- a/libs/fred-core/fred_core/tests/tasks/test_scheduling.py
+++ b/libs/fred-core/fred_core/tests/tasks/test_scheduling.py
@@ -29,7 +29,6 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from fred_core.common import PostgresStoreConfig
-from fred_core.models.base import Base
 from fred_core.sql import create_async_engine_from_config
 from fred_core.tasks.bus import MemoryEventBus
 from fred_core.tasks.models import (
@@ -43,6 +42,7 @@ from fred_core.tasks.models import (
 from fred_core.tasks.service import TaskService
 from fred_core.tasks.store import TaskStore
 from fred_core.tasks.workflow_control import NoopWorkflowControl
+from fred_core.tests.tasks.task_tables import TASK_TABLES, Base
 
 
 async def _service(tmp_path) -> TaskService:
@@ -52,7 +52,9 @@ async def _service(tmp_path) -> TaskService:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     return TaskService(
-        store=TaskStore(engine), bus=MemoryEventBus(), control=NoopWorkflowControl()
+        store=TaskStore(engine, TASK_TABLES),
+        bus=MemoryEventBus(),
+        control=NoopWorkflowControl(),
     )
 
 

--- a/libs/fred-core/fred_core/tests/tasks/test_table_isolation.py
+++ b/libs/fred-core/fred_core/tests/tasks/test_table_isolation.py
@@ -1,0 +1,112 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""#2170: two backends sharing one database must not see each other's tasks.
+
+control-plane and knowledge-flow both migrate the `fred` database. When they
+mapped one shared `task_run`, each backend's `GET /tasks` returned the other's
+rows and the Activity page — which queries every backend and merges client-side
+— listed every task twice. The fix is a prefixed pair per owner, so these tests
+use the same two-owners-one-engine setup the product has.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from fred_core.tasks.orm_models import (
+    TaskEventLogColumns,
+    TaskRunColumns,
+    TaskTables,
+    single_active_migration_index_name,
+    task_event_log_table_args,
+    task_run_table_args,
+)
+from fred_core.tasks.store import TaskStore
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+def _declare(prefix: str) -> TaskTables:
+    run, log = f"{prefix}task_run", f"{prefix}task_event_log"
+    run_cls = type(
+        f"{prefix}TaskRunRow",
+        (TaskRunColumns, _Base),
+        {"__tablename__": run, "__table_args__": task_run_table_args(run)},
+    )
+    log_cls = type(
+        f"{prefix}TaskEventLogRow",
+        (TaskEventLogColumns, _Base),
+        {"__tablename__": log, "__table_args__": task_event_log_table_args(log)},
+    )
+    return TaskTables(run=run_cls, event_log=log_cls)
+
+
+_ALPHA = _declare("alpha_")
+_BETA = _declare("beta_")
+
+
+@pytest.mark.asyncio
+async def test_each_owner_only_lists_its_own_tasks(tmp_path) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'shared.sqlite3'}")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(_Base.metadata.create_all)
+
+        alpha = TaskStore(engine, _ALPHA)
+        beta = TaskStore(engine, _BETA)
+        await alpha.create(task_id="a-1", kind="migration", created_by="u")
+        await beta.create(task_id="b-1", kind="ingestion", created_by="u")
+
+        assert [t.task_id for t in await alpha.list_tasks()] == ["a-1"]
+        assert [t.task_id for t in await beta.list_tasks()] == ["b-1"]
+        # Cross-reads miss entirely rather than returning a foreign row.
+        assert await alpha.get_run("b-1") is None
+        assert await beta.get_run("a-1") is None
+    finally:
+        await engine.dispose()
+
+
+def test_owners_share_no_index_name() -> None:
+    """Postgres scopes index names per schema, so two owners in one database
+    cannot both name an index `ix_task_run_kind`. Every index must carry its
+    table name — this fails the moment someone adds a hardcoded one."""
+    names = {}
+    for label, tables in (("alpha", _ALPHA), ("beta", _BETA)):
+        names[label] = {
+            ix.name
+            for model in (tables.run, tables.event_log)
+            for ix in model.__table__.indexes  # type: ignore[attr-defined]
+        } | {
+            c.name
+            for model in (tables.run, tables.event_log)
+            for c in model.__table__.constraints  # type: ignore[attr-defined]
+            if c.name is not None
+        }
+    assert names["alpha"] and names["beta"]
+    assert not names["alpha"] & names["beta"]
+
+
+def test_exclusion_index_name_tracks_the_table() -> None:
+    """`import_export/api.py` recognises a concurrent-migration 409 by this exact
+    string, derived from the same helper rather than restated — so the helper and
+    the index it names must agree for whatever table an owner picks."""
+    assert single_active_migration_index_name("alpha_task_run") in {
+        ix.name
+        for ix in _ALPHA.run.__table__.indexes  # type: ignore[attr-defined]
+    }


### PR DESCRIPTION
Closes #2170.

## What changed

control-plane and knowledge-flow both run Alembic against the same `fred` database, and both mapped the **same** `task_run`/`task_event_log` declared on fred-core's shared `CoreBase`. Nothing scoped either backend's `GET /tasks` to the rows it created, so each returned the other's and the Activity page — which queries every backend and merges client-side, by design — listed every task twice.

Each backend now declares its own prefixed pair on its own declarative `Base`:

| Owner | Tables | Alembic tree |
|---|---|---|
| control-plane | `cp_task_run`, `cp_task_event_log` | `alembic_version_control_plane` |
| knowledge-flow | `kf_task_run`, `kf_task_event_log` | `alembic_version_knowledge_flow` |
| evaluation | `task_run`, `task_event_log` | its own database, unchanged |

`fred_core.tasks.orm_models` maps nothing. It exposes column mixins plus `task_run_table_args`/`task_event_log_table_args`, and `TaskStore`/`TaskService.build` take the concrete pair as a `TaskTables`. Column definitions still live once.

## Why not the dedicated database the issue asked for

The RFC's rev. 4 remedy (`POSTGRES_KNOWLEDGE_FLOW_DB`, a second engine in `ApplicationContext`, `fred-deployment-factory` provisioning) was confirmed but never built. Distinct table names fix the same bug with **no infrastructure change at all** — and they do something the dedicated database could not. #2314 says of this issue:

> a dedicated knowledge-flow database would sidestep cross-service collision, but would not fix autogenerate proposing foreign tables within a tree

Moving each pair onto its owner's `Base` does fix that for these two tables: each pair is now in exactly one tree's metadata, which is what `make_alembic_env`'s `include_name` filter reads. Two of #2314's eight disputed rows are gone rather than worked around.

## The migrations create only — the old pair is left orphaned on purpose

This is expand-now, contract-later, and the reason is specific rather than general caution. `knowledge-flow-worker` and `control-plane-worker` have **no `migration:` block** in `deploy/charts/fred/values.yaml`, so unlike the API Deployments they get no `hook-scale-down` Job and keep running old code through the entire hook phase and the rolling update. Old knowledge-flow worker code writes the shared `task_run` from `emit_ingestion_task_event` — an unguarded `@activity.defn` invoked as the **first** step of `ProcessPushFile` with `maximum_attempts=1`, whose failure propagates up to the parent batch workflow.

Dropping the table mid-deploy would therefore not merely lose task bookkeeping: it would fail the workflow before any extraction runs, take the rest of the batch with it, and the documents would never be ingested, with no retry. One dead table pair for one release is the cheaper side of that trade. **Follow-up: #2377 drops `task_run`/`task_event_log`.** 🛑 It must ship in a release **strictly after** the one containing this PR — never the same tag. Merge order is not the constraint; the release tag is. During any rollout the two Temporal workers still run the previous image, and the previous image writes that table.

No backfill either — task rows are progress bookkeeping, and the issue decided against carrying them over.

## Incidental fix

`c1d2e3f4a5b6` (CP) and `e2f3a4b5c6d7` (KF) share a guard whose "table absent → treat as present" sentinel is right for `upgrade` (skip the create) but made `downgrade` attempt `DROP INDEX` on a missing table. Now guarded by `_task_run_exists()`.

## Verification

CI only validates `base → head` on an **empty** database (#2375), so the deploy path was exercised by hand:

- Upgrade on a **populated** DB at the previous heads (`a7d2e9c41f38`/`bcd7cbdbedca`) carrying rows from both backends
- Upgrade on a **real dev database**: 194 `task_run` rows and 580 event rows, **all `kind=ingestion`** — i.e. all knowledge-flow's, sitting in control-plane's table. The bug, concretely.
- `alembic check` clean on the **upgraded** (not rebuilt) database, both trees
- Rollback, then re-upgrade — replayable
- Both combined migration checks (SQLite + Postgres), plus KF-first and mid-tree interleaved orderings, which CI does not cover and the chart does not pin
- Live runtime: each backend's `TaskService.list_tasks()` returns only its own task, re-read after the other created one; one row per physical table
- Ownership: the Helm migration hook reuses `.app.env`/`.app.envFrom`, so the new tables are owned by the same role (`fred`) as every existing table — verified by running the migration as that user
- `make code-quality` clean; 2198 tests pass (516 fred-core / 729 CP / 953 KF), including a new `test_table_isolation.py` that pins the two-owners-one-engine guarantee and asserts the two owners' index names stay disjoint

## Out of scope, deliberately

- **#2314 / #2313** — knowledge-flow's unfiltered startup `CoreBase.metadata.create_all` stays. Its removal is an explicit acceptance criterion of #2314 (which is where #2313 was consolidated), and bundling it here would violate CLAUDE.md's scope discipline. Note that `CoreBase` no longer carries any task table, so that `create_all` can no longer resurrect `task_run` after a future release drops it.
- **`fred-agent-evaluator`** — a separate repo, listed in the contract doc as the third task owner. It must declare its own pair from the mixins before it picks up the next `fred-core`.

## Task close-out

- **Code:** per-backend task tables; fred-core's task ORM becomes mixins + a `TaskTables` handed to `TaskStore`/`TaskService.build`; two create-only migrations; one asymmetric-guard fix.
- **Tests:** 2198 pass. New `test_table_isolation.py` (3 tests) pins the isolation guarantee and the index-name disjointness that forced the rename.
- **Docs updated:** `docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md` (§ Persistence — the durable what/why), `docs/swift/rfc/TASK-EVENT-STREAM-RFC.md` (rev. 5 amendment; §2.6/§2.9 trimmed to pointers per the RFC-vs-doc rule).
- **Tracking:** #2170.
- **Skipped steps:** Step 1 (RFC) — the design was already settled by rev. 4's diagnosis; only the remedy changed, and per CLAUDE.md a settled decision belongs in the compact doc, so the durable text went to the contract doc and the RFC was trimmed rather than extended.

