### PR TITLE
fix(knowledge-flow): put the venv bin/ on PATH for every make recipe

### DIFF
--- a/apps/knowledge-flow-backend/Makefile
+++ b/apps/knowledge-flow-backend/Makefile
@@ -16,6 +16,20 @@ include ../../scripts/makefiles/help.mk
 ENV_FILE := $(ROOT_DIR)/config/.env
 export ENV_FILE
 
+# Put the venv's bin/ on PATH for every recipe in this project.
+#
+# Why: the DOCX processor shells out to `pandoc` by name, and the only pandoc we
+# ship is the one bundled by the `pypandoc-binary` dependency, exposed as
+# $(VENV)/bin/pandoc. Running $(PYTHON) by absolute path does NOT put $(VENV)/bin
+# on PATH — only `source .venv/bin/activate` does — so a locally started worker
+# died with `FileNotFoundError: 'pandoc'` while the binary sat unused in the venv.
+# The Docker images already do exactly this (`ENV PATH="/app/venv/bin:$PATH"`);
+# this makes local runs behave the same. Guarded so recursive make does not
+# prepend it twice.
+ifeq (,$(findstring $(VENV)/bin:,$(PATH)))
+export PATH := $(VENV)/bin:$(PATH)
+endif
+
 PADDLE_MODELS_DIR ?= ./models
 
 ##@ Run
@@ -31,7 +45,8 @@ tools-check:
 	@if ! command -v pandoc >/dev/null 2>&1; then \
 		echo "================================================================================"; \
 		echo "WARNING: pandoc not found on PATH. Doc ingestion (markdown/PDF conversions) will fail locally."; \
-		echo "Install pandoc or use the provided Docker image."; \
+		echo "It normally comes from the pypandoc-binary dependency ($(VENV)/bin/pandoc):"; \
+		echo "run 'make dev' to install it, or install a system pandoc."; \
 		echo "================================================================================"; \
 	fi
 	@if ! command -v pdfinfo >/dev/null 2>&1; then \

--- a/docs/swift/platform/PROCESSING_GUIDE.md
+++ b/docs/swift/platform/PROCESSING_GUIDE.md
@@ -217,12 +217,18 @@ Symptom examples:
 
 - invalid DOCX zip
 - pandoc conversion error
+- `FileNotFoundError: [Errno 2] No such file or directory: 'pandoc'`
 - EMF image not converted
 
 Action:
 
 1. Validate file is a real DOCX archive.
-2. Ensure `pandoc` is installed.
+2. Ensure `pandoc` is on PATH. The processor shells out to it by name; in the
+   images it is apt-installed, and locally it comes from the `pypandoc-binary`
+   dependency as `.venv/bin/pandoc`. The project Makefile prepends `.venv/bin`
+   to PATH, so `make run-worker` / `make run` after `make dev` is enough — a
+   worker started outside `make` without activating the venv will raise the
+   `FileNotFoundError` above even though the binary is installed.
 3. Ensure `inkscape` is installed if EMF media is expected.
 
 ### Unexpected model/network calls in offline setup


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**Issue:** no issue — mechanical local-dev fix (one Makefile variable + the matching troubleshooting entry).

**Problem in one sentence:** a knowledge-flow worker started through `make` dies with `FileNotFoundError: [Errno 2] No such file or directory: 'pandoc'` even though pandoc *is* installed, because `.venv/bin` is never on PATH.

**Backlog ref:** n/a — not a backlog item.

---

## 2. Before you wrote a single line of code

**RFC written?** Not required — mechanical fix. No design choice, no schema, no endpoint, no new component: it aligns the local `make` environment with what the Docker images already do.

**Plan presented to the team before implementation?** No — the change is two lines of Makefile plus a docs paragraph, found while debugging a local DOCX ingestion failure.

**Confirmation received?** Implement-immediately instruction from the developer.

---

## 3. What you built

`apps/knowledge-flow-backend/Makefile` now exports `PATH := $(VENV)/bin:$(PATH)` for every recipe in the project, guarded by a `findstring` check so recursive `make` invocations cannot prepend it twice.

The reason it was needed: the DOCX processor shells out to `pandoc` **by name**, and the only pandoc shipped locally is the binary bundled by the `pypandoc-binary` dependency at `.venv/bin/pandoc`. Running `$(PYTHON)` by absolute path does not put the venv's `bin/` on PATH — only `source .venv/bin/activate` does — so the subprocess lookup failed while the binary sat unused in the venv. The Docker images already do exactly this (`ENV PATH="/app/venv/bin:$PATH"`); this makes local runs behave the same.

The `tools-check` warning was also reworded: it used to suggest only "install pandoc or use Docker", which sends you hunting for a system package. It now names `$(VENV)/bin/pandoc` and points at `make dev`.

---

## 4. Proof of quality

**Tests added or updated:** none. The change is a Makefile PATH export and a docs paragraph — there is no Python code path to assert on, and the behaviour is verified by running the target that previously warned.

| Test | File | What it covers |
| ---- | ---- | -------------- |
| n/a  | n/a  | Makefile/docs-only change — verified by running `make tools-check` |

Verification performed:

```
$ cd apps/knowledge-flow-backend && make tools-check
================================================================================
WARNING: inkscape not found on PATH. EMF/SVG conversions will be skipped or fail locally.
Install inkscape or use the provided Docker image.
================================================================================
```

The pandoc warning is gone (the venv binary is now resolved); the remaining inkscape warning is pre-existing and unrelated.

**`make code-quality` output:** n/a — no Python or TypeScript source touched (Makefile + Markdown only).

**Raw `basedpyright` output:** n/a — no Python source touched.

**`make test` output:** n/a — no Python source touched; no test exercises Makefile PATH construction.

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — not a backlog item |
| New behaviour, API field, or contract change                      | n/a — no API or contract surface touched |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — untouched |
| UX component implemented or visual status changed                 | n/a — no UI change |
| Phase progress row exists for this area                           | n/a |
| WORKPLAN sprint item finished                                     | n/a — WORKPLAN is frozen |
| Code and a design doc now diverge                                 | `docs/swift/platform/PROCESSING_GUIDE.md` — the DOCX troubleshooting section now lists the `FileNotFoundError: 'pandoc'` symptom and explains where pandoc actually comes from in each environment |

---

## 6. Close-out statement

```
## Task close-out
- Code: apps/knowledge-flow-backend/Makefile exports $(VENV)/bin on PATH for all recipes (guarded against double-prepend); tools-check warning now points at `make dev` / the pypandoc-binary pandoc.
- Tests: none added — Makefile + docs only; verified by `make tools-check` no longer warning about pandoc.
- Docs updated: docs/swift/platform/PROCESSING_GUIDE.md (DOCX troubleshooting: new FileNotFoundError symptom + where pandoc comes from locally vs. in the images).
- Backlog: none — not a backlog item.
- Skipped steps: Step 1 (RFC) — mechanical fix, no open design question. Step 2 (backlog link) — n/a. Step 3.5 (GitHub issue) — none opened; happy to file one if the team wants local-dev friction tracked.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** Scope is limited to recipes in `apps/knowledge-flow-backend/Makefile`. The risk is shadowing: a tool that exists both in the venv and on the system now resolves to the venv copy. That is the intended behaviour and matches the Docker images. Nothing outside this project's `make` invocations is affected — no shell, CI job, or other module inherits the export.

**How do we roll back?** Revert the commit; it is self-contained and touches no runtime code.
