### PR TITLE
fix(#2398): hide private teams from the marketplace and lock joining mode

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2073,7 +2073,9 @@
           "label": "Joining mode",
           "support": "Users can join your team freely or by invitation only.",
           "open": "Open",
-          "inviteOnly": "Invite only"
+          "inviteOnly": "Invite only",
+          "manual": "Manual only",
+          "privateSupport": "A private team is not listed on the marketplace: its members are added manually by a team admin."
         },
         "visibility": {
           "label": "Team visibility",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2073,7 +2073,9 @@
           "label": "Mode d'adhésion",
           "support": "Les utilisateurs peuvent rejoindre votre équipe librement ou uniquement sur invitation.",
           "open": "Ouverte",
-          "inviteOnly": "Sur invitation"
+          "inviteOnly": "Sur invitation",
+          "manual": "Ajout manuel",
+          "privateSupport": "Une équipe privée n'apparaît pas sur la marketplace : ses membres sont ajoutés manuellement par un administrateur de l'équipe."
         },
         "visibility": {
           "label": "Visibilité de l'équipe",

--- a/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.test.tsx
+++ b/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.test.tsx
@@ -106,6 +106,40 @@ describe("MarketplaceTeams personal-space exclusion", () => {
   });
 });
 
+describe("MarketplaceTeams private-team exclusion", () => {
+  beforeEach(() => {
+    h.bootstrap = {
+      activeTeam: { id: "personal-me" } as TeamWithPermissions,
+      availableTeams: [{ id: "personal-me" }, { id: "fredlab" }] as Team[],
+      bootstrap: undefined,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  // #2398: the server withholds the ReBAC `public` relation from a private
+  // team, but that filter is skipped when authorization is disabled — the
+  // page must not depend on it to keep a private team out of "discover".
+  it("never renders a private team the caller is not a member of", () => {
+    h.teams = {
+      data: [
+        { id: "acme", name: "acme", is_member: false, visibility: "private" } as Team,
+        { id: "globex", name: "globex", is_member: false, visibility: "public" } as Team,
+      ],
+    };
+    const html = render();
+    expect(html).not.toContain("team-card-acme");
+    expect(html).toContain("team-card-globex");
+  });
+
+  it("still renders a private team the caller is a member of", () => {
+    h.teams = {
+      data: [{ id: "fredlab", name: "fredlab", is_member: true, visibility: "private" } as Team],
+    };
+    expect(render()).toContain("team-card-fredlab");
+  });
+});
+
 describe("MarketplaceTeams card navigability", () => {
   beforeEach(() => {
     h.bootstrap = {

--- a/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.tsx
+++ b/apps/frontend/src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.tsx
@@ -71,8 +71,16 @@ export default function MarketplaceTeams() {
   // `GET /teams` intentionally includes personal spaces (it also feeds the
   // bootstrap-driven sidebar/team switcher), but the marketplace must never
   // list one, including the caller's own — see #2068.
+  //
+  // Same stance for private teams (#2398): the server already withholds the
+  // ReBAC `public` relation from them, but that filter is skipped entirely
+  // when authorization is disabled, and discoverability is this page's own
+  // product rule — so never offer a private team to a non-member here,
+  // whatever the endpoint returned. A member keeps seeing their own private
+  // teams under "your teams": they need them to navigate.
   const yourTeams = teams && teams.filter((t) => t.is_member && !isPersonalTeamId(t.id));
-  const otherTeams = teams && teams.filter((t) => !t.is_member && !isPersonalTeamId(t.id));
+  const otherTeams =
+    teams && teams.filter((t) => !t.is_member && !isPersonalTeamId(t.id) && t.visibility !== "private");
 
   const filteredYourTeams = useMemo(() => filterTeams(yourTeams, search), [yourTeams, search]);
   const filteredOtherTeams = useMemo(() => filterTeams(otherTeams, search), [otherTeams, search]);

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
@@ -103,3 +103,10 @@
   color: var(--on-surface-retreat);
   font: var(--font-body-small);
 }
+
+/* #2398: read-only stand-in for the joining-mode toggle while the team is
+ * private — reads as a stated fact, not as a control that refuses clicks. */
+.team-settings-toggle-static {
+  color: var(--on-surface-retreat);
+  font: var(--font-label-large);
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
@@ -104,11 +104,9 @@
   font: var(--font-body-small);
 }
 
-/* #2398: read-only stand-in for the joining-mode toggle while the team is
- * private — reads as a stated fact, not as a control that refuses clicks. */
-.team-settings-toggle-static {
+/* #2398: the label column takes the row's free width, so the private-team
+ * "manual only" button must not shrink or wrap (`.btn` clips overflow). */
+.team-settings-toggle-action {
   flex-shrink: 0;
-  color: var(--on-surface-retreat);
-  font: var(--font-label-large);
   white-space: nowrap;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
@@ -107,6 +107,8 @@
 /* #2398: read-only stand-in for the joining-mode toggle while the team is
  * private — reads as a stated fact, not as a control that refuses clicks. */
 .team-settings-toggle-static {
+  flex-shrink: 0;
   color: var(--on-surface-retreat);
   font: var(--font-label-large);
+  white-space: nowrap;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.test.tsx
@@ -18,8 +18,8 @@
 // TEAM-10 (2026-07-26): a sibling visibility (public/private) button group
 // was added just above it in the same form-section — a PRIVATE team can
 // never be OPEN, and #2398 replaced the disabled joining-mode group with a
-// static "manual only" state while visibility is private (no invitation flow
-// exists: a team admin adds members by hand).
+// single disabled "manual only" button while visibility is private (no
+// invitation flow exists: a team admin adds members by hand).
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -139,11 +139,15 @@ describe("TeamSettingsParameters joining mode", () => {
     expect(h.updateTeam).not.toHaveBeenCalled();
   });
 
-  it("renders no toggle at all while the team is private, only the manual state", () => {
+  it("renders one disabled manual-only button instead of the toggle while the team is private", () => {
     render(<TeamSettingsParameters team={baseTeam("invite_only", "private")} />);
 
     expect(joiningModeRadios()).toHaveLength(0);
-    expect(container.textContent).toContain("rework.teamSettings.parameters.joiningMode.manual");
+    const buttons = Array.from(container.querySelectorAll("button")).filter((button) =>
+      button.textContent?.includes("rework.teamSettings.parameters.joiningMode.manual"),
+    );
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].disabled).toBe(true);
     expect(container.textContent).toContain("rework.teamSettings.parameters.joiningMode.privateSupport");
   });
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.test.tsx
@@ -17,8 +17,9 @@
 // replaced by a 2-way joining_mode button group (open / invite_only).
 // TEAM-10 (2026-07-26): a sibling visibility (public/private) button group
 // was added just above it in the same form-section — a PRIVATE team can
-// never be OPEN, so the joining-mode group is entirely disabled while
-// visibility is private.
+// never be OPEN, and #2398 replaced the disabled joining-mode group with a
+// static "manual only" state while visibility is private (no invitation flow
+// exists: a team admin adds members by hand).
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -138,14 +139,12 @@ describe("TeamSettingsParameters joining mode", () => {
     expect(h.updateTeam).not.toHaveBeenCalled();
   });
 
-  it("is entirely disabled while the team is private", () => {
+  it("renders no toggle at all while the team is private, only the manual state", () => {
     render(<TeamSettingsParameters team={baseTeam("invite_only", "private")} />);
 
-    const radios = joiningModeRadios();
-    expect(radios).toHaveLength(2);
-    for (const radio of radios) {
-      expect((radio as HTMLButtonElement).disabled).toBe(true);
-    }
+    expect(joiningModeRadios()).toHaveLength(0);
+    expect(container.textContent).toContain("rework.teamSettings.parameters.joiningMode.manual");
+    expect(container.textContent).toContain("rework.teamSettings.parameters.joiningMode.privateSupport");
   });
 
   it("is enabled while the team is public", () => {
@@ -154,6 +153,7 @@ describe("TeamSettingsParameters joining mode", () => {
     for (const radio of joiningModeRadios()) {
       expect((radio as HTMLButtonElement).disabled).toBe(false);
     }
+    expect(container.textContent).toContain("rework.teamSettings.parameters.joiningMode.support");
   });
 });
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx
@@ -99,8 +99,9 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
   // TEAM-10 (#2398): a PRIVATE team can never be OPEN, and there is no
   // invitation flow either — a team admin adds members by hand. So while
   // private, the joining-mode toggle is not a setting at all: it is replaced
-  // by a static "manual only" state rather than rendered as a two-state
-  // control that refuses every click.
+  // by a single disabled "manual only" button rather than a two-state control
+  // that refuses every click — one inert, locked state reads as the fact it
+  // is, where a greyed-out toggle still reads as a choice.
   const visibility = team.visibility ?? "public";
   const isPrivate = visibility === "private";
   const handleSelectVisibility = (index: number) => {
@@ -231,9 +232,16 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
             </span>
           </div>
           {isPrivate ? (
-            <span className={styles["team-settings-toggle-static"]}>
+            <Button
+              className={styles["team-settings-toggle-action"]}
+              color="secondary"
+              variant="outlined"
+              size="small"
+              icon={{ category: "outlined", type: "lock" }}
+              disabled
+            >
               {t("rework.teamSettings.parameters.joiningMode.manual")}
-            </span>
+            </Button>
           ) : (
             <ButtonGroup
               variant="radio"

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx
@@ -96,10 +96,11 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
     });
   };
 
-  // TEAM-10: a PRIVATE team can never be OPEN — disabling the whole group
-  // while private (rather than just the "Open" option) both prevents
-  // picking it and reflects that the server silently downgraded
-  // joining_mode to INVITE_ONLY the moment visibility turned private.
+  // TEAM-10 (#2398): a PRIVATE team can never be OPEN, and there is no
+  // invitation flow either — a team admin adds members by hand. So while
+  // private, the joining-mode toggle is not a setting at all: it is replaced
+  // by a static "manual only" state rather than rendered as a two-state
+  // control that refuses every click.
   const visibility = team.visibility ?? "public";
   const isPrivate = visibility === "private";
   const handleSelectVisibility = (index: number) => {
@@ -224,22 +225,30 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
           <div className={styles["team-settings-toggle-label"]}>
             <span>{t("rework.teamSettings.parameters.joiningMode.label")}</span>
             <span className={styles["team-settings-toggle-support"]}>
-              {t("rework.teamSettings.parameters.joiningMode.support")}
+              {isPrivate
+                ? t("rework.teamSettings.parameters.joiningMode.privateSupport")
+                : t("rework.teamSettings.parameters.joiningMode.support")}
             </span>
           </div>
-          <ButtonGroup
-            variant="radio"
-            size="small"
-            color="secondary"
-            backgroundColor="var(--surface-container-lowest)"
-            aria-label={t("rework.teamSettings.parameters.joiningMode.label")}
-            selectedIndex={JOINING_MODES.indexOf(joiningMode)}
-            onSelectedIndexChange={handleSelectJoiningMode}
-            items={[
-              { label: t("rework.teamSettings.parameters.joiningMode.open"), disabled: isPrivate },
-              { label: t("rework.teamSettings.parameters.joiningMode.inviteOnly"), disabled: isPrivate },
-            ]}
-          />
+          {isPrivate ? (
+            <span className={styles["team-settings-toggle-static"]}>
+              {t("rework.teamSettings.parameters.joiningMode.manual")}
+            </span>
+          ) : (
+            <ButtonGroup
+              variant="radio"
+              size="small"
+              color="secondary"
+              backgroundColor="var(--surface-container-lowest)"
+              aria-label={t("rework.teamSettings.parameters.joiningMode.label")}
+              selectedIndex={JOINING_MODES.indexOf(joiningMode)}
+              onSelectedIndexChange={handleSelectJoiningMode}
+              items={[
+                { label: t("rework.teamSettings.parameters.joiningMode.open") },
+                { label: t("rework.teamSettings.parameters.joiningMode.inviteOnly") },
+              ]}
+            />
+          )}
         </div>
       </div>
       {/* Data & Retention (CTRLP-12 B6): lives here rather than a dedicated tab. */}

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1330,21 +1330,24 @@ mechanism. No client-side write of `joining_mode` ever accompanies a
 visibility PATCH — the resulting `joining_mode`, if it changes, comes back
 from the server on refetch.
 
-**Joining mode while private — static state, no toggle (#2398,
+**Joining mode while private — one disabled button, no toggle (#2398,
 2026-08-20).** A `private` team can never be `open`, and the product has no
 invitation flow at all (there is no invite endpoint — a team admin adds
 members by hand from `TeamSettingsMembers`). So while
 `visibility === "private"` the joining-mode row renders no `ButtonGroup`:
-the control slot holds one static, unstyled-as-interactive label
-(`.team-settings-toggle-static`, `on-surface-retreat` /
-`--font-label-large`) reading "Manual only", and the row's support line
-switches to the `privateSupport` copy ("a private team is not listed on the
-marketplace: its members are added manually by a team admin"). This
-replaced the original 2026-07-26 treatment, which kept the group mounted
-with every item `disabled` — a two-state toggle that refuses every click
-still reads as a setting, and "Invite only" named a mechanism that does not
-exist. The group returns unchanged the moment visibility goes back to
-`public`.
+the control slot holds a single **disabled** `Button` (`secondary` /
+`outlined` / `small`, `lock` icon) reading "Manual only", and the row's
+support line switches to the `privateSupport` copy ("a private team is not
+listed on the marketplace: its members are added manually by a team
+admin"). One inert, locked control states the fact; the original 2026-07-26
+treatment kept the whole group mounted with every item `disabled`, and a
+greyed-out *two-state* toggle still reads as a live choice — while "Invite
+only" named a mechanism that does not exist. Plain muted text was tried
+first and read as too weak for the row (it also wrapped onto two lines),
+hence a real button shape. `.team-settings-toggle-action` carries the
+`flex-shrink: 0` + `white-space: nowrap` the row needs: the label column
+takes the free width and `.btn` clips its own overflow. The group returns
+unchanged the moment visibility goes back to `public`.
 
 **`ButtonGroupItem` — `:disabled` visual state (2026-07-26).** The atom
 previously had no disabled styling at all — a `disabled` item was

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1281,6 +1281,22 @@ dropped from the enum entirely; see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §29.
 
 ---
 
+### `MarketplaceTeams` — what the discover section may list (#2398)
+
+**Location:** `src/rework/components/pages/marketplace/MarketplaceTeams/MarketplaceTeams.tsx`
+**Status:** `Functional`
+
+`GET /teams` is a general-purpose listing, not a marketplace feed: the page
+decides on its own what is discoverable, and drops from the "discover"
+(non-member) bucket every team that is a personal space (#2068) or whose
+`visibility` is `private` (#2398). The server already withholds the ReBAC
+`public` relation from a private team, but that filter is skipped entirely
+when authorization is disabled — so the page never relies on it. A team the
+caller *is* a member of stays listed under "your teams" whatever its
+visibility: members need it to navigate.
+
+---
+
 ### `TeamSettingsParameters` — visibility + joining-mode controls
 
 **Location:** `src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx`
@@ -1289,7 +1305,8 @@ dropped from the enum entirely; see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §29.
 Two stacked rows (`.team-settings-toggle-row`, label left / control right)
 share one `form-section` (`.team-settings-toggles`, `flex-direction: column`,
 `gap: var(--spacing-s)`): **visibility** (`public`/`private`) on top,
-**joining mode** below it. Both are `ButtonGroup`s (`variant="radio"`,
+**joining mode** below it (a `ButtonGroup` only while the team is public —
+see the #2398 note below). Both are `ButtonGroup`s (`variant="radio"`,
 `size="small"`, plain group-level `color="secondary"` — no per-item color,
 same pattern as the theme/language pickers in `UserSettingsPage.tsx`).
 Selecting an option PATCHes immediately (no separate save step), mirroring
@@ -1309,15 +1326,25 @@ follows now.
 **Visibility control (TEAM-10, 2026-07-26).** New `ButtonGroup`
 (`public`/`private`, default `public`) gating marketplace discoverability
 — see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §30 for the full ReBAC
-mechanism. A `private` team can never be `open`: while
-`visibility === "private"`, every item in the joining-mode `ButtonGroup`
-below carries `disabled` (the whole group reads as inert, not just the
-`open` option) — enforced this way rather than only disabling `open`
-because the server may have just silently downgraded a stored `open` to
-`invite_only` the moment visibility flipped, and a half-disabled group
-would misrepresent that as still a live choice. No client-side write of
-`joining_mode` ever accompanies a visibility PATCH — the resulting
-`joining_mode`, if it changes, comes back from the server on refetch.
+mechanism. No client-side write of `joining_mode` ever accompanies a
+visibility PATCH — the resulting `joining_mode`, if it changes, comes back
+from the server on refetch.
+
+**Joining mode while private — static state, no toggle (#2398,
+2026-08-20).** A `private` team can never be `open`, and the product has no
+invitation flow at all (there is no invite endpoint — a team admin adds
+members by hand from `TeamSettingsMembers`). So while
+`visibility === "private"` the joining-mode row renders no `ButtonGroup`:
+the control slot holds one static, unstyled-as-interactive label
+(`.team-settings-toggle-static`, `on-surface-retreat` /
+`--font-label-large`) reading "Manual only", and the row's support line
+switches to the `privateSupport` copy ("a private team is not listed on the
+marketplace: its members are added manually by a team admin"). This
+replaced the original 2026-07-26 treatment, which kept the group mounted
+with every item `disabled` — a two-state toggle that refuses every click
+still reads as a setting, and "Invite only" named a mechanism that does not
+exist. The group returns unchanged the moment visibility goes back to
+`public`.
 
 **`ButtonGroupItem` — `:disabled` visual state (2026-07-26).** The atom
 previously had no disabled styling at all — a `disabled` item was
@@ -1327,12 +1354,14 @@ identical to an enabled one. Added `&:disabled` with `pointer-events: none`
 `:hover`/`:active` rules individually) plus, scoped to
 `.stateLayer:not([data-selected="true"])` only, a transparent background
 and `on-surface-muted` label color. Scoping to the unselected sub-case
-matters: the joining-mode group's disabled-while-private state always has
-one selected item (`invite_only`, forced) and one not (`open`) — the
-selected item keeps its normal filled selected-color styling, only the
-unselected `open` option reads as muted/transparent. Generic addition to
-the shared atom (any future disabled+unselected item elsewhere gets the
-same treatment for free), not special-cased to this one call site.
+mattered for the original driving call site — the joining-mode group's
+disabled-while-private state, which always had one selected item
+(`invite_only`, forced) and one not (`open`): the selected item kept its
+normal filled selected-color styling, only the unselected `open` option
+read as muted/transparent. That call site is gone since #2398 (see above),
+but the rule was a generic addition to the shared atom, never special-cased
+to it — any disabled+unselected item elsewhere still gets the treatment for
+free.
 
 **`ButtonGroup` — pill `backgroundColor` override (2026-07-26).** Gained an
 optional `backgroundColor` prop (default `var(--surface-container)`,


### PR DESCRIPTION
Closes #2398.

Frontend only — no backend, contract, or generated-client change.

## 1. A private team never reaches the marketplace "Discover" section

`MarketplaceTeams` rendered whatever `GET /teams` returned, minus personal
spaces. Private teams were kept out **only** by the server-side ReBAC
`CAN_READ` filter (`can_read = team_member or public`), which `_list_teams`
skips entirely when authorization is disabled — so on a no-security
deployment the discover section listed private teams.

Discoverability is this page's own product rule, so the non-member bucket now
also drops `visibility === "private"`, exactly like the personal-space
exclusion added in #2068. A team the caller *is* a member of stays under "Your
teams" whatever its visibility — members need it to navigate.

## 2. No dead joining-mode toggle while private

`PRIVATE` + `OPEN` is invalid (the server downgrades to `INVITE_ONLY` on any
patch that would produce it, TEAM-10), so the panel used to keep the
joining-mode `ButtonGroup` mounted with **both** items `disabled`. A two-state
toggle that refuses every click still reads as a setting — and "Invite only"
names a mechanism that does not exist: there is no invitation endpoint, a team
admin adds members by hand from the members table.

While private, the control slot now holds a static "Manual only" label and the
row's support line becomes "A private team is not listed on the marketplace:
its members are added manually by a team admin." The normal group comes back
unchanged as soon as visibility returns to public.

| | Before | After |
| --- | --- | --- |
| Discover section | private teams listed when ReBAC is off | never listed |
| Joining mode (private) | 2-state toggle, both items disabled | static "Manual only" + explanatory support line |
| Joining mode (public) | unchanged | unchanged |

## Tests

- `MarketplaceTeams.test.tsx` — a non-member private team is not rendered; a
  member private team still is
- `TeamSettingsParameters.test.tsx` — no radios at all while private, manual +
  privateSupport copy present; public path unchanged

`make code-quality` and `make test` green in `apps/frontend` (137 files / 1353
tests).

## Docs

`docs/swift/ux/COMPONENT-UX.md`: new `MarketplaceTeams` section (what the
discover bucket may list), rewritten TEAM-10 visibility note, and the
`ButtonGroupItem :disabled` paragraph corrected — its driving call site is
gone, the generic atom rule stays.
