### PR TITLE
fix(#2372): harden managed chat rejection recovery

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 // Copyright Thales 2026
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +13,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createRef, type ReactNode } from "react";
+import { act, createRef, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
+
+const assistantTurnRenderMock = vi.hoisted(() => vi.fn());
 
 vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock("@shared/organisms/ChatMessagesArea/ChatMessagesArea", () => ({
   ChatMessagesArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 vi.mock("@shared/organisms/UserTurn/UserTurn", () => ({ UserTurn: () => null }));
-vi.mock("@shared/organisms/AssistantTurn/AssistantTurn", () => ({ AssistantTurn: () => null }));
+vi.mock("@shared/organisms/AssistantTurn/AssistantTurn", async () => {
+  const { memo } = await vi.importActual<typeof import("react")>("react");
+  return {
+    AssistantTurn: memo(function AssistantTurn(props: { pendingToolCallIds?: readonly string[] | null }) {
+      assistantTurnRenderMock(props);
+      return null;
+    }),
+  };
+});
 vi.mock("@shared/molecules/HitlPrompt/HitlPrompt.tsx", () => ({
   HitlPrompt: (props: {
     maxChatInputChars?: number;
@@ -65,5 +77,51 @@ describe("ConversationThread HITL input policy wiring", () => {
     expect(html).toContain('data-free-text="full draft"');
     expect(html).toContain('data-has-answer-handler="true"');
     expect(html).toContain('data-has-change-handler="true"');
+  });
+
+  it("does not re-render historical assistant turns when only the HITL draft changes", () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    assistantTurnRenderMock.mockClear();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const pendingHitl = {
+      type: "awaiting_human" as const,
+      session_id: "session-1",
+      exchange_id: "exchange-1",
+      payload: { free_text: true, pending_calls: [] },
+    };
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant" as const,
+        text: "historical markdown",
+        traceMessages: [],
+        sources: [],
+        uiParts: [],
+        isStreaming: false,
+      },
+    ];
+    const render = (hitlFreeText: string) => (
+      <ConversationThread
+        messages={messages}
+        pendingHitl={pendingHitl}
+        isLoading={false}
+        isStreaming={false}
+        scrollContainerRef={createRef<HTMLDivElement>()}
+        onHitlAnswer={() => undefined}
+        maxChatInputChars={5_000}
+        hitlFreeText={hitlFreeText}
+        onHitlFreeTextChange={() => undefined}
+      />
+    );
+
+    act(() => root.render(render("a")));
+    expect(assistantTurnRenderMock).toHaveBeenCalledTimes(1);
+    act(() => root.render(render("ab")));
+    expect(assistantTurnRenderMock).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    container.remove();
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
@@ -15,7 +15,7 @@
 // Page-local composition of organisms for ManagedChatPage.
 // Lives under pages/ so it may import from shared/organisms freely.
 
-import { memo, type ReactNode, type RefObject } from "react";
+import { memo, useMemo, type ReactNode, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { RuntimeAwaitingHumanEvent } from "@hooks/useChatSse";
 import { useAssistantCopyInterception } from "@hooks/useAssistantCopyInterception";
@@ -63,8 +63,10 @@ export const ConversationThread = memo(function ConversationThread({
   // #2177: one prompt can batch several calls at once) — lets the trace row
   // for each of those tools render "awaiting confirmation" instead of
   // "running" while the prompt below is still unanswered.
-  const pendingToolCallIds =
-    pendingHitl?.payload.pending_calls?.map((c) => c.tool_call_id).filter((id): id is string => !!id) ?? null;
+  const pendingToolCallIds = useMemo(
+    () => pendingHitl?.payload.pending_calls?.map((c) => c.tool_call_id).filter((id): id is string => !!id) ?? null,
+    [pendingHitl],
+  );
 
   return (
     <ChatMessagesArea

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.test.tsx
@@ -25,12 +25,18 @@ vi.mock("react-i18next", () => ({
 let chatValue: Record<string, unknown>;
 vi.mock("./useManagedChat", () => ({ useManagedChat: () => chatValue }));
 vi.mock("@shared/molecules/RichInputField/RichInputField", () => ({
-  RichInputField: (props: { sendDisabled?: boolean; characterCount?: number; characterLimit?: number }) => (
+  RichInputField: (props: {
+    sendDisabled?: boolean;
+    characterCount?: number;
+    characterLimit?: number;
+    onInterrupt?: () => void;
+  }) => (
     <div
       data-testid="composer"
       data-send-disabled={props.sendDisabled}
       data-character-count={props.characterCount}
       data-character-limit={props.characterLimit}
+      data-has-interrupt={typeof props.onInterrupt === "function"}
     />
   ),
 }));
@@ -106,50 +112,57 @@ vi.mock("@shared/molecules/ComposerActionsMenu/ComposerActionsMenu", () => ({
 
 import ManagedChatPage from "./ManagedChatPage";
 
+const noop = () => undefined;
+
+function managedChatValue(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agentDisplayName: "Agent",
+    attachments: [],
+    attachmentsUploading: false,
+    capabilityIds: [],
+    chatControls: [],
+    commitTitle: noop,
+    contextPrompts: [],
+    deletePersistedAttachment: noop,
+    handleAbort: noop,
+    handleAddAttachments: noop,
+    handleHitlAnswer: noop,
+    handleSend: noop,
+    hitlFreeText: "complete HITL draft",
+    input: "six!!",
+    inputCharacterCount: 6,
+    inputTooLong: true,
+    isHydratingAttachments: false,
+    isLoadingHistory: false,
+    isPreparingSend: false,
+    maxChatInputChars: 5,
+    messages: [],
+    pendingHitl: { session_id: "session-1", exchange_id: "exchange-1", payload: { free_text: true } },
+    persistedAttachments: [],
+    ragScope: "all",
+    reasoning: false,
+    removeAttachment: noop,
+    searchPolicy: "hybrid",
+    selectedDocumentUids: [],
+    selectedLibraryIds: [],
+    sessionId: "session-1",
+    sessionTitle: "Chat",
+    setHitlFreeText: noop,
+    setInput: noop,
+    setRagScope: noop,
+    setReasoning: noop,
+    setSearchPolicy: noop,
+    setSelectedDocumentUids: noop,
+    setSelectedLibraryIds: noop,
+    threadMessages: [],
+    waitResponse: false,
+    ...overrides,
+  };
+}
+
 describe("ManagedChatPage chat-input policy wiring", () => {
   it("passes the runtime policy to both the composer and active HITL prompt", () => {
-    const noop = () => undefined;
-    chatValue = {
-      agentDisplayName: "Agent",
-      attachments: [],
-      attachmentsUploading: false,
-      capabilityIds: [],
-      chatControls: [],
-      commitTitle: noop,
-      contextPrompts: [],
-      deletePersistedAttachment: noop,
-      handleAbort: noop,
-      handleAddAttachments: noop,
-      handleHitlAnswer: noop,
-      handleSend: noop,
-      hitlFreeText: "complete HITL draft",
-      input: "six!!",
-      inputCharacterCount: 6,
-      inputTooLong: true,
-      isHydratingAttachments: false,
-      isLoadingHistory: false,
-      maxChatInputChars: 5,
-      messages: [],
-      pendingHitl: { session_id: "session-1", exchange_id: "exchange-1", payload: { free_text: true } },
-      persistedAttachments: [],
-      ragScope: "all",
-      reasoning: false,
-      removeAttachment: noop,
-      searchPolicy: "hybrid",
-      selectedDocumentUids: [],
-      selectedLibraryIds: [],
-      sessionId: "session-1",
-      sessionTitle: "Chat",
-      setHitlFreeText: noop,
-      setInput: noop,
-      setRagScope: noop,
-      setReasoning: noop,
-      setSearchPolicy: noop,
-      setSelectedDocumentUids: noop,
-      setSelectedLibraryIds: noop,
-      threadMessages: [],
-      waitResponse: false,
-    };
+    chatValue = managedChatValue();
 
     const html = renderToStaticMarkup(<ManagedChatPage />);
 
@@ -160,5 +173,13 @@ describe("ManagedChatPage chat-input policy wiring", () => {
     expect(html).toContain('data-testid="thread"');
     expect(html).toContain('data-hitl-draft="complete HITL draft"');
     expect(html).toContain('data-has-hitl-change-handler="true"');
+  });
+
+  it("exposes Stop only while the chat hook owns an active runtime request", () => {
+    chatValue = managedChatValue({ isPreparingSend: true, waitResponse: false });
+    expect(renderToStaticMarkup(<ManagedChatPage />)).toContain('data-has-interrupt="false"');
+
+    chatValue = managedChatValue({ isPreparingSend: false, waitResponse: true });
+    expect(renderToStaticMarkup(<ManagedChatPage />)).toContain('data-has-interrupt="true"');
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -293,27 +293,28 @@ export default function ManagedChatPage() {
   const hasToolControls = chat.chatControls.some(
     (control) => control.widget !== "attach_files" && !COMPOSER_CHIP_WIDGETS.has(control.widget),
   );
-  const composerControlsDisabled = chat.waitResponse || chat.isLoadingHistory;
+  const composerBusy = chat.isPreparingSend || chat.waitResponse;
+  const composerControlsDisabled = composerBusy || chat.isLoadingHistory;
 
   const composer = (
     <RichInputField
       value={chat.input}
       onChange={chat.setInput}
       onSend={chat.handleSend}
-      onInterrupt={chat.handleAbort}
-      disabled={chat.waitResponse || chat.isLoadingHistory}
+      onInterrupt={chat.waitResponse ? chat.handleAbort : undefined}
+      disabled={composerBusy || chat.isLoadingHistory}
       sendDisabled={chat.attachmentsUploading || chat.inputTooLong}
       characterCount={chat.inputCharacterCount}
       characterLimit={chat.maxChatInputChars}
       enableVoiceInput
       onTranscribeAudio={handleTranscribeAudio}
-      voiceInputDisabled={chat.waitResponse || chat.isLoadingHistory}
+      voiceInputDisabled={composerBusy || chat.isLoadingHistory}
       onVoiceInputError={reportVoiceInputError}
       focusEndRequestId={focusEndRequestId}
       showSendButton
       aboveTextSlot={
         chat.attachments.length > 0 ? (
-          <AttachmentChips attachments={chat.attachments} onRemove={chat.removeAttachment} />
+          <AttachmentChips attachments={chat.attachments} onRemove={composerBusy ? undefined : chat.removeAttachment} />
         ) : undefined
       }
       rightExtraSlot={

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.test.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 // Copyright Thales 2026
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +13,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, it } from "vitest";
-import type { SessionAttachment } from "@rework/types/attachments";
-import { buildAttachmentsMarkdown, excludeDeletedAttachments } from "./useChatAttachments";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatAttachment, SessionAttachment } from "@rework/types/attachments";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const hookMocks = vi.hoisted(() => ({
+  deleteMutation: vi.fn(),
+  fastIngestMutation: vi.fn(),
+  notifyApiError: vi.fn(),
+  persistMutation: vi.fn(),
+}));
+
+vi.mock("react-redux", () => ({ useDispatch: () => vi.fn() }));
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("@core/hooks/useApiErrorToast.ts", () => ({
+  useApiErrorToast: () => ({ notifyApiError: hookMocks.notifyApiError }),
+}));
+vi.mock("../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
+  useFastIngestKnowledgeFlowV1FastIngestPostMutation: () => [hookMocks.fastIngestMutation],
+}));
+vi.mock("../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
+  useGetTeamSessionAttachmentsControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsGetQuery: () => ({
+    data: [{ attachment_id: "attachment-1", name: "report.pdf", summary_md: "summary" }],
+    isFetching: false,
+  }),
+  usePostTeamSessionAttachmentControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsPostMutation: () => [
+    hookMocks.persistMutation,
+  ],
+  useDeleteTeamSessionAttachmentControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsAttachmentIdDeleteMutation: () => [
+    hookMocks.deleteMutation,
+  ],
+}));
+vi.mock("../../../features/tasks/taskSlice", () => ({
+  taskEventReceived: (payload: unknown) => payload,
+  taskRegistered: (payload: unknown) => payload,
+}));
+
+import {
+  buildAttachmentsMarkdown,
+  excludeDeletedAttachments,
+  mergeRestoredReadyAttachments,
+  useChatAttachments,
+} from "./useChatAttachments";
 
 describe("buildAttachmentsMarkdown", () => {
   it("announces persisted attachments to the runtime", () => {
@@ -46,5 +93,262 @@ describe("buildAttachmentsMarkdown", () => {
     const remaining = excludeDeletedAttachments([attachment], new Set(["attachment-1"]));
 
     expect(buildAttachmentsMarkdown(remaining, [])).toBeNull();
+  });
+
+  it("announces a ready transient document until the persisted attachment query catches up", () => {
+    const transient = {
+      id: "attachment-2",
+      name: "late-report.pdf",
+      size: 10,
+      mime: "application/pdf",
+      status: "ready",
+      isImage: false,
+      documentUid: "document-2",
+      taskIds: [],
+    } satisfies ChatAttachment;
+
+    expect(buildAttachmentsMarkdown([], [transient])).toContain(
+      "- late-report.pdf [document-2]: conversation document",
+    );
+
+    const persisted = {
+      attachmentId: transient.id,
+      name: transient.name,
+      documentUid: transient.documentUid,
+    } as SessionAttachment;
+    const caughtUp = buildAttachmentsMarkdown([persisted], [transient]) ?? "";
+    expect(caughtUp.match(/late-report\.pdf/g)).toHaveLength(1);
+  });
+});
+
+describe("mergeRestoredReadyAttachments", () => {
+  it("restores missing ready attachments with inline-image context without duplicating existing ids", () => {
+    const existing = {
+      id: "existing",
+      name: "existing.pdf",
+      size: 10,
+      mime: "application/pdf",
+      status: "ready",
+      isImage: false,
+      taskIds: [],
+    } satisfies ChatAttachment;
+    const image = {
+      id: "image",
+      name: "diagram.png",
+      size: 42,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      imageContext: {
+        name: "diagram.png",
+        mime: "image/png",
+        size: 42,
+        dataUrl: "data:image/png;base64,cGl4ZWxz",
+      },
+      taskIds: ["task-1"],
+    } satisfies ChatAttachment;
+
+    const merged = mergeRestoredReadyAttachments([existing], [existing, image]);
+
+    expect(merged).toEqual([existing, image]);
+    expect(merged[1]?.imageContext?.dataUrl).toBe(image.imageContext.dataUrl);
+  });
+
+  it("does not resurrect an attachment deleted while the rejected turn was in flight", () => {
+    const deleted = {
+      id: "deleted",
+      name: "deleted.pdf",
+      size: 10,
+      mime: "application/pdf",
+      status: "ready",
+      isImage: false,
+      taskIds: [],
+    } satisfies ChatAttachment;
+
+    expect(mergeRestoredReadyAttachments([], [deleted], new Set([deleted.id]))).toEqual([]);
+  });
+});
+
+describe("useChatAttachments deletion ownership", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: ReturnType<typeof useChatAttachments>;
+  const requests: Array<ReturnType<typeof deferred<void>>> = [];
+
+  function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  function Host({ sessionId }: { sessionId: string }) {
+    latest = useChatAttachments({ teamId: "team-1", sessionId });
+    return null;
+  }
+
+  const render = (sessionId: string) => {
+    act(() => root.render(createElement(Host, { sessionId })));
+  };
+
+  beforeEach(() => {
+    hookMocks.notifyApiError.mockClear();
+    hookMocks.deleteMutation.mockReset();
+    requests.length = 0;
+    hookMocks.deleteMutation.mockImplementation(() => {
+      const request = deferred<void>();
+      requests.push(request);
+      return { unwrap: () => request.promise };
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("does not let an old deletion failure clear a newer tombstone for the same session and id", async () => {
+    render("session-a");
+    let firstAttempt!: Promise<void>;
+    await act(async () => {
+      firstAttempt = latest.deletePersistedAttachment("attachment-1");
+      await Promise.resolve();
+    });
+    expect(latest.persistedAttachments).toEqual([]);
+
+    render("session-b");
+    render("session-a");
+    let secondAttempt!: Promise<void>;
+    await act(async () => {
+      secondAttempt = latest.deletePersistedAttachment("attachment-1");
+      await Promise.resolve();
+    });
+    expect(latest.persistedAttachments).toEqual([]);
+
+    await act(async () => {
+      requests[0]?.reject(new Error("old delete failed"));
+      await firstAttempt;
+    });
+    expect(latest.persistedAttachments).toEqual([]);
+
+    await act(async () => {
+      requests[1]?.reject(new Error("current delete failed"));
+      await secondAttempt;
+    });
+    expect(latest.persistedAttachments.map((attachment) => attachment.attachmentId)).toEqual(["attachment-1"]);
+  });
+});
+
+describe("useChatAttachments rejection rollback", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: ReturnType<typeof useChatAttachments>;
+
+  function Host() {
+    latest = useChatAttachments({ teamId: "team-1", sessionId: "session-a" });
+    return null;
+  }
+
+  beforeEach(() => {
+    hookMocks.deleteMutation.mockReset();
+    hookMocks.deleteMutation.mockReturnValue({ unwrap: async () => undefined });
+    hookMocks.fastIngestMutation.mockReset();
+    hookMocks.fastIngestMutation.mockReturnValue({
+      unwrap: async () => ({ document_uid: "document-1", summary_md: "summary" }),
+    });
+    hookMocks.persistMutation.mockReset();
+    hookMocks.persistMutation.mockReturnValue({ unwrap: async () => undefined });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(createElement(Host)));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("clears only captured ready attachments and preserves later-ready files for the next turn", async () => {
+    const submittedImage = new File(["pixels"], "diagram.png", { type: "image/png" });
+    const nextTurnImage = new File(["later"], "later.png", { type: "image/png" });
+    let cleared: readonly ChatAttachment[] = [];
+
+    await act(async () => {
+      await latest.addFiles([submittedImage], "picker", "session-a");
+    });
+    const submittedId = latest.attachments[0]?.id;
+    expect(submittedId).toBeDefined();
+
+    await act(async () => {
+      await latest.addFiles([nextTurnImage], "picker", "session-a");
+      cleared = latest.clearReadyAttachments([submittedId!]);
+    });
+
+    expect(cleared).toHaveLength(1);
+    expect(cleared[0]?.name).toBe("diagram.png");
+    expect(cleared[0]?.imageContext?.dataUrl).toContain("data:image/png");
+    expect(latest.attachments.map((attachment) => attachment.name)).toEqual(["later.png"]);
+
+    act(() => latest.restoreReadyAttachments(cleared));
+    expect(latest.attachments.map((attachment) => attachment.name)).toEqual(["later.png", "diagram.png"]);
+    expect(latest.attachments[1]?.imageContext?.dataUrl).toBe(cleared[0]?.imageContext?.dataUrl);
+  });
+
+  it("reads ready attachment ids and context from the synchronous turn-start snapshot", async () => {
+    const document = new File(["content"], "late-report.pdf", { type: "application/pdf" });
+
+    await act(async () => {
+      await latest.addFiles([document], "picker", "session-a");
+    });
+
+    const snapshot = latest.getReadyAttachmentSnapshot();
+    expect(snapshot.attachmentIds).toEqual([latest.attachments[0]?.id]);
+    expect(snapshot.attachmentsMarkdown).toContain("- late-report.pdf [document-1]: conversation document");
+  });
+
+  it("keeps failed attachment chips outside a submitted turn's ready snapshot", async () => {
+    hookMocks.fastIngestMutation.mockReturnValueOnce({
+      unwrap: async () => {
+        throw new Error("ingestion failed");
+      },
+    });
+    const failed = new File(["content"], "failed.pdf", { type: "application/pdf" });
+
+    await act(async () => {
+      await latest.addFiles([failed], "picker", "session-a");
+    });
+    const failedId = latest.attachments[0]?.id;
+    expect(latest.attachments[0]?.status).toBe("error");
+
+    const cleared = latest.clearReadyAttachments([failedId!]);
+    expect(cleared).toEqual([]);
+    expect(latest.attachments.map((attachment) => attachment.id)).toEqual([failedId]);
+  });
+
+  it("does not restore a persisted attachment deleted in the same render window", async () => {
+    const deleted = {
+      id: "attachment-1",
+      name: "report.pdf",
+      size: 10,
+      mime: "application/pdf",
+      status: "ready",
+      isImage: false,
+      taskIds: [],
+    } satisfies ChatAttachment;
+
+    await act(async () => {
+      const deletion = latest.deletePersistedAttachment(deleted.id);
+      latest.restoreReadyAttachments([deleted]);
+      await deletion;
+    });
+
+    expect(latest.attachments).toEqual([]);
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
@@ -29,6 +29,7 @@ import type { ChatAttachment, ChatImageContext, SessionAttachment } from "@rewor
 
 const MAX_INLINE_IMAGE_BYTES = 4 * 1024 * 1024;
 const ALLOWED_INLINE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+const NO_ATTACHMENT_IDS: ReadonlySet<string> = new Set();
 
 interface FastIngestResponse {
   document_uid?: string;
@@ -116,6 +117,15 @@ export function buildAttachmentsMarkdown(persisted: SessionAttachment[], transie
   const persistedLines = persisted.map(
     (attachment) => `- ${attachment.name}${uidSuffix(attachment.documentUid)}: conversation document`,
   );
+  const persistedIds = new Set(persisted.map((attachment) => attachment.attachmentId));
+  // The mutation marks the local attachment ready synchronously, while the
+  // persisted-attachments query can update on a later render. Keep that short
+  // cache gap from dropping a newly ready document from the turn-start context.
+  const transientDocumentLines = transient.flatMap((attachment) =>
+    attachment.status === "ready" && !attachment.imageContext && !persistedIds.has(attachment.id)
+      ? [`- ${attachment.name}${uidSuffix(attachment.documentUid)}: conversation document`]
+      : [],
+  );
   const inlineImageLines = transient.flatMap((attachment) =>
     attachment.imageContext
       ? [
@@ -125,7 +135,12 @@ export function buildAttachmentsMarkdown(persisted: SessionAttachment[], transie
       : [],
   );
 
-  const lines = ["## Attached files for this conversation", ...persistedLines, ...inlineImageLines];
+  const lines = [
+    "## Attached files for this conversation",
+    ...persistedLines,
+    ...transientDocumentLines,
+    ...inlineImageLines,
+  ];
   return lines.length > 1 ? lines.join("\n") : null;
 }
 
@@ -134,6 +149,18 @@ export function excludeDeletedAttachments(
   deletedAttachmentIds: ReadonlySet<string>,
 ): SessionAttachment[] {
   return persisted.filter((attachment) => !deletedAttachmentIds.has(attachment.attachmentId));
+}
+
+export function mergeRestoredReadyAttachments(
+  current: ChatAttachment[],
+  restored: readonly ChatAttachment[],
+  excludedIds: ReadonlySet<string> = NO_ATTACHMENT_IDS,
+): ChatAttachment[] {
+  const existingIds = new Set(current.map((attachment) => attachment.id));
+  const missing = restored.filter(
+    (attachment) => attachment.status === "ready" && !existingIds.has(attachment.id) && !excludedIds.has(attachment.id),
+  );
+  return missing.length > 0 ? [...current, ...missing] : current;
 }
 
 interface UseChatAttachmentsParams {
@@ -146,10 +173,29 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
   const { t } = useTranslation();
   const { notifyApiError } = useApiErrorToast();
   const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
+  // Synchronous source of truth for transitions that can share one React render
+  // window (upload completion, turn-start clear, and rejection rollback).
+  const attachmentsRef = useRef<ChatAttachment[]>([]);
+  const updateAttachments = useCallback((update: (current: ChatAttachment[]) => ChatAttachment[]) => {
+    const next = update(attachmentsRef.current);
+    attachmentsRef.current = next;
+    setAttachments(next);
+  }, []);
   const [deletedAttachmentIds, setDeletedAttachmentIds] = useState<ReadonlySet<string>>(new Set());
-
+  // Synchronous mirror for rejection rollback. The delete action and the
+  // runtime's 422 can settle in the same render window, before React has
+  // committed the state update used by persistedAttachments.
+  const deletedAttachmentIdsRef = useRef<ReadonlySet<string>>(new Set());
+  // Owns rollback per (session, attachment). A failed request may settle after
+  // the user revisits the same session and starts a newer deletion for the
+  // same id; only the latest attempt may remove its tombstone.
+  const deleteAttemptOwnersRef = useRef<Map<string, symbol>>(new Map());
+  const activeSessionIdRef = useRef(sessionId);
+  activeSessionIdRef.current = sessionId;
   useEffect(() => {
-    setDeletedAttachmentIds(new Set());
+    const empty = new Set<string>();
+    deletedAttachmentIdsRef.current = empty;
+    setDeletedAttachmentIds(empty);
   }, [sessionId]);
 
   const { data: persistedAttachmentsData = [], isFetching: isHydratingAttachments } =
@@ -172,6 +218,8 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
       ),
     [deletedAttachmentIds, persistedAttachmentsData],
   );
+  const persistedAttachmentsRef = useRef(persistedAttachments);
+  persistedAttachmentsRef.current = persistedAttachments;
 
   const fastIngestAttachment = useCallback(
     async (file: File, activeSessionId: string | null | undefined): Promise<FastIngestResponse | null> => {
@@ -193,8 +241,13 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
   const deletePersistedAttachment = useCallback(
     async (attachmentId: string) => {
       if (!teamId || !sessionId) return;
-      setAttachments((prev) => prev.filter((attachment) => attachment.id !== attachmentId));
-      setDeletedAttachmentIds((prev) => new Set(prev).add(attachmentId));
+      const attemptKey = JSON.stringify([sessionId, attachmentId]);
+      const attemptOwner = Symbol(attemptKey);
+      deleteAttemptOwnersRef.current.set(attemptKey, attemptOwner);
+      updateAttachments((prev) => prev.filter((attachment) => attachment.id !== attachmentId));
+      const withDeletedAttachment = new Set(deletedAttachmentIdsRef.current).add(attachmentId);
+      deletedAttachmentIdsRef.current = withDeletedAttachment;
+      setDeletedAttachmentIds(withDeletedAttachment);
       try {
         await deletePersistedAttachmentMutation({
           teamId,
@@ -202,11 +255,15 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
           attachmentId,
         }).unwrap();
       } catch (error) {
-        setDeletedAttachmentIds((prev) => {
-          const next = new Set(prev);
-          next.delete(attachmentId);
-          return next;
-        });
+        if (
+          activeSessionIdRef.current === sessionId &&
+          deleteAttemptOwnersRef.current.get(attemptKey) === attemptOwner
+        ) {
+          const withoutFailedDeletion = new Set(deletedAttachmentIdsRef.current);
+          withoutFailedDeletion.delete(attachmentId);
+          deletedAttachmentIdsRef.current = withoutFailedDeletion;
+          setDeletedAttachmentIds(withoutFailedDeletion);
+        }
         notifyApiError(error, {
           summary: t("chatbot.errors.attachmentDeleteFailedSummary"),
           fallbackDetail: t("chatbot.errors.attachmentDeleteFailedDetail"),
@@ -216,9 +273,13 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
         // and don't await it -- the error is already surfaced via the toast
         // above and local state is already rolled back, so don't rethrow: an
         // unawaited rejection here becomes an unhandled promise rejection.
+      } finally {
+        if (deleteAttemptOwnersRef.current.get(attemptKey) === attemptOwner) {
+          deleteAttemptOwnersRef.current.delete(attemptKey);
+        }
       }
     },
-    [deletePersistedAttachmentMutation, notifyApiError, sessionId, t, teamId],
+    [deletePersistedAttachmentMutation, notifyApiError, sessionId, t, teamId, updateAttachments],
   );
 
   const addFiles = useCallback(
@@ -247,7 +308,7 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
           { type: "attachment", id, label: file.name },
           source === "drop" ? t("chatbot.attachments.processingPrepare") : t("chatbot.attachments.processingFast"),
         );
-        setAttachments((prev) => [
+        updateAttachments((prev) => [
           ...prev,
           {
             id,
@@ -291,7 +352,7 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
             t("chatbot.attachments.processingDone"),
           );
 
-          setAttachments((prev) =>
+          updateAttachments((prev) =>
             prev.map((attachment) =>
               attachment.id === id
                 ? {
@@ -314,7 +375,7 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
             t("chatbot.attachments.processingFailed"),
             errorMessage,
           );
-          setAttachments((prev) =>
+          updateAttachments((prev) =>
             prev.map((attachment) =>
               attachment.id === id ? { ...attachment, status: "error", error: errorMessage } : attachment,
             ),
@@ -322,34 +383,61 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
         }
       }
     },
-    [dispatch, fastIngestAttachment, persistAttachmentMutation, sessionId, t, teamId],
+    [dispatch, fastIngestAttachment, persistAttachmentMutation, sessionId, t, teamId, updateAttachments],
   );
 
   const removeAttachment = useCallback(
     (id: string) => {
-      setAttachments((prev) => prev.filter((attachment) => attachment.id !== id));
+      updateAttachments((prev) => prev.filter((attachment) => attachment.id !== id));
       const persisted = persistedAttachments.find((attachment) => attachment.attachmentId === id);
       if (persisted) {
         void deletePersistedAttachment(id);
       }
     },
-    [deletePersistedAttachment, persistedAttachments],
+    [deletePersistedAttachment, persistedAttachments, updateAttachments],
   );
 
-  const clearReadyAttachments = useCallback(() => {
-    setAttachments((prev) =>
-      prev.filter((attachment) => attachment.status === "uploading" || attachment.status === "ingesting"),
+  /** Clears the ready attachments owned by one submitted turn and returns
+   *  exactly those removed so a later rejection can restore the same set. */
+  const clearReadyAttachments = useCallback(
+    (attachmentIds: readonly string[]): readonly ChatAttachment[] => {
+      if (attachmentIds.length === 0) return [];
+      const selectedIds = new Set(attachmentIds);
+      const current = attachmentsRef.current;
+      const cleared = current.filter((attachment) => attachment.status === "ready" && selectedIds.has(attachment.id));
+      updateAttachments((attachmentsAtClear) =>
+        attachmentsAtClear.filter((attachment) => !(attachment.status === "ready" && selectedIds.has(attachment.id))),
+      );
+      return cleared;
+    },
+    [updateAttachments],
+  );
+
+  const restoreReadyAttachments = useCallback(
+    (readyAttachments: readonly ChatAttachment[]) => {
+      if (readyAttachments.length === 0) return;
+      updateAttachments((current) =>
+        mergeRestoredReadyAttachments(current, readyAttachments, deletedAttachmentIdsRef.current),
+      );
+    },
+    [updateAttachments],
+  );
+
+  // Read at the final turn-start boundary rather than when Send is clicked.
+  // Upload completion and deletion both update their refs synchronously, so a
+  // file that becomes ready during async preflight is represented consistently
+  // in both the wire context and the set of chips owned by that turn.
+  const getReadyAttachmentSnapshot = useCallback(() => {
+    const readyAttachments = attachmentsRef.current.filter((attachment) => attachment.status === "ready");
+    const visiblePersisted = excludeDeletedAttachments(
+      persistedAttachmentsRef.current,
+      deletedAttachmentIdsRef.current,
     );
+    return {
+      attachmentIds: readyAttachments.map((attachment) => attachment.id),
+      attachmentsMarkdown: buildAttachmentsMarkdown(visiblePersisted, readyAttachments),
+    };
   }, []);
-
-  const attachmentsMarkdown = useMemo(
-    () =>
-      buildAttachmentsMarkdown(
-        persistedAttachments,
-        attachments.filter((attachment) => attachment.status === "ready"),
-      ),
-    [attachments, persistedAttachments],
-  );
 
   // True while any attachment is still uploading/ingesting. Used to block message
   // send until every attachment has finished, so the agent never answers before
@@ -363,11 +451,12 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
     attachments,
     persistedAttachments,
     isHydratingAttachments,
-    attachmentsMarkdown,
     hasUploadingAttachments,
     addFiles,
     removeAttachment,
     deletePersistedAttachment,
+    getReadyAttachmentSnapshot,
     clearReadyAttachments,
+    restoreReadyAttachments,
   };
 }

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.test.tsx
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Regression coverage for the context-prompt / session-write reliability
-// finding, and its go-live consolidation pass. These tests drive
+// Regression coverage for context-prompt and session-write reliability. These tests drive
 // `useManagedChat` through a minimal host component (no
 // @testing-library/react in this repo) and assert the fixed contract:
 //
@@ -96,22 +95,29 @@ const chatSseResetMock = vi.fn();
 // test that forgets fails on its own assertion rather than on a TypeError.
 const sendHitlResumeMock = vi.fn(async () => true);
 const abortMock = vi.fn();
-const replaceAllMessagesMock = vi.fn();
 // Mutable so the #2239 departure-snapshot test below can put a displayed
 // thread on screen; reset to [] in beforeEach.
 let chatSseMessages: unknown[] = [];
+// Models the real hook's state write. History tests must observe replacement
+// through the same messages value useManagedChat renders on the next pass.
+const replaceAllMessagesMock = vi.fn((msgs: unknown[]) => {
+  chatSseMessages = msgs;
+});
 let chatSseMaxChatInputChars: number | undefined;
 let capturedFlushPendingWrites: ((sid: string | null) => Promise<boolean>) | undefined;
 let capturedOnTurnStarted: (() => void) | undefined;
 let capturedOnTurnRejected: ((draft: string, sessionId: string) => void) | undefined;
+let capturedOnTurnRetryStateReleased: ((draft: string, sessionId: string) => void) | undefined;
 let capturedIsTurnCurrent: ((sessionId: string) => boolean) | undefined;
 let capturedOnError: ((msg: string) => void) | undefined;
 let capturedOnAwaitingHuman: ((event: unknown) => void) | undefined;
+let capturedGetLiveActivityRevision: (() => number) | undefined;
 vi.mock("@hooks/useChatSse", () => ({
   useChatSse: (params: {
     flushPendingWrites?: (sid: string | null) => Promise<boolean>;
     onTurnStarted?: () => void;
     onTurnRejected?: (draft: string, sessionId: string) => void;
+    onTurnRetryStateReleased?: (draft: string, sessionId: string) => void;
     isTurnCurrent?: (sessionId: string) => boolean;
     onError?: (msg: string) => void;
     onAwaitingHuman?: (event: unknown) => void;
@@ -119,6 +125,7 @@ vi.mock("@hooks/useChatSse", () => ({
     capturedFlushPendingWrites = params.flushPendingWrites;
     capturedOnTurnStarted = params.onTurnStarted;
     capturedOnTurnRejected = params.onTurnRejected;
+    capturedOnTurnRetryStateReleased = params.onTurnRetryStateReleased;
     capturedIsTurnCurrent = params.isTurnCurrent;
     capturedOnError = params.onError;
     capturedOnAwaitingHuman = params.onAwaitingHuman;
@@ -156,8 +163,17 @@ vi.mock("./useComposerSettings", () => ({
 }));
 
 const sessionHistoryValue = { isLoading: false };
+let capturedOnHistoryLoaded: ((messages: ChatMessage[]) => void) | undefined;
 vi.mock("./useSessionHistory", () => ({
-  useSessionHistory: () => sessionHistoryValue,
+  useSessionHistory: (params: {
+    onLoaded?: (messages: ChatMessage[]) => void;
+    isTurnActive?: () => boolean;
+    getLiveActivityRevision?: () => number;
+  }) => {
+    capturedOnHistoryLoaded = params.onLoaded;
+    capturedGetLiveActivityRevision = params.getLiveActivityRevision;
+    return sessionHistoryValue;
+  },
 }));
 
 const chatAttachmentsValue = {
@@ -169,7 +185,27 @@ const chatAttachmentsValue = {
   addFiles: vi.fn(),
   removeAttachment: vi.fn(),
   deletePersistedAttachment: vi.fn(),
-  clearReadyAttachments: vi.fn(),
+  getReadyAttachmentSnapshot: vi.fn(() => {
+    const ready = (chatAttachmentsValue.attachments as { id: string; status?: string }[]).filter(
+      (attachment) => attachment.status === "ready",
+    );
+    return {
+      attachmentIds: ready.map((attachment) => attachment.id),
+      attachmentsMarkdown: chatAttachmentsValue.attachmentsMarkdown,
+    };
+  }),
+  // Models both effects of the real hook: it reports and removes only the
+  // ready attachments captured for the submitted turn.
+  clearReadyAttachments: vi.fn((attachmentIds: readonly string[]) => {
+    const selectedIds = new Set(attachmentIds);
+    const current = chatAttachmentsValue.attachments as { id: string; status?: string }[];
+    const cleared = current.filter((attachment) => attachment.status === "ready" && selectedIds.has(attachment.id));
+    chatAttachmentsValue.attachments = current.filter(
+      (attachment) => !(attachment.status === "ready" && selectedIds.has(attachment.id)),
+    );
+    return cleared;
+  }),
+  restoreReadyAttachments: vi.fn(),
 };
 vi.mock("./useChatAttachments", () => ({
   useChatAttachments: () => chatAttachmentsValue,
@@ -238,6 +274,7 @@ vi.mock("../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
 
 import { useManagedChat } from "./useManagedChat";
 import { clearSessionHistoryCache, getCachedSessionHistory } from "./sessionHistoryCache";
+import type { ChatMessage } from "../../../../slices/runtime/runtimeOpenApi";
 
 function TestHost({ onRender }: { onRender: (hook: ReturnType<typeof useManagedChat>) => void }) {
   const hook = useManagedChat({ teamId: "team-1", agentInstanceId: "agent-1" });
@@ -286,6 +323,10 @@ describe("useManagedChat — session write reliability", () => {
     clearSessionHistoryCache();
     chatSseMessages = [];
     chatSseMaxChatInputChars = undefined;
+    chatAttachmentsValue.attachments = [];
+    chatAttachmentsValue.persistedAttachments = [];
+    chatAttachmentsValue.attachmentsMarkdown = null;
+    chatAttachmentsValue.hasUploadingAttachments = false;
     registerSessionImpl = async () => ({});
     patchSessionImpl = async () => ({});
     registerSessionCalls.length = 0;
@@ -316,7 +357,9 @@ describe("useManagedChat — session write reliability", () => {
       composerBindSessionMock,
       showErrorMock,
       notifyApiErrorMock,
+      chatAttachmentsValue.getReadyAttachmentSnapshot,
       chatAttachmentsValue.clearReadyAttachments,
+      chatAttachmentsValue.restoreReadyAttachments,
     ]) {
       mock.mockReset();
     }
@@ -325,9 +368,12 @@ describe("useManagedChat — session write reliability", () => {
     capturedFlushPendingWrites = undefined;
     capturedOnTurnStarted = undefined;
     capturedOnTurnRejected = undefined;
+    capturedOnTurnRetryStateReleased = undefined;
     capturedIsTurnCurrent = undefined;
     capturedOnError = undefined;
     capturedOnAwaitingHuman = undefined;
+    capturedOnHistoryLoaded = undefined;
+    capturedGetLiveActivityRevision = undefined;
   });
 
   afterEach(async () => {
@@ -350,10 +396,12 @@ describe("useManagedChat — session write reliability", () => {
     const firstOnError = capturedOnError;
     const firstOnAwaitingHuman = capturedOnAwaitingHuman;
     const firstOnTurnStarted = capturedOnTurnStarted;
+    const firstOnTurnRetryStateReleased = capturedOnTurnRetryStateReleased;
     const firstHandleHitlAnswer = latest.handleHitlAnswer;
     expect(firstOnError).toBeDefined();
     expect(firstOnAwaitingHuman).toBeDefined();
     expect(firstOnTurnStarted).toBeDefined();
+    expect(firstOnTurnRetryStateReleased).toBeDefined();
 
     act(() => {
       latest.setInput("o");
@@ -367,7 +415,20 @@ describe("useManagedChat — session write reliability", () => {
     expect(capturedOnError).toBe(firstOnError);
     expect(capturedOnAwaitingHuman).toBe(firstOnAwaitingHuman);
     expect(capturedOnTurnStarted).toBe(firstOnTurnStarted);
+    expect(capturedOnTurnRetryStateReleased).toBe(firstOnTurnRetryStateReleased);
     expect(latest.handleHitlAnswer).toBe(firstHandleHitlAnswer);
+  });
+
+  it("increments the history activity revision when a turn starts and when a HITL prompt arrives", () => {
+    mount();
+    const initialRevision = capturedGetLiveActivityRevision?.();
+    expect(initialRevision).toBe(0);
+
+    act(() => capturedOnTurnStarted?.());
+    expect(capturedGetLiveActivityRevision?.()).toBe(1);
+
+    act(() => capturedOnAwaitingHuman?.(awaitingHumanEvent));
+    expect(capturedGetLiveActivityRevision?.()).toBe(2);
   });
 
   it("counts trimmed Unicode code points and blocks an over-limit draft without clearing it", async () => {
@@ -434,7 +495,24 @@ describe("useManagedChat — session write reliability", () => {
     expect(composerResetMock.mock.calls.length).toBe(resetsBeforeSend);
   });
 
-  it("restores the complete ordinary draft after a backend length rejection", async () => {
+  it("restores the complete ordinary draft and transient attachments after a backend length rejection", async () => {
+    const readyImage = {
+      id: "attachment-1",
+      name: "diagram.png",
+      size: 42,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      imageContext: {
+        name: "diagram.png",
+        mime: "image/png",
+        size: 42,
+        dataUrl: "data:image/png;base64,cGl4ZWxz",
+      },
+      taskIds: ["task-1"],
+    };
+    chatAttachmentsValue.attachments = [readyImage];
+    chatAttachmentsValue.attachmentsMarkdown = "## Attached files for this conversation";
     mount();
     const draft = "  full draft 🙂  ";
 
@@ -448,6 +526,7 @@ describe("useManagedChat — session write reliability", () => {
     act(() => capturedOnTurnStarted?.());
     rerender();
     expect(latest.input).toBe("");
+    expect(chatAttachmentsValue.clearReadyAttachments).toHaveBeenCalledWith(["attachment-1"]);
 
     const sentSessionId = sendMock.mock.calls[0][1] as string;
     expect(capturedIsTurnCurrent?.(sentSessionId)).toBe(true);
@@ -455,10 +534,218 @@ describe("useManagedChat — session write reliability", () => {
     act(() => capturedOnTurnRejected?.(draft.trim(), "another-session"));
     rerender();
     expect(latest.input).toBe("");
+    expect(chatAttachmentsValue.restoreReadyAttachments).not.toHaveBeenCalled();
 
     act(() => capturedOnTurnRejected?.(draft.trim(), sentSessionId));
     rerender();
     expect(latest.input).toBe(draft);
+    expect(chatAttachmentsValue.restoreReadyAttachments).toHaveBeenCalledWith([readyImage]);
+
+    act(() => latest.setInput("newer draft"));
+    rerender();
+    act(() => capturedOnTurnRejected?.(draft.trim(), sentSessionId));
+    rerender();
+    expect(latest.input).toBe("newer draft");
+    expect(chatAttachmentsValue.restoreReadyAttachments).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an attachment that becomes ready after the final turn-start context snapshot", async () => {
+    const submitted = {
+      id: "submitted",
+      name: "submitted.png",
+      size: 10,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      taskIds: [],
+    };
+    const nextTurn = {
+      id: "next-turn",
+      name: "next-turn.png",
+      size: 20,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      taskIds: [],
+    };
+    chatAttachmentsValue.attachments = [submitted];
+    chatAttachmentsValue.attachmentsMarkdown = "submitted context";
+    mount();
+
+    act(() => latest.setInput("hello"));
+    rerender();
+    await act(async () => latest.handleSend());
+
+    const resolveRuntimeContext = sendMock.mock.calls[0][4] as (() => unknown) | undefined;
+    expect(resolveRuntimeContext).toBeTypeOf("function");
+    resolveRuntimeContext?.();
+
+    // This file becomes ready after the turn-start context snapshot, so it
+    // belongs to the next turn.
+    chatAttachmentsValue.attachments = [submitted, nextTurn];
+    act(() => capturedOnTurnStarted?.());
+    rerender();
+
+    expect(chatAttachmentsValue.clearReadyAttachments).toHaveBeenCalledWith(["submitted"]);
+    expect(chatAttachmentsValue.attachments).toEqual([nextTurn]);
+  });
+
+  it("includes attachments that become ready during asynchronous send preparation", async () => {
+    const submitted = {
+      id: "submitted-before-barrier",
+      name: "submitted.png",
+      size: 10,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      taskIds: [],
+    };
+    const later = {
+      id: "ready-during-barrier",
+      name: "later.png",
+      size: 20,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      taskIds: [],
+    };
+    const create = deferred<unknown>();
+    registerSessionImpl = () => create.promise;
+    chatAttachmentsValue.attachments = [submitted];
+    chatAttachmentsValue.attachmentsMarkdown = "context before barrier";
+    mount();
+    act(() => latest.setInput("hello"));
+    rerender();
+
+    const sendPromise = latest.handleSend();
+    await vi.waitFor(() => expect(registerSessionCalls).toHaveLength(1));
+    rerender();
+    expect(latest.isPreparingSend).toBe(true);
+    act(() => latest.setInput("next draft"));
+    rerender();
+    chatAttachmentsValue.attachments = [submitted, later];
+    chatAttachmentsValue.attachmentsMarkdown = "context after barrier";
+
+    await act(async () => {
+      create.resolve({});
+      await sendPromise;
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(latest.isPreparingSend).toBe(false);
+    const resolveRuntimeContext = sendMock.mock.calls[0][4] as (() => { attachments_markdown?: string }) | undefined;
+    expect(resolveRuntimeContext).toBeTypeOf("function");
+    expect(resolveRuntimeContext?.()).toMatchObject({ attachments_markdown: "context after barrier" });
+    act(() => capturedOnTurnStarted?.());
+    expect(chatAttachmentsValue.clearReadyAttachments).toHaveBeenCalledWith([
+      "submitted-before-barrier",
+      "ready-during-barrier",
+    ]);
+    expect(chatAttachmentsValue.attachments).toEqual([]);
+    rerender();
+    expect(latest.input).toBe("next draft");
+
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    act(() => capturedOnTurnRejected?.("hello", sentSessionId));
+    rerender();
+    expect(latest.input).toBe("hello\nnext draft");
+  });
+
+  it.each([
+    ["voice transcript", "hello dictated text", "dictated text"],
+    ["library prompt", "hello\n\ninserted prompt", "inserted prompt"],
+  ])("keeps only a late %s after the submitted prefix is accepted", async (_producer, updatedDraft, remaining) => {
+    mount();
+    act(() => latest.setInput("hello"));
+    rerender();
+    await act(async () => latest.handleSend());
+
+    act(() => latest.setInput(updatedDraft));
+    act(() => capturedOnTurnStarted?.());
+    rerender();
+
+    expect(latest.input).toBe(remaining);
+  });
+
+  it.each([
+    ["repeated voice prefix", "hi", "hi hi there", "hi there"],
+    ["identical voice text", "summarize", "summarize summarize", "summarize"],
+  ])(
+    "restores the exact draft after a 422 with a late %s",
+    async (_producer, submittedDraft, draftBeforeTurnStart, retainedSuffix) => {
+      mount();
+      act(() => latest.setInput(submittedDraft));
+      rerender();
+      await act(async () => latest.handleSend());
+      const sentSessionId = sendMock.mock.calls[0][1] as string;
+
+      act(() => latest.setInput(draftBeforeTurnStart));
+      act(() => capturedOnTurnStarted?.());
+      rerender();
+      expect(latest.input).toBe(retainedSuffix);
+
+      act(() => capturedOnTurnRejected?.(submittedDraft, sentSessionId));
+      rerender();
+      expect(latest.input).toBe(draftBeforeTurnStart);
+    },
+  );
+
+  it("ignores an older rejection for another draft in the same session", async () => {
+    mount();
+    act(() => latest.setInput("draft A"));
+    rerender();
+    await act(async () => latest.handleSend());
+    const session = sendMock.mock.calls[0][1] as string;
+    act(() => capturedOnTurnStarted?.());
+
+    act(() => latest.setInput("draft B"));
+    rerender();
+    await act(async () => latest.handleSend());
+    act(() => capturedOnTurnStarted?.());
+    rerender();
+    expect(latest.input).toBe("");
+
+    act(() => capturedOnTurnRejected?.("draft A", session));
+    rerender();
+    expect(latest.input).toBe("");
+
+    act(() => capturedOnTurnRejected?.("draft B", session));
+    rerender();
+    expect(latest.input).toBe("draft B");
+  });
+
+  it("releases the retained attachment snapshot after a successful ordinary turn settles", async () => {
+    const readyImage = {
+      id: "attachment-1",
+      name: "diagram.png",
+      size: 42,
+      mime: "image/png",
+      status: "ready",
+      isImage: true,
+      imageContext: {
+        name: "diagram.png",
+        mime: "image/png",
+        size: 42,
+        dataUrl: "data:image/png;base64,cGl4ZWxz",
+      },
+      taskIds: ["task-1"],
+    };
+    chatAttachmentsValue.attachments = [readyImage];
+    chatAttachmentsValue.attachmentsMarkdown = "## Attached files for this conversation";
+    mount();
+
+    act(() => latest.setInput("hello"));
+    rerender();
+    await act(async () => latest.handleSend());
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    act(() => capturedOnTurnStarted?.());
+    rerender();
+    act(() => capturedOnTurnRetryStateReleased?.("hello", sentSessionId));
+    act(() => capturedOnTurnRejected?.("hello", sentSessionId));
+    rerender();
+
+    expect(latest.input).toBe("");
+    expect(chatAttachmentsValue.restoreReadyAttachments).not.toHaveBeenCalled();
   });
 
   it("selecting a context prompt persists it and a send proceeds", async () => {
@@ -1330,6 +1617,147 @@ describe("useManagedChat — session write reliability", () => {
     expect(sendHitlResumeMock).toHaveBeenCalledWith(freeTextEvent, undefined, "🙂🙂🙂🙂🙂");
   });
 
+  it("restores a displaced HITL prompt when an ordinary message is rejected for length", async () => {
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setHitlFreeText("answer in progress");
+      latest.setInput("ordinary draft");
+    });
+    rerender();
+    await act(async () => latest.handleSend());
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    act(() => capturedOnTurnStarted?.());
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+
+    act(() => capturedOnTurnRejected?.("ordinary draft", sentSessionId));
+    rerender();
+
+    expect(latest.input).toBe("ordinary draft");
+    expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
+    expect(latest.hitlFreeText).toBe("answer in progress");
+  });
+
+  it("keeps a newer HITL prompt authoritative when an older ordinary send is rejected", async () => {
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setHitlFreeText("answer for the displaced prompt");
+      latest.setInput("ordinary draft");
+    });
+    rerender();
+    await act(async () => latest.handleSend());
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    act(() => capturedOnTurnStarted?.());
+
+    const newerPrompt = {
+      ...awaitingHumanEvent,
+      exchange_id: "exch-2",
+      payload: { ...awaitingHumanEvent.payload, interrupt_id: "interrupt-b" },
+    };
+    act(() => {
+      capturedOnAwaitingHuman?.(newerPrompt);
+      latest.setHitlFreeText("answer for the newer prompt");
+    });
+    rerender();
+
+    act(() => capturedOnTurnRejected?.("ordinary draft", sentSessionId));
+    rerender();
+
+    expect(latest.pendingHitl).toEqual(newerPrompt);
+    expect(latest.hitlFreeText).toBe("answer for the newer prompt");
+  });
+
+  it("restores a displaced HITL prompt when the ordinary send fails during preflight", async () => {
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setHitlFreeText("answer in progress");
+      latest.setInput("ordinary draft");
+    });
+    rerender();
+    await act(async () => latest.handleSend());
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+
+    // Preflight failed before onTurnStarted, so the ordinary draft was never
+    // accepted and the displaced checkpoint must become answerable again.
+    act(() => capturedOnTurnRetryStateReleased?.("ordinary draft", sentSessionId));
+    rerender();
+
+    expect(latest.input).toBe("ordinary draft");
+    expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
+    expect(latest.hitlFreeText).toBe("answer in progress");
+
+    // The release consumes the snapshot; a later stale callback is inert.
+    act(() => capturedOnTurnRejected?.("ordinary draft", sentSessionId));
+    rerender();
+    expect(chatAttachmentsValue.restoreReadyAttachments).not.toHaveBeenCalled();
+  });
+
+  it("keeps an edited HITL draft when background history revalidates the same prompt", async () => {
+    mount();
+    bindSession("session-1");
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setHitlFreeText("still editing this answer");
+    });
+    rerender();
+
+    const matchingHistoryPrompt = {
+      session_id: "session-1",
+      exchange_id: "exch-1",
+      rank: 1,
+      timestamp: "2026-08-13T00:00:00.000Z",
+      role: "system",
+      channel: "hitl_request",
+      parts: [
+        {
+          type: "hitl_request",
+          question: null,
+          choices: [],
+          free_text: true,
+          interrupt_id: "interrupt-a",
+          checkpoint_id: null,
+          pending_calls: [],
+        },
+      ],
+      metadata: {},
+    } as ChatMessage;
+
+    act(() => capturedOnHistoryLoaded?.([matchingHistoryPrompt]));
+    rerender();
+    expect(latest.pendingHitl?.exchange_id).toBe("exch-1");
+    expect(latest.hitlFreeText).toBe("still editing this answer");
+
+    const differentInterrupt = {
+      ...matchingHistoryPrompt,
+      parts: [
+        {
+          ...(matchingHistoryPrompt.parts[0] as Record<string, unknown>),
+          interrupt_id: "interrupt-b",
+        },
+      ],
+    } as ChatMessage;
+    act(() => capturedOnHistoryLoaded?.([differentInterrupt]));
+    rerender();
+    expect(latest.pendingHitl?.payload.interrupt_id).toBe("interrupt-b");
+    expect(latest.hitlFreeText).toBe("");
+
+    act(() => capturedOnHistoryLoaded?.([]));
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+    expect(latest.hitlFreeText).toBe("");
+  });
+
   it("restores the HITL prompt when the resume never reached the backend", async () => {
     sendHitlResumeMock.mockResolvedValueOnce(false);
     mount();
@@ -1371,13 +1799,8 @@ describe("useManagedChat — session write reliability", () => {
     act(() => {
       latest.handleHitlAnswer("proceed");
     });
-    // The user sends a new message while the resume is still in flight. The
-    // supersede must land HERE, synchronously at the point of intent — waiting
-    // for onTurnStarted (a preflight + prepare-execution round trip later)
-    // loses the race against the aborted resume's continuation.
-    // A turn that genuinely starts appends its optimistic user message under a
-    // NEW exchange_id — that, not a counter, is what marks the prompt stale.
-    chatSseMessages = [{ session_id: "session-1", exchange_id: "exch-2", rank: 1 }];
+    // The user sends a new message while the resume is still in flight. No
+    // optimistic message exists yet: ordinary-send preflight has not completed.
     act(() => {
       latest.setInput("a new message");
     });
@@ -1385,6 +1808,125 @@ describe("useManagedChat — session write reliability", () => {
     await act(async () => {
       await latest.handleSend();
     });
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+
+    await act(async () => {
+      resolveResume(false);
+      await Promise.resolve();
+    });
+    rerender();
+
+    // The old prompt is held by the ordinary attempt's rollback snapshot, not
+    // rendered over that attempt while it is still preflighting.
+    expect(latest.pendingHitl).toBeNull();
+
+    act(() => capturedOnTurnStarted?.());
+    act(() => capturedOnTurnRetryStateReleased?.("a new message", sentSessionId));
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+  });
+
+  it("keeps a superseded prompt hidden when its resume settles after the ordinary turn starts", async () => {
+    let resolveResume: (v: boolean) => void = () => {};
+    sendHitlResumeMock.mockImplementationOnce(() => new Promise<boolean>((resolve) => (resolveResume = resolve)));
+    mount();
+    bindSession("session-1");
+
+    act(() => capturedOnAwaitingHuman?.(awaitingHumanEvent));
+    rerender();
+    act(() => latest.handleHitlAnswer("proceed"));
+    act(() => latest.setInput("a new message"));
+    rerender();
+    await act(async () => latest.handleSend());
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+
+    act(() => capturedOnTurnStarted?.());
+    await act(async () => {
+      resolveResume(false);
+      await Promise.resolve();
+    });
+    rerender();
+
+    expect(latest.pendingHitl).toBeNull();
+
+    act(() => capturedOnTurnRetryStateReleased?.("a new message", sentSessionId));
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+  });
+
+  it("restores a superseded prompt when the started ordinary turn is rejected", async () => {
+    let resolveResume: (v: boolean) => void = () => {};
+    sendHitlResumeMock.mockImplementationOnce(() => new Promise<boolean>((resolve) => (resolveResume = resolve)));
+    mount();
+    bindSession("session-1");
+
+    act(() => capturedOnAwaitingHuman?.(awaitingHumanEvent));
+    rerender();
+    act(() => latest.handleHitlAnswer("proceed"));
+    act(() => latest.setInput("a new message"));
+    rerender();
+    await act(async () => latest.handleSend());
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+
+    act(() => capturedOnTurnStarted?.());
+    chatSseMessages = [
+      {
+        session_id: "session-1",
+        exchange_id: "ordinary-exchange",
+        rank: 2,
+        timestamp: "2026-08-14T00:00:00.000Z",
+        role: "user",
+        channel: "final",
+        parts: [{ type: "text", text: "a new message" }],
+        metadata: { extras: { optimistic_user: true } },
+      },
+    ];
+    rerender();
+    await act(async () => {
+      resolveResume(false);
+      await Promise.resolve();
+    });
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+
+    act(() => capturedOnTurnRejected?.("a new message", sentSessionId));
+    rerender();
+    expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
+  });
+
+  it("does not restore a superseded resume after the thread advances to a different exchange", async () => {
+    let resolveResume: (v: boolean) => void = () => {};
+    sendHitlResumeMock.mockImplementationOnce(() => new Promise<boolean>((r) => (resolveResume = r)));
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+    });
+    rerender();
+    act(() => latest.handleHitlAnswer("proceed"));
+
+    chatSseMessages = [
+      {
+        session_id: "session-1",
+        exchange_id: "exch-2",
+        rank: 2,
+        timestamp: "2026-08-14T00:00:00.000Z",
+        role: "user",
+        channel: "final",
+        parts: [{ type: "text", text: "newer turn" }],
+        metadata: {},
+      },
+    ];
+    rerender();
+
+    // Keep every other restore guard open: the session still owns the prompt,
+    // there is no newer prompt, and no ordinary send created a rollback
+    // snapshot. The different final exchange is therefore the only reason the
+    // superseded resume must stay dismissed.
+    expect(latest.sessionId).toBe("session-1");
+    expect(latest.pendingHitl).toBeNull();
+    expect(sendMock).not.toHaveBeenCalled();
 
     await act(async () => {
       resolveResume(false);
@@ -1431,7 +1973,56 @@ describe("useManagedChat — session write reliability", () => {
     });
     rerender();
 
+    expect(latest.pendingHitl).toBeNull();
+    const sentSessionId = sendMock.mock.calls[0][1] as string;
+    act(() => capturedOnTurnRetryStateReleased?.("a new message", sentSessionId));
+    rerender();
     expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
+  });
+
+  it("restores a displaced prompt when the user stops an ordinary send during preflight", async () => {
+    chatSseMessages = [{ session_id: "session-1", exchange_id: "exch-1", rank: 1 }];
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setInput("a new message");
+    });
+    rerender();
+
+    await act(async () => {
+      await latest.handleSend();
+    });
+    rerender();
+    expect(latest.pendingHitl).toBeNull();
+
+    // The ordinary attempt has not reached onTurnStarted, so Stop cancels a
+    // preflight rather than a committed turn. Its displaced prompt is still
+    // the valid checkpoint UI and must be offered again.
+    act(() => latest.handleAbort());
+    rerender();
+
+    expect(abortMock).toHaveBeenCalledTimes(1);
+    expect(latest.pendingHitl).toEqual(awaitingHumanEvent);
+  });
+
+  it("does not restore a displaced prompt when stopping after the ordinary turn started", async () => {
+    chatSseMessages = [{ session_id: "session-1", exchange_id: "exch-1", rank: 1 }];
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+      latest.setInput("a new message");
+    });
+    rerender();
+    await act(async () => latest.handleSend());
+    act(() => capturedOnTurnStarted?.());
+    act(() => latest.handleAbort());
+    rerender();
+
+    expect(latest.pendingHitl).toBeNull();
   });
 
   it("restores the prompt when a superseding send never reaches the backend", async () => {
@@ -1448,6 +2039,14 @@ describe("useManagedChat — session write reliability", () => {
     };
     mount();
     bindSession("session-1");
+
+    // Put a genuinely failing write in this session's barrier. Merely swapping
+    // the mock implementation does not enqueue anything and would let send()
+    // run, which is a different rollback path.
+    act(() => {
+      latest.setContextPrompts(["will-fail"]);
+    });
+    await tick();
 
     act(() => {
       capturedOnAwaitingHuman?.(awaitingHumanEvent);
@@ -1573,6 +2172,40 @@ describe("useManagedChat — session write reliability", () => {
 
     await act(async () => {
       resolveResume(true);
+      await Promise.resolve();
+    });
+    rerender();
+
+    expect(latest.pendingHitl).toEqual(newerPrompt);
+    expect(latest.hitlFreeText).toBe("answer for the newer prompt");
+  });
+
+  it("does not replace a newer HITL prompt when an older resume reports not reached", async () => {
+    let resolveResume: (v: boolean) => void = () => {};
+    sendHitlResumeMock.mockImplementationOnce(() => new Promise<boolean>((r) => (resolveResume = r)));
+    mount();
+    bindSession("session-1");
+
+    act(() => {
+      capturedOnAwaitingHuman?.(awaitingHumanEvent);
+    });
+    rerender();
+    act(() => latest.handleHitlAnswer("proceed"));
+
+    const newerPrompt = {
+      ...awaitingHumanEvent,
+      // Keep the exchange id the same so this test reaches the empty-slot
+      // ownership guard rather than passing through the exchange-id guard.
+      payload: { ...awaitingHumanEvent.payload, interrupt_id: "interrupt-b" },
+    };
+    act(() => {
+      capturedOnAwaitingHuman?.(newerPrompt);
+      latest.setHitlFreeText("answer for the newer prompt");
+    });
+    rerender();
+
+    await act(async () => {
+      resolveResume(false);
       await Promise.resolve();
     });
     rerender();

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useManagedChat.ts
@@ -34,6 +34,7 @@ import { useChatAttachments } from "./useChatAttachments";
 import { buildComposerRuntimeContext } from "./runtimeContextBuilder";
 import { reconstructPendingHitl, toThreadMessages } from "./toThreadMessages";
 import type { ChatMessage } from "../../../../slices/runtime/runtimeOpenApi";
+import type { ChatAttachment } from "@rework/types/attachments";
 import { countUnicodeCodePoints } from "@core/utils/chatInput";
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
@@ -43,6 +44,29 @@ interface UseManagedChatParams {
   agentInstanceId: string;
 }
 
+interface SubmittedDraft {
+  sessionId: string;
+  wireDraft: string;
+  draft: string;
+  started: boolean;
+  draftBeforeTurnStart?: string;
+  draftAfterTurnStart?: string;
+  readyAttachmentIds: readonly string[];
+  readyAttachments: readonly ChatAttachment[];
+  pendingHitl: RuntimeAwaitingHumanEvent | null;
+  hitlDraftOwner: number;
+}
+
+function isSameHitlPrompt(current: RuntimeAwaitingHumanEvent | null, next: RuntimeAwaitingHumanEvent | null): boolean {
+  if (current === null || next === null) return current === next;
+  return (
+    current.session_id === next.session_id &&
+    current.exchange_id === next.exchange_id &&
+    (current.payload.interrupt_id ?? null) === (next.payload.interrupt_id ?? null) &&
+    (current.payload.checkpoint_id ?? null) === (next.payload.checkpoint_id ?? null)
+  );
+}
+
 export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { showError } = useToast();
@@ -50,9 +74,17 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   const { t } = useTranslation();
 
   const sessionId = searchParams.get("session");
-  const [input, setInput] = useState("");
-  const submittedDraftRef = useRef<{ sessionId: string; draft: string } | null>(null);
+  const [input, setInputState] = useState("");
+  const inputRef = useRef(input);
+  const setInput = useCallback((next: string) => {
+    inputRef.current = next;
+    setInputState(next);
+  }, []);
+  const [isPreparingSend, setIsPreparingSend] = useState(false);
+  const submittedDraftRef = useRef<SubmittedDraft | null>(null);
   const [pendingHitl, setPendingHitl] = useState<RuntimeAwaitingHumanEvent | null>(null);
+  const pendingHitlRef = useRef<RuntimeAwaitingHumanEvent | null>(pendingHitl);
+  pendingHitlRef.current = pendingHitl;
   const [hitlFreeText, setHitlFreeText] = useState("");
   // Identifies the HITL prompt that owns `hitlFreeText`. A resume can settle
   // after another prompt has arrived; only its own draft may be cleared.
@@ -87,6 +119,14 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   // (a single, not-per-session piece of UI state) or show a toast for it.
   const activeSessionIdRef = useRef(sessionId);
   activeSessionIdRef.current = sessionId;
+  // Invalidates a history request when a turn starts or a HITL prompt changes
+  // while that request is in flight. Active state alone cannot detect a turn
+  // that starts and settles before the response arrives.
+  const liveActivityRevisionRef = useRef(0);
+  const markLiveActivity = useCallback(() => {
+    liveActivityRevisionRef.current += 1;
+  }, []);
+  const getLiveActivityRevision = useCallback(() => liveActivityRevisionRef.current, []);
   // Live mirror of the rendered thread. `handleHitlAnswer`'s continuation
   // settles after arbitrary delay and must read the CURRENT thread, not the one
   // captured when the user answered.
@@ -246,24 +286,99 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   // composer keystroke — would silently invalidate that memoization on every
   // keystroke too, cascading into handleHitlAnswer below and defeating
   // ConversationThread's React.memo (#2221).
-  const handleAwaitingHuman = useCallback((event: RuntimeAwaitingHumanEvent) => {
-    hitlDraftOwnerRef.current += 1;
-    setHitlFreeText("");
-    setPendingHitl(event);
-  }, []);
+  const handleAwaitingHuman = useCallback(
+    (event: RuntimeAwaitingHumanEvent) => {
+      markLiveActivity();
+      hitlDraftOwnerRef.current += 1;
+      setHitlFreeText("");
+      pendingHitlRef.current = event;
+      setPendingHitl(event);
+    },
+    [markLiveActivity],
+  );
   const handleChatError = useCallback((msg: string) => showError({ summary: "Agent error", detail: msg }), [showError]);
   // Fires only once prepare-execution has actually succeeded and the turn is
   // really starting — clearing the composer any earlier would lose the
   // user's text/attachments on a prepare-execution failure (404/503/network).
   const handleTurnStarted = useCallback(() => {
-    setInput("");
-    attachments.clearReadyAttachments();
-  }, [attachments.clearReadyAttachments]);
-  const handleTurnRejected = useCallback((_wireDraft: string, rejectedSessionId: string) => {
+    markLiveActivity();
+    // Clear only the attachments captured in this turn's final wire context.
+    // Files still processing at that boundary remain for the next turn.
     const submitted = submittedDraftRef.current;
-    if (activeSessionIdRef.current !== rejectedSessionId || submitted?.sessionId !== rejectedSessionId) return;
-    setInput(submitted.draft);
+    // The composer is disabled during the write barrier, but an already-running
+    // async producer (for example voice transcription) can still settle. Never
+    // erase text that was not part of this submitted draft.
+    const currentDraft = inputRef.current;
+    if (submitted === null || currentDraft === submitted.draft) {
+      setInput("");
+    } else if (currentDraft.startsWith(submitted.draft)) {
+      // Voice transcription and prompt insertion can finish while preflight is
+      // running. Consume the exact prefix that was accepted and retain only
+      // the late producer's suffix as the next draft.
+      const remainingDraft = currentDraft.slice(submitted.draft.length).trimStart();
+      submitted.draftBeforeTurnStart = currentDraft;
+      submitted.draftAfterTurnStart = remainingDraft;
+      setInput(remainingDraft);
+    }
+    const cleared = attachments.clearReadyAttachments(submitted?.readyAttachmentIds ?? []);
+    if (submitted !== null) {
+      submitted.started = true;
+      submitted.readyAttachments = cleared;
+    }
+  }, [attachments.clearReadyAttachments, markLiveActivity, setInput]);
+  const restoreDisplacedHitl = useCallback((submitted: SubmittedDraft) => {
+    if (
+      submitted.pendingHitl !== null &&
+      hitlDraftOwnerRef.current === submitted.hitlDraftOwner &&
+      pendingHitlRef.current === null
+    ) {
+      pendingHitlRef.current = submitted.pendingHitl;
+      setPendingHitl(submitted.pendingHitl);
+    }
   }, []);
+  const handleTurnRejected = useCallback(
+    (wireDraft: string, rejectedSessionId: string) => {
+      const submitted = submittedDraftRef.current;
+      if (
+        activeSessionIdRef.current !== rejectedSessionId ||
+        submitted?.sessionId !== rejectedSessionId ||
+        submitted.wireDraft !== wireDraft
+      ) {
+        return;
+      }
+      submittedDraftRef.current = null;
+      const currentDraft = inputRef.current;
+      if (
+        submitted.draftBeforeTurnStart !== undefined &&
+        submitted.draftAfterTurnStart !== undefined &&
+        currentDraft === submitted.draftAfterTurnStart
+      ) {
+        // The retained suffix is unchanged. Restore the exact combined draft
+        // captured before turn start, including the producer's separator and
+        // repeated text that may itself begin with the submitted prefix.
+        setInput(submitted.draftBeforeTurnStart);
+      } else if (currentDraft.length === 0) {
+        setInput(submitted.draft);
+      } else if (currentDraft !== submitted.draft && !currentDraft.startsWith(submitted.draft)) {
+        // A producer that settled after Send may have installed a new draft.
+        // Keep both edits instead of choosing which user-authored text to lose.
+        setInput(`${submitted.draft}\n${currentDraft}`);
+      }
+      attachments.restoreReadyAttachments(submitted.readyAttachments);
+      restoreDisplacedHitl(submitted);
+    },
+    [attachments.restoreReadyAttachments, restoreDisplacedHitl, setInput],
+  );
+  const handleTurnRetryStateReleased = useCallback(
+    (wireDraft: string, settledSessionId: string) => {
+      const submitted = submittedDraftRef.current;
+      if (submitted?.sessionId === settledSessionId && submitted.wireDraft === wireDraft) {
+        if (!submitted.started) restoreDisplacedHitl(submitted);
+        submittedDraftRef.current = null;
+      }
+    },
+    [restoreDisplacedHitl],
+  );
   const isTurnCurrent = useCallback((turnSessionId: string) => activeSessionIdRef.current === turnSessionId, []);
 
   const {
@@ -287,9 +402,16 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     onError: handleChatError,
     onTurnStarted: handleTurnStarted,
     onTurnRejected: handleTurnRejected,
+    onTurnRetryStateReleased: handleTurnRetryStateReleased,
     isTurnCurrent,
   });
   latestMessagesRef.current = messages;
+
+  // Async history callbacks need the current streaming state, not a boolean
+  // captured when their request started.
+  const waitResponseRef = useRef(waitResponse);
+  waitResponseRef.current = waitResponse;
+  const isTurnActive = useCallback(() => waitResponseRef.current, []);
 
   // Chat controls are resolved per agent instance/config, not per session — a
   // session change should keep showing the last-known controls (no composer
@@ -297,13 +419,6 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   // old agentChatOptionsRef pattern this replaces.
   const chatControlsRef = useRef(chatControls);
   chatControlsRef.current = chatControls;
-
-  // Live-turn indicator handed to useSessionHistory — its async closures need
-  // the CURRENT streaming state at response-arrival time, not the render-time
-  // value a plain boolean capture would freeze.
-  const waitResponseRef = useRef(waitResponse);
-  waitResponseRef.current = waitResponse;
-  const isTurnActive = useCallback(() => waitResponseRef.current, []);
 
   // Mirrors read by the departure-snapshot cleanup below: a cleanup closure
   // captures its own render's values, but must snapshot what is on screen at
@@ -338,11 +453,12 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     }
     console.debug(`[useManagedChat] sessionId changed → reset() — sessionId=${sessionId ?? "null"}`);
     reset();
-    // reset() aborts any in-flight turn synchronously, but the waitResponse
-    // STATE only flips false on the next render — too late for the history
-    // effect running later in this same commit, whose isTurnActive() must
-    // already see "no live turn" or a cached thread would refuse to render.
+    // reset() clears state synchronously through its ref-owned transport, but
+    // React state updates on the next render. History loading in this commit
+    // must already observe that no turn remains active.
     waitResponseRef.current = false;
+    submittedDraftRef.current = null;
+    pendingHitlRef.current = null;
     setPendingHitl(null);
     hitlDraftOwnerRef.current += 1;
     setHitlFreeText("");
@@ -357,7 +473,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     // — not only inside send() — so the composer control slot isn't empty
     // until the first message. Safe with no session yet (sessionId null).
     void prepareChatControls(sessionId).catch(() => {});
-  }, [sessionId, reset, composer.reset, prepareChatControls]);
+  }, [sessionId, reset, composer.reset, prepareChatControls, setInput]);
 
   useEffect(() => {
     if (sessionData?.title != null) setSessionTitle(sessionData.title);
@@ -397,9 +513,18 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
   const handleHistoryLoaded = useCallback(
     (msgs: ChatMessage[]) => {
       replaceAllMessages(msgs);
-      hitlDraftOwnerRef.current += 1;
-      setHitlFreeText("");
-      setPendingHitl(reconstructPendingHitl(msgs));
+      const reconstructed = reconstructPendingHitl(msgs);
+      const same = isSameHitlPrompt(pendingHitlRef.current, reconstructed);
+      if (!same) {
+        hitlDraftOwnerRef.current += 1;
+        setHitlFreeText("");
+      }
+      // Keep the existing object when the prompt is unchanged. Cache replay
+      // and revalidation can both load the same prompt; preserving identity
+      // avoids invalidating the memoized conversation thread.
+      const next = same ? pendingHitlRef.current : reconstructed;
+      pendingHitlRef.current = next;
+      setPendingHitl(next);
     },
     [replaceAllMessages],
   );
@@ -410,6 +535,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     agentInstanceId,
     onLoaded: handleHistoryLoaded,
     isTurnActive,
+    getLiveActivityRevision,
   });
   isLoadingHistoryRef.current = isLoadingHistory;
 
@@ -477,7 +603,9 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
 
   const handleSend = useCallback(async () => {
     const text = input.trim();
-    const attachmentContext = attachments.attachmentsMarkdown;
+    const initialAttachmentSnapshot = attachments.getReadyAttachmentSnapshot();
+    const attachmentContext = initialAttachmentSnapshot.attachmentsMarkdown;
+    const readyAttachmentIds = initialAttachmentSnapshot.attachmentIds;
     console.debug(
       `[useManagedChat] handleSend() — inputChars=${inputCharacterCount} waitResponse=${waitResponse} sessionId=${sessionId ?? "null"}`,
     );
@@ -492,6 +620,7 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       return;
     }
     handleSendOwnerRef.current = true;
+    setIsPreparingSend(true);
     try {
       // Composer input is left untouched until the session write barrier below
       // confirms success — clearing it eagerly would lose the user's message if
@@ -531,6 +660,11 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       // onTurnStarted, once prepare-execution inside send() has actually
       // succeeded. A prepare-execution failure (404/503/network) must never
       // wipe text the user still needs to retry with; see useChatSse.ts.
+      // Read the live mirror, not the render-time closure: a history load can
+      // resolve while the write barrier is awaited and reconstruct a prompt.
+      const displacedHitl = pendingHitlRef.current;
+      const displacedHitlDraftOwner = hitlDraftOwnerRef.current;
+      pendingHitlRef.current = null;
       setPendingHitl(null);
       console.debug(`[useManagedChat] handleSend() — calling send() with sid=${sid}`);
       // `document_scope`'s params carry the same `bound_library_ids` the retired
@@ -564,29 +698,45 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       // `false` that would suppress reasoning the agent never offered to begin
       // with.
       const offersReasoning = chatControls.some((c) => c.widget === "reasoning_toggle");
-      touchSessionActivity(sid);
-      // `send()` receives the trimmed wire value, but a backend rejection must
-      // restore the complete editable draft, including surrounding whitespace.
-      submittedDraftRef.current = { sessionId: sid, draft: input };
-      send(
-        text,
-        sid,
+      const buildTurnRuntimeContext = (attachmentsMarkdown: string | null) =>
         buildComposerRuntimeContext({
           selectedLibraryIds: composer.selectedLibraryIds,
           selectedDocumentUids: composer.selectedDocumentUids,
           searchPolicy: composer.searchPolicy,
           ragScope: composer.ragScope,
           boundLibraryIds,
-          attachmentsMarkdown: attachmentContext,
+          attachmentsMarkdown,
           ...(offersReasoning ? { reasoning: composer.reasoning } : {}),
-        }),
-        turnOptions,
-      );
+        });
+      touchSessionActivity(sid);
+      // `send()` receives the trimmed wire value, but a backend rejection must
+      // restore the complete editable draft, including surrounding whitespace.
+      submittedDraftRef.current = {
+        sessionId: sid,
+        wireDraft: text,
+        draft: input,
+        started: false,
+        readyAttachmentIds,
+        // Filled by handleTurnStarted with the attachments actually removed.
+        // A length rejection restores those same chips and inline-image data.
+        readyAttachments: [],
+        pendingHitl: displacedHitl,
+        hitlDraftOwner: displacedHitlDraftOwner,
+      };
+      send(text, sid, buildTurnRuntimeContext(attachmentContext), turnOptions, () => {
+        const finalAttachmentSnapshot = attachments.getReadyAttachmentSnapshot();
+        const submitted = submittedDraftRef.current;
+        if (submitted?.sessionId === sid && submitted.wireDraft === text && !submitted.started) {
+          submitted.readyAttachmentIds = finalAttachmentSnapshot.attachmentIds;
+        }
+        return buildTurnRuntimeContext(finalAttachmentSnapshot.attachmentsMarkdown);
+      });
     } finally {
       handleSendOwnerRef.current = false;
+      setIsPreparingSend(false);
     }
   }, [
-    attachments.attachmentsMarkdown,
+    attachments.getReadyAttachmentSnapshot,
     attachments.hasUploadingAttachments,
     input,
     inputCharacterCount,
@@ -619,6 +769,12 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       }
       const prompt = pendingHitl;
       const draftOwner = hitlDraftOwnerRef.current;
+      markLiveActivity();
+      // A HITL resume takes over the transport slot from any ordinary turn.
+      // Its ordinary retry snapshot can no longer be used and may retain an
+      // inline-image data URL, so release it at the same point of intent.
+      submittedDraftRef.current = null;
+      pendingHitlRef.current = null;
       setPendingHitl(null);
       // Restore the prompt when the resume never reached the backend: the
       // checkpoint is still paused, so dropping it would strand the turn with
@@ -627,24 +783,41 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       // Whether the restore is still WANTED is derived from the thread itself,
       // not accumulated in a counter. `sendHitlResume` also reports
       // "not reached" when a newer interaction aborted it, and its continuation
-      // can settle arbitrarily late — but if the user has genuinely moved on,
-      // the new turn has already appended its optimistic user message under a
-      // DIFFERENT exchange_id, so the thread says so. A turn that failed before
-      // committing (write barrier, prepare-execution, the token floor) appends
-      // nothing, which is exactly when the prompt should come back.
+      // can settle arbitrarily late. An ordinary attempt that displaced this
+      // prompt owns that decision through its rollback snapshot. Without such
+      // an owner, a different latest exchange means the thread genuinely moved
+      // on and the old prompt must stay dismissed.
       //
-      // This replaced a turn-generation counter with rollbacks and ownership:
-      // three rounds of review found three holes in it (bumping on rejected
-      // sends, a bail that skipped the rollback, one rollback slot with several
-      // owners). Nothing here accumulates, so there is nothing to unwind.
+      // This uses current thread ownership instead of an accumulated counter,
+      // so rejected attempts and competing owners require no counter rollback.
       const restoreIfStillWanted = () => {
         if (activeSessionIdRef.current !== prompt.session_id) return;
+        // A newer awaiting_human that arrived meanwhile owns the slot and must
+        // not be stomped. `pendingHitlRef` is the synchronous truth, so decide
+        // from it rather than mutating a ref inside a setState updater —
+        // updaters must be pure and React double-invokes them under StrictMode.
+        if (pendingHitlRef.current !== null) return;
+
+        // An ordinary send may have displaced this prompt while the resume was
+        // in flight. Rendering the old prompt now would put a stale card over
+        // that newer attempt. Hand it to the ordinary attempt's rollback
+        // snapshot instead: a 422 restores it, while an accepted turn consumes
+        // it when the retry state is released.
+        const submitted = submittedDraftRef.current;
+        if (submitted?.sessionId === prompt.session_id) {
+          if (submitted.pendingHitl === null) {
+            submitted.pendingHitl = prompt;
+            submitted.hitlDraftOwner = draftOwner;
+          }
+          return;
+        }
+
         const thread = latestMessagesRef.current;
         const last = thread.length > 0 ? thread[thread.length - 1] : undefined;
         if (last && last.exchange_id !== prompt.exchange_id) return;
-        // Functional update: a newer awaiting_human that arrived meanwhile owns
-        // the slot and must not be stomped.
-        setPendingHitl((current) => current ?? prompt);
+
+        pendingHitlRef.current = prompt;
+        setPendingHitl(prompt);
       };
       void sendHitlResume(prompt, answer, freeText)
         .then((reached) => {
@@ -663,10 +836,12 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
           restoreIfStillWanted();
         });
     },
-    [maxChatInputChars, pendingHitl, sendHitlResume],
+    [markLiveActivity, maxChatInputChars, pendingHitl, sendHitlResume],
   );
 
   const startNewConversation = useCallback(() => {
+    submittedDraftRef.current = null;
+    pendingHitlRef.current = null;
     setPendingHitl(null);
     hitlDraftOwnerRef.current += 1;
     setHitlFreeText("");
@@ -679,6 +854,15 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
       { replace: true },
     );
   }, [setSearchParams]);
+
+  const handleAbort = useCallback(() => {
+    const submitted = submittedDraftRef.current;
+    if (submitted !== null && !submitted.started) {
+      restoreDisplacedHitl(submitted);
+    }
+    submittedDraftRef.current = null;
+    abort();
+  }, [abort, restoreDisplacedHitl]);
 
   const commitTitle = useCallback(
     (title: string) => {
@@ -785,10 +969,11 @@ export function useManagedChat({ teamId, agentInstanceId }: UseManagedChatParams
     threadMessages,
     messages,
     waitResponse,
+    isPreparingSend,
     isLoadingHistory,
     handleSend,
     handleHitlAnswer,
-    handleAbort: abort,
+    handleAbort,
     startNewConversation,
     commitTitle,
   };

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.test.tsx
@@ -25,7 +25,7 @@
 //   brand-new session;
 // - the cache is a bounded LRU.
 
-import { act } from "react";
+import { act, StrictMode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage } from "../../../../slices/runtime/runtimeOpenApi";
@@ -81,14 +81,23 @@ function TestHost({
   sessionId,
   onLoaded,
   isTurnActive,
+  getLiveActivityRevision,
   onRender,
 }: {
   sessionId: string | null;
   onLoaded: (messages: ChatMessage[]) => void;
   isTurnActive: () => boolean;
+  getLiveActivityRevision: () => number;
   onRender: (hook: ReturnType<typeof useSessionHistory>) => void;
 }) {
-  const hook = useSessionHistory({ sessionId, teamId: "team-1", agentInstanceId: "agent-1", onLoaded, isTurnActive });
+  const hook = useSessionHistory({
+    sessionId,
+    teamId: "team-1",
+    agentInstanceId: "agent-1",
+    onLoaded,
+    isTurnActive,
+    getLiveActivityRevision,
+  });
   onRender(hook);
   return null;
 }
@@ -99,18 +108,23 @@ describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
   let latest: ReturnType<typeof useSessionHistory>;
   const onLoaded = vi.fn();
   let turnActive = false;
+  let liveActivityRevision = 0;
   const isTurnActive = () => turnActive;
+  const getLiveActivityRevision = () => liveActivityRevision;
+
+  const host = (sessionId: string | null) => (
+    <TestHost
+      sessionId={sessionId}
+      onLoaded={onLoaded}
+      isTurnActive={isTurnActive}
+      getLiveActivityRevision={getLiveActivityRevision}
+      onRender={(h) => (latest = h)}
+    />
+  );
 
   const render = (sessionId: string | null) => {
     act(() => {
-      root.render(
-        <TestHost
-          sessionId={sessionId}
-          onLoaded={onLoaded}
-          isTurnActive={isTurnActive}
-          onRender={(h) => (latest = h)}
-        />,
-      );
+      root.render(host(sessionId));
     });
   };
 
@@ -133,6 +147,7 @@ describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
     onLoaded.mockClear();
     prepareExecutionCalls.length = 0;
     turnActive = false;
+    liveActivityRevision = 0;
     fetchImpl = async () => okResponse([]);
     vi.stubGlobal("fetch", (url: string) => fetchImpl(String(url)));
   });
@@ -162,6 +177,42 @@ describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
     expect(getCachedSessionHistory("session-a")).toEqual(history);
   });
 
+  it("keeps an uncached StrictMode load visible until its request settles", async () => {
+    const history = [msg("m1")];
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<StrictMode>{host("session-a")}</StrictMode>);
+    });
+
+    expect(latest.isLoading).toBe(true);
+
+    response.resolve(okResponse(history));
+    await settle();
+
+    expect(latest.isLoading).toBe(false);
+    expect(onLoaded).toHaveBeenCalledWith(history);
+  });
+
+  it("resets loading when switching from an uncached session to a cached session", () => {
+    const cachedHistory = [msg("b1")];
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    setCachedSessionHistory("session-b", cachedHistory);
+    fetchImpl = () => response.promise;
+
+    mount("session-a");
+    expect(latest.isLoading).toBe(true);
+
+    render("session-b");
+
+    expect(latest.isLoading).toBe(false);
+    expect(onLoaded).toHaveBeenLastCalledWith(cachedHistory);
+  });
+
   it("cache hit: renders synchronously with no loading state, then revalidates in the background", async () => {
     const cachedHistory = [msg("m1")];
     const freshHistory = [msg("m1"), msg("m2-from-another-device")];
@@ -180,6 +231,16 @@ describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
     expect(latest.isLoading).toBe(false);
     expect(onLoaded).toHaveBeenLastCalledWith(freshHistory);
     expect(getCachedSessionHistory("session-a")).toEqual(freshHistory);
+  });
+
+  it("does not replay cached history over a turn that is already active", async () => {
+    setCachedSessionHistory("session-a", [msg("cached-before-live-turn")]);
+    turnActive = true;
+
+    mount("session-a");
+
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(latest.isLoading).toBe(false);
   });
 
   it("a response landing after a session switch is neither applied nor cached under either session", async () => {
@@ -202,6 +263,24 @@ describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
     expect(getCachedSessionHistory("session-b")).toEqual(bHistory);
   });
 
+  it("does not let an older session request clear the active session's loading state", async () => {
+    const aResponse = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    const bResponse = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = (url) => (url.includes("session-a") ? aResponse.promise : bResponse.promise);
+
+    mount("session-a");
+    render("session-b");
+    expect(latest.isLoading).toBe(true);
+
+    aResponse.resolve(okResponse([msg("a1")]));
+    await settle();
+    expect(latest.isLoading).toBe(true);
+
+    bResponse.resolve(okResponse([msg("b1")]));
+    await settle();
+    expect(latest.isLoading).toBe(false);
+  });
+
   it("an empty response is not applied — a brand-new session's optimistic first message survives", async () => {
     fetchImpl = async () => okResponse([]);
     mount("session-new");
@@ -211,17 +290,110 @@ describe("useSessionHistory — #2239 serve-then-revalidate cache", () => {
     expect(getCachedSessionHistory("session-new")).toBeUndefined();
   });
 
-  it("a response never replaces a live streamed turn, and is not cached over it", async () => {
+  it("does not apply or cache a response that arrives during a live turn", async () => {
     const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
     fetchImpl = () => response.promise;
 
     mount("session-a");
-    turnActive = true; // a turn starts streaming while history is in flight
+    turnActive = true;
     response.resolve(okResponse([msg("stale-history")]));
     await settle();
 
     expect(onLoaded).not.toHaveBeenCalled();
     expect(getCachedSessionHistory("session-a")).toBeUndefined();
+  });
+
+  it("discards history started before a turn even when that turn has already settled", async () => {
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+
+    mount("session-a");
+    liveActivityRevision += 1;
+    response.resolve(okResponse([msg("stale-history")]));
+    await settle();
+
+    expect(turnActive).toBe(false);
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(getCachedSessionHistory("session-a")).toBeUndefined();
+  });
+
+  it("discards an overlapping response without scheduling a retry", async () => {
+    vi.useFakeTimers();
+    try {
+      let call = 0;
+      fetchImpl = async () => {
+        call += 1;
+        return okResponse([msg("stale-history")]);
+      };
+
+      mount("session-a");
+      liveActivityRevision += 1;
+      await settle();
+
+      expect(onLoaded).not.toHaveBeenCalled();
+      expect(getCachedSessionHistory("session-a")).toBeUndefined();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+      });
+
+      expect(call).toBe(1);
+      expect(onLoaded).not.toHaveBeenCalled();
+      expect(getCachedSessionHistory("session-a")).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not apply or cache an overlapping response that settles after unmount", async () => {
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+
+    mount("session-a");
+    liveActivityRevision += 1;
+    act(() => root.render(null));
+    response.resolve(okResponse([msg("stale-history")]));
+    await settle();
+
+    expect(prepareExecutionCalls).toHaveLength(1);
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(getCachedSessionHistory("session-a")).toBeUndefined();
+  });
+
+  it("discards a response whose request began while a turn was active", async () => {
+    const response = deferred<{ ok: boolean; json: () => Promise<ChatMessage[]> }>();
+    fetchImpl = () => response.promise;
+    turnActive = true;
+
+    mount("session-a");
+    turnActive = false;
+    response.resolve(okResponse([msg("history-without-active-turn")]));
+    await settle();
+
+    expect(onLoaded).not.toHaveBeenCalled();
+    expect(getCachedSessionHistory("session-a")).toBeUndefined();
+  });
+
+  it("replays the cache when the user returns to a session this mount already fetched", async () => {
+    // The fetch guard must sit BELOW the cache replay. Above it, browser
+    // Back/Forward on the same agent (no remount, sessionId → null → same id)
+    // returns to a permanently empty thread.
+    fetchImpl = async () => okResponse([msg("m1")]);
+    mount("session-a");
+    await settle();
+    expect(onLoaded).toHaveBeenCalledWith([msg("m1")]);
+    onLoaded.mockClear();
+    prepareExecutionCalls.length = 0;
+
+    render(null);
+    await settle();
+    render("session-a");
+    await settle();
+
+    expect(onLoaded).toHaveBeenCalledWith([msg("m1")]);
+    // Served from cache — the guard still suppresses a duplicate fetch.
+    expect(prepareExecutionCalls).toHaveLength(0);
   });
 
   it("does not re-fetch on an effect re-fire for the same session", async () => {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useSessionHistory.ts
@@ -23,10 +23,13 @@ interface UseSessionHistoryArgs {
   teamId: string | undefined;
   agentInstanceId: string | undefined;
   onLoaded: (messages: ChatMessage[]) => void;
-  // True while a streamed turn is in progress. A history response — cached or
-  // fetched — must never replace a live turn: history necessarily lacks the
-  // in-flight exchange, so applying it would visibly eat the user's message.
+  // True while a streamed turn is in progress. Cached or fetched history must
+  // not replace a live turn because it cannot contain the in-flight exchange.
   isTurnActive: () => boolean;
+  // A turn can start and finish while a history request is in flight. This
+  // revision detects that overlap even when the turn is no longer active when
+  // the response arrives.
+  getLiveActivityRevision: () => number;
 }
 
 function expandMessagesUrl(template: string, sessionId: string): string {
@@ -39,6 +42,7 @@ export function useSessionHistory({
   agentInstanceId,
   onLoaded,
   isTurnActive,
+  getLiveActivityRevision,
 }: UseSessionHistoryArgs) {
   const [isLoading, setIsLoading] = useState(false);
   // Session whose fetch this mount has already started — keeps an effect
@@ -51,6 +55,25 @@ export function useSessionHistory({
   // staleness can only be detected against a ref.
   const activeSessionIdRef = useRef(sessionId);
   activeSessionIdRef.current = sessionId;
+  const isMountedRef = useRef(true);
+  const loadGenerationRef = useRef(0);
+  const loadingResetSessionRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    // Run once per session identity. Re-running this for the session already
+    // being fetched would leave the loading indicator out of step with its request.
+    if (loadingResetSessionRef.current === sessionId) return;
+    loadingResetSessionRef.current = sessionId;
+    loadGenerationRef.current += 1;
+    setIsLoading(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const [prepareExecution] =
     usePostPrepareExecutionControlPlaneV1TeamsTeamIdAgentInstancesAgentInstanceIdPrepareExecutionPostMutation();
@@ -61,12 +84,20 @@ export function useSessionHistory({
     // #2239 instant switch: a previously opened conversation renders straight
     // from the cache — synchronously, no spinner, composer stays enabled —
     // while the fetch below revalidates against the runtime (the source of
-    // truth) in the background and swaps in the fresh history when it lands.
+    // truth) in the background and replaces it with fresh history when safe.
+    // Replayed on EVERY effect run, including a return to a session this mount
+    // already fetched. The fetch guard below must stay BELOW this line: above
+    // it, re-entering a session (browser Back/Forward on the same agent, which
+    // does not remount) renders an empty thread forever.
     const cached = getCachedSessionHistory(sessionId);
     if (cached !== undefined && cached.length > 0 && !isTurnActive()) onLoaded(cached);
 
     if (startedForRef.current === sessionId) return;
     startedForRef.current = sessionId;
+
+    const turnWasActiveAtStart = isTurnActive();
+    const liveActivityRevisionAtStart = getLiveActivityRevision();
+    const loadGeneration = ++loadGenerationRef.current;
 
     const load = async () => {
       // A cache hit downgrades the fetch to a silent background revalidation:
@@ -81,16 +112,14 @@ export function useSessionHistory({
         const resp = await fetch(url.toString(), { headers: { Authorization: `Bearer ${token}` } });
         if (!resp.ok) return;
         const msgs: ChatMessage[] = await resp.json();
-        // Guards, in order:
-        // - stale response: the user switched sessions while this fetch was
-        //   in flight — applying would render session A's history under
-        //   session B and poison the cache;
-        // - live turn: see `isTurnActive` above;
-        // - empty history: a brand-new session bound at send time has no
-        //   persisted history yet — applying [] would wipe the optimistic
-        //   first message.
-        if (activeSessionIdRef.current !== sessionId) return;
-        if (isTurnActive()) return;
+        // A response that overlapped live activity cannot contain the current
+        // turn. Applying or caching it would replace newer state with an older
+        // snapshot. Do not retry automatically: persistence can still lag the
+        // completed turn, so a later full replacement is not inherently safer.
+        if (!isMountedRef.current || activeSessionIdRef.current !== sessionId) return;
+        if (turnWasActiveAtStart || isTurnActive() || getLiveActivityRevision() !== liveActivityRevisionAtStart) {
+          return;
+        }
         if (msgs.length === 0) return;
         setCachedSessionHistory(sessionId, msgs);
         onLoaded(msgs);
@@ -98,12 +127,18 @@ export function useSessionHistory({
         // History load failure is non-fatal — user continues with the cached
         // (or empty) view.
       } finally {
-        setIsLoading(false);
+        if (
+          isMountedRef.current &&
+          activeSessionIdRef.current === sessionId &&
+          loadGenerationRef.current === loadGeneration
+        ) {
+          setIsLoading(false);
+        }
       }
     };
 
     void load();
-  }, [sessionId, teamId, agentInstanceId, prepareExecution, onLoaded, isTurnActive]);
+  }, [sessionId, teamId, agentInstanceId, prepareExecution, onLoaded, isTurnActive, getLiveActivityRevision]);
 
   return { isLoading };
 }

--- a/apps/frontend/src/rework/components/shared/molecules/AttachmentChips/AttachmentChips.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/AttachmentChips/AttachmentChips.tsx
@@ -24,7 +24,7 @@ import styles from "./AttachmentChips.module.css";
 
 interface AttachmentChipsProps {
   attachments: ChatAttachment[];
-  onRemove: (id: string) => void;
+  onRemove?: (id: string) => void;
 }
 
 interface TasksRootState {
@@ -87,7 +87,7 @@ export function AttachmentChips({ attachments, onRemove }: AttachmentChipsProps)
           label={attachment.name}
           secondary={attachment.taskIds.length === 0 ? fileLabel(attachment, t) : undefined}
           trailing={<AttachmentTaskStatus taskIds={attachment.taskIds} />}
-          onRemove={() => onRemove(attachment.id)}
+          onRemove={onRemove ? () => onRemove(attachment.id) : undefined}
           removeAriaLabel={t("chatbot.attachmentChip.removeAria", { name: attachment.name })}
         />
       ))}

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 // Copyright Thales 2026
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { act, type ComponentProps } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { HitlPrompt } from "./HitlPrompt";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -76,10 +85,82 @@ describe("HitlPrompt chat-input limit", () => {
 
   it("omits limit UI for an older runtime while preserving free text", () => {
     const html = renderToStaticMarkup(
-      <HitlPrompt event={event} onAnswer={() => undefined} freeTextValue="🙂🙂🙂🙂🙂🙂" />,
+      <HitlPrompt
+        event={event}
+        onAnswer={() => undefined}
+        freeTextValue="🙂🙂🙂🙂🙂🙂"
+        onFreeTextChange={() => undefined}
+      />,
     );
 
     expect(html).not.toContain("chatbot.characterCounter");
     expect(html).toContain("🙂🙂🙂🙂🙂🙂");
+  });
+
+  it("localizes both values in the character counter", () => {
+    const html = renderToStaticMarkup(
+      <HitlPrompt
+        event={event}
+        onAnswer={() => undefined}
+        maxChatInputChars={5_000}
+        freeTextValue={"x".repeat(5_001)}
+        onFreeTextChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("chatbot.characterCounter:5,001:5,000");
+  });
+
+  it("submits only the fixed choice id and never an unrelated free-text draft", () => {
+    const onAnswer = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      act(() => {
+        root.render(
+          <HitlPrompt
+            event={event}
+            onAnswer={onAnswer}
+            freeTextValue="unrelated free-text draft"
+            onFreeTextChange={() => undefined}
+          />,
+        );
+      });
+      const choiceButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Proceed",
+      );
+      expect(choiceButton).toBeDefined();
+
+      act(() => {
+        choiceButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(onAnswer.mock.calls).toEqual([["proceed"]]);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("requires controlled free-text props together at compile time", () => {
+    const baseProps = { event, onAnswer: () => undefined };
+    const uncontrolled: ComponentProps<typeof HitlPrompt> = baseProps;
+    const controlled: ComponentProps<typeof HitlPrompt> = {
+      ...baseProps,
+      freeTextValue: "draft",
+      onFreeTextChange: () => undefined,
+    };
+
+    // @ts-expect-error freeTextValue requires onFreeTextChange.
+    const missingChangeHandler: ComponentProps<typeof HitlPrompt> = { ...baseProps, freeTextValue: "draft" };
+    // @ts-expect-error onFreeTextChange requires freeTextValue.
+    const missingControlledValue: ComponentProps<typeof HitlPrompt> = {
+      ...baseProps,
+      onFreeTextChange: () => undefined,
+    };
+
+    expect([uncontrolled, controlled, missingChangeHandler, missingControlledValue]).toHaveLength(4);
   });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/HitlPrompt/HitlPrompt.tsx
@@ -22,14 +22,24 @@ import type { ButtonVariant, ColorTheme } from "@shared/utils/Type.ts";
 import type { RuntimeAwaitingHumanEvent } from "@hooks/useChatSse";
 import styles from "./HitlPrompt.module.css";
 
-interface HitlPromptProps {
+interface HitlPromptBaseProps {
   event: RuntimeAwaitingHumanEvent;
   onAnswer: (answer: string | boolean | undefined, freeText?: string) => void;
   readonly?: boolean;
   maxChatInputChars?: number;
-  freeTextValue?: string;
-  onFreeTextChange?: (value: string) => void;
 }
+
+type HitlPromptProps = HitlPromptBaseProps &
+  (
+    | {
+        freeTextValue: string;
+        onFreeTextChange: (value: string) => void;
+      }
+    | {
+        freeTextValue?: never;
+        onFreeTextChange?: never;
+      }
+  );
 
 /**
  * Visual treatment for one HITL choice button. The tool-approval gate

--- a/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/RichInputField/RichInputField.test.tsx
@@ -57,6 +57,8 @@ describe("RichInputField send gating", () => {
 
     expect(html).not.toContain("chatbot.characterCounter");
     expect(html).not.toContain("chatbot.errors.chatInputTooLong");
+    expect(html).toContain('<span aria-live="polite"></span>');
+    expect(html).not.toMatch(/aria-live="polite"[^>]*>[^<]*chatbot\.characterCounter/);
     expect(html).not.toContain("maxLength=");
     expect(textarea).not.toBe("");
     expect(textarea).not.toContain("aria-invalid");

--- a/apps/frontend/src/rework/core/errors/normalizeApiError.test.ts
+++ b/apps/frontend/src/rework/core/errors/normalizeApiError.test.ts
@@ -113,6 +113,35 @@ describe("normalizeApiError", () => {
       });
     });
 
+    it("leaves a top-level message to the caller's contextual fallback", () => {
+      expect(normalizeApiError({ status: 503, data: { message: "Temporarily unavailable" } })).toEqual({
+        kind: "unknown",
+        status: 503,
+      });
+    });
+
+    it("prefers a FastAPI validation detail over a generic top-level message", () => {
+      const error = {
+        status: 422,
+        data: {
+          message: "Validation failed",
+          detail: [{ msg: "The title is too long" }],
+        },
+      };
+      expect(normalizeApiError(error).detail).toBe("The title is too long");
+    });
+
+    it("prefers an app error detail over a generic top-level message", () => {
+      const error = {
+        status: 422,
+        data: {
+          message: "Validation failed",
+          errors: [{ detail: "The selected document is unavailable" }],
+        },
+      };
+      expect(normalizeApiError(error).detail).toBe("The selected document is unavailable");
+    });
+
     it("ignores a blank data.detail", () => {
       expect(normalizeApiError({ status: 400, data: { detail: "  " } }).detail).toBeUndefined();
     });

--- a/apps/frontend/src/rework/core/errors/normalizeApiError.ts
+++ b/apps/frontend/src/rework/core/errors/normalizeApiError.ts
@@ -30,7 +30,7 @@ const asString = (value: unknown): string | undefined => {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 };
 
-const getDetailFromData = (data: unknown): string | undefined => {
+export const getDetailFromData = (data: unknown): string | undefined => {
   if (!isRecord(data)) return undefined;
 
   const directDetail = asString(data.detail);
@@ -50,12 +50,12 @@ const getDetailFromData = (data: unknown): string | undefined => {
   }
 
   const errors = data.errors;
-  if (!Array.isArray(errors)) return undefined;
-
-  for (const entry of errors) {
-    if (!isRecord(entry)) continue;
-    const message = asString(entry.detail) || asString(entry.message);
-    if (message) return message;
+  if (Array.isArray(errors)) {
+    for (const entry of errors) {
+      if (!isRecord(entry)) continue;
+      const message = asString(entry.detail) || asString(entry.message);
+      if (message) return message;
+    }
   }
 
   return undefined;

--- a/apps/frontend/src/rework/core/hooks/useChatSse.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.test.tsx
@@ -116,6 +116,7 @@ vi.mock("../../../slices/controlPlane/controlPlaneOpenApi", () => ({
 
 import { useChatSse } from "./useChatSse";
 import type { RuntimeAwaitingHumanEvent } from "./useChatSse";
+import type { ChatMessage } from "../../../slices/runtime/runtimeOpenApi";
 
 function TestHost({ onRender }: { onRender: (hook: ReturnType<typeof useChatSse>) => void }) {
   const hook = useChatSse({
@@ -125,6 +126,7 @@ function TestHost({ onRender }: { onRender: (hook: ReturnType<typeof useChatSse>
     onError: (msg) => onErrorMock(msg),
     onTurnStarted: () => onTurnStartedMock(),
     onTurnRejected: (draft, sessionId) => onTurnRejectedMock(draft, sessionId),
+    onTurnRetryStateReleased: (draft, sessionId) => onTurnRetryStateReleasedMock(draft, sessionId),
     isTurnCurrent,
   });
   onRender(hook);
@@ -136,6 +138,7 @@ let isTurnCurrent: ((sessionId: string) => boolean) | undefined;
 const onErrorMock = vi.fn();
 const onTurnStartedMock = vi.fn();
 const onTurnRejectedMock = vi.fn();
+const onTurnRetryStateReleasedMock = vi.fn();
 
 describe("useChatSse — send() ordering barrier and prepare-execution failure handling", () => {
   let container: HTMLDivElement;
@@ -157,6 +160,7 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     onErrorMock.mockClear();
     onTurnStartedMock.mockClear();
     onTurnRejectedMock.mockClear();
+    onTurnRetryStateReleasedMock.mockClear();
     dispatchMock.mockClear();
     prepareExecutionCalls.length = 0;
     prepareExecutionImpl = async () => ({
@@ -192,6 +196,7 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     expect(latest.waitResponse).toBe(false);
     // The turn never started — the caller must not clear composer state.
     expect(onTurnStartedMock).not.toHaveBeenCalled();
+    expect(onTurnRetryStateReleasedMock).toHaveBeenCalledWith("hello", "session-1");
   });
 
   it("passes the target session id to the write barrier", async () => {
@@ -230,13 +235,129 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     fetchSpy.mockRestore();
   });
 
+  it("resolves runtime context after asynchronous preflight and before the turn starts", async () => {
+    flushPendingWrites = async () => true;
+    const preparation = deferred<unknown>();
+    prepareExecutionImpl = () => preparation.promise;
+    let attachmentContext = "context before preflight";
+    const ordering: string[] = [];
+    const resolveRuntimeContext = vi.fn(() => {
+      ordering.push("context");
+      return { attachments_markdown: attachmentContext };
+    });
+    onTurnStartedMock.mockImplementation(() => ordering.push("started"));
+    let requestBody: Record<string, unknown> | undefined;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      ordering.push("fetch");
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      throw new Error("stop after request capture");
+    });
+    mount();
+
+    const sendPromise = latest.send(
+      "hello",
+      "session-1",
+      { attachments_markdown: "stale context" },
+      undefined,
+      resolveRuntimeContext,
+    );
+    await vi.waitFor(() => expect(prepareExecutionCalls).toHaveLength(1));
+    attachmentContext = "context ready during preflight";
+
+    await act(async () => {
+      preparation.resolve({
+        execute_stream_url: "http://runtime.test/execute_stream",
+        chat_controls: [],
+        capability_base_urls: {},
+      });
+      await sendPromise;
+    });
+
+    expect(resolveRuntimeContext).toHaveBeenCalledTimes(1);
+    expect(ordering).toEqual(["context", "started", "fetch"]);
+    expect(requestBody?.runtime_context).toMatchObject({
+      attachments_markdown: "context ready during preflight",
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it("keeps the turn uncommitted when late runtime-context resolution fails", async () => {
+    flushPendingWrites = async () => true;
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1", undefined, undefined, () => {
+        throw new Error("snapshot failed");
+      });
+    });
+
+    expect(onTurnStartedMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(onTurnRetryStateReleasedMock).toHaveBeenCalledWith("hello", "session-1");
+    expect(onErrorMock).toHaveBeenCalledWith("Could not prepare this turn: snapshot failed");
+    expect(latest.waitResponse).toBe(false);
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("releases caller rollback state immediately after a 2xx response, before the stream finishes", async () => {
+    flushPendingWrites = async () => true;
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(responseBody, { status: 200, headers: { "Content-Type": "text/event-stream" } }));
+    mount();
+
+    let sendSettled = false;
+    let streamClosed = false;
+    let sendPromise: Promise<void> | undefined;
+    try {
+      await act(async () => {
+        sendPromise = latest.send("hello", "session-1");
+        void sendPromise.then(() => {
+          sendSettled = true;
+        });
+        await vi.waitFor(() => {
+          expect(onTurnRetryStateReleasedMock).toHaveBeenCalledWith("hello", "session-1");
+        });
+      });
+
+      expect(onTurnRetryStateReleasedMock).toHaveBeenCalledTimes(1);
+      expect(sendSettled).toBe(false);
+      expect(latest.waitResponse).toBe(true);
+
+      await act(async () => {
+        streamController.close();
+        streamClosed = true;
+        await sendPromise;
+      });
+      expect(onTurnRetryStateReleasedMock).toHaveBeenCalledTimes(1);
+      expect(latest.waitResponse).toBe(false);
+    } finally {
+      if (!streamClosed) {
+        await act(async () => {
+          streamController.close();
+          await sendPromise;
+        });
+      }
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("parses a structured length rejection, removes the optimistic message, and restores the full draft", async () => {
     flushPendingWrites = async () => true;
     prepareExecutionImpl = async () => ({
       execute_stream_url: "http://runtime.test/execute_stream",
       chat_controls: [],
       capability_base_urls: {},
-      max_chat_input_chars: 5,
+      max_chat_input_chars: 10,
     });
     const rejectedDraft = "🙂🙂🙂🙂🙂🙂";
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -262,11 +383,565 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
 
     expect(onTurnStartedMock).toHaveBeenCalledTimes(1);
     expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(onTurnRetryStateReleasedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
     expect(latest.messages).toHaveLength(0);
     expect(latest.maxChatInputChars).toBe(5);
     expect(onErrorMock).toHaveBeenCalledWith("chatbot.errors.chatInputTooLong:5");
     expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain(rejectedDraft);
     expect(errorSpy.mock.calls.flat().join(" ")).not.toContain(rejectedDraft);
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it.each([
+    ["non-positive", 0],
+    ["fractional", 5.5],
+    ["unsafe", Number.MAX_SAFE_INTEGER + 1],
+  ])("ignores a malformed %s rejection limit instead of pinning the composer", async (_kind, rejectedLimit) => {
+    flushPendingWrites = async () => true;
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: 5_000,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: rejectedLimit,
+            actual_chars: 6,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send("abcdef", "session-1");
+    });
+
+    expect(latest.maxChatInputChars).toBe(5_000);
+    expect(onTurnRejectedMock).toHaveBeenCalledWith("abcdef", "session-1");
+    expect(onErrorMock).toHaveBeenCalledWith("safe backend message");
+    fetchSpy.mockRestore();
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["fractional", 5.5],
+    ["unsafe", Number.MAX_SAFE_INTEGER + 1],
+  ])("ignores an invalid %s preparation limit", async (_kind, preparedLimit) => {
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: preparedLimit,
+    });
+    mount();
+
+    await act(async () => {
+      await latest.prepareChatControls("session-1");
+    });
+
+    expect(latest.maxChatInputChars).toBeUndefined();
+  });
+
+  it.each([
+    ["fractional", 5.5],
+    ["unsafe", Number.MAX_SAFE_INTEGER + 1],
+  ])("does not let a present malformed %s preparation erase a valid advisory limit", async (_kind, malformed) => {
+    let preparedLimit = 5_000;
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: preparedLimit,
+    });
+    mount();
+
+    await act(async () => {
+      await latest.prepareChatControls("session-1");
+    });
+    expect(latest.maxChatInputChars).toBe(5_000);
+
+    preparedLimit = malformed;
+    await act(async () => {
+      await latest.prepareChatControls("session-1");
+    });
+
+    expect(latest.maxChatInputChars).toBe(5_000);
+  });
+
+  it("keeps a rejection authoritative over older preparations, then accepts a newly prepared limit", async () => {
+    flushPendingWrites = async () => true;
+    const stalePreparation = deferred<unknown>();
+    let preparationCall = 0;
+    prepareExecutionImpl = async () => {
+      preparationCall += 1;
+      if (preparationCall === 1) return stalePreparation.promise;
+      const preparation = {
+        execute_stream_url: "http://runtime.test/execute_stream",
+        chat_controls: [],
+        capability_base_urls: {},
+      };
+      return preparationCall === 3 ? preparation : { ...preparation, max_chat_input_chars: 5_000 };
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: 100,
+            actual_chars: 101,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mount();
+
+    // Eager preparation starts first but remains in flight while a send reaches
+    // another replica and receives that replica's authoritative rejection.
+    const staleControlsPromise = latest.prepareChatControls("session-1");
+
+    // A rejection is adopted immediately: the composer must reflect what the
+    // runtime actually refused, for the very next keystroke.
+    await act(async () => {
+      await latest.send("x".repeat(101), "session-1");
+    });
+    expect(latest.maxChatInputChars).toBe(100);
+
+    // The older request resolves last. Its advisory value predates the 422 and
+    // must not immediately make the composer accept the same rejected draft.
+    await act(async () => {
+      stalePreparation.resolve({
+        execute_stream_url: "http://runtime.test/execute_stream",
+        chat_controls: [],
+        capability_base_urls: {},
+        max_chat_input_chars: 5_000,
+      });
+      await staleControlsPromise;
+    });
+    expect(latest.maxChatInputChars).toBe(100);
+
+    // A legacy replica omitting the optional projection cannot invalidate the
+    // authoritative limit already learned from a rejection.
+    await act(async () => {
+      await latest.prepareChatControls("session-1");
+    });
+    expect(latest.maxChatInputChars).toBe(100);
+
+    // The rejection is not a permanent floor: a successful preparation STARTED
+    // after it may publish a raised deployment value.
+    await act(async () => {
+      await latest.prepareChatControls("session-1");
+    });
+    expect(latest.maxChatInputChars).toBe(5_000);
+
+    // A session-local reset keeps the last known limit, so the counter does not
+    // flicker while the next eager preparation is in flight.
+    act(() => latest.reset());
+    expect(latest.maxChatInputChars).toBe(5_000);
+
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves a bounded top-level runtime message", async () => {
+    flushPendingWrites = async () => true;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "Temporarily unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Temporarily unavailable");
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves a nested runtime message independently of status", async () => {
+    flushPendingWrites = async () => true;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: { message: "upstream unavailable" } }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: upstream unavailable");
+    fetchSpy.mockRestore();
+  });
+
+  it("truncates runtime messages by complete Unicode code points", async () => {
+    flushPendingWrites = async () => true;
+    const message = "🙂".repeat(1_001);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith(`Streaming failed: ${"🙂".repeat(1_000)}…`);
+    expect(onErrorMock.mock.calls[0][0]).not.toContain("�");
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves a string FastAPI detail as the runtime error message", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Unknown agent instance." }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Unknown agent instance.");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves the first safe message from a FastAPI validation-detail array", async () => {
+    flushPendingWrites = async () => true;
+    const rejectedDraft = "keep this FastAPI-rejected draft";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: [
+            {
+              type: "string_too_long",
+              loc: ["body", "input"],
+              msg: "String should have at most 5,000 characters",
+              input: "private rejected content",
+            },
+          ],
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: String should have at most 5,000 characters");
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain("private rejected content");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves the first safe message from an app-level errors array", async () => {
+    flushPendingWrites = async () => true;
+    const rejectedDraft = "keep this app-rejected draft";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          errors: [{ detail: "The selected document is unavailable" }],
+          private_context: "must not be surfaced",
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: The selected document is unavailable");
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain("must not be surfaced");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("does not expose an unstructured plain-text runtime error body", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response("runtime unavailable", { status: 503, headers: { "Content-Type": "text/plain" } }),
+      );
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (503)");
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain("runtime unavailable");
+    expect(onTurnRetryStateReleasedMock).toHaveBeenCalledWith("hello", "session-1");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("does not expose a bare JSON-string runtime error body", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify("private rejected content"), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (500)");
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain("private rejected content");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects an oversized runtime error body before reading it", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const getReader = vi.fn();
+    const cancel = vi.fn(async () => undefined);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 502,
+      headers: new Headers({ "Content-Length": String(32 * 1024) }),
+      body: { getReader, cancel },
+    } as unknown as Response);
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(getReader).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (502)");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("restores the ordinary draft when a 422 error body is too large to inspect", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const rejectedDraft = "keep this draft";
+    const getReader = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: new Headers({ "Content-Length": String(32 * 1024) }),
+      body: { getReader },
+    } as unknown as Response);
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(getReader).not.toHaveBeenCalled();
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(latest.maxChatInputChars).toBeUndefined();
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (422)");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("restores the ordinary draft when a 422 response body is already locked", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const rejectedDraft = "keep this locked-body draft";
+    const cancelFailure = Promise.reject(new TypeError("Cannot cancel a locked ReadableStream"));
+    const cancelCatch = vi.spyOn(cancelFailure, "catch");
+    const cancel = vi.fn(() => cancelFailure);
+    const getReader = vi.fn(() => {
+      throw new TypeError("ReadableStream is locked");
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: new Headers(),
+      body: { getReader, cancel },
+    } as unknown as Response);
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(latest.maxChatInputChars).toBeUndefined();
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (422)");
+    expect(getReader).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancelCatch).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("restores the ordinary draft when a 422 response has a readable but empty body", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const rejectedDraft = "keep this empty-body draft";
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      {
+        status: 422,
+        headers: { "Content-Length": "0" },
+      },
+    );
+    expect(response.body).not.toBeNull();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (422)");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("restores the ordinary draft when reading a 422 response body fails", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const rejectedDraft = "keep this failed-read draft";
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            throw new Error("read failed");
+          },
+          cancel,
+          releaseLock,
+        }),
+      },
+    } as unknown as Response);
+    mount();
+
+    await act(async () => {
+      await latest.send(rejectedDraft, "session-1");
+    });
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(onTurnRejectedMock).toHaveBeenCalledWith(rejectedDraft, "session-1");
+    expect(latest.messages).toHaveLength(0);
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (422)");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("stops streaming a runtime error body once the byte limit is exceeded", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let cancelled = false;
+    let chunk = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (chunk >= 17) {
+          controller.close();
+          return;
+        }
+        chunk += 1;
+        controller.enqueue(new Uint8Array(1025));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 502 }));
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(chunk).toBe(17);
+    expect(cancelled).toBe(true);
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (502)");
+    errorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("cancels a transport chunk that crosses the runtime error buffer limit", async () => {
+    flushPendingWrites = async () => true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const oversizedChunk = new TextEncoder().encode(
+      JSON.stringify({ detail: { message: "private runtime content ".repeat(1_000) } }),
+    );
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false, value: oversizedChunk })
+      .mockResolvedValueOnce({ done: true, value: undefined });
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 502,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({ read, cancel, releaseLock }),
+      },
+    } as unknown as Response);
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(oversizedChunk.byteLength).toBeGreaterThan(16 * 1024);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(onErrorMock).toHaveBeenCalledWith("Streaming failed: Runtime request failed (502)");
+    expect(onErrorMock.mock.calls.flat().join(" ")).not.toContain("private runtime content");
     errorSpy.mockRestore();
     fetchSpy.mockRestore();
   });
@@ -306,7 +981,7 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
 
     expect(onTurnRejectedMock).not.toHaveBeenCalled();
     expect(onErrorMock).not.toHaveBeenCalled();
-    expect(latest.maxChatInputChars).toBeUndefined();
+    expect(latest.maxChatInputChars).toBe(10);
     expect(latest.messages).toHaveLength(0);
     fetchSpy.mockRestore();
   });
@@ -349,6 +1024,7 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     expect(onTurnRejectedMock).not.toHaveBeenCalled();
     expect(onErrorMock).not.toHaveBeenCalled();
     expect(latest.maxChatInputChars).toBe(10);
+    expect(latest.waitResponse).toBe(false);
     fetchSpy.mockRestore();
   });
 
@@ -384,6 +1060,7 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     // The turn never started — composer input/attachments must survive so a
     // retry doesn't force the user to retype.
     expect(onTurnStartedMock).not.toHaveBeenCalled();
+    expect(onTurnRetryStateReleasedMock).toHaveBeenCalledWith("hello", "session-1");
   });
 
   it("a retry after a prepare-execution failure starts exactly one turn", async () => {
@@ -1004,6 +1681,43 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     fetchSpy.mockRestore();
   });
 
+  it("suppresses a HITL length rejection that settles after the attempt was superseded", async () => {
+    prepareExecutionImpl = async () => ({
+      execute_stream_url: "http://runtime.test/execute_stream",
+      chat_controls: [],
+      capability_base_urls: {},
+      max_chat_input_chars: 10,
+    });
+    const response = deferred<Response>();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockReturnValue(response.promise);
+    mount();
+
+    let reachedPromise!: Promise<boolean>;
+    await act(async () => {
+      reachedPromise = latest.sendHitlResume(hitlEvent, undefined, "sixsix");
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    });
+    act(() => latest.abort());
+    response.resolve(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "chat_input_too_long",
+            message: "safe backend message",
+            limit_chars: 5,
+            actual_chars: 6,
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(reachedPromise).resolves.toBe(false);
+    expect(latest.maxChatInputChars).toBe(10);
+    expect(onErrorMock).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it("preserves exact HITL free text and canonical choice fields on the wire", async () => {
     const requestBodies: Array<Record<string, unknown>> = [];
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
@@ -1060,6 +1774,20 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     fetchSpy.mockRestore();
   });
 
+  it("sendHitlResume() reports reached when a successful response has no body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    mount();
+
+    let reached: boolean | undefined;
+    await act(async () => {
+      reached = await latest.sendHitlResume(hitlEvent, "proceed");
+    });
+
+    expect(reached).toBe(true);
+    expect(onErrorMock).toHaveBeenCalledWith("HITL resume failed: Empty response body from runtime");
+    fetchSpy.mockRestore();
+  });
+
   it("a refused HITL resume releases the composer instead of wedging it", async () => {
     // sendHitlResume takes abortRef (and clears preflightOwnerRef) from any
     // send() still preflighting, so send()'s ownership-checked cleanup will not
@@ -1101,5 +1829,65 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     await expect(result).resolves.toBe(false);
     expect(prepareExecutionCalls).toHaveLength(0);
     expect(onErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("sendHitlResume() aborted before a runtime response reports not-reached", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const error = new Error("aborted before response");
+          error.name = "AbortError";
+          reject(error);
+        });
+      });
+    });
+    mount();
+
+    let result!: Promise<boolean>;
+    act(() => {
+      result = latest.sendHitlResume(hitlEvent, "proceed");
+    });
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+    let reached: boolean | undefined;
+    await act(async () => {
+      latest.abort();
+      reached = await result;
+    });
+
+    expect(reached).toBe(false);
+    expect(onErrorMock).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+  it("replaceAllMessages installs the authoritative history snapshot", () => {
+    mount();
+    const current = {
+      session_id: "session-1",
+      exchange_id: "exch-current",
+      rank: 99,
+      role: "user",
+      channel: "final",
+      timestamp: "2026-08-14T00:00:01.000Z",
+      parts: [{ type: "text", text: "current" }],
+      metadata: {},
+    } as unknown as ChatMessage;
+    const persisted = {
+      ...current,
+      exchange_id: "exch-persisted",
+      rank: 1,
+      parts: [{ type: "text", text: "persisted" }],
+    } as unknown as ChatMessage;
+
+    act(() => {
+      latest.replaceAllMessages([current]);
+    });
+    expect(latest.messages).toHaveLength(1);
+
+    act(() => {
+      latest.replaceAllMessages([persisted]);
+    });
+    expect(latest.messages).toHaveLength(1);
+    expect(latest.messages[0].rank).toBe(1);
+    expect((latest.messages[0].parts?.[0] as { text?: string } | undefined)?.text).toBe("persisted");
   });
 });

--- a/apps/frontend/src/rework/core/hooks/useChatSse.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.ts
@@ -19,6 +19,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { setCapabilityBaseUrls } from "../../../common/capabilityRoutingSlice";
 import { KeyCloakService } from "../../../security/KeycloakService";
+import { getDetailFromData } from "@core/errors/normalizeApiError.ts";
 import type { ChatControlDescriptor, ExecutionPreparation } from "../../../slices/controlPlane/controlPlaneOpenApi";
 import { usePostPrepareExecutionControlPlaneV1TeamsTeamIdAgentInstancesAgentInstanceIdPrepareExecutionPostMutation } from "../../../slices/controlPlane/controlPlaneOpenApi";
 import type {
@@ -193,7 +194,6 @@ class RuntimeHttpError extends Error {
     readonly status: number,
     readonly code?: string,
     readonly limitChars?: number,
-    readonly actualChars?: number,
     message = `Runtime request failed (${status})`,
   ) {
     super(message);
@@ -201,26 +201,119 @@ class RuntimeHttpError extends Error {
   }
 }
 
+const RUNTIME_ERROR_MESSAGE_MAX_CHARS = 1_000;
+const RUNTIME_ERROR_BODY_MAX_BYTES = 16 * 1024;
+
 function recordValue(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
 }
 
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function boundedErrorMessage(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const message = value.trim();
+  if (!message) return undefined;
+  // Bound by CODE POINTS, not UTF-16 units, matching `countUnicodeCodePoints`
+  // used by the rest of this feature. `slice()` on units can cut a surrogate
+  // pair in half, which renders as a replacement box in the toast.
+  const points = Array.from(message);
+  return points.length <= RUNTIME_ERROR_MESSAGE_MAX_CHARS
+    ? message
+    : `${points.slice(0, RUNTIME_ERROR_MESSAGE_MAX_CHARS).join("")}…`;
+}
+
+async function readBoundedResponseText(response: Response): Promise<string | undefined> {
+  // Abandoning a body without cancelling pins the underlying HTTP connection
+  // until GC finalizes the stream. The `await response.json()` this replaced
+  // always drained it, so every early return here has to cancel explicitly.
+  const discard = (): undefined => {
+    try {
+      // Synchronous throw, not a rejection, when the body is already locked —
+      // so `.catch()` alone would not contain it.
+      void response.body?.cancel()?.catch(() => {});
+    } catch {
+      /* nothing to release */
+    }
+    return undefined;
+  };
+
+  const contentLengthHeader = response.headers.get("Content-Length");
+  if (contentLengthHeader !== null && /^\d+$/.test(contentLengthHeader)) {
+    const contentLength = Number(contentLengthHeader);
+    if (Number.isSafeInteger(contentLength) && contentLength > RUNTIME_ERROR_BODY_MAX_BYTES) return discard();
+  }
+
+  // `getReader()` throws on an already-locked or disturbed body. It must be
+  // inside a try: an escaping TypeError would surface from `runtimeHttpError`
+  // instead of a RuntimeHttpError, and the caller's `chat_input_too_long`
+  // branch — which restores the user's draft — would never match.
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  try {
+    const bodyReader = response.body?.getReader();
+    if (!bodyReader) return undefined;
+    reader = bodyReader;
+  } catch {
+    return discard();
+  }
+
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let bytesRead = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > RUNTIME_ERROR_BODY_MAX_BYTES) {
+        await reader.cancel().catch(() => {});
+        return undefined;
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+    return chunks.join("");
+  } catch {
+    await reader.cancel().catch(() => {});
+    return undefined;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 async function runtimeHttpError(response: Response): Promise<RuntimeHttpError> {
+  const rawBody = await readBoundedResponseText(response);
+  // A zero-length network response still exposes a readable stream in browsers;
+  // only `new Response(null)` has `body === null`. Treat both forms as
+  // unavailable so an ordinary 422 still reaches draft recovery when the
+  // server or proxy omitted its error envelope.
+  if (rawBody === undefined || rawBody.length === 0) {
+    return new RuntimeHttpError(response.status);
+  }
+
   let body: unknown;
   try {
-    body = await response.json();
+    body = JSON.parse(rawBody) as unknown;
   } catch {
     return new RuntimeHttpError(response.status);
   }
+
   const detail = recordValue(recordValue(body)?.detail);
   return new RuntimeHttpError(
     response.status,
     typeof detail?.code === "string" ? detail.code : undefined,
-    typeof detail?.limit_chars === "number" ? detail.limit_chars : undefined,
-    typeof detail?.actual_chars === "number" ? detail.actual_chars : undefined,
-    typeof detail?.message === "string" ? detail.message : undefined,
+    positiveInteger(detail?.limit_chars),
+    // `detail.message` is this app's own HTTPException shape. A bare string
+    // `detail`, FastAPI's validation-error array, and app-level `errors[]` are
+    // handled by `getDetailFromData`; top-level `message` stays runtime-local
+    // so this bounded display policy does not widen every API error consumer.
+    boundedErrorMessage(detail?.message) ??
+      boundedErrorMessage(getDetailFromData(body)) ??
+      boundedErrorMessage(recordValue(body)?.message),
   );
 }
 
@@ -262,6 +355,8 @@ export type ChatSseCallbacks = {
   onTurnStarted?: () => void;
   /** Restores an ordinary composer draft after a runtime length rejection. */
   onTurnRejected?: (draft: string, sessionId: string) => void;
+  /** Releases caller-owned retry state once a length rejection is no longer possible. */
+  onTurnRetryStateReleased?: (draft: string, sessionId: string) => void;
   /** Reads current navigation ownership before applying late turn side effects. */
   isTurnCurrent?: (sessionId: string) => boolean;
   /**
@@ -302,6 +397,7 @@ export function useChatSse(
     onError,
     onTurnStarted,
     onTurnRejected,
+    onTurnRetryStateReleased,
     isTurnCurrent,
     flushPendingWrites,
   } = params;
@@ -355,6 +451,27 @@ export function useChatSse(
   // registry (plugin first, then the capability-agnostic stock kit).
   const [chatControls, setChatControls] = useState<ChatControlDescriptor[]>([]);
   const [maxChatInputChars, setMaxChatInputChars] = useState<number | undefined>();
+  // Invalidates preparation responses that were already in flight when a
+  // runtime rejected a message. A preparation started afterward captures the
+  // new generation and may legitimately publish a raised deployment value.
+  const chatInputLimitRejectionGenerationRef = useRef(0);
+  // Distinguishes a runtime-authoritative rejection value from an advisory
+  // preparation value. An older/legacy runtime may omit the optional
+  // projection; that omission must not erase a limit the execution endpoint
+  // just enforced, while it may still clear an earlier advisory value.
+  const chatInputLimitLearnedFromRejectionRef = useRef(false);
+
+  // A rejection is authoritative over preparations that predate it, but it is
+  // not a permanent floor. This ordering prevents an old eager preparation from
+  // immediately restoring the value another replica just rejected while still
+  // allowing a newly prepared raised deployment limit to take effect.
+  const adoptRejectedChatInputLimit = useCallback((limit: number) => {
+    const adopted = positiveInteger(limit);
+    if (adopted === undefined) return;
+    chatInputLimitRejectionGenerationRef.current += 1;
+    chatInputLimitLearnedFromRejectionRef.current = true;
+    setMaxChatInputChars(adopted);
+  }, []);
 
   const setAll = useCallback((next: ChatMessage[]) => {
     messagesRef.current = next;
@@ -364,13 +481,21 @@ export function useChatSse(
   // Applies a prepare-execution response's session-scoped side effects, shared
   // by the eager open-time prep, every send(), and HITL resume.
   const applyPreparation = useCallback(
-    (prep: ExecutionPreparation) => {
+    (prep: ExecutionPreparation, chatInputLimitRejectionGenerationAtStart: number) => {
       setChatControls(prep.chat_controls ?? []);
-      setMaxChatInputChars(
-        typeof prep.max_chat_input_chars === "number" && prep.max_chat_input_chars > 0
-          ? prep.max_chat_input_chars
-          : undefined,
-      );
+      if (chatInputLimitRejectionGenerationAtStart === chatInputLimitRejectionGenerationRef.current) {
+        const rawPreparedLimit = prep.max_chat_input_chars;
+        const preparedLimit = positiveInteger(rawPreparedLimit);
+        if (preparedLimit !== undefined) {
+          chatInputLimitLearnedFromRejectionRef.current = false;
+          setMaxChatInputChars(preparedLimit);
+        } else if (rawPreparedLimit == null && !chatInputLimitLearnedFromRejectionRef.current) {
+          // Absence is a legitimate legacy-runtime response and clears an
+          // advisory value. A present malformed value is ignored instead: it
+          // must not erase the last value known to be usable.
+          setMaxChatInputChars(undefined);
+        }
+      }
       // #1979: publish the instance-bound capability route base URLs so each
       // capability's generated RTK slice can reach its pod routes directly.
       dispatch(setCapabilityBaseUrls(prep.capability_base_urls ?? {}));
@@ -391,7 +516,11 @@ export function useChatSse(
     thoughtBufsRef.current.clear();
     setAll([]);
     setChatControls([]);
-    setMaxChatInputChars(undefined);
+    // `maxChatInputChars` is deliberately NOT cleared here: a session-local
+    // reset would otherwise drop the counter and re-enable an over-long draft
+    // for the moment before the next preparation lands. The eager prep for the
+    // next session overwrites it, and the mount is keyed on agentInstanceId
+    // (common/router.tsx), so it cannot leak across agents.
   }, [setAll]);
   const replaceAllMessages = useCallback((msgs: ChatMessage[]) => setAll(msgs), [setAll]);
 
@@ -734,9 +863,12 @@ export function useChatSse(
         throw await runtimeHttpError(response);
       }
 
-      if (!response.body) throw new Error("Empty response body from runtime");
-
+      // A 2xx is the runtime's acceptance boundary. Even a malformed success
+      // response must not restore a draft or HITL checkpoint the runtime may
+      // already have consumed; body validation remains a visible protocol error.
       onAccepted?.();
+
+      if (!response.body) throw new Error("Empty response body from runtime");
 
       const rankRef = { current: messagesRef.current.length + 1 };
       const deltaRankRef: { current: number | null } = { current: null };
@@ -757,6 +889,7 @@ export function useChatSse(
       sessionId: string | null,
       runtimeContext?: RuntimeContext,
       turnOptions?: RuntimeExecuteRequest["turn_options"],
+      resolveRuntimeContext?: () => RuntimeContext,
     ) => {
       const sendId = Math.random().toString(36).slice(2, 8);
       console.debug(
@@ -782,6 +915,20 @@ export function useChatSse(
       // the send button disables right away, matching the synchronous lock.
       setWaitResponse(true);
 
+      let callerRetryStateReleased = false;
+      const releaseCallerRetryState = (turnSessionId: string) => {
+        if (
+          callerRetryStateReleased ||
+          ac.signal.aborted ||
+          abortRef.current !== ac ||
+          isTurnCurrent?.(turnSessionId) === false
+        ) {
+          return;
+        }
+        callerRetryStateReleased = true;
+        onTurnRetryStateReleased?.(input, turnSessionId);
+      };
+
       // Releases the preflight lock on every early-return path below —
       // INCLUDING every error path (a rejected await must never leave the
       // lock or waitResponse stuck, or the composer becomes permanently
@@ -796,6 +943,7 @@ export function useChatSse(
           preflightOwnerRef.current = null;
         }
         if (abortRef.current === ac) {
+          releaseCallerRetryState(sessionId ?? "draft");
           abortRef.current = null;
           setWaitResponse(false);
         }
@@ -861,9 +1009,7 @@ export function useChatSse(
       // Pass the session id so the control-plane can resolve and concatenate the
       // session's attached chat-context prompts into `context_prompt_text`.
       let prep: ExecutionPreparation;
-      let effectiveContext: RuntimeContext;
-      let exchangeId: string;
-      let effectiveSessionId: string;
+      const chatInputLimitRejectionGenerationAtPrepareStart = chatInputLimitRejectionGenerationRef.current;
       try {
         prep = await prepareExecution({
           teamId,
@@ -878,33 +1024,7 @@ export function useChatSse(
         console.debug(
           `[useChatSse][${sendId}] prepareExecution done — aborted=${ac.signal.aborted} execute_stream_url=${prep.execute_stream_url}`,
         );
-        applyPreparation(prep);
-
-        // RUNTIME-07 rev. 2: the pod authorizes the user against OpenFGA on the
-        // team carried in runtime_context (no signed grant). Always include team_id.
-        // `language` rides the same way: it drives backend-rendered copy (e.g.
-        // FredHitlMiddleware's approval prompt), which otherwise defaults to
-        // English regardless of the UI's own locale — read live off i18next
-        // (not memoized) so a mid-session language switch takes effect on the
-        // very next turn, matching the existing pattern for voice transcription
-        // (ManagedChatPage.tsx's handleTranscribeAudio).
-        effectiveContext = mergeReasoningActivation(
-          mergeRoutingPolicy(
-            mergeContextPromptText(
-              {
-                ...(runtimeContext ?? {}),
-                team_id: canonicalizeRuntimeTeamId(teamId),
-                language: i18n.language?.split("-")[0] || undefined,
-              },
-              prep.context_prompt_text,
-            ),
-            prep.chat_default_profile_id,
-            prep.agent_profile_overrides,
-          ),
-          prep.reasoning_enabled_model_ids,
-        );
-        exchangeId = uuidv4();
-        effectiveSessionId = sessionId ?? "draft";
+        applyPreparation(prep, chatInputLimitRejectionGenerationAtPrepareStart);
       } catch (err) {
         // Was previously unguarded: a rejection here (e.g. an unknown/foreign
         // session_id, an unreachable runtime source) propagated as an
@@ -936,6 +1056,44 @@ export function useChatSse(
         failPreflight("token refresh", new Error(staleToken));
         return;
       }
+
+      let effectiveContext: RuntimeContext;
+      try {
+        // Resolve caller-owned context at the final undoable boundary. In
+        // particular, attachment ingestion can finish while token refresh,
+        // session writes, or prepare-execution are awaited. The same late
+        // snapshot then owns both the wire payload and the chips cleared by
+        // `onTurnStarted` immediately below.
+        const callerRuntimeContext = resolveRuntimeContext?.() ?? runtimeContext;
+        // RUNTIME-07 rev. 2: the pod authorizes the user against OpenFGA on the
+        // team carried in runtime_context (no signed grant). Always include team_id.
+        // `language` rides the same way: it drives backend-rendered copy (e.g.
+        // FredHitlMiddleware's approval prompt), which otherwise defaults to
+        // English regardless of the UI's own locale — read live off i18next
+        // (not memoized) so a mid-session language switch takes effect on the
+        // very next turn, matching the existing pattern for voice transcription
+        // (ManagedChatPage.tsx's handleTranscribeAudio).
+        effectiveContext = mergeReasoningActivation(
+          mergeRoutingPolicy(
+            mergeContextPromptText(
+              {
+                ...(callerRuntimeContext ?? {}),
+                team_id: canonicalizeRuntimeTeamId(teamId),
+                language: i18n.language?.split("-")[0] || undefined,
+              },
+              prep.context_prompt_text,
+            ),
+            prep.chat_default_profile_id,
+            prep.agent_profile_overrides,
+          ),
+          prep.reasoning_enabled_model_ids,
+        );
+      } catch (err) {
+        failPreflight("runtime context resolution", err);
+        return;
+      }
+      const exchangeId = uuidv4();
+      const effectiveSessionId = sessionId ?? "draft";
 
       // The turn is now genuinely starting. Preflight is over — release the
       // reentrancy lock so the existing "a new send() replaces the current
@@ -984,6 +1142,7 @@ export function useChatSse(
           exchangeId,
           effectiveSessionId,
           ac.signal,
+          () => releaseCallerRetryState(effectiveSessionId),
         );
         console.debug(`[useChatSse][${sendId}] streamToMessages completed normally`);
       } catch (err) {
@@ -993,20 +1152,24 @@ export function useChatSse(
           console.debug(`[useChatSse][${sendId}] stream error settled after cancellation — side effects suppressed`);
         } else if (name === "AbortError") {
           console.debug(`[useChatSse][${sendId}] streamToMessages aborted (AbortError) — swallowed`);
-        } else if (err instanceof RuntimeHttpError && err.code === "chat_input_too_long") {
+        } else if (err instanceof RuntimeHttpError && err.status === 422) {
           messagesRef.current = messagesRef.current.filter(
             (message) => !(message.exchange_id === exchangeId && message.metadata?.extras?.optimistic_user === true),
           );
           setMessages([...messagesRef.current]);
           onTurnRejected?.(input, effectiveSessionId);
-          if (err.limitChars !== undefined) setMaxChatInputChars(err.limitChars);
-          onError?.(
-            err.limitChars === undefined
-              ? err.message
-              : i18n.t("chatbot.errors.chatInputTooLong", {
-                  limit: err.limitChars.toLocaleString(i18n.language),
-                }),
-          );
+          if (err.code === "chat_input_too_long") {
+            if (err.limitChars !== undefined) adoptRejectedChatInputLimit(err.limitChars);
+            onError?.(
+              err.limitChars === undefined
+                ? err.message
+                : i18n.t("chatbot.errors.chatInputTooLong", {
+                    limit: err.limitChars.toLocaleString(i18n.language),
+                  }),
+            );
+          } else {
+            onError?.(`Streaming failed: ${err.message}`);
+          }
         } else {
           console.error(`[useChatSse][${sendId}] streamToMessages error — ${name}: ${msg}`);
           onError?.(`Streaming failed: ${msg}`);
@@ -1015,7 +1178,9 @@ export function useChatSse(
         console.debug(
           `[useChatSse][${sendId}] finally — ac.signal.aborted=${ac.signal.aborted} → will ${ac.signal.aborted ? "NOT" : ""} clear waitResponse`,
         );
-        if (!ac.signal.aborted) {
+        if (!ac.signal.aborted && abortRef.current === ac) {
+          releaseCallerRetryState(effectiveSessionId);
+          abortRef.current = null;
           setWaitResponse(false);
         }
       }
@@ -1028,9 +1193,11 @@ export function useChatSse(
       onError,
       onTurnStarted,
       onTurnRejected,
+      onTurnRetryStateReleased,
       isTurnCurrent,
       flushPendingWrites,
       applyPreparation,
+      adoptRejectedChatInputLimit,
       i18n,
     ],
   );
@@ -1092,6 +1259,7 @@ export function useChatSse(
       }
 
       let prep: ExecutionPreparation;
+      const chatInputLimitRejectionGenerationAtPrepareStart = chatInputLimitRejectionGenerationRef.current;
       try {
         prep = await prepareExecution({ teamId, agentInstanceId }).unwrap();
       } catch (err) {
@@ -1127,7 +1295,7 @@ export function useChatSse(
       // seconds stale by the time the stream opened, and any refresh those
       // awaits triggered would have been discarded.
       const token = KeyCloakService.GetToken() ?? "";
-      applyPreparation(prep);
+      applyPreparation(prep, chatInputLimitRejectionGenerationAtPrepareStart);
 
       // Optimistic cancel: flip every tool call this HITL prompt gated from
       // "running" straight to a cancelled state, without waiting for the resume
@@ -1236,19 +1404,20 @@ export function useChatSse(
         );
       } catch (err) {
         const status = (err as { status?: number })?.status;
-        const aborted = (err as Error)?.name === "AbortError";
+        const abortError = (err as Error)?.name === "AbortError";
+        const superseded = ac.signal.aborted || abortRef.current !== ac || isTurnCurrent?.(sessionId) === false;
         // 409 = the runtime says this checkpoint is not waiting for a resume
         // (already answered, or a stale interrupt_id after a reload). Restoring
         // the prompt there produces an unanswerable card that re-409s on every
-        // attempt. An abort is the user's own choice and may land AFTER the
-        // resume was delivered, so it must not resurrect a consumed checkpoint
-        // either. Both count as reached.
-        if (status === 409 || aborted) {
+        // attempt. A mid-stream AbortError after a 2xx has already flipped
+        // `acceptedByRuntime` through `onAccepted`; an AbortError before any
+        // response must remain not-reached so the caller can restore safely.
+        if (status === 409) {
           acceptedByRuntime = true;
         }
-        if (!aborted) {
+        if (!superseded && !abortError) {
           if (err instanceof RuntimeHttpError && err.code === "chat_input_too_long") {
-            if (err.limitChars !== undefined) setMaxChatInputChars(err.limitChars);
+            if (err.limitChars !== undefined) adoptRejectedChatInputLimit(err.limitChars);
             onError?.(
               err.limitChars === undefined
                 ? err.message
@@ -1270,7 +1439,17 @@ export function useChatSse(
       // prompt — the checkpoint was consumed. A failure before it never ran.
       return acceptedByRuntime;
     },
-    [agentInstanceId, teamId, prepareExecution, streamToMessages, onError, applyPreparation, i18n],
+    [
+      agentInstanceId,
+      teamId,
+      prepareExecution,
+      streamToMessages,
+      onError,
+      applyPreparation,
+      adoptRejectedChatInputLimit,
+      isTurnCurrent,
+      i18n,
+    ],
   );
 
   // Eager prep (RFC §3.7): call prepare-execution at chat open — not only
@@ -1280,12 +1459,13 @@ export function useChatSse(
   // (selected libraries/policy/scope) is unaffected until a real send happens.
   const prepareChatControls = useCallback(
     async (sessionId?: string | null) => {
+      const chatInputLimitRejectionGenerationAtPrepareStart = chatInputLimitRejectionGenerationRef.current;
       const prep = await prepareExecution({
         teamId,
         agentInstanceId,
         ...(sessionId ? { sessionId } : {}),
       }).unwrap();
-      applyPreparation(prep);
+      applyPreparation(prep, chatInputLimitRejectionGenerationAtPrepareStart);
       return prep;
     },
     [teamId, agentInstanceId, prepareExecution, applyPreparation],

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -2830,9 +2830,10 @@ where the resume never reached the runtime — token refusal, prepare-execution
 failure, an abort/supersession before the stream started, *or* the runtime
 rejecting the request outright (a fetch failure, or a non-2xx such as 503 from
 an unready pod). The dividing line is the runtime's own acceptance:
-`streamToMessages` signals `onAccepted` once past its status check, and only
-after that does a failure count as reached — a mid-stream reset must NOT
-resurrect the prompt, because the checkpoint has already been consumed.
+`streamToMessages` signals `onAccepted` immediately once past its status check,
+before validating the success body. Only after that does a failure count as
+reached — a missing body or mid-stream reset must NOT resurrect the prompt,
+because the checkpoint may already have been consumed.
 
 Not-reached is a fact about the backend, not about who owns the UI, so
 `handleHitlAnswer` guards the restore itself, three ways: same session
@@ -2841,12 +2842,15 @@ the thread's last message carries a *different* `exchange_id` than the prompt �
 a turn that genuinely starts appends its optimistic user message under a new
 `exchange_id`, so the thread itself says whether the user has moved past the
 exchange, while a send that fails before committing appends nothing, which is
-exactly when the prompt should return), and empty slot only (a functional
-update, so a newer `awaiting_human` is never overwritten by a late-settling
-continuation). No counter or rollback state is kept for this: nothing
-accumulates, so nothing needs unwinding when a superseding send fails. A
-`.catch()` mirrors the same restore, since `pendingHitl` is cleared before the
-await and this continuation is the only path that can put it back. For the same reason the optimistic "cancelled"
+exactly when the prompt should return), and empty slot only (checked
+synchronously through `pendingHitlRef`, so a newer `awaiting_human` is never
+overwritten by a late-settling continuation). The direct resume path needs no
+counter. If an ordinary send displaces the prompt while the resume is pending,
+the prompt is transferred into that send's attempt-owned `submittedDraftRef`:
+a pre-acceptance failure restores it, while acceptance consumes the rollback
+state. A `.catch()` mirrors the same guarded restore, since `pendingHitl` is
+cleared before the await and this continuation is the only path that can put it
+back. For the same reason the optimistic "cancelled"
 tool_results now go in **after** prepare-execution succeeds, not before:
 applied earlier, a failed preparation left the gated calls displayed as
 cancelled by an attempt that never ran, and because those messages are ranked
@@ -2966,13 +2970,13 @@ runtime.**
    re-check `ac.signal.aborted` after the new await, since it is one more
    window in which the attempt can be superseded.
 
-   Deliberately NOT changed alongside it, both reviewed and kept: `state.closed`
-   stays a one-way door per event loop (a pod boots once and dies once;
-   reopening reintroduces the "rebuild a pool nothing closes" leak the flag
-   exists to stop), and an aborted HITL resume still counts as delivered (a
-   prompt stranded that way is recovered by `reconstructPendingHitl` from
-   server history on reload, whereas restoring it eagerly risks an unanswerable
-   card that 409s on every attempt).
+   `state.closed` deliberately stays a one-way door per event loop (a pod boots
+   once and dies once; reopening reintroduces the "rebuild a pool nothing
+   closes" leak the flag exists to stop). HITL resume delivery follows the
+   runtime-acceptance boundary instead: abort or supersession before a 2xx is
+   reported as not reached and permits the ownership-guarded prompt restore;
+   after any 2xx, a missing body or mid-stream failure still counts as accepted
+   because the checkpoint may already have been consumed.
 
 Regression tests: `test_awrap_tool_call_is_error_artifact_marks_failed`
 (asserts the timer's *absence* of `error_code`/`exception_type`,
@@ -3027,6 +3031,37 @@ project one replica's value while the browser's execution request reaches
 another. The displayed limit is therefore advisory; the receiving runtime
 remains authoritative, returns its own `limit_chars` on rejection, and managed
 chat adopts that returned limit for subsequent validation.
+A valid rejection supersedes execution preparations that were already in flight
+when it arrived, so an older advisory response cannot immediately restore a
+value another replica just rejected. It is not a permanent floor: the next
+successful preparation started after that rejection and carrying a valid limit
+may replace it, including when the deployed limit has been raised. A legacy
+preparation that omits the optional projection does not erase a limit learned
+from an authoritative rejection. The last adopted limit survives a
+session-local reset, so the counter does not flicker while the next eager
+preparation is in flight. Non-positive or non-integral rejection metadata is
+ignored rather than becoming frontend policy. A present malformed preparation
+projection is likewise ignored instead of erasing the last valid advisory
+value; only an omitted legacy projection may clear an advisory value that was
+not learned from a runtime rejection.
+Managed chat appends and decodes at most 16 KiB from a non-success runtime
+response and only surfaces bounded, structured error fields (`detail`,
+`detail.message`, validation-array `msg`/`message`, app-level
+`errors[].detail`/`message`, or top-level `message`). Without a trustworthy
+`Content-Length`, Fetch may deliver one transport chunk larger than the
+remaining budget; the reader cancels immediately without appending or decoding
+that crossing chunk. The browser may hold that chunk transiently, so this is an
+application-buffer bound rather than a transport-read bound. Oversized,
+unreadable, bare-string, and non-JSON bodies become a generic status error so
+rejected input or gateway diagnostics cannot be copied into browser logs and
+persistent toasts. Any explicit HTTP 422
+restores the submitted ordinary draft because the request was rejected before
+stream execution; only `chat_input_too_long` changes the displayed limit. This
+also applies when the 422 body cannot be read within the bound.
+Managed chat resolves caller-owned runtime context immediately before the turn
+starts. This lets attachments that become ready during asynchronous preflight
+join the same wire payload and the same rollback snapshot; attachments still
+processing at that boundary remain owned by the next turn.
 This semantic handler check occurs after HTTP body parsing; whole-request byte
 limits and HTTP 413 remain outside issue #2253.
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -733,7 +733,8 @@ itself owns only `aria-invalid` and its send gating.
 
 - At or below the limit, nothing is visible — no counter, no error colour — and send stays
   available. An ordinary message sits far below a limit measured in thousands of code points
-  (5,000 in the default template, but it is per-template and admin-configurable), so a
+  (5,000 by default, set per runtime pod in its deployment configuration — not per template;
+  every template of a pod reports that pod's single value), so a
   permanently visible counter would report a non-problem for the whole life of the draft
   (2026-08-13, issue #2358).
 - Above the limit, the error copy and the counter appear together as one error-coloured region,
@@ -748,9 +749,33 @@ itself owns only `aria-invalid` and its send gating.
   region — inside, it would re-announce on every keystroke.
 - Text remains fully editable: neither component sets native `maxLength`, truncates pasted or
   dictated content, nor clears an oversized draft. A backend length rejection restores the
-  ordinary draft or pending HITL prompt safely.
+  ordinary draft and its transient ready attachments (including inline-image context), or the
+  pending HITL prompt, safely. Rollback never resurrects an attachment deleted while the request
+  was in flight; deletion rollback is attempt-owned so an older failure cannot clear a newer
+  tombstone for the same file. Failed attachment chips are not part of a turn's ready snapshot and
+  remain visible when that turn starts. If that deletion later fails, the file returns as a
+  conversation document, but its inline-image data is not restored into the retry; the user must
+  attach the image again to send it as inline context. A displaced HITL prompt is also restored when the
+  ordinary send fails during preflight, and the retained retry snapshot is released as soon as
+  the owning request can no longer return a length rejection. Composer editing is disabled and
+  chip removal is unavailable while the session-write barrier prepares a Send; an asynchronous
+  producer that was already running cannot have its later text erased — once the turn starts, only
+  the accepted draft prefix is consumed and any newly appended suffix remains in the composer; a
+  later 422 restores their exact pre-turn combination when that retained suffix was not edited.
+  Attachment context and chip ownership are captured together at the final turn-start boundary:
+  files that become ready during asynchronous preparation join the current turn, while files still
+  processing at that boundary remain available for the next turn.
+- Background history revalidation preserves an in-progress HITL free-text draft when it
+  reconstructs the same prompt identity; a different or closed prompt clears the old draft.
+  Runtime history replaces the displayed thread only when no live activity overlapped the request.
+  A response started during a turn, received during a turn, or invalidated by a turn that started
+  and settled in between is neither displayed nor cached. No automatic retry follows because
+  persistence may still lag the completed turn, making a later full replacement unsafe. Returning
+  to a conversation this page already loaded still replays its cache immediately instead of
+  rendering empty.
 - During a rolling upgrade, an older runtime may omit the policy. In that state no counter is
-  shown and the runtime remains the authoritative enforcement boundary.
+  shown unless this mounted chat already learned a stricter limit from a runtime rejection; the
+  runtime remains the authoritative enforcement boundary.
 
 ---
 


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**Issue:** #2372 (follow-up to #2253). Durable history convergence split out to #2378.

**Problem in one sentence:** Managed chat could lose or replace an active draft, its attachments, a displaced HITL prompt, or thread history when a runtime rejection overlapped asynchronous send preparation, and runtime error bodies were consumed without bounds.



---

## 2. Before you wrote a single line of code

**RFC written?** Not required — this is hardening of behaviour already specified by #2253, with the required changes enumerated in #2372 itself. The one genuine design decision (dropping automatic history retry) is recorded in #2372's amended body and split into #2378 rather than a separate RFC.

---

## 3. What you built

- **Runtime errors** — read at most 16 KiB from an unsuccessful response, cancel oversized or unread bodies, survive a locked stream without losing draft recovery, bound displayed messages by Unicode code points, and parse only supported envelopes (`detail`, `detail.message`, FastAPI validation arrays, `errors[].detail`/`errors[].message`, top-level `message`). Anything else stays generic, so rejected content cannot reach logs or toasts.
- **Limit handling** — `chat_input_too_long.limit_chars` is authoritative; an older in-flight preparation cannot overwrite a newer rejection; a later valid preparation may still raise the limit; invalid, non-positive and non-integral metadata is ignored.
- **Draft and attachment recovery** — each send owns its rollback explicitly. Attachment context resolves at the final turn-start boundary, so a file that becomes ready during preparation joins that turn and a later one is retained for the next. A rejection restores the exact rejected draft without overwriting newer edits.
- **HITL and history** — a superseded resume cannot replace a newer prompt; fixed-choice and free-text behaviour are preserved; a history snapshot cannot replace live activity. The #2221 conversation-rendering boundary is retained.

### Scope decision reviewers should weigh

#2372 originally required **retrying** history responses discarded because of live activity. That was deliberately reversed: persistence can lag a completed turn, so a later full-thread replacement is not inherently more authoritative and retrying risks overwriting newer local turns. This branch discards without retry, the issue body and both contracts were amended to match, and durable convergence is tracked in #2378. Agree with the reversal or say so — it is the one substantive design change here.

---

## 4. Proof of quality

**Tests added or updated:** this branch adds race-discriminating coverage across acceptance, rejection, limits, attachments, HITL, history, loading and rendering — 20 files, +2,931/−281. Rather than list every case, the coverage was verified by a counterfactual (mutation) pass: **42 mutations** applied across error handling, limit adoption, draft/attachment rollback, HITL guards and history discard. **Every one produced a failing test**; none passed silently.

Mutations that each proved a distinct guard include: the 16 KiB byte cap; `discard()`/`reader.cancel()` on unread bodies; code-point (not UTF-16) truncation; all six error-shape branches; both halves of `positiveInteger`; the `err.status === 422` recovery gate; whitespace-exact draft restore; attempt-owned delete rollback; the superseded-resume and newer-prompt HITL guards; and all three history-discard limbs.

**`make code-quality` output:**

```
npx tsc --noEmit
npx prettier . --check
Checking formatting...
All matched files use Prettier code style!
npx eslint "src/**/*.{ts,tsx}"
All frontend code quality checks completed
```

Root `make code-quality` was **not** run: it loops the eight Python packages plus frontend, and this branch changes **0 `.py` files** (11 tsx, 7 ts, 2 md), so the Python legs are identical to base. `basedpyright` n/a for the same reason.

**`make test` output:**

```
Test Files  137 passed | 1 skipped (138)
Tests       1427 passed | 2 skipped (1429)
```

Green with no exceptions. An earlier revision of this branch carried 2 inherited `DocumentUploadDrawer.maxDepth` failures; rebasing onto current `swift` picked up their fix, so that caveat no longer applies.

One gap worth stating rather than hiding:

- The two changed `docs/**/*.md` files fail `prettier`. They fail **identically on `origin/swift`**, and `docs/` is outside `apps/frontend`, so no gate covers them. Not a regression (re-verified after the rebase).
- **No CI workflow runs the frontend test suite** (`vitest` appears in no workflow). Frontend `type-check` and `format-check` do run and pass. So the coverage this branch adds is not enforced by CI.

---

## 5. Docs updated

| What changed | File updated |
| ------------ | ------------ |
| Backlog `[ ]` item is now done | n/a — backlog frozen; tracked on #2372 |
| New behaviour, API field, or contract change | `docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md` |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — frontend-only, no backend or generated client touched |
| UX component implemented or visual status changed | `docs/swift/ux/COMPONENT-UX.md` |
| Phase progress row exists for this area | n/a |
| WORKPLAN sprint item finished | n/a — WORKPLAN frozen |
| Code and a design doc now diverge | No — both contracts amended in this branch to match the no-retry decision |

---

## 6. Close-out statement

```
## Task close-out
- Code: bounded runtime-error consumption, authoritative limit adoption, per-send rollback
  ownership for drafts/attachments, HITL prompt authority, and history discard-without-retry
- Tests: 1427 passed / 2 skipped / 0 failures; 42-mutation counterfactual pass, all caught
- Docs updated: RUNTIME-EXECUTION-CONTRACT.md, COMPONENT-UX.md
- Backlog: n/a (frozen) — tracked on #2372; durable history convergence split to #2378
- Skipped steps: root make code-quality (0 .py changed); Python gates and migration checks n/a
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** The blast radius is the managed-chat composer. A regression in rollback ownership loses a user's draft or attachment chips on a runtime rejection; a regression in the HITL guards can render a stale prompt over a live turn, and answering it would resume against a consumed checkpoint. The history change is the highest-judgement item: discarding without retry means an overlapping response is not re-fetched while the user stays on that session — a session switch or remount does refetch, and live/local messages remain visible.

**How do we roll back?** Frontend-only, single commit, no migration and no backend or generated-client change — revert the commit and redeploy the frontend. No data or schema is affected.

