### PR TITLE
feat(#2400): config-driven full-width info banner on every page + optional auto-hide eased transition

### DIFF
--- a/apps/control-plane-backend/config/configuration.yaml
+++ b/apps/control-plane-backend/config/configuration.yaml
@@ -60,14 +60,34 @@ policies:
   purge_catalog_path: ./conversation_policy_catalog.yaml
 
 platform:
-  # Optional deployer-configured banner shown on upload surfaces (document
-  # upload drawer, chat attachments). Omit the whole block to show nothing.
+  # Optional deployer-configured frontend banners; each block is independent
+  # and can be omitted to show nothing. Texts are resolved from the user's
+  # locale, "en" fallback.
+  # - upload_warning: banner shown on upload surfaces (document upload
+  #   drawer, chat attachments).
+  # - info_banner: full-width announcement banner shown above the app content
+  #   on every page (including pre-auth pages). Non-dismissable; persistent
+  #   by default, or auto-hidden after auto_hide_seconds.
   # frontend:
   #   upload_warning:
   #     severity: warning # info | warning | error | success
   #     messages:
   #       en: "Do not upload classified documents."
   #       fr: "Ne téléversez pas de documents classifiés."
+  #   info_banner:
+  #     color: "#00BBDD"
+  #     auto_hide_seconds: 30 # omit for a persistent banner (the default)
+  #     titles:
+  #       en: "New version available"
+  #       fr: "Nouvelle version disponible"
+  #     messages:
+  #       en: "Access the Fred documentation & blog"
+  #       fr: "Accédez à la documentation et au blog de Fred."
+  #     links:
+  #       - url: "https://fredk8.dev"
+  #         labels:
+  #           en: "Go to the Fred blog"
+  #           fr: "Accéder au blog de Fred"
   # Runtime pod references only. Managed agent instance enrollment is DB-backed.
   knowledge_flow_base_url: http://127.0.0.1:8111/knowledge-flow/v1
   runtime_catalog_sources:

--- a/apps/control-plane-backend/config/configuration_prod.yaml
+++ b/apps/control-plane-backend/config/configuration_prod.yaml
@@ -81,13 +81,31 @@ policies:
   purge_catalog_path: ./conversation_policy_catalog.yaml
 
 platform:
-  # # Banner shown on upload surfaces (document upload drawer, chat attachments).
+  # # upload_warning: banner shown on upload surfaces (document upload drawer,
+  # # chat attachments). info_banner: full-width announcement banner shown
+  # # above the app content on every page (including pre-auth pages),
+  # # non-dismissable — persistent by default, or auto-hidden after
+  # # auto_hide_seconds. Omit either block to show nothing.
   # frontend:
   #   upload_warning:
   #     severity: warning
   #     messages:
   #       en: "Do not upload sensitive or classified documents."
   #       fr: "Ne téléversez pas de documents sensibles ou classifiés."
+  #   info_banner:
+  #     color: "#00BBDD"
+  #     auto_hide_seconds: 30 # omit for a persistent banner (the default)
+  #     titles:
+  #       en: "New version available"
+  #       fr: "Nouvelle version disponible"
+  #     messages:
+  #       en: "Access the Fred documentation & blog"
+  #       fr: "Accédez à la documentation et au blog de Fred."
+  #     links:
+  #       - url: "https://fredk8.dev"
+  #         labels:
+  #           en: "Go to the Fred blog"
+  #           fr: "Accéder au blog de Fred"
   # Runtime pod references only. Managed agent instance enrollment is DB-backed.
   knowledge_flow_base_url: http://127.0.0.1:8111/knowledge-flow/v1
   runtime_catalog_sources:

--- a/apps/control-plane-backend/config/schema/configuration.schema.json
+++ b/apps/control-plane-backend/config/schema/configuration.schema.json
@@ -131,6 +131,18 @@
           ],
           "default": null,
           "description": "Optional banner shown on upload surfaces (document upload drawer, chat attachments). Omit to show nothing."
+        },
+        "info_banner": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InfoBanner"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional informative banner shown above the app content on every page. Omit to show nothing."
         }
       },
       "title": "FrontendBootstrapConfig",
@@ -221,6 +233,82 @@
         "type"
       ],
       "title": "InMemoryLogStorageConfig",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "InfoBanner": {
+      "description": "Deployer-configured global announcement banner.\n\nFull-width and non-dismissable, shown above the app content on every page\n\u2014 including the pre-auth GCU-acceptance and root-bootstrap screens.\nPersistent by default; set `auto_hide_seconds` to make it disappear on\nits own. Texts are resolved from the user's locale with \"en\" fallback.\nOmit the whole block to show nothing.",
+      "properties": {
+        "color": {
+          "default": "#00BBDD",
+          "description": "Banner background CSS color.",
+          "title": "Color",
+          "type": "string"
+        },
+        "auto_hide_seconds": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Seconds after which the banner hides itself, measured from app load. Omit for a persistent banner \u2014 the default.",
+          "title": "Auto Hide Seconds"
+        },
+        "titles": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Locale \u2192 title map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+          "title": "Titles",
+          "type": "object"
+        },
+        "messages": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Locale \u2192 message map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+          "title": "Messages",
+          "type": "object"
+        },
+        "links": {
+          "description": "Links rendered on the right side of the banner.",
+          "items": {
+            "$ref": "#/$defs/InfoBannerLink"
+          },
+          "title": "Links",
+          "type": "array"
+        }
+      },
+      "title": "InfoBanner",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "InfoBannerLink": {
+      "description": "One link rendered on the right side of the info banner.",
+      "properties": {
+        "url": {
+          "description": "Link target URL.",
+          "title": "Url",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Locale \u2192 label map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+          "title": "Labels",
+          "type": "object"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "title": "InfoBannerLink",
       "type": "object",
       "additionalProperties": false
     },

--- a/apps/control-plane-backend/control_plane_backend/config/models.py
+++ b/apps/control-plane-backend/control_plane_backend/config/models.py
@@ -93,6 +93,52 @@ class UploadWarning(BaseModel):
     )
 
 
+class InfoBannerLink(BaseModel):
+    """One link rendered on the right side of the info banner."""
+
+    url: str = Field(description="Link target URL.")
+    labels: dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → label map (e.g. {"en": "...", "fr": "..."}).',
+    )
+
+
+class InfoBanner(BaseModel):
+    """Deployer-configured global announcement banner.
+
+    Full-width and non-dismissable, shown above the app content on every page
+    — including the pre-auth GCU-acceptance and root-bootstrap screens.
+    Persistent by default; set `auto_hide_seconds` to make it disappear on
+    its own. Texts are resolved from the user's locale with "en" fallback.
+    Omit the whole block to show nothing.
+    """
+
+    color: str = Field(
+        default="#00BBDD",
+        description="Banner background CSS color.",
+    )
+    auto_hide_seconds: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Seconds after which the banner hides itself, measured from app "
+            "load. Omit for a persistent banner — the default."
+        ),
+    )
+    titles: dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → title map (e.g. {"en": "...", "fr": "..."}).',
+    )
+    messages: dict[str, str] = Field(
+        default_factory=dict,
+        description='Locale → message map (e.g. {"en": "...", "fr": "..."}).',
+    )
+    links: list[InfoBannerLink] = Field(
+        default_factory=list,
+        description="Links rendered on the right side of the banner.",
+    )
+
+
 class FrontendBootstrapConfig(BaseModel):
     """Static frontend bootstrap configuration served by control-plane."""
 
@@ -102,6 +148,13 @@ class FrontendBootstrapConfig(BaseModel):
         description=(
             "Optional banner shown on upload surfaces (document upload drawer, "
             "chat attachments). Omit to show nothing."
+        ),
+    )
+    info_banner: InfoBanner | None = Field(
+        default=None,
+        description=(
+            "Optional informative banner shown above the app content on every "
+            "page. Omit to show nothing."
         ),
     )
 

--- a/apps/control-plane-backend/control_plane_backend/product/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/product/schemas.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from control_plane_backend.agent_instances.suspension import SuspensionReason
 from control_plane_backend.config.models import (
     FrontendFeatureFlags,
+    InfoBanner,
     ManagedAgentFieldSpec,
     ManagedAgentTuning,
     UploadWarning,
@@ -139,6 +140,20 @@ class FrontendConfig(BaseModel):
             "'not completed' alone as 'must show the bootstrap page'. The "
             "frontend must gate on this field, not re-derive the ReBAC/auth "
             "predicate itself."
+        ),
+    )
+    info_banner: InfoBanner | None = Field(
+        default=None,
+        description=(
+            "Deployer-configured global announcement banner, from "
+            "`platform.frontend.info_banner`. `None` "
+            "when the deployment configures none — the frontend then renders "
+            "nothing. Deliberately on this public pre-auth surface, not the "
+            "authenticated `FrontendBootstrap`: the banner shows on every "
+            "page, including the GCU-acceptance and root-bootstrap screens, "
+            "which render before `/frontend/bootstrap` can succeed. Carries "
+            "only deployer-authored announcement content — never anything "
+            "sensitive."
         ),
     )
 

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -367,22 +367,21 @@ async def build_frontend_config(deps: ProductServiceDependencies) -> FrontendCon
         and deps.team_dependencies.rebac.enabled
         and not root_bootstrap_completed
     )
-    if user_security.enabled:
-        return FrontendConfig(
-            user_auth=FrontendUserAuthConfig(
-                enabled=True,
-                realm_url=str(user_security.realm_url),
-                client_id=user_security.client_id,
-            ),
-            gcu_version=gcu_version,
-            root_bootstrap_completed=root_bootstrap_completed,
-            root_bootstrap_required=root_bootstrap_required,
+    user_auth = (
+        FrontendUserAuthConfig(
+            enabled=True,
+            realm_url=str(user_security.realm_url),
+            client_id=user_security.client_id,
         )
+        if user_security.enabled
+        else FrontendUserAuthConfig(enabled=False)
+    )
     return FrontendConfig(
-        user_auth=FrontendUserAuthConfig(enabled=False),
+        user_auth=user_auth,
         gcu_version=gcu_version,
         root_bootstrap_completed=root_bootstrap_completed,
         root_bootstrap_required=root_bootstrap_required,
+        info_banner=deps.configuration.platform.frontend.info_banner,
     )
 
 

--- a/apps/control-plane-backend/tests/test_main.py
+++ b/apps/control-plane-backend/tests/test_main.py
@@ -26,6 +26,8 @@ from control_plane_backend.agent_instances.store import (
 from control_plane_backend.app.dependencies import get_application_container_from_app
 from control_plane_backend.bootstrap.store import PlatformBootstrapStore
 from control_plane_backend.config.models import (
+    InfoBanner,
+    InfoBannerLink,
     ManagedAgentFieldSpec,
     ManagedAgentTuning,
     RuntimeCatalogSourceConfig,
@@ -1066,6 +1068,48 @@ async def test_frontend_config_disabled_omits_oidc_client() -> None:
     assert "client_id" not in payload["user_auth"]
     # `response_model_exclude_none=True` omits the key entirely when gating is off.
     assert payload.get("gcu_version") is None
+    # No `platform.frontend.info_banner` configured → the key is omitted and
+    # the frontend renders no banner.
+    assert "info_banner" not in payload
+
+
+@pytest.mark.asyncio
+async def test_frontend_config_exposes_configured_info_banner() -> None:
+    """The public pre-auth config carries `platform.frontend.info_banner` so
+    the global banner can render on every page — including the GCU-acceptance
+    and root-bootstrap screens, which render before the authenticated
+    `/frontend/bootstrap` can succeed."""
+    app = create_app()
+    container = get_application_container_from_app(app)
+    container.configuration.platform.frontend.info_banner = InfoBanner(
+        color="#00BBDD",
+        auto_hide_seconds=30,
+        titles={"en": "New version available"},
+        messages={
+            "en": "Access the Fred documentation & blog",
+            "fr": "Accédez à la doc",
+        },
+        links=[
+            InfoBannerLink(
+                url="https://fredk8.dev", labels={"en": "Go to the Fred blog"}
+            )
+        ],
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/control-plane/v1/frontend/config")
+
+    assert resp.status_code == 200
+    banner = resp.json()["info_banner"]
+    assert banner["color"] == "#00BBDD"
+    assert banner["auto_hide_seconds"] == 30
+    assert banner["titles"] == {"en": "New version available"}
+    assert banner["messages"]["fr"] == "Accédez à la doc"
+    assert banner["links"] == [
+        {"url": "https://fredk8.dev", "labels": {"en": "Go to the Fred blog"}}
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/app/App.module.css
+++ b/apps/frontend/src/app/App.module.css
@@ -13,6 +13,20 @@
   }
 }
 
+/* Full-viewport shell: the only place allowed to size against the viewport.
+   The InfoBanner renders (or not) as the first flex child; .appContent takes
+   the remaining height and everything routed below it uses height: 100%. */
+.appShell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.appContent {
+  flex: 1;
+  min-height: 0;
+}
+
 .loadingScreen {
   display: flex;
   justify-content: center;

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -17,6 +17,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RouterProvider } from "react-router-dom";
 import { ConfirmationDialogProvider } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider";
+import InfoBanner from "@shared/molecules/InfoBanner/InfoBanner";
 import { ToastProvider } from "@shared/molecules/Toast/ToastProvider";
 import { useFrontendProperties } from "../hooks/useFrontendProperties";
 import { AuthProvider } from "../security/AuthContext";
@@ -98,15 +99,25 @@ function FredUiContent() {
       }
     >
       <AuthProvider>
-        <GcuGuard>
-          <BootstrapGuard>
-            <ConfirmationDialogProvider>
-              <ToastProvider>
-                <RouterProvider router={router} />
-              </ToastProvider>
-            </ConfirmationDialogProvider>
-          </BootstrapGuard>
-        </GcuGuard>
+        {/* The InfoBanner (config-driven, absent by default) sits above the
+            guards so it shows on every page — GCU acceptance and root
+            bootstrap included — and pushes the app down instead of covering
+            it. Routed pages size with height: 100% against .appContent,
+            never 100vh. */}
+        <div className={styles.appShell}>
+          <InfoBanner />
+          <div className={styles.appContent}>
+            <GcuGuard>
+              <BootstrapGuard>
+                <ConfirmationDialogProvider>
+                  <ToastProvider>
+                    <RouterProvider router={router} />
+                  </ToastProvider>
+                </ConfirmationDialogProvider>
+              </BootstrapGuard>
+            </GcuGuard>
+          </div>
+        </div>
       </AuthProvider>
     </React.Suspense>
   );

--- a/apps/frontend/src/common/config.tsx
+++ b/apps/frontend/src/common/config.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { createKeycloakInstance } from "../security/KeycloakService";
-import type { FrontendConfig } from "../slices/controlPlane/controlPlaneOpenApi";
+import type { FrontendConfig, InfoBanner } from "../slices/controlPlane/controlPlaneOpenApi";
 
 /** Public pre-auth control-plane config surface. */
 const FRONTEND_CONFIG_URL = "/control-plane/v1/frontend/config";
@@ -49,6 +49,15 @@ export interface AppConfig {
    * marker is also `false`.
    */
   root_bootstrap_required: boolean;
+  /**
+   * Deployer-configured global announcement banner
+   * (`platform.frontend.info_banner`), or `null` when the deployment
+   * configures none. Sourced from the public pre-auth `/frontend/config` so
+   * the banner can render on every page — including the GCU-acceptance and
+   * root-bootstrap screens, which render before the authenticated bootstrap
+   * can succeed.
+   */
+  info_banner: InfoBanner | null;
 }
 
 type RawAppConfig = {
@@ -89,7 +98,7 @@ export const loadConfig = async () => {
 
   const base = (await res.json()) as RawAppConfig;
 
-  const { user_auth, gcu_version, root_bootstrap_required } = await loadPublicConfig();
+  const { user_auth, gcu_version, root_bootstrap_required, info_banner } = await loadPublicConfig();
 
   config = {
     frontend_basename: base.frontend_basename ?? "/",
@@ -98,6 +107,7 @@ export const loadConfig = async () => {
     user_auth,
     gcu_version,
     root_bootstrap_required,
+    info_banner,
   };
 
   if (config.user_auth?.enabled) {
@@ -125,11 +135,9 @@ export const loadConfig = async () => {
  * - called by `loadConfig()` at Stage 0; failures abort startup like a missing
  *   `/config.json`, since the control-plane is required to run the app
  */
-const loadPublicConfig = async (): Promise<{
-  user_auth: UserAuthConfig;
-  gcu_version: string | null;
-  root_bootstrap_required: boolean;
-}> => {
+const loadPublicConfig = async (): Promise<
+  Pick<AppConfig, "user_auth" | "gcu_version" | "root_bootstrap_required" | "info_banner">
+> => {
   const res = await fetch(FRONTEND_CONFIG_URL);
   if (!res.ok) {
     throw new Error(`Cannot load ${FRONTEND_CONFIG_URL}: ${res.status} ${res.statusText}`);
@@ -149,6 +157,7 @@ const loadPublicConfig = async (): Promise<{
     // frontend must not otherwise re-derive ReBAC/auth policy itself.
     root_bootstrap_required:
       payload.root_bootstrap_required ?? (payload.user_auth.enabled && !payload.root_bootstrap_completed),
+    info_banner: payload.info_banner ?? null,
   };
 };
 
@@ -228,3 +237,18 @@ export const getGcuVersion = (): string | null => getConfig().gcu_version;
  * - call after `loadConfig()`; `true` means the bootstrap screen must be shown
  */
 export const getRootBootstrapRequired = (): boolean => getConfig().root_bootstrap_required;
+
+/**
+ * Return the deployer-configured global announcement banner, or `null` when
+ * the deployment configures none.
+ *
+ * Why this function exists:
+ * - the `InfoBanner` component renders on every page, including the pre-auth
+ *   GCU-acceptance and root-bootstrap screens, so its content must come from
+ *   the public pre-auth `/frontend/config` rather than the authenticated
+ *   bootstrap
+ *
+ * How to use it:
+ * - call after `loadConfig()`; `null` means no banner is rendered
+ */
+export const getInfoBanner = (): InfoBanner | null => getConfig().info_banner;

--- a/apps/frontend/src/pages/ComingSoon.module.css
+++ b/apps/frontend/src/pages/ComingSoon.module.css
@@ -6,8 +6,8 @@
   gap: var(--spacing-xs);
   background: var(--surface-main);
   padding: var(--spacing-l);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   color: var(--on-surface);
 }
 

--- a/apps/frontend/src/rework/components/pages/BootstrapPage/BootstrapPage.module.css
+++ b/apps/frontend/src/rework/components/pages/BootstrapPage/BootstrapPage.module.css
@@ -6,7 +6,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-xs) 0 var(--spacing-m) 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/apps/frontend/src/rework/components/pages/DocumentViewerPage/DocumentViewerPage.module.css
+++ b/apps/frontend/src/rework/components/pages/DocumentViewerPage/DocumentViewerPage.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   background: var(--surface-container-lowest);
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
 }
 

--- a/apps/frontend/src/rework/components/pages/GcuPage/GcuPage.module.css
+++ b/apps/frontend/src/rework/components/pages/GcuPage/GcuPage.module.css
@@ -5,7 +5,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-xs) 0 var(--spacing-m) 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/apps/frontend/src/rework/components/pages/GdprPage/GdprPage.module.css
+++ b/apps/frontend/src/rework/components/pages/GdprPage/GdprPage.module.css
@@ -5,7 +5,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-xs) 0 var(--spacing-m) 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/apps/frontend/src/rework/components/pages/HelpCenterPage/HelpCenterPage.module.scss
+++ b/apps/frontend/src/rework/components/pages/HelpCenterPage/HelpCenterPage.module.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   background: var(--surface-container);
-  height: 100vh;
+  height: 100%;
   color: var(--on-surface);
 }
 

--- a/apps/frontend/src/rework/components/pages/PptFillerHelpPage/PptFillerHelpPage.module.css
+++ b/apps/frontend/src/rework/components/pages/PptFillerHelpPage/PptFillerHelpPage.module.css
@@ -6,7 +6,7 @@
   align-items: flex-start;
   background-color: var(--surface-main);
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow-y: auto;
   color: var(--on-surface);
 }

--- a/apps/frontend/src/rework/components/pages/ReleaseNotesPage/ReleaseNotesPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ReleaseNotesPage/ReleaseNotesPage.module.css
@@ -4,7 +4,7 @@
   background-color: var(--surface-main);
   padding: var(--spacing-m);
   width: 100%;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color: var(--on-surface);
 }

--- a/apps/frontend/src/rework/components/pages/UserSettingsPage/UserSettingsPage.module.scss
+++ b/apps/frontend/src/rework/components/pages/UserSettingsPage/UserSettingsPage.module.scss
@@ -4,8 +4,8 @@
   align-items: flex-start;
   box-sizing: border-box;
   padding: var(--spacing-xl) var(--spacing-m);
-  width: 100vw;
-  min-height: 100vh;
+  width: 100%;
+  min-height: 100%;
 }
 
 .userSettingsPage {

--- a/apps/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.module.css
+++ b/apps/frontend/src/rework/components/shared/layouts/MainLayout/MainLayout.module.css
@@ -1,7 +1,7 @@
 .mainLayout {
   display: flex;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
 }
 
 .sidebar {

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.autoHide.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.autoHide.test.tsx
@@ -59,6 +59,9 @@ afterEach(() => {
 
 const render = () => act(() => root.render(<InfoBanner />));
 const bannerElement = () => container.querySelector('[role="status"]');
+// The collapse wrapper is aria-hidden only while the eased exit plays (the
+// test banners configure no links, so no separator carries aria-hidden).
+const exitingWrapper = () => container.querySelector('[aria-hidden="true"]');
 
 describe("InfoBanner auto-hide", () => {
   it("stays visible when auto_hide_seconds is not set (persistent default)", () => {
@@ -71,7 +74,7 @@ describe("InfoBanner auto-hide", () => {
     expect(bannerElement()).not.toBeNull();
   });
 
-  it("hides itself once the configured number of seconds has elapsed", () => {
+  it("plays the eased collapse once the delay elapses, then unmounts", () => {
     mockGetInfoBanner.mockReturnValue({
       color: "#00BBDD",
       auto_hide_seconds: 30,
@@ -85,8 +88,16 @@ describe("InfoBanner auto-hide", () => {
 
     act(() => vi.advanceTimersByTime(29_999));
     expect(bannerElement()).not.toBeNull();
+    expect(exitingWrapper()).toBeNull();
 
+    // Delay elapsed: the banner starts its eased exit — still in the DOM for
+    // sighted users, already aria-hidden for screen readers.
     act(() => vi.advanceTimersByTime(1));
+    expect(bannerElement()).not.toBeNull();
+    expect(exitingWrapper()).not.toBeNull();
+
+    // Collapse transition over (HIDE_TRANSITION_MS): the node is removed.
+    act(() => vi.advanceTimersByTime(300));
     expect(bannerElement()).toBeNull();
   });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.autoHide.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.autoHide.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The auto-hide contract is a *transition* — visible now, gone after the
+// configured delay — which a static render cannot show, so these tests drive
+// real mounts with `createRoot` + `act` and fake timers (the repo's idiom,
+// see CharacterLimitNotice.test.tsx). The static rendering contract lives in
+// InfoBanner.test.tsx.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InfoBanner as InfoBannerConfig } from "src/slices/controlPlane/controlPlaneOpenApi";
+import InfoBanner from "./InfoBanner";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockGetInfoBanner = vi.fn<() => InfoBannerConfig | null>();
+
+vi.mock("src/common/config", () => ({
+  getInfoBanner: () => mockGetInfoBanner(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+});
+
+const render = () => act(() => root.render(<InfoBanner />));
+const bannerElement = () => container.querySelector('[role="status"]');
+
+describe("InfoBanner auto-hide", () => {
+  it("stays visible when auto_hide_seconds is not set (persistent default)", () => {
+    mockGetInfoBanner.mockReturnValue({ color: "#00BBDD", titles: { en: "Maintenance" }, messages: {}, links: [] });
+
+    render();
+    expect(bannerElement()).not.toBeNull();
+
+    act(() => vi.advanceTimersByTime(3_600_000));
+    expect(bannerElement()).not.toBeNull();
+  });
+
+  it("hides itself once the configured number of seconds has elapsed", () => {
+    mockGetInfoBanner.mockReturnValue({
+      color: "#00BBDD",
+      auto_hide_seconds: 30,
+      titles: { en: "Maintenance" },
+      messages: {},
+      links: [],
+    });
+
+    render();
+    expect(bannerElement()).not.toBeNull();
+
+    act(() => vi.advanceTimersByTime(29_999));
+    expect(bannerElement()).not.toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(bannerElement()).toBeNull();
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.module.css
@@ -1,0 +1,68 @@
+/* Generic informative top banner, see InfoBanner.tsx */
+
+/* Deliberate hardcoded color (guidelines §2.2 exception, tracked as an open
+   UX issue in COMPONENT-UX.md): the background comes from configuration
+   (`--banner-bg`, set by InfoBanner.tsx from `info_banner.color`) and is
+   outside the theme, so no design token can pair with it. The fixed dark
+   text assumes the configured color stays light, like the documented
+   #00BBDD example. */
+
+.banner {
+  --banner-text: #00222c;
+
+  display: flex;
+  flex-shrink: 0;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-s);
+  animation: slide-in 200ms ease-out;
+  background-color: var(--banner-bg);
+  padding: var(--spacing-m) var(--spacing-xl);
+  color: var(--banner-text);
+}
+
+.message {
+  margin: 0;
+  color: var(--banner-text);
+  font: var(--font-body-medium);
+}
+
+.message strong {
+  font: var(--font-body-medium-emphasized);
+}
+
+.actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.link {
+  color: var(--banner-text);
+  font: var(--font-body-medium-emphasized);
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.separator {
+  color: var(--banner-text);
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateY(-8px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .banner {
+    animation: none;
+  }
+}

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.module.css
@@ -7,11 +7,33 @@
    text assumes the configured color stays light, like the documented
    #00BBDD example. */
 
+/* Collapsible wrapper for the auto-hide exit: animating grid-template-rows
+   1fr → 0fr eases an auto height down to nothing, so the app content slides
+   up smoothly instead of jumping when the banner goes. Duration must match
+   HIDE_TRANSITION_MS in InfoBanner.tsx. */
+.collapse {
+  display: grid;
+  grid-template-rows: 1fr;
+  flex-shrink: 0;
+  transition:
+    grid-template-rows 300ms ease,
+    opacity 300ms ease;
+}
+
+.collapsing {
+  grid-template-rows: 0fr;
+  opacity: 0;
+}
+
+.collapseInner {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .banner {
   --banner-text: #00222c;
 
   display: flex;
-  flex-shrink: 0;
   justify-content: space-between;
   align-items: center;
   gap: var(--spacing-s);
@@ -64,5 +86,9 @@
 @media (prefers-reduced-motion: reduce) {
   .banner {
     animation: none;
+  }
+
+  .collapse {
+    transition: none;
   }
 }

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.test.tsx
@@ -1,0 +1,108 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { InfoBanner as InfoBannerConfig } from "src/slices/controlPlane/controlPlaneOpenApi";
+import InfoBanner from "./InfoBanner";
+
+const mockGetInfoBanner = vi.fn<() => InfoBannerConfig | null>();
+let mockLanguage = "en";
+
+vi.mock("src/common/config", () => ({
+  getInfoBanner: () => mockGetInfoBanner(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: mockLanguage } }),
+}));
+
+const banner: InfoBannerConfig = {
+  color: "#00BBDD",
+  titles: { en: "New version available", fr: "Nouvelle version disponible" },
+  messages: { en: "Access the Fred documentation & blog" },
+  links: [{ url: "https://fredk8.dev", labels: { en: "Go to the Fred blog" } }],
+};
+
+describe("InfoBanner", () => {
+  it("renders nothing when no banner is configured", () => {
+    mockGetInfoBanner.mockReturnValue(null);
+    mockLanguage = "en";
+
+    expect(renderToStaticMarkup(<InfoBanner />)).toBe("");
+  });
+
+  it("renders nothing when the banner has neither title nor message for any locale", () => {
+    mockGetInfoBanner.mockReturnValue({ color: "#00BBDD", titles: {}, messages: {}, links: [] });
+    mockLanguage = "en";
+
+    expect(renderToStaticMarkup(<InfoBanner />)).toBe("");
+  });
+
+  it("renders the localized title, message, configured color and links", () => {
+    mockGetInfoBanner.mockReturnValue(banner);
+    mockLanguage = "en";
+
+    const html = renderToStaticMarkup(<InfoBanner />);
+
+    expect(html).toContain("New version available");
+    expect(html).toContain("Access the Fred documentation &amp; blog");
+    expect(html).toContain("--banner-bg:#00BBDD");
+    expect(html).toContain('href="https://fredk8.dev"');
+    expect(html).toContain("Go to the Fred blog");
+  });
+
+  it("resolves a regional i18next tag to its base locale and falls back to en", () => {
+    mockGetInfoBanner.mockReturnValue(banner);
+    // "fr-FR" → "fr" for the title; the message has no "fr" entry → "en" fallback.
+    mockLanguage = "fr-FR";
+
+    const html = renderToStaticMarkup(<InfoBanner />);
+
+    expect(html).toContain("Nouvelle version disponible");
+    expect(html).toContain("Access the Fred documentation &amp; blog");
+  });
+
+  it("falls back to the link URL when no label matches the locale", () => {
+    mockGetInfoBanner.mockReturnValue({
+      ...banner,
+      links: [{ url: "https://fredk8.dev", labels: {} }],
+    });
+    mockLanguage = "en";
+
+    const html = renderToStaticMarkup(<InfoBanner />);
+
+    expect(html).toContain(">https://fredk8.dev</a>");
+  });
+
+  it("drops non-http(s) links but keeps relative ones", () => {
+    mockGetInfoBanner.mockReturnValue({
+      ...banner,
+      // Config URLs reach an unauthenticated surface via Helm values, so a
+      // javascript:/data: scheme must never become a clickable href.
+      links: [
+        { url: "javascript:alert(1)", labels: { en: "evil" } },
+        { url: "data:text/html,x", labels: { en: "also evil" } },
+        { url: "/release-notes", labels: { en: "Release notes" } },
+      ],
+    });
+    mockLanguage = "en";
+
+    const html = renderToStaticMarkup(<InfoBanner />);
+
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain("data:text/html");
+    expect(html).toContain('href="/release-notes"');
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.tsx
@@ -1,0 +1,100 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ---------------------------------------------------------------------------
+// Generic informative top banner.
+// Announces, without a dismiss action, whatever platform operators
+// configure. Color, texts and links come from the control-plane
+// `platform.frontend.info_banner`, served on the public pre-auth
+// `/frontend/config`; without it, nothing renders. Persistent by default;
+// `auto_hide_seconds` makes it disappear on its own that long after app
+// load. Rendered once at the app root (see App.tsx), above the guards and
+// routed content, so it shows on every page — the pre-auth GCU-acceptance
+// and root-bootstrap screens included — and pushes the rest of the app down
+// instead of covering it.
+// ---------------------------------------------------------------------------
+
+import { CSSProperties, Fragment, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getInfoBanner } from "src/common/config";
+import { resolveLocalizedText } from "@core/hooks/useLocalizedUploadWarning";
+import styles from "./InfoBanner.module.css";
+
+// Config URLs travel through Helm values to an unauthenticated surface, so
+// only render links that resolve to http(s) — never `javascript:`/`data:`.
+// The base only anchors relative URLs; any base works for scheme detection.
+const isSafeHref = (url: string): boolean => {
+  try {
+    const protocol = new URL(url, "https://base.invalid").protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export default function InfoBanner() {
+  const { i18n } = useTranslation();
+  const banner = getInfoBanner();
+  const autoHideSeconds = banner?.auto_hide_seconds ?? null;
+  const [hidden, setHidden] = useState(false);
+
+  // Persistent by default: the timer exists only when the deployer sets
+  // `auto_hide_seconds`. The config is loaded once before React renders and
+  // the banner mounts once at the app root, so the countdown starts at app
+  // load, not per navigation.
+  useEffect(() => {
+    if (!autoHideSeconds) return;
+    const timer = window.setTimeout(() => setHidden(true), autoHideSeconds * 1000);
+    return () => window.clearTimeout(timer);
+  }, [autoHideSeconds]);
+
+  if (!banner || hidden) return null;
+
+  const title = resolveLocalizedText(banner.titles, i18n.language);
+  const message = resolveLocalizedText(banner.messages, i18n.language);
+  if (!title && !message) return null;
+
+  const links = (banner.links ?? []).filter((link) => isSafeHref(link.url));
+
+  return (
+    <div
+      className={styles.banner}
+      style={{ "--banner-bg": banner.color } as CSSProperties}
+      role="status"
+      aria-live="polite"
+    >
+      <p className={styles.message}>
+        {title && <strong>{title}</strong>}
+        {title && message && " "}
+        {message}
+      </p>
+      {links.length > 0 && (
+        <div className={styles.actions}>
+          {links.map((link, index) => (
+            <Fragment key={`${index}-${link.url}`}>
+              {index > 0 && (
+                <span className={styles.separator} aria-hidden="true">
+                  ·
+                </span>
+              )}
+              <a className={styles.link} href={link.url} target="_blank" rel="noopener noreferrer">
+                {resolveLocalizedText(link.labels, i18n.language) ?? link.url}
+              </a>
+            </Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InfoBanner/InfoBanner.tsx
@@ -43,11 +43,17 @@ const isSafeHref = (url: string): boolean => {
   }
 };
 
+// Must match the transition duration in InfoBanner.module.css (.collapse):
+// the DOM node is removed only after the eased collapse has finished.
+const HIDE_TRANSITION_MS = 300;
+
 export default function InfoBanner() {
   const { i18n } = useTranslation();
   const banner = getInfoBanner();
   const autoHideSeconds = banner?.auto_hide_seconds ?? null;
-  const [hidden, setHidden] = useState(false);
+  // visible → (auto_hide_seconds later) hiding: eased collapse plays
+  //         → (HIDE_TRANSITION_MS later)  hidden: unmounted from the DOM
+  const [phase, setPhase] = useState<"visible" | "hiding" | "hidden">("visible");
 
   // Persistent by default: the timer exists only when the deployer sets
   // `auto_hide_seconds`. The config is loaded once before React renders and
@@ -55,11 +61,20 @@ export default function InfoBanner() {
   // load, not per navigation.
   useEffect(() => {
     if (!autoHideSeconds) return;
-    const timer = window.setTimeout(() => setHidden(true), autoHideSeconds * 1000);
+    const timer = window.setTimeout(() => setPhase("hiding"), autoHideSeconds * 1000);
     return () => window.clearTimeout(timer);
   }, [autoHideSeconds]);
 
-  if (!banner || hidden) return null;
+  // Fixed-delay removal rather than a transitionend listener: under
+  // prefers-reduced-motion the transition never fires an end event (the
+  // collapse snaps), while the timeout removes the node either way.
+  useEffect(() => {
+    if (phase !== "hiding") return;
+    const timer = window.setTimeout(() => setPhase("hidden"), HIDE_TRANSITION_MS);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
+
+  if (!banner || phase === "hidden") return null;
 
   const title = resolveLocalizedText(banner.titles, i18n.language);
   const message = resolveLocalizedText(banner.messages, i18n.language);
@@ -69,32 +84,41 @@ export default function InfoBanner() {
 
   return (
     <div
-      className={styles.banner}
-      style={{ "--banner-bg": banner.color } as CSSProperties}
-      role="status"
-      aria-live="polite"
+      className={phase === "hiding" ? `${styles.collapse} ${styles.collapsing}` : styles.collapse}
+      // Screen readers drop the banner as soon as the exit starts; sighted
+      // users watch the eased collapse for HIDE_TRANSITION_MS more.
+      aria-hidden={phase === "hiding" || undefined}
     >
-      <p className={styles.message}>
-        {title && <strong>{title}</strong>}
-        {title && message && " "}
-        {message}
-      </p>
-      {links.length > 0 && (
-        <div className={styles.actions}>
-          {links.map((link, index) => (
-            <Fragment key={`${index}-${link.url}`}>
-              {index > 0 && (
-                <span className={styles.separator} aria-hidden="true">
-                  ·
-                </span>
-              )}
-              <a className={styles.link} href={link.url} target="_blank" rel="noopener noreferrer">
-                {resolveLocalizedText(link.labels, i18n.language) ?? link.url}
-              </a>
-            </Fragment>
-          ))}
+      <div className={styles.collapseInner}>
+        <div
+          className={styles.banner}
+          style={{ "--banner-bg": banner.color } as CSSProperties}
+          role="status"
+          aria-live="polite"
+        >
+          <p className={styles.message}>
+            {title && <strong>{title}</strong>}
+            {title && message && " "}
+            {message}
+          </p>
+          {links.length > 0 && (
+            <div className={styles.actions}>
+              {links.map((link, index) => (
+                <Fragment key={`${index}-${link.url}`}>
+                  {index > 0 && (
+                    <span className={styles.separator} aria-hidden="true">
+                      ·
+                    </span>
+                  )}
+                  <a className={styles.link} href={link.url} target="_blank" rel="noopener noreferrer">
+                    {resolveLocalizedText(link.labels, i18n.language) ?? link.url}
+                  </a>
+                </Fragment>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.ts
+++ b/apps/frontend/src/rework/core/hooks/useLocalizedUploadWarning.ts
@@ -23,6 +23,22 @@ type LocalizedUploadWarning = {
 };
 
 /**
+ * Resolve one deployer-configured locale map ({locale → text}) for an i18next
+ * language tag ("fr-FR" → "fr"), falling back to "en", then to nothing.
+ *
+ * The single home of the config locale-fallback contract: `upload_warning`
+ * and `info_banner` both resolve their texts through this — do not
+ * duplicate the chain at a call site.
+ */
+export function resolveLocalizedText(
+  map: { [locale: string]: string } | undefined | null,
+  language: string | undefined,
+): string | null {
+  if (!map) return null;
+  return map[language?.split("-")[0] ?? "en"] ?? map["en"] ?? null;
+}
+
+/**
  * Resolve the warning message for an i18next language tag ("fr-FR" → "fr"),
  * falling back to "en", then to nothing (banner hidden).
  *
@@ -33,8 +49,7 @@ export function resolveUploadWarningMessage(
   uploadWarning: UploadWarning | null,
   language: string | undefined,
 ): string | null {
-  if (!uploadWarning?.messages) return null;
-  return uploadWarning.messages[language?.split("-")[0] ?? "en"] ?? uploadWarning.messages["en"] ?? null;
+  return resolveLocalizedText(uploadWarning?.messages, language);
 }
 
 /**

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -1837,6 +1837,30 @@ export type FrontendUserAuthConfig = {
   realm_url?: string | null;
   client_id?: string | null;
 };
+export type InfoBannerLink = {
+  /** Link target URL. */
+  url: string;
+  /** Locale → label map (e.g. {"en": "...", "fr": "..."}). */
+  labels?: {
+    [key: string]: string;
+  };
+};
+export type InfoBanner = {
+  /** Banner background CSS color. */
+  color?: string;
+  /** Seconds after which the banner hides itself, measured from app load. Omit for a persistent banner — the default. */
+  auto_hide_seconds?: number | null;
+  /** Locale → title map (e.g. {"en": "...", "fr": "..."}). */
+  titles?: {
+    [key: string]: string;
+  };
+  /** Locale → message map (e.g. {"en": "...", "fr": "..."}). */
+  messages?: {
+    [key: string]: string;
+  };
+  /** Links rendered on the right side of the banner. */
+  links?: InfoBannerLink[];
+};
 export type FrontendConfig = {
   user_auth: FrontendUserAuthConfig;
   gcu_version?: string | null;
@@ -1844,6 +1868,8 @@ export type FrontendConfig = {
   root_bootstrap_completed: boolean;
   /** The authoritative frontend gating decision for BootstrapGuard — true only when `security.user.enabled AND security.rebac.enabled AND NOT root_bootstrap_completed`. Deliberately distinct from `root_bootstrap_completed`, which stays the truthful durable historical marker and is never reinterpreted: on deployments where user authentication or ReBAC is disabled, `root_bootstrap_completed` is still False on a fresh database even though `POST /bootstrap/platform-admin` deliberately refuses with 503 there, so the frontend must not treat 'not completed' alone as 'must show the bootstrap page'. The frontend must gate on this field, not re-derive the ReBAC/auth predicate itself. */
   root_bootstrap_required: boolean;
+  /** Deployer-configured global announcement banner, from `platform.frontend.info_banner`. `None` when the deployment configures none — the frontend then renders nothing. Deliberately on this public pre-auth surface, not the authenticated `FrontendBootstrap`: the banner shows on every page, including the GCU-acceptance and root-bootstrap screens, which render before `/frontend/bootstrap` can succeed. Carries only deployer-authored announcement content — never anything sensitive. */
+  info_banner?: InfoBanner | null;
 };
 export type ManagedAgentUiHints = {
   multiline?: boolean;

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -12594,6 +12594,88 @@
                           ],
                           "default": null,
                           "description": "Optional banner shown on upload surfaces (document upload drawer, chat attachments). Omit to show nothing."
+                        },
+                        "info_banner": {
+                          "anyOf": [
+                            {
+                              "description": "Deployer-configured global announcement banner.\n\nFull-width and non-dismissable, shown above the app content on every page\n\u2014 including the pre-auth GCU-acceptance and root-bootstrap screens.\nPersistent by default; set `auto_hide_seconds` to make it disappear on\nits own. Texts are resolved from the user's locale with \"en\" fallback.\nOmit the whole block to show nothing.",
+                              "properties": {
+                                "color": {
+                                  "default": "#00BBDD",
+                                  "description": "Banner background CSS color.",
+                                  "title": "Color",
+                                  "type": "string"
+                                },
+                                "auto_hide_seconds": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null,
+                                  "description": "Seconds after which the banner hides itself, measured from app load. Omit for a persistent banner \u2014 the default.",
+                                  "title": "Auto Hide Seconds"
+                                },
+                                "titles": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Locale \u2192 title map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                  "title": "Titles",
+                                  "type": "object"
+                                },
+                                "messages": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Locale \u2192 message map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                  "title": "Messages",
+                                  "type": "object"
+                                },
+                                "links": {
+                                  "description": "Links rendered on the right side of the banner.",
+                                  "items": {
+                                    "description": "One link rendered on the right side of the info banner.",
+                                    "properties": {
+                                      "url": {
+                                        "description": "Link target URL.",
+                                        "title": "Url",
+                                        "type": "string"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "Locale \u2192 label map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                        "title": "Labels",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "title": "InfoBannerLink",
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "title": "Links",
+                                  "type": "array"
+                                }
+                              },
+                              "title": "InfoBanner",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Optional informative banner shown above the app content on every page. Omit to show nothing."
                         }
                       },
                       "title": "FrontendBootstrapConfig",
@@ -14555,6 +14637,88 @@
                           ],
                           "default": null,
                           "description": "Optional banner shown on upload surfaces (document upload drawer, chat attachments). Omit to show nothing."
+                        },
+                        "info_banner": {
+                          "anyOf": [
+                            {
+                              "description": "Deployer-configured global announcement banner.\n\nFull-width and non-dismissable, shown above the app content on every page\n\u2014 including the pre-auth GCU-acceptance and root-bootstrap screens.\nPersistent by default; set `auto_hide_seconds` to make it disappear on\nits own. Texts are resolved from the user's locale with \"en\" fallback.\nOmit the whole block to show nothing.",
+                              "properties": {
+                                "color": {
+                                  "default": "#00BBDD",
+                                  "description": "Banner background CSS color.",
+                                  "title": "Color",
+                                  "type": "string"
+                                },
+                                "auto_hide_seconds": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null,
+                                  "description": "Seconds after which the banner hides itself, measured from app load. Omit for a persistent banner \u2014 the default.",
+                                  "title": "Auto Hide Seconds"
+                                },
+                                "titles": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Locale \u2192 title map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                  "title": "Titles",
+                                  "type": "object"
+                                },
+                                "messages": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Locale \u2192 message map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                  "title": "Messages",
+                                  "type": "object"
+                                },
+                                "links": {
+                                  "description": "Links rendered on the right side of the banner.",
+                                  "items": {
+                                    "description": "One link rendered on the right side of the info banner.",
+                                    "properties": {
+                                      "url": {
+                                        "description": "Link target URL.",
+                                        "title": "Url",
+                                        "type": "string"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "Locale \u2192 label map (e.g. {\"en\": \"...\", \"fr\": \"...\"}).",
+                                        "title": "Labels",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "title": "InfoBannerLink",
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "title": "Links",
+                                  "type": "array"
+                                }
+                              },
+                              "title": "InfoBanner",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null,
+                          "description": "Optional informative banner shown above the app content on every page. Omit to show nothing."
                         }
                       },
                       "title": "FrontendBootstrapConfig",

--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -1650,15 +1650,34 @@ applications:
       scheduler: *cp-scheduler
       storage:   *cp-storage
       platform:
-        # Optional deployer-configured banner shown on upload surfaces
-        # (document upload drawer, chat attachments). Message resolved from
-        # the user's locale, "en" fallback. Omit the block to show nothing.
+        # Optional deployer-configured frontend banners; each block is
+        # independent and can be omitted to show nothing. Texts resolved from
+        # the user's locale, "en" fallback.
+        # - upload_warning: banner shown on upload surfaces (document upload
+        #   drawer, chat attachments).
+        # - info_banner: full-width announcement banner shown above the app
+        #   content on every page (including pre-auth pages). Non-dismissable;
+        #   persistent by default, or auto-hidden after auto_hide_seconds.
         # frontend:
         #   upload_warning:
         #     severity: warning # info | warning | error | success
         #     messages:
         #       en: "Do not upload sensitive or classified documents."
         #       fr: "Ne téléversez pas de documents sensibles ou classifiés."
+        #   info_banner:
+        #     color: "#00BBDD"
+        #     auto_hide_seconds: 30 # omit for a persistent banner (the default)
+        #     titles:
+        #       en: "New version available"
+        #       fr: "Nouvelle version disponible"
+        #     messages:
+        #       en: "Access the Fred documentation & blog"
+        #       fr: "Accédez à la documentation et au blog de Fred."
+        #     links:
+        #       - url: "https://fredk8.dev"
+        #         labels:
+        #           en: "Go to the Fred blog"
+        #           fr: "Accéder au blog de Fred"
         knowledge_flow_base_url: *kf-url
         runtime_catalog_sources:
           - runtime_id: fred-agents

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -178,6 +178,10 @@ value is served by a separate **public (unauthenticated)** surface:
   - `gcu_version` — **added 2026-06-22 (FRONT-10)** — active Terms-of-Use / CGU
     version the deployment requires, or omitted/`null` when gating is off. This
     is the **authoritative** source the frontend GCU guard reads.
+  - `info_banner` — **added 2026-08-19** — optional deployer-configured
+    global announcement banner (`platform.frontend.info_banner`), rendered
+    full-width above the app on every page. Omitted/`null` → nothing
+    rendered. See §42 for why it is pre-auth.
 
 The handler derives `user_auth` directly from `fred_core` `SecurityConfiguration.user`
 (`security.user`), the same config that drives backend JWT validation — so the backend
@@ -2701,3 +2705,31 @@ enablement by design (§40's ReBAC exemption).
 surfacing the deciding precedence level in the UI, per-turn re-resolution, and
 any non-chat capability — `embedding` has no
 production consumer.
+
+## 42. Contract Notes — global info banner (2026-08-19)
+
+`FrontendConfig` (§3.1.1) gains one optional field, `info_banner`
+(`InfoBanner`: `color` + `titles`/`messages` locale maps + `links: [{url,
+labels}]` + `auto_hide_seconds`), sourced from control-plane deployment
+config `platform.frontend.info_banner`. When set, the frontend renders one
+full-width, non-dismissable announcement banner (`InfoBanner`, mounted once
+at the app root) above the app content on **every** page, resolving texts
+from the active i18next locale with `en` fallback and pushing content down
+instead of overlaying it. Persistent by default; the optional
+`auto_hide_seconds` (integer > 0) makes the banner remove itself that many
+seconds after app load. `null`/omitted → nothing rendered — the shipped
+default: `values.yaml` (prod) and `configuration*.yaml` (dev) carry only
+commented-out example blocks.
+
+Boundary rationale (§3.1.1 vs §23): unlike `upload_warning` (post-auth
+surfaces only), the banner's whole point is to show on every page — the
+GCU-acceptance and root-bootstrap screens included, which render *before*
+the authenticated `/frontend/bootstrap` can succeed. So it follows the
+`gcu_version` precedent, not the `upload_warning` one: a pre-auth field on
+the public surface. It carries only deployer-authored announcement content
+— never secrets or per-user state — keeping §3.1.1's "no second bootstrap
+payload" rule intact. One deliberate scope note: on auth-enabled
+deployments the login page itself is Keycloak-hosted (`login-required`
+redirects away before the SPA renders), so the banner cannot cover the
+login screen — pre-auth here means "before the authenticated bootstrap",
+not "on the IdP's page".

--- a/docs/swift/platform/FRONTEND_CODING_GUIDELINES.md
+++ b/docs/swift/platform/FRONTEND_CODING_GUIDELINES.md
@@ -124,6 +124,22 @@ inheritance when the background changes.
 
 The M3 pairing rule: every `--foo` background pairs with `--on-foo` text.
 
+### 2.5 Never size a page or layout against the viewport
+
+Since the global `InfoBanner`, the app shell (`.appShell` in
+`src/app/App.module.css`) is the **only** element that sizes against the
+viewport (`height: 100vh`). Routed pages and layouts render inside
+`.appContent`, whose height is the viewport minus the banner, so a page
+declaring `height: 100vh` / `min-height: 100vh` / `width: 100vw` overflows
+the shell by the banner height the moment a deployment configures a banner —
+and the overflow is unreachable (`html` is `overflow: hidden` and scroll is
+reset). Use `height: 100%` / `width: 100%` instead; the failure is invisible
+in dev because the banner ships disabled by default.
+
+Viewport units remain fine where they are genuinely viewport-relative:
+portaled overlays (dialogs, popovers) using `max-height: calc(100vh - …)` or
+`min()` clamps.
+
 ---
 
 ## 3. Token Reference

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3249,7 +3249,10 @@ pages size with `height: 100%`, never `100vh` — see
 `platform.frontend.info_banner` (public pre-auth `/frontend/config`): without
 the config block, nothing renders — there is no default banner. Persistent
 by default; the optional `auto_hide_seconds` removes it that many seconds
-after app load (content reflows up when it goes). Background
+after app load with a 300ms eased collapse (opacity + `grid-template-rows`
+1fr→0fr, so the content below slides up instead of jumping; snaps under
+`prefers-reduced-motion`, and the banner is aria-hidden as soon as the exit
+starts). Background
 color comes from configuration via the `--banner-bg` custom property
 (deliberate token exception, comment in the module CSS); title/message/link
 labels are locale maps resolved with `en` fallback; links open in a new tab,

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3233,6 +3233,38 @@ clears the binding back to "Using pod default".
 
 ---
 
+## Global info banner (2026-08-19)
+
+### `InfoBanner`
+
+**Location:** `src/rework/components/shared/molecules/InfoBanner/`
+**Status:** `Functional`
+
+Full-width, non-dismissable announcement banner mounted once at
+the app root (`src/app/App.tsx`), above the GCU/bootstrap guards, so it shows
+on every page — pre-auth ones included — and pushes the app content down
+instead of overlaying it (the app shell is now a `100vh` flex column; routed
+pages size with `height: 100%`, never `100vh` — see
+`FRONTEND_CODING_GUIDELINES.md` §2.5). Entirely config-driven from
+`platform.frontend.info_banner` (public pre-auth `/frontend/config`): without
+the config block, nothing renders — there is no default banner. Persistent
+by default; the optional `auto_hide_seconds` removes it that many seconds
+after app load (content reflows up when it goes). Background
+color comes from configuration via the `--banner-bg` custom property
+(deliberate token exception, comment in the module CSS); title/message/link
+labels are locale maps resolved with `en` fallback; links open in a new tab,
+separated by a `·`, and only http(s)/relative URLs are rendered.
+`role="status"` + `aria-live="polite"`.
+
+#### Open UX issues
+
+- **Fixed dark text over a configured background.** `--banner-text: #00222c`
+  assumes the configured color stays light (like the documented `#00BBDD`
+  example); a dark configured color would fail contrast. Revisit only if a
+  deployment actually needs a dark banner.
+
+---
+
 ## UX review agenda
 
 _Priority order for the next UX session. Update before each session._


### PR DESCRIPTION
Closes #2400

## What

A full-width, non-dismissable announcement banner shown above the app content on **every** page - pre-auth GCU-acceptance and root-bootstrap screens included. Entirely config-driven: omit the block and nothing renders. **No default ships** - `values.yaml` (prod) and `configuration*.yaml` (dev) carry commented-out example blocks only.

```yaml
# frontend:
#   info_banner:
#     color: "#00BBDD"
#     auto_hide_seconds: 30 # omit for a persistent banner (the default)
#     titles:
#       en: "New version available"
#       fr: "Nouvelle version disponible"
#     messages:
#       en: "Access the Fred documentation & blog"
#     links:
#       - url: "https://fredk8.dev"
#         labels:
#           en: "Go to the Fred blog"
```

## How

- **control-plane**: new `platform.frontend.info_banner` block, exposed on the public pre-auth `GET /frontend/config` so the banner renders before the authenticated bootstrap (rationale recorded in `CONTROL-PLANE-PRODUCT-CONTRACT.md` §42); `build_frontend_config` now has a single return path - only `user_auth` depends on the auth switch
- **frontend**: rework molecule `InfoBanner` mounted once at the app root above the guards; the app shell becomes a `100vh` flex column and every routed page sizes with `100%` instead of `100vh`/`100vw` (new rule: `FRONTEND_CODING_GUIDELINES.md` §2.5); locale fallback shared with the upload warning (`resolveLocalizedText`); only http(s)/relative link URLs are rendered
- **auto-hide**: optional `auto_hide_seconds` (integer > 0) removes the banner after that delay with a 300ms eased collapse (`grid-template-rows` 1fr→0fr + opacity, content slides up; snaps under `prefers-reduced-motion`; `aria-hidden` as soon as the exit starts)
- **generated artifacts** regenerated: `controlPlaneOpenApi.ts`, `configuration.schema.json`, `values.schema.json`

## Tests

- backend: `/frontend/config` exposes the configured banner, omits the key when unconfigured (809+ suite green)
- frontend: 8 `InfoBanner` tests - static rendering contract, locale fallback, unsafe-link filtering, and the timed two-phase exit with fake timers (1359-test suite green)
- `make code-quality` from the monorepo root: green
