### PR TITLE
fix(ui): keep the chat list meta line on one line and align nav panel widths

### DIFF
--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/AdminNavbar/AdminNavbar.module.css
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/AdminNavbar/AdminNavbar.module.css
@@ -1,5 +1,7 @@
+/* 272px: kept in sync with the other nav panels (see TeamContentNavbar) — they
+ * swap in the same grid column, a mismatch makes the column jump. */
 .adminNavbarContainer {
-  width: 240px;
+  width: 272px;
 }
 
 .adminNavbarTitle {

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/HomeNavPanel/HomeNavPanel.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/HomeNavPanel/HomeNavPanel.module.scss
@@ -13,10 +13,12 @@
  * limitations under the License.
  */
 
+/* 272px: kept in sync with the other nav panels (see TeamContentNavbar) — they
+ * swap in the same grid column, a mismatch makes the column jump. */
 .panel {
   display: flex;
   flex-direction: column;
-  width: 240px;
+  width: 272px;
   height: 100%;
   min-height: 0;
 }

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/MarketplaceNavbar/MarketplaceNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/MarketplaceNavbar/MarketplaceNavbar.module.scss
@@ -1,3 +1,5 @@
+/* 272px: kept in sync with the other nav panels (see TeamContentNavbar) — they
+ * swap in the same grid column, a mismatch makes the column jump. */
 .marketplace-navbar-container {
-  width: 240px;
+  width: 272px;
 }

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.module.scss
@@ -1,10 +1,16 @@
 /* The main nav panel — the second column that swaps content by mainNavBar
  * selection (team nav here, Home team list, marketplace, admin). Renamed from
- * `teamContentNavbarContainer` (#2298): it is no longer team-only. */
+ * `teamContentNavbarContainer` (#2298): it is no longer team-only.
+ *
+ * 272px (was 240px): the conversation list's meta line "<agent> · DD/MM/YY -
+ * HH:mm" is the widest content this column carries, and at 240px it left too
+ * little room for the agent name once the date is kept intact. All four panels
+ * share this width — they swap in the same grid column, so any mismatch shows
+ * up as the column jumping when switching modes. */
 .mainNavPanel {
   display: flex;
   flex-direction: column;
-  width: 240px;
+  width: 272px;
   height: 100%;
   min-height: 0;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/AgentCard/AgentCard.module.scss
@@ -254,8 +254,12 @@
   --btn-text-color: var(--on-surface);
   /* design-token exception: full-spectrum conic gradient (white→cyan→violet→peach→pink→white),
      matching the card's former hover treatment. No semantic token family covers this rainbow
-     sequence; discretising to 5 tokens would destroy the animation effect. */
+     sequence; discretising to 5 tokens would destroy the animation effect.
+     2026-08-21: colour stops saturated and moderately darkened (same hues,
+     shared with the composer's Boost text in ReasoningChip.module.css) — the
+     pastels washed out on the light theme, a fully darkened pass sank into
+     the dark one; these sit halfway between. One gradient, both themes. */
   background:
     linear-gradient(var(--surface-container), var(--surface-container)) padding-box,
-    conic-gradient(from var(--angle), #ffffff, #65e0f6, #9299ff, #e1c39c, #d665b4, #ffffff) border-box;
+    conic-gradient(from var(--angle), #ffffff, #37c9e4, #6f78fc, #e4ae66, #db47ae, #ffffff) border-box;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.module.scss
@@ -21,14 +21,19 @@
   overflow-y: auto;
 }
 
-/* Sub-list header shown above each agent's conversations when grouping is on. */
+/* Sub-list header shown above each agent's conversations when grouping is on.
+ * Truncated like the inline agent name below it — a long name must not wrap the
+ * header onto a second line. */
 .groupHeader {
   margin-top: 4px;
   border-radius: var(--radius-xs);
   background-color: var(--surface-container-lowest);
   padding: var(--spacing-2xs) var(--spacing-xs) var(--spacing-2xs);
+  overflow: hidden;
   color: var(--primary);
   font: var(--font-label-small);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chatListPlaceholder {

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatList.tsx
@@ -144,7 +144,9 @@ export default function ChatList({ teamId }: ChatListProps) {
         {groups
           ? groups.map(([agentName, groupSessions]) => (
               <div key={agentName}>
-                <div className={styles.groupHeader}>{agentName}</div>
+                <div className={styles.groupHeader} title={agentName}>
+                  {agentName}
+                </div>
                 {groupSessions.map((session) => renderItem(session, false))}
               </div>
             ))

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.module.scss
@@ -35,13 +35,31 @@
   white-space: nowrap;
 }
 
-.date {
+/* One line, never two: the whole meta row is nowrap and the only flexible part
+ * is the agent name. `min-width: 0` lets it actually shrink below its content
+ * width so the ellipsis kicks in instead of the row overflowing. */
+.meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-3xs);
+  min-width: 0;
   color: var(--on-surface-muted);
   font: var(--font-label-small);
+  white-space: nowrap;
 }
 
 .agentName {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
   color: var(--primary);
+  text-overflow: ellipsis;
+}
+
+/* Separator and date keep their intrinsic width — the name absorbs the squeeze. */
+.metaSeparator,
+.dateLabel {
+  flex: 0 0 auto;
 }
 
 .chatActions {

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.module.scss
@@ -48,8 +48,11 @@
   white-space: nowrap;
 }
 
+/* Grows to fill the row so its box is the same width on every line: short
+ * names leave a gap, long names ellipsize, and the separator + date land at
+ * the same x everywhere — a fixed-width column without a hardcoded width. */
 .agentName {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   color: var(--primary);
@@ -60,6 +63,12 @@
 .metaSeparator,
 .dateLabel {
   flex: 0 0 auto;
+}
+
+/* Uniform-width digits: "DD/MM/YY - HH:MM" always renders at the same width
+ * regardless of which digits it contains, so the date column stays aligned. */
+.dateLabel {
+  font-variant-numeric: tabular-nums;
 }
 
 .chatActions {

--- a/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.tsx
@@ -34,11 +34,19 @@ export function ChatListItem({ sessionId, href, label, agentName, dateLabel, onD
     <Link to={href} className={styles.chatItemContainer} data-selected={isSelected}>
       <div className={styles.chatDescription}>
         <div className={styles.title}>{label}</div>
+        {/* Meta line: the date is the fixed part and must stay whole ("18/08/26
+            - 09:42" split over two lines was unreadable), so only the agent
+            name gives way — it shrinks and ellipsizes, with the full name on
+            hover. */}
         {(agentName || dateLabel) && (
-          <div className={styles.date}>
-            {agentName && <span className={styles.agentName}>{agentName}</span>}
-            {agentName && dateLabel && " · "}
-            {dateLabel}
+          <div className={styles.meta}>
+            {agentName && (
+              <span className={styles.agentName} title={agentName}>
+                {agentName}
+              </span>
+            )}
+            {agentName && dateLabel && <span className={styles.metaSeparator}>·</span>}
+            {dateLabel && <span className={styles.dateLabel}>{dateLabel}</span>}
           </div>
         )}
       </div>

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.module.css
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.module.css
@@ -105,9 +105,14 @@
    themes.
 
    The WORD still carries the state on its own, so this is reinforcement and
-   never the only signal — a colour-blind reader reads "Boost" vs "Rapide". */
+   never the only signal — a colour-blind reader reads "Boost" vs "Rapide".
+
+   2026-08-21: stops saturated and moderately darkened (same hues) — the
+   original pastels were near-invisible on the light surface, and a fully
+   darkened pass sank into the dark one. These sit halfway between the two so
+   the single gradient reads on both themes. */
 .state[data-on] {
-  background: linear-gradient(90deg, #65e0f6, #9299ff, #d665b4);
+  background: linear-gradient(90deg, #37c9e4, #6f78fc, #db47ae);
   background-clip: text;
   -webkit-background-clip: text;
   /* Fallback first: any engine that ignores background-clip: text keeps a

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1237,10 +1237,16 @@ onto a second line whenever the agent name was long, colliding with the next
 row and making the list unreadable. Two changes:
 
 - The meta line is now a nowrap flex row where **only the agent name flexes**
-  (`flex: 0 1 auto; min-width: 0; text-overflow: ellipsis`, full name in
+  (`flex: 1 1 auto; min-width: 0; text-overflow: ellipsis`, full name in
   `title`); the separator and the date are `flex: 0 0 auto`, so the date and
   time always render whole. Same ellipsis treatment on `.groupHeader`, the
   per-agent sub-list header shown when grouping is on.
+- Vertical column alignment (2026-08-21): the agent name **grows** to fill the
+  row, so its box is the same width on every line — short names leave a gap,
+  long names ellipsize — and the `·` separator and date start at the same x
+  everywhere. The date also uses `font-variant-numeric: tabular-nums`, so the
+  fixed `DD/MM/YY - HH:mm` format always renders at the same width regardless
+  of which digits it contains.
 - All four nav panels went **240px → 272px**. They swap into the same sidebar
   grid column, so the width must stay identical across them or the column
   jumps when switching between Home / team / marketplace / admin.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -232,7 +232,11 @@ but is a hole in text, invisible on the light theme) — leaving cyan → violet
 pink. A solid `--primary` sits underneath as the fallback for engines that
 ignore `background-clip: text`, and `forced-colors` drops the gradient for the
 system palette. The WORD carries the state either way, so colour is
-reinforcement, never the only signal.
+reinforcement, never the only signal. 2026-08-21: the shared stops were
+saturated and moderately darkened (same hues) in both places — the original
+pastels were near-invisible on the light surface, a fully darkened pass sank
+into the dark one; the retained stops sit halfway between, so the single
+gradient reads on both themes.
 
 Deliberately NOT a low/medium/high picker — a same-day effort picker was
 withdrawn (providers 400 on values they don't support,
@@ -1274,7 +1278,7 @@ Displays one managed agent instance. Current layout (#2096, superseding the #207
 #### Open UX issues
 
 - Not yet design-reviewed against a live stack. First functional pass only.
-- **Gradient animation colours** — the Chat button's conic-gradient uses hardcoded hex stops (`#65e0f6`, `#9299ff`, `#e1c39c`, `#d665b4`). Intentional branding colours not in the design token system — confirm with designer whether they should be tokenised or kept as-is.
+- **Gradient animation colours** — the Chat button's conic-gradient uses hardcoded hex stops (`#37c9e4`, `#6f78fc`, `#e4ae66`, `#db47ae` — saturated and moderately darkened 2026-08-21 from the original pastels, same hues: the pastels washed out on the light theme, a fully darkened pass sank into the dark one, so these sit halfway between; one gradient serves both themes). Intentional branding colours not in the design token system — confirm with designer whether they should be tokenised or kept as-is. Shared with the composer's `Boost` text (`ReasoningChip.module.css`), minus the white stops and peach.
 
 #### Resolved
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1224,6 +1224,29 @@ UUID-prefix fallback from the open issue above) — same shape as
 
 ---
 
+### `ChatList` meta line and nav panel width (2026-08-20)
+
+**Location:**
+`src/rework/components/shared/organisms/ChatList/ChatListItem/ChatListItem.tsx`,
+`src/rework/components/shared/organisms/ChatList/ChatList.module.scss`,
+`Sidebar/{TeamContentNavbar,HomeNavPanel,MarketplaceNavbar,AdminNavbar}` stylesheets
+**Status:** `Functional`
+
+The conversation row's second line (`<agent name> · DD/MM/YY - HH:mm`) wrapped
+onto a second line whenever the agent name was long, colliding with the next
+row and making the list unreadable. Two changes:
+
+- The meta line is now a nowrap flex row where **only the agent name flexes**
+  (`flex: 0 1 auto; min-width: 0; text-overflow: ellipsis`, full name in
+  `title`); the separator and the date are `flex: 0 0 auto`, so the date and
+  time always render whole. Same ellipsis treatment on `.groupHeader`, the
+  per-agent sub-list header shown when grouping is on.
+- All four nav panels went **240px → 272px**. They swap into the same sidebar
+  grid column, so the width must stay identical across them or the column
+  jumps when switching between Home / team / marketplace / admin.
+
+---
+
 ### `AgentCard`
 
 **Location:** `src/rework/components/shared/organisms/AgentCard/AgentCard.tsx`


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**Issue:** #2404 — opened retroactively for this fix. Closes #2404.

**Problem in one sentence:** In the conversation list, the meta line under each chat title (`<agent name> · DD/MM/YY - HH:mm`) wrapped onto a second line as soon as the agent name was long, pushing the date onto its own line and colliding with the next row.

**Backlog ref:** n/a — not a backlog item.

---

## 2. Before you wrote a single line of code

**RFC written?**
Not required — mechanical fix. No design choice, no schema, no endpoint, no new component: existing markup made to lay out correctly, plus a width constant bumped across the four panels that already shared it.

**Plan presented to the team before implementation?**
No — a two-file layout bug found and fixed in place. Nothing here commits the codebase to a direction that would need discussion first.

**Confirmation received?**
No prior confirmation; this PR *is* the review request. Nothing is merged without it.

---

## 3. What you built

`ChatListItem.tsx` — the meta line is now an explicit flex row (`.meta`) instead of a bare text node with a `" · "` string literal. The agent name is the only flexible child (`flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis`), with the full name in `title` on hover; the separator and the date are `flex: 0 0 auto`. Result: the date and time always render whole on one line, and a long agent name ellipsizes instead of wrapping the row.

`ChatList.tsx` / `ChatList.module.scss` — the same ellipsis treatment on `.groupHeader`, the per-agent sub-list header shown when grouping is on, so a long name can't push that header onto two lines either. Added `title={agentName}` there too.

`Sidebar/{TeamContentNavbar,HomeNavPanel,MarketplaceNavbar,AdminNavbar}` stylesheets — width **240px → 272px**. The meta line is the widest content this column carries, and 240px left too little room for an agent name once the date is kept intact. All four panels swap into the same sidebar grid column, so the width has to move together or the column visibly jumps when switching between Home / team / marketplace / admin. Each file carries a comment saying so.

---

## 4. Proof of quality

**Tests added or updated:** none.

| Test | File | What it covers |
| ---- | ---- | -------------- |
| —    | —    | —              |

This is a pure CSS-layout fix: what it changes (wrapping vs. ellipsizing, panel width in px) is not observable in jsdom, which has no layout engine — a test asserting it would assert nothing. The one behavioural addition, the `title` attribute, is a one-line accessibility affordance. Verified by hand in the browser: long agent name, short agent name, no agent name, grouping on and off, and switching across all four nav panels to confirm the column no longer jumps.

**`make code-quality` output:**

```
npx tsc --noEmit
npx prettier . --check
All matched files use Prettier code style!
npx eslint "src/**/*.{ts,tsx}"
All frontend code quality checks completed
```

**Raw `basedpyright` output:** n/a — no Python touched.

**`make test` output:**

```
 Test Files  139 passed | 1 skipped (140)
      Tests  1361 passed | 2 skipped (1363)
```

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — not a backlog item |
| New behaviour, API field, or contract change                      | n/a — no API or contract surface touched |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — untouched |
| UX component implemented or visual status changed                 | `docs/swift/ux/COMPONENT-UX.md` — new `ChatList` meta line and nav panel width entry (2026-08-20), status `Functional` |
| Phase progress row exists for this area                           | n/a |
| WORKPLAN sprint item finished                                     | n/a — WORKPLAN is frozen |
| Code and a design doc now diverge                                 | No divergence introduced |

---

## 6. Close-out statement

```
## Task close-out
- Code: ChatList meta line rebuilt as a nowrap flex row where only the agent name flexes and ellipsizes, so the date stays whole on one line; same ellipsis on the grouped sub-list header; all four sidebar nav panels widened 240px → 272px in lockstep.
- Tests: none added — CSS layout is not observable in jsdom; verified by hand across long/short/absent agent names, grouping on/off, and all four panels. Existing suite green (1361 passed, 2 skipped).
- Docs updated: docs/swift/ux/COMPONENT-UX.md
- Backlog: n/a
- Skipped steps: Step 1 (RFC) — mechanical layout fix, no design question. Step 2 (backlog link) — n/a. Step 3.5 — tracking issue #2404 opened retroactively. Step 3 (pre-implementation confirmation) — not obtained, this PR is the review request.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** Blast radius is the sidebar's second column only — no data, no API, no state. Worst realistic case: 272px is judged too wide and squeezes the main content area on small viewports, or a very long agent name is now ellipsized where someone wanted it wrapped. Both are visual, immediately visible, and harmless.

**How do we roll back?** `git revert` the merge commit. No migration, no feature flag, no persisted state to unwind.


---

## 8. Addendum (2026-08-21) — follow-up commits

- `fix(ui): align chat list meta line into fixed columns` — same legibility problem, second half: nothing lined up vertically. The agent name now **grows** to fill the meta row (`flex: 1 1 auto`), so its box is the same width on every line and the `·` + date start at the same x everywhere; the date uses `font-variant-numeric: tabular-nums`, so the fixed `DD/MM/YY - HH:mm` format always renders at the same width regardless of which digits it contains. `COMPONENT-UX.md` entry updated to match.
- Also rides along: a small colour-contrast touch-up on the shared composer/agent-card gradient stops (same hues, a bit more saturated) so they read on the light theme too.

Verified by hand on both themes; `make code-quality` green from the monorepo root after each commit.
