### PR TITLE
feat(#2383): explain team roles on hover, show the implicit Member baseline

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1948,7 +1948,7 @@
         "team_admin": "Governs the team: manages members and their roles, and sets the team policy (quotas, allowed models, MCP servers, storage limits). Grants no control over agents, prompts, or routing — that is the Editor role.",
         "team_editor": "Manages what the team builds: agents, shared prompts, the routing policy, and the document corpus. Grants no control over members or the team policy.",
         "team_analyst": "Creates and runs agent evaluation campaigns, and manages the evaluation corpora.",
-        "team_member": "The baseline everyone on the team holds — added automatically by any role above. Use the team's agents and prompts, and manage your own personal prompts."
+        "team_member": "Default access for everyone in the team: use the team's agents and prompts, and manage your own. No configuration or administration rights."
       },
       "warnings": {
         "team_analyst": "Technical role: it also opens access to the limited conversation slices those evaluation datasets are built from. Grant it deliberately."

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1945,7 +1945,7 @@
       "team_analyst": "Analyst",
       "team_member": "Member",
       "descriptions": {
-        "team_admin": "Governs the team: manages members and their roles, and sets the team policy (quotas, allowed models, MCP servers, storage limits). Grants no control over agents, prompts, or routing — that is the Editor role.",
+        "team_admin": "Governs the team: manages members and their roles, and sets the team policy (quotas, allowed models, MCP servers, storage limits). Grants no control over agents, prompts, or routing - that is the Editor role.",
         "team_editor": "Manages what the team builds: agents, shared prompts, the routing policy, and the document corpus. Grants no control over members or the team policy.",
         "team_analyst": "Creates and runs agent evaluation campaigns, and manages the evaluation corpora.",
         "team_member": "Default access for everyone in the team: use the team's agents and prompts, and manage your own. No configuration or administration rights."

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1943,7 +1943,16 @@
       "team_admin": "Admin",
       "team_editor": "Editor",
       "team_analyst": "Analyst",
-      "team_member": "Member"
+      "team_member": "Member",
+      "descriptions": {
+        "team_admin": "Governs the team: manages members and their roles, and sets the team policy (quotas, allowed models, MCP servers, storage limits). Grants no control over agents, prompts, or routing — that is the Editor role.",
+        "team_editor": "Manages what the team builds: agents, shared prompts, the routing policy, and the document corpus. Grants no control over members or the team policy.",
+        "team_analyst": "Creates and runs agent evaluation campaigns, and manages the evaluation corpora.",
+        "team_member": "The baseline everyone on the team holds — added automatically by any role above. Use the team's agents and prompts, and manage your own personal prompts."
+      },
+      "warnings": {
+        "team_analyst": "Technical role: it also opens access to the conversation data those evaluations are built from. Grant it deliberately."
+      }
     },
     "teamSettings": {
       "members": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1951,7 +1951,7 @@
         "team_member": "The baseline everyone on the team holds — added automatically by any role above. Use the team's agents and prompts, and manage your own personal prompts."
       },
       "warnings": {
-        "team_analyst": "Technical role: it also opens access to the conversation data those evaluations are built from. Grant it deliberately."
+        "team_analyst": "Technical role: it also opens access to the limited conversation slices those evaluation datasets are built from. Grant it deliberately."
       }
     },
     "teamSettings": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1948,7 +1948,7 @@
         "team_admin": "Gouverne l'équipe : gère les membres et leurs rôles, et définit la politique d'équipe (quotas, modèles autorisés, serveurs MCP, limites de stockage). Ne donne aucun droit sur les agents, les prompts ou le routage — c'est le rôle Éditeur.",
         "team_editor": "Gère ce que l'équipe construit : agents, prompts partagés, politique de routage et corpus documentaire. Ne donne aucun droit sur les membres ni sur la politique d'équipe.",
         "team_analyst": "Crée et lance les campagnes d'évaluation d'agents, et gère les corpus d'évaluation.",
-        "team_member": "La base que porte tout membre de l'équipe — ajoutée automatiquement par n'importe quel rôle ci-dessus. Permet d'utiliser les agents et prompts de l'équipe et de gérer ses prompts personnels."
+        "team_member": "L'accès par défaut de toute personne de l'équipe : utiliser les agents et les prompts de l'équipe, et gérer les siens. Aucun droit de configuration ni d'administration."
       },
       "warnings": {
         "team_analyst": "Rôle technique : il ouvre aussi l'accès aux extraits de conversation limités sur lesquels ces jeux d'évaluation sont construits. À accorder en connaissance de cause."

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1943,7 +1943,16 @@
       "team_admin": "Admin",
       "team_editor": "Editeur",
       "team_analyst": "Analyste",
-      "team_member": "Membre"
+      "team_member": "Membre",
+      "descriptions": {
+        "team_admin": "Gouverne l'équipe : gère les membres et leurs rôles, et définit la politique d'équipe (quotas, modèles autorisés, serveurs MCP, limites de stockage). Ne donne aucun droit sur les agents, les prompts ou le routage — c'est le rôle Éditeur.",
+        "team_editor": "Gère ce que l'équipe construit : agents, prompts partagés, politique de routage et corpus documentaire. Ne donne aucun droit sur les membres ni sur la politique d'équipe.",
+        "team_analyst": "Crée et lance les campagnes d'évaluation d'agents, et gère les corpus d'évaluation.",
+        "team_member": "La base que porte tout membre de l'équipe — ajoutée automatiquement par n'importe quel rôle ci-dessus. Permet d'utiliser les agents et prompts de l'équipe et de gérer ses prompts personnels."
+      },
+      "warnings": {
+        "team_analyst": "Rôle technique : il ouvre aussi l'accès aux données de conversation sur lesquelles ces évaluations s'appuient. À accorder en connaissance de cause."
+      }
     },
     "teamSettings": {
       "members": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1941,7 +1941,7 @@
     },
     "teamRoles": {
       "team_admin": "Admin",
-      "team_editor": "Editeur",
+      "team_editor": "Éditeur",
       "team_analyst": "Analyste",
       "team_member": "Membre",
       "descriptions": {
@@ -1951,7 +1951,7 @@
         "team_member": "La base que porte tout membre de l'équipe — ajoutée automatiquement par n'importe quel rôle ci-dessus. Permet d'utiliser les agents et prompts de l'équipe et de gérer ses prompts personnels."
       },
       "warnings": {
-        "team_analyst": "Rôle technique : il ouvre aussi l'accès aux données de conversation sur lesquelles ces évaluations s'appuient. À accorder en connaissance de cause."
+        "team_analyst": "Rôle technique : il ouvre aussi l'accès aux extraits de conversation limités sur lesquels ces jeux d'évaluation sont construits. À accorder en connaissance de cause."
       }
     },
     "teamSettings": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1945,7 +1945,7 @@
       "team_analyst": "Analyste",
       "team_member": "Membre",
       "descriptions": {
-        "team_admin": "Gouverne l'équipe : gère les membres et leurs rôles, et définit la politique d'équipe (quotas, modèles autorisés, serveurs MCP, limites de stockage). Ne donne aucun droit sur les agents, les prompts ou le routage — c'est le rôle Éditeur.",
+        "team_admin": "Gouverne l'équipe : gère les membres et leurs rôles, et définit la politique d'équipe (quotas, modèles autorisés, serveurs MCP, limites de stockage). Ne donne aucun droit sur les agents, les prompts ou le routage - c'est le rôle Éditeur.",
         "team_editor": "Gère ce que l'équipe construit : agents, prompts partagés, politique de routage et corpus documentaire. Ne donne aucun droit sur les membres ni sur la politique d'équipe.",
         "team_analyst": "Crée et lance les campagnes d'évaluation d'agents, et gère les corpus d'évaluation.",
         "team_member": "L'accès par défaut de toute personne de l'équipe : utiliser les agents et les prompts de l'équipe, et gérer les siens. Aucun droit de configuration ni d'administration."

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -24,12 +24,23 @@
   white-space: nowrap;
 }
 
-// The implicit `team_member` baseline. Visually identical to a role toggle at
-// rest, on purpose — it belongs to the same row and the same set. What it does
-// not have is any affordance: no pointer, no hover, no active state, no click
-// handler. It states a fact; it is not a fourth toggle.
+// The "held" appearance. Shared, because a held role and the baseline badge
+// mean the same thing to the reader — this person has it — and so must look
+// the same. The baseline wears it unconditionally: `team_member` is always
+// held, which is the whole point of showing it.
+%pill-held {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: var(--on-primary);
+}
+
+// The implicit `team_member` baseline. Same pill as a role toggle and the same
+// held fill, on purpose — it belongs to the same row and the same set, and it
+// is genuinely on. What it does not have is any affordance: no pointer, no
+// hover, no toggling. It states a fact; it is not a fourth toggle.
 .baselineChip {
   @extend %pill;
+  @extend %pill-held;
 
   cursor: default;
 }
@@ -50,9 +61,7 @@
   }
 
   &[data-active="true"] {
-    border-color: var(--primary);
-    background: var(--primary);
-    color: var(--on-primary);
+    @extend %pill-held;
   }
 
   // Keyed off `aria-disabled`, not `:disabled` — the chip stays a focusable,

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -7,14 +7,16 @@
   gap: var(--spacing-xs);
 }
 
-// Geometry shared by the baseline badge and the role toggles. They sit side by
-// side in one row, so neither owns these numbers alone — retuning chip height
-// or padding in `.roleChip` without this would silently desync the two.
+// The pill the baseline badge and the role toggles both wear. They sit side by
+// side in one row and are meant to look like one set, so the whole resting
+// appearance lives here — retuning it in `.roleChip` alone would desync them.
 %pill {
   display: flex;
   justify-content: center;
   align-items: center;
+  border: 1px solid var(--outline);
   border-radius: 999px;
+  background: transparent;
   padding: 0 var(--spacing-s);
   height: 2rem;
   color: var(--on-surface-retreat);
@@ -22,14 +24,14 @@
   white-space: nowrap;
 }
 
-// The implicit `team_member` baseline: same pill geometry as `.roleChip`,
-// deliberately none of its affordances — dashed border, no hover or active
-// state, no pointer. It must read as a statement of fact, not a fourth toggle.
+// The implicit `team_member` baseline. Visually identical to a role toggle at
+// rest, on purpose — it belongs to the same row and the same set. What it does
+// not have is any affordance: no pointer, no hover, no active state, no click
+// handler. It states a fact; it is not a fourth toggle.
 .baselineChip {
   @extend %pill;
 
   cursor: default;
-  border: 1px dashed var(--outline-variant);
 }
 
 .roleChip {
@@ -40,8 +42,6 @@
     border-color 100ms ease,
     color 100ms ease;
   cursor: pointer;
-  border: 1px solid var(--outline);
-  background: transparent;
 
   &:hover:not([data-active="true"]):not([aria-disabled="true"]) {
     border-color: var(--outline);

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -7,15 +7,13 @@
   gap: var(--spacing-xs);
 }
 
-// The implicit `team_member` baseline. Shares the pill geometry of `.roleChip`
-// but deliberately not its affordances: dashed border, no hover/active state,
-// no pointer — it must read as a statement of fact, not a fourth toggle.
-.baselineChip {
+// Geometry shared by the baseline badge and the role toggles. They sit side by
+// side in one row, so neither owns these numbers alone — retuning chip height
+// or padding in `.roleChip` without this would silently desync the two.
+%pill {
   display: flex;
   justify-content: center;
   align-items: center;
-  cursor: default;
-  border: 1px dashed var(--outline-variant);
   border-radius: 999px;
   padding: 0 var(--spacing-s);
   height: 2rem;
@@ -24,25 +22,28 @@
   white-space: nowrap;
 }
 
+// The implicit `team_member` baseline: same pill geometry as `.roleChip`,
+// deliberately none of its affordances — dashed border, no hover or active
+// state, no pointer. It must read as a statement of fact, not a fourth toggle.
+.baselineChip {
+  @extend %pill;
+
+  cursor: default;
+  border: 1px dashed var(--outline-variant);
+}
+
 .roleChip {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  @extend %pill;
+
   transition:
     background 100ms ease,
     border-color 100ms ease,
     color 100ms ease;
   cursor: pointer;
   border: 1px solid var(--outline);
-  border-radius: 999px;
   background: transparent;
-  padding: 0 var(--spacing-s);
-  height: 2rem;
-  color: var(--on-surface-retreat);
-  font: var(--font-label-medium);
-  white-space: nowrap;
 
-  &:hover:not([data-active="true"]):not(:disabled) {
+  &:hover:not([data-active="true"]):not([aria-disabled="true"]) {
     border-color: var(--outline);
     background: var(--surface-container-high);
     color: var(--on-surface);
@@ -54,19 +55,17 @@
     color: var(--on-primary);
   }
 
-  &:disabled {
+  // Keyed off `aria-disabled`, not `:disabled` — the chip stays a focusable,
+  // hoverable button on purpose so its tooltip still explains the role to
+  // someone who cannot grant it (TeamRoleChips.tsx). Inertness is enforced in
+  // the click handler, so this rule only has to say "not actionable".
+  &[aria-disabled="true"] {
     cursor: default;
     border-color: var(--outline-variant);
-    // Lets the pointer fall through to the wrapping `Tooltip` span: browsers
-    // suppress pointer events on disabled form controls, so without this a
-    // chip the actor may not administer would also silently lose its
-    // description — exactly the reader who most needs to know what the role
-    // is and why it's out of reach.
-    pointer-events: none;
     color: var(--state-text-disabled);
   }
 
-  &[data-active="true"]:disabled {
+  &[data-active="true"][aria-disabled="true"] {
     border-color: var(--outline-variant);
     background: var(--state-on-surface-disabled);
     color: var(--state-text-disabled);

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -7,6 +7,23 @@
   gap: var(--spacing-xs);
 }
 
+// The implicit `team_member` baseline. Shares the pill geometry of `.roleChip`
+// but deliberately not its affordances: dashed border, no hover/active state,
+// no pointer — it must read as a statement of fact, not a fourth toggle.
+.baselineChip {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: default;
+  border: 1px dashed var(--outline-variant);
+  border-radius: 999px;
+  padding: 0 var(--spacing-s);
+  height: 2rem;
+  color: var(--on-surface-retreat);
+  font: var(--font-label-medium);
+  white-space: nowrap;
+}
+
 .roleChip {
   display: flex;
   justify-content: center;
@@ -40,6 +57,12 @@
   &:disabled {
     cursor: default;
     border-color: var(--outline-variant);
+    // Lets the pointer fall through to the wrapping `Tooltip` span: browsers
+    // suppress pointer events on disabled form controls, so without this a
+    // chip the actor may not administer would also silently lose its
+    // description — exactly the reader who most needs to know what the role
+    // is and why it's out of reach.
+    pointer-events: none;
     color: var(--state-text-disabled);
   }
 
@@ -48,4 +71,39 @@
     background: var(--state-on-surface-disabled);
     color: var(--state-text-disabled);
   }
+}
+
+// `.tooltip-content-rich` zeroes the atom's own padding and hands spacing to
+// the content, so this panel owns both. Width is capped because these are
+// prose sentences, not the short label/value rows the atom's nowrap default
+// was sized for.
+.roleTooltip {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  padding: var(--spacing-xs) var(--spacing-s);
+  max-width: 22rem;
+  text-align: left;
+  white-space: normal;
+}
+
+.roleTooltipTitle {
+  color: var(--on-surface);
+  font: var(--font-label-large);
+}
+
+.roleTooltipText {
+  color: var(--on-surface-retreat);
+  font: var(--font-body-small);
+}
+
+.roleTooltipWarning {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2xs);
+  margin-top: var(--spacing-2xs);
+  border-top: 1px solid var(--outline-muted);
+  padding-top: var(--spacing-xs);
+  color: var(--warning);
+  font: var(--font-body-small);
 }

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.module.scss
@@ -24,25 +24,21 @@
   white-space: nowrap;
 }
 
-// The "held" appearance. Shared, because a held role and the baseline badge
-// mean the same thing to the reader — this person has it — and so must look
-// the same. The baseline wears it unconditionally: `team_member` is always
-// held, which is the whole point of showing it.
-%pill-held {
-  border-color: var(--primary);
-  background: var(--primary);
-  color: var(--on-primary);
-}
-
-// The implicit `team_member` baseline. Same pill as a role toggle and the same
-// held fill, on purpose — it belongs to the same row and the same set, and it
-// is genuinely on. What it does not have is any affordance: no pointer, no
-// hover, no toggling. It states a fact; it is not a fourth toggle.
+// The implicit `team_member` baseline. Filled, so it reads as on — but tonal
+// `secondary-container` rather than the toggles' `--primary`, because in this
+// row `--primary` means "someone granted this, and someone can revoke it".
+// Member is neither granted nor revocable: it is simply always true, the floor
+// every team member stands on. The same tonal pairing already marks
+// non-interactive identity elsewhere in the app (`UserAvatar`,
+// `MessageBubble`, the agent-card icon). The border stays 1px and transparent
+// so the pill matches the toggles' geometry exactly.
 .baselineChip {
   @extend %pill;
-  @extend %pill-held;
 
   cursor: default;
+  border-color: transparent;
+  background: var(--secondary-container);
+  color: var(--on-secondary-container);
 }
 
 .roleChip {
@@ -61,7 +57,9 @@
   }
 
   &[data-active="true"] {
-    @extend %pill-held;
+    border-color: var(--primary);
+    background: var(--primary);
+    color: var(--on-primary);
   }
 
   // Keyed off `aria-disabled`, not `:disabled` — the chip stays a focusable,

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.test.tsx
@@ -102,6 +102,21 @@ describe("TeamRoleChips — the implicit Member baseline", () => {
     expect(toggleFor("team_analyst")?.getAttribute("aria-pressed")).toBe("false");
   });
 
+  // Order is deliberate: the three grantable roles first, the baseline closing
+  // the row. Reading left to right, the row goes from "what you can change" to
+  // "what is always true".
+  it("places the Member badge last, after the three role toggles", () => {
+    renderChips({ heldRoles: [] });
+
+    const group = container.querySelector('[role="group"]')!;
+    expect(Array.from(group.children).map((child) => child.textContent)).toEqual([
+      "rework.teamRoles.team_admin",
+      "rework.teamRoles.team_editor",
+      "rework.teamRoles.team_analyst",
+      "rework.teamRoles.team_member",
+    ]);
+  });
+
   it("keeps showing the Member badge alongside an elevated role", () => {
     renderChips({ heldRoles: ["team_admin"] });
 

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Coverage: the two things this component has to get right for a team admin
+// who does not already know the role model — (a) a member holding no elevated
+// role still reads as a Member rather than as three inactive pills, and (b)
+// every badge, including the ones the actor may not administer, can explain
+// itself on hover. Hover is driven via `mouseover` because React delegates
+// onMouseEnter from that bubbling event (see Tooltip.test.tsx).
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserTeamRelation } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import TeamRoleChips from "./TeamRoleChips.tsx";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function renderChips(props: Partial<React.ComponentProps<typeof TeamRoleChips>> = {}) {
+  const onToggle = props.onToggle ?? vi.fn();
+  act(() => {
+    root.render(<TeamRoleChips heldRoles={[]} onToggle={onToggle} {...props} />);
+  });
+  return onToggle;
+}
+
+function toggleFor(role: UserTeamRelation): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) => b.textContent === `rework.teamRoles.${role}`);
+}
+
+function baselineBadge(): HTMLElement {
+  const el = Array.from(container.querySelectorAll("span")).find(
+    (s) => s.textContent === "rework.teamRoles.team_member",
+  );
+  if (!el) throw new Error("baseline Member badge not found");
+  return el as HTMLElement;
+}
+
+// Hovers, reads the portaled panel, then un-hovers. The un-hover matters:
+// only one badge can be hovered at a time in the real UI, but nothing tears
+// the portal down for us, so leaving it mounted would make the next `hover`
+// in the same test read the *previous* badge's panel.
+function hover(el: Element): string {
+  act(() => {
+    el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+  });
+  const text = document.querySelector('[role="tooltip"]')?.textContent ?? "";
+  act(() => {
+    el.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }));
+  });
+  return text;
+}
+
+describe("TeamRoleChips — the implicit Member baseline", () => {
+  it("shows a Member badge even when the person holds no elevated role", () => {
+    renderChips({ heldRoles: [] });
+
+    expect(baselineBadge()).not.toBeNull();
+    expect(toggleFor("team_admin")?.getAttribute("aria-pressed")).toBe("false");
+    expect(toggleFor("team_editor")?.getAttribute("aria-pressed")).toBe("false");
+    expect(toggleFor("team_analyst")?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("keeps showing the Member badge alongside an elevated role", () => {
+    renderChips({ heldRoles: ["team_admin"] });
+
+    expect(baselineBadge()).not.toBeNull();
+    expect(toggleFor("team_admin")?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  // The API refuses to revoke a member's last relation, and `team_member` is
+  // implied by every elevated role — so offering it as a toggle would promise
+  // an action that cannot happen.
+  it("renders the Member baseline as a non-button that cannot be toggled", () => {
+    const onToggle = renderChips({ heldRoles: [] });
+
+    const badge = baselineBadge();
+    expect(badge.tagName).toBe("SPAN");
+    expect(badge.getAttribute("aria-pressed")).toBeNull();
+
+    act(() => {
+      badge.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});
+
+describe("TeamRoleChips — role descriptions", () => {
+  it("describes each elevated role on hover", () => {
+    renderChips({ heldRoles: [] });
+
+    for (const role of ["team_admin", "team_editor", "team_analyst"] as UserTeamRelation[]) {
+      const chip = toggleFor(role);
+      expect(chip).toBeDefined();
+      expect(hover(chip!)).toContain(`rework.teamRoles.descriptions.${role}`);
+    }
+  });
+
+  it("describes the Member baseline on hover too", () => {
+    renderChips({ heldRoles: [] });
+
+    expect(hover(baselineBadge())).toContain("rework.teamRoles.descriptions.team_member");
+  });
+
+  it("adds a warning to the Analyst description, and only to that one", () => {
+    renderChips({ heldRoles: [] });
+
+    expect(hover(toggleFor("team_analyst")!)).toContain("rework.teamRoles.warnings.team_analyst");
+    expect(hover(toggleFor("team_admin")!)).not.toContain("rework.teamRoles.warnings");
+    expect(hover(toggleFor("team_editor")!)).not.toContain("rework.teamRoles.warnings");
+  });
+
+  // A chip the actor cannot administer is rendered `disabled`, and browsers
+  // suppress pointer events on disabled controls — the CSS drops
+  // `pointer-events` so the hover still reaches the Tooltip wrapper. Without
+  // that, the reader least able to act on a role would also be the one denied
+  // the explanation of what it is. Only the wiring is asserted here: happy-dom
+  // does no hit-testing, so whether the pointer actually reaches the wrapper
+  // is a real-browser question this test cannot answer — hence dispatching on
+  // the wrapper directly, which is where the CSS is meant to land the event.
+  it("still explains a role the actor is not allowed to administer", () => {
+    renderChips({ heldRoles: [], canAdminister: () => false });
+
+    const chip = toggleFor("team_analyst")!;
+    expect(chip.disabled).toBe(true);
+
+    act(() => {
+      chip.parentElement!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    expect(document.querySelector('[role="tooltip"]')?.textContent).toContain(
+      "rework.teamRoles.descriptions.team_analyst",
+    );
+  });
+});
+
+describe("TeamRoleChips — toggling", () => {
+  it("reports the role and its current held state to the caller", () => {
+    const onToggle = renderChips({ heldRoles: ["team_editor"] });
+
+    act(() => {
+      toggleFor("team_editor")!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onToggle).toHaveBeenCalledWith("team_editor", true);
+
+    act(() => {
+      toggleFor("team_admin")!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onToggle).toHaveBeenCalledWith("team_admin", false);
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.test.tsx
@@ -65,9 +65,13 @@ function toggleFor(role: UserTeamRelation): HTMLButtonElement | undefined {
   return Array.from(container.querySelectorAll("button")).find((b) => b.textContent === `rework.teamRoles.${role}`);
 }
 
+// Matched on the CSS-module class, not on "a span whose text is Member": the
+// Tooltip wrapper is itself a span with the same textContent and comes first in
+// the DOM, so a text-only lookup silently returns the wrapper and every
+// assertion below about the badge's own tag/attributes passes vacuously.
 function baselineBadge(): HTMLElement {
-  const el = Array.from(container.querySelectorAll("span")).find(
-    (s) => s.textContent === "rework.teamRoles.team_member",
+  const el = Array.from(container.querySelectorAll("*")).find((e) =>
+    /(^|\s|_)baselineChip/.test(e.className.toString()),
   );
   if (!el) throw new Error("baseline Member badge not found");
   return el as HTMLElement;
@@ -143,26 +147,45 @@ describe("TeamRoleChips — role descriptions", () => {
     renderChips({ heldRoles: [] });
 
     expect(hover(toggleFor("team_analyst")!)).toContain("rework.teamRoles.warnings.team_analyst");
-    expect(hover(toggleFor("team_admin")!)).not.toContain("rework.teamRoles.warnings");
-    expect(hover(toggleFor("team_editor")!)).not.toContain("rework.teamRoles.warnings");
+
+    // Each negative is paired with a positive on the same panel: `hover()`
+    // returns "" when no tooltip opened at all, which would let a broken
+    // tooltip satisfy `not.toContain` and report this as "only Analyst warns".
+    for (const role of ["team_admin", "team_editor"] as UserTeamRelation[]) {
+      const panel = hover(toggleFor(role)!);
+      expect(panel).toContain(`rework.teamRoles.descriptions.${role}`);
+      expect(panel).not.toContain("rework.teamRoles.warnings");
+    }
   });
 
-  // A chip the actor cannot administer is rendered `disabled`, and browsers
-  // suppress pointer events on disabled controls — the CSS drops
-  // `pointer-events` so the hover still reaches the Tooltip wrapper. Without
-  // that, the reader least able to act on a role would also be the one denied
-  // the explanation of what it is. Only the wiring is asserted here: happy-dom
-  // does no hit-testing, so whether the pointer actually reaches the wrapper
-  // is a real-browser question this test cannot answer — hence dispatching on
-  // the wrapper directly, which is where the CSS is meant to land the event.
+  // A chip the actor cannot administer is marked `aria-disabled` rather than
+  // `disabled`, precisely so it keeps explaining itself: a truly `disabled`
+  // button leaves the tab order and fires no pointer events, which would deny
+  // the description to the reader least able to act on the role.
   it("still explains a role the actor is not allowed to administer", () => {
+    const onToggle = renderChips({ heldRoles: [], canAdminister: () => false });
+
+    const chip = toggleFor("team_analyst")!;
+    expect(chip.getAttribute("aria-disabled")).toBe("true");
+    expect(chip.disabled).toBe(false);
+    expect(hover(chip)).toContain("rework.teamRoles.descriptions.team_analyst");
+
+    // Still inert — the guard lives in the click handler, not in the DOM.
+    act(() => {
+      chip.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  // The counterpart to the hover path: keyboard users reach the description by
+  // tabbing, which only works because the chip stays focusable.
+  it("explains a non-administrable role on keyboard focus as well", () => {
     renderChips({ heldRoles: [], canAdminister: () => false });
 
     const chip = toggleFor("team_analyst")!;
-    expect(chip.disabled).toBe(true);
-
     act(() => {
-      chip.parentElement!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+      chip.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     });
     expect(document.querySelector('[role="tooltip"]')?.textContent).toContain(
       "rework.teamRoles.descriptions.team_analyst",

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
@@ -26,10 +27,15 @@ import styles from "./TeamRoleChips.module.scss";
 export const ELEVATED_TEAM_ROLES: UserTeamRelation[] = ["team_admin", "team_editor", "team_analyst"];
 
 // `team_analyst` grants evaluation-campaign execution plus access to the
-// conversation slices those datasets are built from (REBAC.md §Team analyst).
+// limited conversation slices those datasets are built from (REBAC.md §Team
+// analyst — keep the "limited" scoping, the role does not confer general
+// access to the team's conversations).
 // That is a materially different kind of access from "edit team content", and
 // the flat pill row gives no hint of it — hence the extra warning row.
 const ROLES_WITH_WARNING: readonly UserTeamRelation[] = ["team_analyst"];
+
+// The implicit baseline, rendered as a static badge rather than a toggle.
+const BASELINE_TEAM_ROLE: UserTeamRelation = "team_member";
 
 interface TeamRoleChipsProps {
   heldRoles: UserTeamRelation[];
@@ -41,18 +47,27 @@ interface TeamRoleChipsProps {
 export default function TeamRoleChips({ heldRoles, onToggle, canAdminister }: TeamRoleChipsProps) {
   const { t } = useTranslation();
 
-  const describe = (role: UserTeamRelation) => (
-    <span className={styles.roleTooltip}>
-      <span className={styles.roleTooltipTitle}>{t(`rework.teamRoles.${role}`)}</span>
-      <span className={styles.roleTooltipText}>{t(`rework.teamRoles.descriptions.${role}`)}</span>
-      {ROLES_WITH_WARNING.includes(role) && (
-        <span className={styles.roleTooltipWarning}>
-          <Icon category="outlined" type="warning" />
-          <span>{t(`rework.teamRoles.warnings.${role}`)}</span>
-        </span>
-      )}
-    </span>
-  );
+  // Built once per instance instead of once per render: the members table
+  // mounts one of these per member row and re-renders every row on each search
+  // keystroke, yet these panels are identical every time and are discarded
+  // unrendered unless the badge is actually hovered.
+  const panels = useMemo(() => {
+    const describe = (role: UserTeamRelation) => (
+      <span className={styles.roleTooltip}>
+        <span className={styles.roleTooltipTitle}>{t(`rework.teamRoles.${role}`)}</span>
+        <span className={styles.roleTooltipText}>{t(`rework.teamRoles.descriptions.${role}`)}</span>
+        {ROLES_WITH_WARNING.includes(role) && (
+          <span className={styles.roleTooltipWarning}>
+            <Icon category="outlined" type="warning" />
+            <span>{t(`rework.teamRoles.warnings.${role}`)}</span>
+          </span>
+        )}
+      </span>
+    );
+    return Object.fromEntries(
+      [BASELINE_TEAM_ROLE, ...ELEVATED_TEAM_ROLES].map((role) => [role, describe(role)]),
+    ) as Record<UserTeamRelation, ReactNode>;
+  }, [t]);
 
   return (
     <div className={styles.roleChips} role="group">
@@ -61,24 +76,32 @@ export default function TeamRoleChips({ heldRoles, onToggle, canAdminister }: Te
           directly to anyone holding none (REBAC.md §Team member) — and the API
           refuses to revoke a member's last remaining relation. Rendering it as
           a static badge keeps a plain member from reading as role-less, which
-          three inactive pills otherwise look exactly like. */}
-      <Tooltip content={describe("team_member")}>
-        <span className={styles.baselineChip} tabIndex={0}>
-          {t("rework.teamRoles.team_member")}
+          three inactive pills otherwise look exactly like. `role="note"` plus
+          the tab stop is what makes its description reachable without a mouse;
+          without them the badge is bare text inside a group of controls. */}
+      <Tooltip content={panels[BASELINE_TEAM_ROLE]}>
+        <span className={styles.baselineChip} role="note" tabIndex={0}>
+          {t(`rework.teamRoles.${BASELINE_TEAM_ROLE}`)}
         </span>
       </Tooltip>
       {ELEVATED_TEAM_ROLES.map((role) => {
         const held = heldRoles.includes(role);
-        const disabled = canAdminister ? !canAdminister(role) : false;
+        // `aria-disabled` rather than `disabled`: a disabled button leaves the
+        // tab order and stops firing pointer events, so it would silently lose
+        // the very description that tells the reader what the role they cannot
+        // grant actually is. The click guard below is what makes it inert.
+        const readOnly = canAdminister ? !canAdminister(role) : false;
         return (
-          <Tooltip key={role} content={describe(role)}>
+          <Tooltip key={role} content={panels[role]}>
             <button
               type="button"
               className={styles.roleChip}
               data-active={held}
               aria-pressed={held}
-              disabled={disabled}
-              onClick={() => onToggle(role, held)}
+              aria-disabled={readOnly}
+              onClick={() => {
+                if (!readOnly) onToggle(role, held);
+              }}
             >
               {t(`rework.teamRoles.${role}`)}
             </button>

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import { useTranslation } from "react-i18next";
+import Icon from "@shared/atoms/Icon/Icon.tsx";
+import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
 import { UserTeamRelation } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 import styles from "./TeamRoleChips.module.scss";
 
@@ -22,6 +24,12 @@ import styles from "./TeamRoleChips.module.scss";
 // excluded: it's the implicit baseline when none of the three apply, not a
 // toggle of its own.
 export const ELEVATED_TEAM_ROLES: UserTeamRelation[] = ["team_admin", "team_editor", "team_analyst"];
+
+// `team_analyst` grants evaluation-campaign execution plus access to the
+// conversation slices those datasets are built from (REBAC.md §Team analyst).
+// That is a materially different kind of access from "edit team content", and
+// the flat pill row gives no hint of it — hence the extra warning row.
+const ROLES_WITH_WARNING: readonly UserTeamRelation[] = ["team_analyst"];
 
 interface TeamRoleChipsProps {
   heldRoles: UserTeamRelation[];
@@ -33,23 +41,48 @@ interface TeamRoleChipsProps {
 export default function TeamRoleChips({ heldRoles, onToggle, canAdminister }: TeamRoleChipsProps) {
   const { t } = useTranslation();
 
+  const describe = (role: UserTeamRelation) => (
+    <span className={styles.roleTooltip}>
+      <span className={styles.roleTooltipTitle}>{t(`rework.teamRoles.${role}`)}</span>
+      <span className={styles.roleTooltipText}>{t(`rework.teamRoles.descriptions.${role}`)}</span>
+      {ROLES_WITH_WARNING.includes(role) && (
+        <span className={styles.roleTooltipWarning}>
+          <Icon category="outlined" type="warning" />
+          <span>{t(`rework.teamRoles.warnings.${role}`)}</span>
+        </span>
+      )}
+    </span>
+  );
+
   return (
     <div className={styles.roleChips} role="group">
+      {/* Informational, never a fourth toggle: `team_member` is the implicit
+          baseline — automatic for anyone holding an elevated role, granted
+          directly to anyone holding none (REBAC.md §Team member) — and the API
+          refuses to revoke a member's last remaining relation. Rendering it as
+          a static badge keeps a plain member from reading as role-less, which
+          three inactive pills otherwise look exactly like. */}
+      <Tooltip content={describe("team_member")}>
+        <span className={styles.baselineChip} tabIndex={0}>
+          {t("rework.teamRoles.team_member")}
+        </span>
+      </Tooltip>
       {ELEVATED_TEAM_ROLES.map((role) => {
         const held = heldRoles.includes(role);
         const disabled = canAdminister ? !canAdminister(role) : false;
         return (
-          <button
-            key={role}
-            type="button"
-            className={styles.roleChip}
-            data-active={held}
-            aria-pressed={held}
-            disabled={disabled}
-            onClick={() => onToggle(role, held)}
-          >
-            {t(`rework.teamRoles.${role}`)}
-          </button>
+          <Tooltip key={role} content={describe(role)}>
+            <button
+              type="button"
+              className={styles.roleChip}
+              data-active={held}
+              aria-pressed={held}
+              disabled={disabled}
+              onClick={() => onToggle(role, held)}
+            >
+              {t(`rework.teamRoles.${role}`)}
+            </button>
+          </Tooltip>
         );
       })}
     </div>

--- a/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TeamRoleChips/TeamRoleChips.tsx
@@ -71,19 +71,6 @@ export default function TeamRoleChips({ heldRoles, onToggle, canAdminister }: Te
 
   return (
     <div className={styles.roleChips} role="group">
-      {/* Informational, never a fourth toggle: `team_member` is the implicit
-          baseline — automatic for anyone holding an elevated role, granted
-          directly to anyone holding none (REBAC.md §Team member) — and the API
-          refuses to revoke a member's last remaining relation. Rendering it as
-          a static badge keeps a plain member from reading as role-less, which
-          three inactive pills otherwise look exactly like. `role="note"` plus
-          the tab stop is what makes its description reachable without a mouse;
-          without them the badge is bare text inside a group of controls. */}
-      <Tooltip content={panels[BASELINE_TEAM_ROLE]}>
-        <span className={styles.baselineChip} role="note" tabIndex={0}>
-          {t(`rework.teamRoles.${BASELINE_TEAM_ROLE}`)}
-        </span>
-      </Tooltip>
       {ELEVATED_TEAM_ROLES.map((role) => {
         const held = heldRoles.includes(role);
         // `aria-disabled` rather than `disabled`: a disabled button leaves the
@@ -108,6 +95,20 @@ export default function TeamRoleChips({ heldRoles, onToggle, canAdminister }: Te
           </Tooltip>
         );
       })}
+      {/* Closes the row, after the three toggles. Informational, never a fourth
+          toggle: `team_member` is the implicit baseline — automatic for anyone
+          holding an elevated role, granted directly to anyone holding none
+          (REBAC.md §Team member) — and the API refuses to revoke a member's
+          last remaining relation. It therefore always renders held, and keeps a
+          plain member from reading as role-less, which three unheld pills
+          otherwise look exactly like. `role="note"` plus the tab stop is what
+          makes its description reachable without a mouse; without them the
+          badge is bare text inside a group of controls. */}
+      <Tooltip content={panels[BASELINE_TEAM_ROLE]}>
+        <span className={styles.baselineChip} role="note" tabIndex={0}>
+          {t(`rework.teamRoles.${BASELINE_TEAM_ROLE}`)}
+        </span>
+      </Tooltip>
     </div>
   );
 }

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1672,12 +1672,14 @@ cannot drift apart in the same row.
 every badge** (2026-08-17, #2383). Two complaints from team admins, one
 fix. (1) A member holding no elevated role rendered as three *inactive*
 pills — visually indistinguishable from a row that hadn't loaded. A
-non-interactive `Member` badge now leads the row, always visible. It is
-styled *identically* to a role toggle at rest — same `%pill` placeholder,
-same `1px solid outline` border — because it belongs to the same row and
-the same set; what it lacks is affordance, not appearance: `cursor:
-default`, `role="note"`, no hover or active state, no `aria-pressed`, no
-click handler. It is deliberately not a fourth toggle —
+non-interactive `Member` badge now closes the row, after the three toggles,
+always visible. It is styled *identically to a held toggle* — the resting
+pill geometry lives in a `%pill` placeholder and the `--primary` fill in a
+`%pill-held` one, and the badge `@extend`s both — because `team_member` is
+genuinely always held, so anything less than the held fill would misreport
+it. What it lacks is affordance, not appearance: `cursor: default`,
+`role="note"`, no hover state, no `aria-pressed`, no click handler. It is
+deliberately not a fourth toggle —
 `team_member` is the implicit baseline (automatic for anyone holding an
 elevated role, granted directly to anyone holding none) and the API refuses
 to revoke a member's last relation, so a toggle would promise an action

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1664,7 +1664,34 @@ closure of the same logic. Sizing: height `2rem` (`32px`), `label-medium`
 text, default (inactive) border `1px solid outline` — was `0.5px
 outline-variant`, a size/color pair that didn't match any other chip-style
 control in the app. Chip padding-left/right `spacing-s` (`12px`, was
-`spacing-xs`/`8px`).
+`spacing-xs`/`8px`). That geometry now lives in one `%pill` placeholder
+`@extend`ed by both the toggles and the baseline badge below, so the two
+cannot drift apart in the same row.
+
+**`TeamRoleChips`: a static `Member` badge and a description tooltip on
+every badge** (2026-08-17, #2383). Two complaints from team admins, one
+fix. (1) A member holding no elevated role rendered as three *inactive*
+pills — visually indistinguishable from a row that hadn't loaded. A
+non-interactive `Member` badge now leads the row, always visible: dashed
+`1px outline-variant` border, `cursor: default`, `role="note"`, no
+`aria-pressed`, no click handler. It is deliberately not a fourth toggle —
+`team_member` is the implicit baseline (automatic for anyone holding an
+elevated role, granted directly to anyone holding none) and the API refuses
+to revoke a member's last relation, so a toggle would promise an action
+that cannot happen. (2) The role names carried no meaning on the page: all
+four badges now open a rich `Tooltip` (title + one-line description), copy
+condensed from the help centre's `features/roles.md` tables so the two
+surfaces agree. The Analyst panel alone carries a `--warning` footer row —
+it grants evaluation-campaign execution *and* the limited conversation
+slices those datasets are built from, which a flat pill row hinted at
+nowhere.
+
+A chip the actor may not administer switched from `disabled` to
+`aria-disabled` + a guard in the click handler. The visual state is
+unchanged (`[aria-disabled="true"]` replaces `:disabled` in the SCSS), but
+a `disabled` button leaves the tab order and fires no pointer events, so it
+would have been the one badge unable to explain itself — to exactly the
+reader who cannot act on the role and most needs to know what it is.
 
 **Members table: role chips are a live, single-click toggle in both
 directions.** `TeamRoleChips` renders identically here and in the

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1673,13 +1673,17 @@ every badge** (2026-08-17, #2383). Two complaints from team admins, one
 fix. (1) A member holding no elevated role rendered as three *inactive*
 pills — visually indistinguishable from a row that hadn't loaded. A
 non-interactive `Member` badge now closes the row, after the three toggles,
-always visible. It is styled *identically to a held toggle* — the resting
-pill geometry lives in a `%pill` placeholder and the `--primary` fill in a
-`%pill-held` one, and the badge `@extend`s both — because `team_member` is
-genuinely always held, so anything less than the held fill would misreport
-it. What it lacks is affordance, not appearance: `cursor: default`,
-`role="note"`, no hover state, no `aria-pressed`, no click handler. It is
-deliberately not a fourth toggle —
+always visible. It shares the toggles' pill geometry (a `%pill` placeholder
+both `@extend`, so height/padding cannot desync mid-row) but carries its own
+fill: tonal `secondary-container` / `on-secondary-container`, with a
+transparent 1px border to keep the geometry identical. Deliberately *not*
+the toggles' `--primary` fill — in this row `--primary` reads as "someone
+granted this and someone can revoke it", whereas `team_member` is neither
+granted nor revocable, just always true. The same tonal pairing already
+marks non-interactive identity in `UserAvatar`, `MessageBubble`, and the
+agent-card icon. What the badge lacks is affordance, not presence: `cursor:
+default`, `role="note"`, no hover state, no `aria-pressed`, no click
+handler. It is deliberately not a fourth toggle —
 `team_member` is the implicit baseline (automatic for anyone holding an
 elevated role, granted directly to anyone holding none) and the API refuses
 to revoke a member's last relation, so a toggle would promise an action

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1672,9 +1672,12 @@ cannot drift apart in the same row.
 every badge** (2026-08-17, #2383). Two complaints from team admins, one
 fix. (1) A member holding no elevated role rendered as three *inactive*
 pills — visually indistinguishable from a row that hadn't loaded. A
-non-interactive `Member` badge now leads the row, always visible: dashed
-`1px outline-variant` border, `cursor: default`, `role="note"`, no
-`aria-pressed`, no click handler. It is deliberately not a fourth toggle —
+non-interactive `Member` badge now leads the row, always visible. It is
+styled *identically* to a role toggle at rest — same `%pill` placeholder,
+same `1px solid outline` border — because it belongs to the same row and
+the same set; what it lacks is affordance, not appearance: `cursor:
+default`, `role="note"`, no hover or active state, no `aria-pressed`, no
+click handler. It is deliberately not a fourth toggle —
 `team_member` is the implicit baseline (automatic for anyone holding an
 elevated role, granted directly to anyone holding none) and the API refuses
 to revoke a member's last relation, so a toggle would promise an action


### PR DESCRIPTION
Closes #2383.

Frontend only. Both surfaces that use `TeamRoleChips` - the members table and the
add-members dialog - pick this up from the one component.

## What changes

**A static `Member` badge closes the chip row**, after Admin / Editor / Analyst,
always visible. Left to right the row now goes from what an admin can change to
what is always true. It is non-interactive by design: `team_member` is the
implicit baseline (automatic for anyone holding an elevated role, granted
directly to anyone holding none - `REBAC.md` §Team member) and the API refuses to
revoke a member's last relation, so a toggle would promise an action that cannot
happen. It is a `<span role="note">`: no `aria-pressed`, no click handler. This
is what stops a plain member from rendering as three *unheld* pills, which today
looks identical to a row that has not loaded.

**Its fill is tonal rather than the toggles' `--primary`.**
`secondary-container` / `on-secondary-container` - already this app's pairing for
non-interactive identity (`UserAvatar`, `MessageBubble`, the agent-card icon).
Filled, so it reads as *on*, but visibly a different kind of thing from the
toggles beside it: in that row `--primary` means "someone granted this and
someone can revoke it", which Member is not. Pill geometry is shared through a
`%pill` placeholder (the badge carries a transparent 1px border) so the two
cannot desync mid-row.

**All four badges explain themselves on hover or keyboard focus.** Rich `Tooltip`
panels - title plus a one-line description - with copy condensed from the help
centre's `features/roles.md` tables, so the two surfaces agree rather than drift.

**The Analyst panel carries a warning footer.** It grants evaluation-campaign
execution *and* the limited conversation slices those datasets are built from - a
technical role, and the one easiest to hand out by accident. The wording keeps
REBAC's "limited" scoping deliberately: this tooltip exists so an admin can make
an informed grant decision, so overstating the grant would be worse than saying
nothing.

## Worth a reviewer's attention

- **`disabled` -> `aria-disabled` on the toggles** (+ a guard in the click
  handler). Visual state is unchanged; the SCSS just keys off
  `[aria-disabled="true"]`. The reason: a `disabled` button leaves the tab order
  and fires no pointer events, so it would have been the one badge unable to
  explain itself - to exactly the reader who cannot grant the role and most needs
  to know what it is. Worth confirming you are happy with the trade (a
  focusable-but-inert chip) rather than leaving those chips undocumented.
- **One extra tab stop per member row** for the `Member` badge. It is the only
  way its description is reachable without a mouse, but on a large team that is a
  real cost - say the word and I will drop the `tabIndex`.
- **`Editeur` -> `Éditeur`** in the FR label. Not strictly in scope, but the new
  Admin description sends the reader to "le rôle Éditeur" and the chip inches
  away spelled it without the accent; every other occurrence in the file was
  already accented. Easy to split out if you would rather keep this PR pure.
- **`ROLES_WITH_WARNING` is a second source of truth** alongside the `warnings.*`
  i18n block. `i18n.exists()` would derive it instead, but that couples the
  component to i18n internals and breaks the `react-i18next` mock in two existing
  test files. Left as an explicit typed constant; happy to revisit.
- **The tonal fill is a judgement call.** `success-container` (soft green, leans
  more explicitly "granted") or a neutral `surface-container-low` +
  `on-surface-muted` (most "this is just the default", but risks reading as
  disabled next to the unheld outlined chips) are both two-line swaps if the
  purple is not the read you want.

## Verification

- `make code-quality` - clean (tsc + prettier + eslint).
- `make test` - 1287 passed, 2 failed. Both failures are in
  `DocumentUploadDrawer.maxDepth.test.tsx` and **pre-existing on `swift`**: that
  test's `vi.mock` does not export
  `useQuotaPrecheckKnowledgeFlowV1QuotaPrecheckPostMutation`, which the component
  now uses. Untouched by this branch - the diff is the 6 files listed below.
- 10 new tests in `TeamRoleChips.test.tsx`: the baseline badge (present, last in
  the row, not a button, not togglable), per-role descriptions, the Analyst-only
  warning, and the hover *and* keyboard paths for a non-administrable chip.
- The SCSS was compiled with `npx sass` to confirm the `@extend` output keeps the
  `[aria-disabled]` rules winning on specificity.
- Not verifiable in CI: happy-dom does no hit-testing, so whether hover reaches
  an `aria-disabled` chip in a real browser is asserted at the wiring level only.

## Files

- `TeamRoleChips.tsx` / `.module.scss` / `.test.tsx` (new)
- `locales/{en,fr}/translation.json`
- `docs/swift/ux/COMPONENT-UX.md`

No backend or OpenAPI change - `TeamMember.relations` already carried everything.

## Review trail

`/code-review` was run on the first commit and its findings fixed in the second.
What it caught that mattered: the `disabled`-chip accessibility gap above, a test
whose baseline-badge lookup resolved to the `Tooltip` *wrapper* and so passed
vacuously, negative assertions that an unopened tooltip would have satisfied, and
Analyst copy that overstated the conversation-data grant against REBAC.

Commits 3-5 apply design feedback on the badge itself: match it to the chips
rather than dashing it, plainer Member wording, move it to the end of the row,
drop em dashes from the copy, and finally give it a fill that says "always true,
this is the default" instead of borrowing the toggles' blue.
