### PR TITLE
fix(#2403): token badges show marginal cost, not billed per-call totals

### DIFF
--- a/apps/fred-agents/config/.env.template
+++ b/apps/fred-agents/config/.env.template
@@ -22,3 +22,21 @@ MINIO_SECRET_KEY=""
 FRED_POSTGRES_PASSWORD=""
 # Opensearch credentials
 OPENSEARCH_PASSWORD=""
+
+# Required only when observability.tracer=langfuse.
+# LANGFUSE_HOST is the variable the Langfuse SDK actually reads — without it
+# the client silently defaults to Langfuse Cloud, so a local server at :3001
+# receives nothing. LANGFUSE_BASE_URL appears in older .env files and is NOT
+# read by the SDK.
+LANGFUSE_PUBLIC_KEY=""
+LANGFUSE_SECRET_KEY=""
+LANGFUSE_HOST="http://localhost:3001"
+# Exports prompts, model answers and tool payloads to Langfuse. Local
+# debugging ONLY — this breaks the content exclusion of
+# docs/swift/platform/OBSERVABILITY-AND-AUDIT.md §7. Leave unset elsewhere.
+LANGFUSE_CAPTURE_CONTENT="false"
+# Total characters exported per payload (default 100000). Raise it when traces
+# show "…[truncated N chars]" on content you need. This env var is the only
+# working knob when the pod reaches Langfuse with observability.tracer set to
+# something other than "langfuse" — that path never reads configuration.yaml.
+LANGFUSE_MAX_CONTENT_CHARS="100000"

--- a/apps/fred-agents/config/configuration_prod.yaml
+++ b/apps/fred-agents/config/configuration_prod.yaml
@@ -46,6 +46,14 @@ observability:
   langfuse:
     host: "http://localhost:3001"
     # LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY in .env
+    # capture_content exports prompts, model answers and tool payloads to
+    # Langfuse. It breaks the content exclusion of
+    # docs/swift/platform/OBSERVABILITY-AND-AUDIT.md §7 and is for a local
+    # Langfuse only — never a shared or production deployment.
+    # Override per-run with LANGFUSE_CAPTURE_CONTENT=true.
+    capture_content: false
+    # Total characters per exported payload; LANGFUSE_MAX_CONTENT_CHARS overrides.
+    max_content_chars: 100000
 
 storage:
   postgres:

--- a/apps/fred-agents/config/schema/configuration.schema.json
+++ b/apps/fred-agents/config/schema/configuration.schema.json
@@ -111,6 +111,16 @@
           "default": "http://localhost:3001",
           "title": "Host",
           "type": "string"
+        },
+        "capture_content": {
+          "default": false,
+          "title": "Capture Content",
+          "type": "boolean"
+        },
+        "max_content_chars": {
+          "default": 100000,
+          "title": "Max Content Chars",
+          "type": "integer"
         }
       },
       "title": "LangfuseObservabilityConfig",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -327,10 +327,14 @@
     },
     "aiDisclaimer": "This assistant is powered by AI and can make mistakes. Please verify important information.",
     "conversationTokenUsage": {
-      "total_one": "Total: {{count}} token",
-      "total_other": "Total: {{count}} tokens",
-      "cached_one": "{{count}} token served from the provider's prompt cache",
-      "cached_other": "{{count}} tokens served from the provider's prompt cache"
+      "cached_one": "{{count, number}} token served from the provider's prompt cache",
+      "cached_other": "{{count, number}} tokens served from the provider's prompt cache",
+      "received_one": "{{count, number}} token received",
+      "received_other": "{{count, number}} tokens received",
+      "sent_one": "{{count, number}} token sent",
+      "sent_other": "{{count, number}} tokens sent",
+      "total_one": "Total: {{count, number}} token",
+      "total_other": "Total: {{count, number}} tokens"
     },
     "attachFiles": "Attach files",
     "attachmentChip": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -327,10 +327,14 @@
     },
     "aiDisclaimer": "Cet assistant s'appuie sur l'IA et peut se tromper. Vérifiez les informations importantes.",
     "conversationTokenUsage": {
-      "total_one": "Total : {{count}} token",
-      "total_other": "Total : {{count}} tokens",
-      "cached_one": "{{count}} token servi depuis le cache du fournisseur",
-      "cached_other": "{{count}} tokens servis depuis le cache du fournisseur"
+      "cached_one": "{{count, number}} token servi depuis le cache du fournisseur",
+      "cached_other": "{{count, number}} tokens servis depuis le cache du fournisseur",
+      "received_one": "{{count, number}} token reçu",
+      "received_other": "{{count, number}} tokens reçus",
+      "sent_one": "{{count, number}} token envoyé",
+      "sent_other": "{{count, number}} tokens envoyés",
+      "total_one": "Total : {{count, number}} token",
+      "total_other": "Total : {{count, number}} tokens"
     },
     "attachFiles": "Joindre des fichiers",
     "attachmentChip": {

--- a/apps/frontend/src/locales/tokenCountFormat.test.ts
+++ b/apps/frontend/src/locales/tokenCountFormat.test.ts
@@ -1,0 +1,74 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// #2403: token counts are five-digit numbers read at a glance. Without
+// i18next's `number` format specifier, `{{count}}` interpolates the raw
+// integer, so the conversation header rendered "Total : 55735 tokens" beside
+// a badge whose arrows WERE grouped ("↑19 424") — the same quantity shown two
+// ways in one screen. These keys must keep `{{count, number}}`; dropping the
+// specifier is an easy, silent regression in a translation edit.
+
+import i18n, { type i18n as I18n } from "i18next";
+import { beforeAll, describe, expect, it } from "vitest";
+import en from "./en/translation.json";
+import fr from "./fr/translation.json";
+
+const TOKEN_COUNT_KEYS = [
+  "chatbot.conversationTokenUsage.total",
+  "chatbot.conversationTokenUsage.cached",
+  "chatbot.conversationTokenUsage.sent",
+  "chatbot.conversationTokenUsage.received",
+] as const;
+
+const instances: Record<string, I18n> = {};
+
+beforeAll(async () => {
+  for (const lng of ["en", "fr"]) {
+    const instance = i18n.createInstance();
+    await instance.init({
+      lng,
+      resources: { en: { translation: en }, fr: { translation: fr } },
+      interpolation: { escapeValue: false },
+    });
+    instances[lng] = instance;
+  }
+});
+
+describe("token count strings apply locale thousands grouping", () => {
+  for (const key of TOKEN_COUNT_KEYS) {
+    it(`${key} groups in French`, () => {
+      const rendered = instances.fr.t(key, { count: 55735 });
+      // "55735" ungrouped means the `, number` specifier was lost.
+      expect(rendered).not.toContain("55735");
+      expect(rendered).toContain((55735).toLocaleString("fr"));
+    });
+
+    it(`${key} groups in English`, () => {
+      const rendered = instances.en.t(key, { count: 55735 });
+      expect(rendered).not.toContain("55735");
+      expect(rendered).toContain("55,735");
+    });
+  }
+
+  it("still selects the singular form, which the format specifier must not break", () => {
+    expect(instances.en.t("chatbot.conversationTokenUsage.total", { count: 1 })).toBe("Total: 1 token");
+    expect(instances.fr.t("chatbot.conversationTokenUsage.total", { count: 1 })).toBe("Total : 1 token");
+  });
+
+  it("renders the whole header line as one grouped figure", () => {
+    expect(instances.fr.t("chatbot.conversationTokenUsage.total", { count: 55735 })).toBe(
+      `Total : ${(55735).toLocaleString("fr")} tokens`,
+    );
+  });
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
@@ -99,6 +99,7 @@ export const ConversationThread = memo(function ConversationThread({
             sources={msg.sources}
             uiParts={msg.uiParts}
             tokenUsage={msg.tokenUsage}
+            marginalTokenUsage={msg.marginalTokenUsage}
             isStreaming={msg.isStreaming}
             pendingToolCallIds={pendingToolCallIds}
           />

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -159,6 +159,17 @@
   gap: var(--spacing-s);
 }
 
+/* Conversation-wide billed total. Just the number: the per-message badges
+   carry the in/out breakdown, and repeating it here made the header a second
+   place to read the same decomposition (#2403). */
+.conversationTokens {
+  color: var(--on-surface-retreat);
+  font: var(--font-label-small);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}
+
 .topBarActions {
   display: flex;
   align-items: center;

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -29,11 +29,11 @@ import { findTraceEntry, traceEntryKey, type TraceEntry } from "../../../utils/t
 import { ComposerActionsMenu } from "@shared/molecules/ComposerActionsMenu/ComposerActionsMenu";
 import { UploadWarningAckDialog } from "@shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog";
 import IconButton from "@shared/atoms/IconButton/IconButton";
-import { TokenUsageBadge } from "@shared/molecules/TokenUsageBadge/TokenUsageBadge";
 import { CapabilitySidePanelHost } from "../../../features/capabilities/CapabilitySidePanelHost";
 import { ComposerControlSlot } from "../../../features/capabilities/ComposerControlSlot";
 import { COMPOSER_CHIP_WIDGETS, ReasoningChip } from "../../../features/capabilities/ReasoningChip";
 import { selectSidePanelOpenRequest } from "../../../features/capabilities/sidePanelOpenRequestSlice";
+import { conversationTokenTotals } from "./toThreadMessages";
 import { useManagedChat } from "./useManagedChat";
 import { useUploadWarningAcknowledgement } from "../../../core/hooks/useUploadWarningAcknowledgement";
 import { useFrontendBootstrap } from "../../../../hooks/useFrontendBootstrap";
@@ -146,21 +146,7 @@ export default function ManagedChatPage() {
 
   const attachmentsCount = chat.persistedAttachments.length;
 
-  const conversationTokenUsage = useMemo(
-    () =>
-      chat.threadMessages.reduce(
-        (acc, m) => {
-          if (m.tokenUsage) {
-            acc.input_tokens += m.tokenUsage.input_tokens;
-            acc.output_tokens += m.tokenUsage.output_tokens;
-            acc.total_tokens += m.tokenUsage.total_tokens;
-          }
-          return acc;
-        },
-        { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-      ),
-    [chat.threadMessages],
-  );
+  const conversationTokens = useMemo(() => conversationTokenTotals(chat.threadMessages), [chat.threadMessages]);
   // CAPAB-01 #1976: attachments are allowed when the resolved chat controls
   // (ExecutionPreparation.chat_controls) include an `attach_files` descriptor —
   // supersedes the retired `EffectiveChatOptions.attach_files`.
@@ -407,8 +393,10 @@ export default function ManagedChatPage() {
               <div className={styles.topBarAgentName}>{chat.agentDisplayName}</div>
             </div>
             <div className={styles.topBarRight}>
-              {conversationTokenUsage.total_tokens > 0 && (
-                <TokenUsageBadge usage={conversationTokenUsage} variant="stacked" />
+              {conversationTokens.total_tokens > 0 && (
+                <span className={styles.conversationTokens}>
+                  {t("chatbot.conversationTokenUsage.total", { count: conversationTokens.total_tokens })}
+                </span>
               )}
               <div className={styles.topBarActions}>
                 {attachmentsCount > 0 && (

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/marginalTokenUsage.test.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/marginalTokenUsage.test.ts
@@ -1,0 +1,193 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Marginal token accounting (#2403). The per-message badge used to repeat the
+// turn's BILLED total, which re-counts the history once per model call and is
+// already summed in the conversation header — a tool-heavy turn read 57 357
+// tokens where it had genuinely added ~2 400.
+
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../../../../slices/runtime/runtimeOpenApi";
+import { conversationTokenTotals, marginalTokenUsage, toThreadMessages } from "./toThreadMessages";
+
+function turn(exchangeId: string, contextTokens: number | null, output: number, billedInput: number): ChatMessage[] {
+  return [
+    {
+      exchange_id: exchangeId,
+      session_id: "s1",
+      rank: 0,
+      timestamp: "2026-08-21T00:00:00Z",
+      role: "user",
+      channel: "final",
+      parts: [{ type: "text", text: "q" }],
+      metadata: {},
+    },
+    {
+      exchange_id: exchangeId,
+      session_id: "s1",
+      rank: 1,
+      timestamp: "2026-08-21T00:00:01Z",
+      role: "assistant",
+      channel: "final",
+      parts: [{ type: "text", text: "a" }],
+      metadata: {
+        token_usage: { input_tokens: billedInput, output_tokens: output, total_tokens: billedInput + output },
+        ...(contextTokens === null ? {} : { context_tokens: contextTokens }),
+      },
+    },
+  ] as ChatMessage[];
+}
+
+describe("marginalTokenUsage", () => {
+  it("counts a first turn's whole prompt as new", () => {
+    // Nothing was in the context before it — the system prompt and tool
+    // schemas genuinely are new, once.
+    expect(marginalTokenUsage(16704, { input_tokens: 16704, output_tokens: 836, total_tokens: 17540 }, 0)).toEqual({
+      input_tokens: 16704,
+      output_tokens: 836,
+      total_tokens: 17540,
+    });
+  });
+
+  it("subtracts the context the previous turn ended on", () => {
+    // Field case: billed 57 201 in, but the turn only added 3 238.
+    expect(marginalTokenUsage(19942, { input_tokens: 57201, output_tokens: 156, total_tokens: 57357 }, 16704)).toEqual({
+      input_tokens: 3238,
+      output_tokens: 156,
+      total_tokens: 3394,
+    });
+  });
+
+  it("never lets the tool rows exceed the turn's own new-input figure", () => {
+    // The regression that exposed the bad anchor: anchoring on
+    // `contextTokens + output` assumed the previous turn's whole output came
+    // back in the next prompt. Reasoning tokens are counted in `output_tokens`
+    // but dropped from replay (`checkpoint_hygiene.py`), so the anchor
+    // overshot and the badge showed 2534 new input tokens above two tool rows
+    // reading +2254 and +332 — parts larger than the whole.
+    const TURN_1_CONTEXT = 16696;
+    const TURN_1_OUTPUT = 175;
+    const TURN_2_CONTEXT = 19405;
+    const TOOL_GROWTH = 2254 + 332;
+
+    const usage = marginalTokenUsage(
+      TURN_2_CONTEXT,
+      { input_tokens: 55297, output_tokens: 427, total_tokens: 55724 },
+      TURN_1_CONTEXT,
+    );
+
+    expect(usage?.input_tokens).toBe(2709);
+    expect(usage!.input_tokens).toBeGreaterThan(TOOL_GROWTH);
+    // The remainder is the question plus the previous answer as re-sent —
+    // small and positive, where the old anchor made it -52.
+    expect(usage!.input_tokens - TOOL_GROWTH).toBe(123);
+    // Pins the anchor choice itself: adding the previous output back would
+    // reintroduce the defect.
+    expect(
+      marginalTokenUsage(
+        TURN_2_CONTEXT,
+        { input_tokens: 1, output_tokens: 427, total_tokens: 1 },
+        TURN_1_CONTEXT + TURN_1_OUTPUT,
+      )!.input_tokens,
+    ).toBeLessThan(TOOL_GROWTH);
+  });
+
+  it("clamps to zero when trimming left a smaller context than before", () => {
+    const usage = marginalTokenUsage(5000, { input_tokens: 9000, output_tokens: 10, total_tokens: 9010 }, 40000);
+    expect(usage?.input_tokens).toBe(0);
+  });
+
+  it("reports nothing when the previous anchor is unknown", () => {
+    // A broken chain must fall back to the billed total, not subtract a
+    // stale anchor and understate the turn.
+    expect(marginalTokenUsage(19942, { input_tokens: 100, output_tokens: 5, total_tokens: 105 }, null)).toBeNull();
+  });
+
+  it("reports nothing when the turn itself has no context anchor", () => {
+    expect(marginalTokenUsage(null, { input_tokens: 100, output_tokens: 5, total_tokens: 105 }, 0)).toBeNull();
+  });
+});
+
+describe("toThreadMessages — marginal usage across a conversation", () => {
+  it("chains each turn's anchor to the previous one", () => {
+    const messages = [...turn("e1", 16704, 836, 16704), ...turn("e2", 19942, 156, 57201)];
+
+    const assistants = toThreadMessages(messages, false).filter((m) => m.role === "assistant");
+
+    expect(assistants[0].marginalTokenUsage).toEqual({
+      input_tokens: 16704,
+      output_tokens: 836,
+      total_tokens: 17540,
+    });
+    expect(assistants[1].marginalTokenUsage).toEqual({
+      input_tokens: 3238,
+      output_tokens: 156,
+      total_tokens: 3394,
+    });
+    // The billed figure stays intact — the conversation header sums it.
+    expect(assistants[1].tokenUsage?.total_tokens).toBe(57357);
+  });
+
+  it("falls back to the billed total after a turn with no anchor", () => {
+    // A Graph-agent turn (or pre-#2403 history) in the middle breaks the
+    // chain; the turn after it cannot be measured against a stale anchor.
+    const messages = [...turn("e1", 16704, 836, 16704), ...turn("e2", null, 20, 900), ...turn("e3", 30000, 40, 5000)];
+
+    const assistants = toThreadMessages(messages, false).filter((m) => m.role === "assistant");
+
+    expect(assistants[0].marginalTokenUsage).not.toBeNull();
+    expect(assistants[1].marginalTokenUsage).toBeNull();
+    expect(assistants[2].marginalTokenUsage).toBeNull();
+    expect(assistants[2].tokenUsage?.total_tokens).toBe(5040);
+  });
+});
+
+describe("conversationTokenTotals — the header reconciles with the thread", () => {
+  it("sums exactly what the message badges show", () => {
+    // Field case: two turns badged 16 871 and 3 136 sat under a header
+    // reading 72 595, because the header summed the BILLED usage instead.
+    const messages = [...turn("e1", 16696, 175, 16696), ...turn("e2", 19405, 427, 55297)];
+    const assistants = toThreadMessages(messages, false).filter((m) => m.role === "assistant");
+
+    const total = conversationTokenTotals(assistants);
+
+    expect(assistants[0].marginalTokenUsage?.total_tokens).toBe(16871);
+    expect(assistants[1].marginalTokenUsage?.total_tokens).toBe(3136);
+    expect(total.total_tokens).toBe(16871 + 3136);
+  });
+
+  it("telescopes to the final context plus every answer produced", () => {
+    // Each turn contributes contextTokens(T) - contextTokens(T-1), so the
+    // input side collapses to the last context size. That identity is what
+    // makes the header a meaningful quantity rather than an arbitrary sum.
+    const messages = [...turn("e1", 16696, 175, 16696), ...turn("e2", 19405, 427, 55297)];
+    const assistants = toThreadMessages(messages, false).filter((m) => m.role === "assistant");
+
+    const total = conversationTokenTotals(assistants);
+
+    expect(total.input_tokens).toBe(19405);
+    expect(total.output_tokens).toBe(175 + 427);
+  });
+
+  it("falls back to a turn's billed usage when it has no marginal figure", () => {
+    // Otherwise the header would silently omit a message the reader can see.
+    const messages = [...turn("e1", null, 20, 900)];
+    const assistants = toThreadMessages(messages, false).filter((m) => m.role === "assistant");
+
+    const total = conversationTokenTotals(assistants);
+
+    expect(assistants[0].marginalTokenUsage).toBeNull();
+    expect(total.total_tokens).toBe(920);
+  });
+});

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/toThreadMessages.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/toThreadMessages.ts
@@ -123,11 +123,97 @@ export function hitlResponseKey(choiceId: string): string | null {
   return null;
 }
 
+/**
+ * What a turn genuinely ADDED, as opposed to what it was billed (#2403).
+ *
+ * Within a conversation the context only grows, so a turn's new input is the
+ * context it ends with minus the context the PREVIOUS turn ended with. That
+ * span covers the previous answer as it is re-sent, the new question, and the
+ * growth from this turn's tool rounds. Everything else in the billed figure is
+ * older history being re-sent — real cost, shown in the header, but not new.
+ *
+ * The anchor is the previous `contextTokens` ALONE — deliberately not
+ * `+ output(T-1)`. Adding the previous turn's output assumes all of it comes
+ * back in the next prompt, and it does not: reasoning tokens are counted in
+ * `output_tokens` but dropped from replay (`checkpoint_hygiene.py` —
+ * "reasoning from closed turns is dropped"). That over-subtracted by however
+ * much the model had reasoned, understating the turn and, on a short answer
+ * with a long reasoning block, driving the figure negative. Live case: a turn
+ * whose two tool rows read +2254 and +332 displayed 2534 new input tokens —
+ * the parts visibly exceeded the whole.
+ *
+ * The previous answer therefore counts as output when produced and as input
+ * when re-sent. That is not double counting: both are real, at different
+ * rates.
+ *
+ * `previousContextTokens` is `0` before the first turn (nothing in context
+ * yet, so a first turn's whole prompt is genuinely new) and `null` once the
+ * chain is broken by a turn that reported no `contextTokens` — there, the
+ * honest answer is "unknown", and the caller falls back to the billed total
+ * rather than subtracting a stale anchor and understating the turn.
+ */
+export function marginalTokenUsage(
+  contextTokens: number | null | undefined,
+  billed: TokenUsage | null,
+  previousContextTokens: number | null,
+): TokenUsage | null {
+  if (contextTokens == null || billed == null || previousContextTokens == null) return null;
+  // Clamped: history trimming can leave a turn ending on a smaller context
+  // than the one before it, and a negative "new tokens" reads as a bug.
+  const newInput = Math.max(0, contextTokens - previousContextTokens);
+  return {
+    input_tokens: newInput,
+    output_tokens: billed.output_tokens,
+    total_tokens: newInput + billed.output_tokens,
+    // Deliberately no cache_read_tokens: caching is a property of a whole
+    // prompt, not of a delta. The header still reports it.
+  };
+}
+
+/**
+ * Conversation-level total for the chat header (#2403).
+ *
+ * Sums exactly what the per-message badges show, so the header reconciles with
+ * the thread: a reader adding up the messages lands on the header figure.
+ * Summing the provider's per-call usage there instead put 72 595 above two
+ * messages reading 16 871 and 3 136 — the same parts-versus-whole mismatch
+ * that made the per-tool badges unreadable, one level up.
+ *
+ * Because each turn's displayed input is `contextTokens(T) - contextTokens(T-1)`,
+ * the sum telescopes to `contextTokens(last) + every output` — the tokens the
+ * conversation actually holds.
+ */
+export function conversationTokenTotals(messages: ThreadMessage[]): TokenUsage {
+  const total: TokenUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+
+  for (const message of messages) {
+    // Same fallback the badge applies: a turn with no marginal figure shows
+    // its billed one, so the header must add the same number the reader sees.
+    const shown = message.marginalTokenUsage ?? message.tokenUsage;
+    if (!shown) continue;
+    total.input_tokens += shown.input_tokens;
+    total.output_tokens += shown.output_tokens;
+    total.total_tokens += shown.total_tokens;
+  }
+
+  return total;
+}
+
 export function toThreadMessages(messages: ChatMessage[], isStreaming: boolean): ThreadMessage[] {
   const { order, groups } = groupByExchange(messages);
 
   const result: ThreadMessage[] = [];
   const lastEid = order[order.length - 1] as string | undefined;
+  // Rolling anchor for the marginal computation above. Exchanges are walked
+  // in order, so each turn sees the context the previous one ended on.
+  //
+  // Starting at 0 assumes `messages` is the WHOLE conversation, which the
+  // history store currently guarantees (it has no pagination). If windowed
+  // loading is ever added, the first loaded exchange would be a mid-
+  // conversation turn measured against an empty context and would report its
+  // entire prompt as new — seed this from the turn before the window instead
+  // of 0, or pass null to fall back to the billed total.
+  let previousContextTokens: number | null = 0;
 
   for (const eid of order) {
     const msgs = groups.get(eid)!;
@@ -192,6 +278,7 @@ export function toThreadMessages(messages: ChatMessage[], isStreaming: boolean):
     if (traceMessages.length > 0 || finalMessages.length > 0 || (isStreaming && isLast)) {
       const sources: VectorSearchHit[] = [];
       let tokenUsage: TokenUsage | null = null;
+      let contextTokens: number | null = null;
       for (let i = finalMessages.length - 1; i >= 0; i--) {
         const meta = finalMessages[i].metadata as Record<string, unknown> | undefined;
         if (!tokenUsage && meta?.token_usage) {
@@ -202,12 +289,17 @@ export function toThreadMessages(messages: ChatMessage[], isStreaming: boolean):
             total_tokens: tu.total_tokens ?? 0,
           };
         }
+        if (contextTokens === null && typeof meta?.context_tokens === "number") {
+          contextTokens = meta.context_tokens;
+        }
         if (sources.length === 0) {
           const srcs = meta?.sources as VectorSearchHit[] | undefined;
           if (srcs && srcs.length > 0) sources.push(...srcs);
         }
-        if (tokenUsage && sources.length > 0) break;
+        if (tokenUsage && contextTokens !== null && sources.length > 0) break;
       }
+      const marginal = marginalTokenUsage(contextTokens, tokenUsage, previousContextTokens);
+      previousContextTokens = contextTokens;
       // Raw retention (#1977): every ui_part — link, geo, capability kinds,
       // and kinds this build does not know — survives into the view model.
       const uiParts: RawUiPart[] = finalMessages.flatMap((m) => uiPartsOf(m));
@@ -220,6 +312,8 @@ export function toThreadMessages(messages: ChatMessage[], isStreaming: boolean):
         sources,
         uiParts,
         tokenUsage,
+        contextTokens,
+        marginalTokenUsage: marginal,
       });
     }
   }

--- a/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ThoughtTrace/TraceEntryRow/TraceEntryRow.tsx
@@ -21,11 +21,9 @@ import {
   primaryTextForEntry,
   secondaryTextForEntry,
   statusForEntry,
-  tokenUsageForEntry,
   toolDiscriminator,
 } from "../../../../../utils/traceUtils";
 import { useTraceDrawer } from "../traceDrawerContext";
-import { TokenUsageBadge } from "@shared/molecules/TokenUsageBadge/TokenUsageBadge";
 import phaseStyles from "../phaseBadge.module.css";
 import styles from "./TraceEntryRow.module.css";
 
@@ -49,7 +47,6 @@ export function TraceEntryRow({ entry, index = null, pendingToolCallIds }: Trace
   const phase = phaseKeyForEntry(entry);
   const primary = primaryTextForEntry(entry);
   const secondary = secondaryTextForEntry(entry);
-  const tokenUsage = tokenUsageForEntry(entry);
   const isPending = status === "pending";
   const isAwaitingConfirmation = status === "awaiting_confirmation";
   // The turn-crash line is a solo error-channel entry (execution_error). A
@@ -112,8 +109,6 @@ export function TraceEntryRow({ entry, index = null, pendingToolCallIds }: Trace
 
       {/* A cancelled tool never ran — its latency is meaningless, so drop it. */}
       {secondary && !isCancelled && <span className={styles.secondary}>{secondary}</span>}
-
-      {tokenUsage && <TokenUsageBadge usage={tokenUsage} />}
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.module.css
@@ -8,27 +8,10 @@
   user-select: none;
 }
 
-.stacked {
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--spacing-3xs);
-}
-
-.breakdownRow {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-2xs);
-}
-
 .segment {
   opacity: 0.8;
 }
 
 .sep {
   opacity: 0.4;
-}
-
-.total {
-  opacity: 0.9;
-  font-weight: 500;
 }

--- a/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.test.tsx
@@ -18,9 +18,16 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TokenUsageBadge } from "./TokenUsageBadge.tsx";
 
+let mockLanguage = "en";
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key} ${JSON.stringify(opts)}` : key),
+    i18n: {
+      get language() {
+        return mockLanguage;
+      },
+    },
   }),
 }));
 
@@ -41,6 +48,7 @@ afterEach(() => {
     root.unmount();
   });
   container.remove();
+  mockLanguage = "en";
 });
 
 describe("TokenUsageBadge — CACHE-01", () => {
@@ -64,5 +72,46 @@ describe("TokenUsageBadge — CACHE-01", () => {
     render(<TokenUsageBadge usage={{ input_tokens: 50, output_tokens: 10, total_tokens: 60 }} />);
 
     expect(container.textContent).not.toContain("⚡");
+  });
+});
+
+// #2403: the arrows must group against the UI language, not the browser's.
+// A bare `toLocaleString()` disagreed with the header — which goes through
+// i18next's `{{count, number}}` — for anyone whose browser language differed
+// from their Fred language ("↑19,424" under "Total : 20 007 tokens").
+describe("TokenUsageBadge — thousands grouping follows the UI language", () => {
+  it("groups the arrows with the active i18n language, not the browser's", () => {
+    mockLanguage = "fr";
+    render(<TokenUsageBadge usage={{ input_tokens: 19424, output_tokens: 632, total_tokens: 20056 }} />);
+
+    // French groups with U+202F (narrow no-break space), never a comma.
+    expect(container.textContent).toContain(`↑${(19424).toLocaleString("fr")}`);
+    expect(container.textContent).not.toContain("19,424");
+  });
+
+  it("groups them with the English separator when the UI is English", () => {
+    mockLanguage = "en";
+    render(<TokenUsageBadge usage={{ input_tokens: 19424, output_tokens: 632, total_tokens: 20056 }} />);
+
+    expect(container.textContent).toContain("↑19,424");
+  });
+
+  it("shows in and out only — the total belongs to the header", () => {
+    render(<TokenUsageBadge usage={{ input_tokens: 2709, output_tokens: 427, total_tokens: 3136 }} />);
+
+    expect(container.textContent).toBe("↑2,709·↓427");
+    expect(container.textContent).not.toContain("3,136");
+  });
+});
+
+// The arrows are the only label the figures get, and ↑/↓ alone is ambiguous
+// about which way the tokens travelled — each carries the spelled-out count.
+describe("TokenUsageBadge — arrows name their direction on hover", () => {
+  it("titles the up arrow as tokens sent and the down arrow as tokens received", () => {
+    render(<TokenUsageBadge usage={{ input_tokens: 2709, output_tokens: 427, total_tokens: 3136 }} />);
+
+    const titles = [...container.querySelectorAll("[title]")].map((el) => el.getAttribute("title"));
+    expect(titles).toContain('chatbot.conversationTokenUsage.sent {"count":2709}');
+    expect(titles).toContain('chatbot.conversationTokenUsage.received {"count":427}');
   });
 });

--- a/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/TokenUsageBadge/TokenUsageBadge.tsx
@@ -18,43 +18,40 @@ import styles from "./TokenUsageBadge.module.css";
 
 interface TokenUsageBadgeProps {
   usage: TokenUsage;
-  /** "inline" (default): single row, used next to a message. "stacked": total on its
-   *  own line above the in/out breakdown, used for conversation-level aggregates. */
-  variant?: "inline" | "stacked";
 }
 
-export function TokenUsageBadge({ usage, variant = "inline" }: TokenUsageBadgeProps) {
-  const { t } = useTranslation();
+// Per-message badge: in and out, nothing else (#2403). The total was dropped
+// as visual weight — it is the sum of the two figures already on the line, and
+// the conversation total sits in the header.
+export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
+  const { t, i18n } = useTranslation();
 
   const cached = usage.cache_read_tokens;
+  // Grouped against the ACTIVE UI language, not the browser's — the header's
+  // total goes through i18next's `number` formatter, which follows
+  // `i18n.language`, so a bare `toLocaleString()` here would disagree with it
+  // for anyone whose browser language differs from their Fred language.
+  const n = (value: number) => value.toLocaleString(i18n.language);
 
-  const breakdown = (
-    <>
-      <span className={styles.segment}>↑{usage.input_tokens.toLocaleString()}</span>
+  // The arrows alone don't say which direction is which, so each carries the
+  // spelled-out figure on hover.
+  return (
+    <div className={styles.tokensUsage}>
+      <span className={styles.segment} title={t("chatbot.conversationTokenUsage.sent", { count: usage.input_tokens })}>
+        ↑{n(usage.input_tokens)}
+      </span>
       {!!cached && (
         <span className={styles.segment} title={t("chatbot.conversationTokenUsage.cached", { count: cached })}>
-          ⚡{cached.toLocaleString()}
+          ⚡{n(cached)}
         </span>
       )}
       <span className={styles.sep}>·</span>
-      <span className={styles.segment}>↓{usage.output_tokens.toLocaleString()}</span>
-    </>
-  );
-
-  if (variant === "stacked") {
-    return (
-      <div className={`${styles.tokensUsage} ${styles.stacked}`}>
-        <span className={styles.total}>{t("chatbot.conversationTokenUsage.total", { count: usage.total_tokens })}</span>
-        <div className={styles.breakdownRow}>{breakdown}</div>
-      </div>
-    );
-  }
-
-  return (
-    <div className={styles.tokensUsage}>
-      {breakdown}
-      <span className={styles.sep}>·</span>
-      <span className={styles.total}>{usage.total_tokens.toLocaleString()} tokens</span>
+      <span
+        className={styles.segment}
+        title={t("chatbot.conversationTokenUsage.received", { count: usage.output_tokens })}
+      >
+        ↓{n(usage.output_tokens)}
+      </span>
     </div>
   );
 }

--- a/apps/frontend/src/rework/components/shared/organisms/AssistantTurn/AssistantTurn.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/AssistantTurn/AssistantTurn.tsx
@@ -37,7 +37,13 @@ interface AssistantTurnProps {
   sources: VectorSearchHit[];
   /** Raw chat parts (#1977); rendering dispatches through the part-renderer registry. */
   uiParts: RawUiPart[];
+  /** Billed usage for the turn (every model call summed). Shown only as a
+   *  fallback when the marginal figure below could not be computed. */
   tokenUsage?: TokenUsage | null;
+  /** What this turn genuinely ADDED (#2403) — the badge's normal content.
+   *  The conversation header carries the billed running total, so repeating
+   *  it per message told the reader nothing they could act on. */
+  marginalTokenUsage?: TokenUsage | null;
   isStreaming: boolean;
   /** call_ids of every tool call currently gated behind an unanswered HITL prompt, if any — see statusForEntry(). */
   pendingToolCallIds?: readonly string[] | null;
@@ -52,6 +58,7 @@ export const AssistantTurn = memo(function AssistantTurn({
   sources,
   uiParts,
   tokenUsage,
+  marginalTokenUsage,
   isStreaming,
   pendingToolCallIds,
 }: AssistantTurnProps) {
@@ -141,7 +148,13 @@ export const AssistantTurn = memo(function AssistantTurn({
       {!isStreaming && text && (
         <div className={styles.footer}>
           <ActionBar actions={actions} alwaysVisible />
-          {tokenUsage && <TokenUsageBadge usage={tokenUsage} />}
+          {/* Marginal by default; the billed total only when the marginal
+              figure is not computable (Graph agents, pre-#2403 history). */}
+          {marginalTokenUsage ? (
+            <TokenUsageBadge usage={marginalTokenUsage} />
+          ) : (
+            tokenUsage && <TokenUsageBadge usage={tokenUsage} />
+          )}
         </div>
       )}
 

--- a/apps/frontend/src/rework/core/hooks/useChatSse.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.ts
@@ -493,6 +493,7 @@ export function useChatSse(
                     cache_read_tokens: event.token_usage["cache_read_tokens"],
                   }
                 : null,
+              context_tokens: event.context_tokens ?? null,
               extras: {},
             },
           });
@@ -516,16 +517,8 @@ export function useChatSse(
                 args: event.arguments ?? {},
               },
             ],
-            metadata: event.token_usage
-              ? {
-                  token_usage: {
-                    input_tokens: event.token_usage["input_tokens"] ?? 0,
-                    output_tokens: event.token_usage["output_tokens"] ?? 0,
-                    total_tokens: event.token_usage["total_tokens"] ?? 0,
-                    cache_read_tokens: event.token_usage["cache_read_tokens"],
-                  },
-                }
-              : undefined,
+            // No token figure here (#2403): a tool call costs nothing by
+            // itself, and the row deliberately shows latency only.
           });
           break;
         }

--- a/apps/frontend/src/rework/types/thread.ts
+++ b/apps/frontend/src/rework/types/thread.ts
@@ -34,7 +34,20 @@ export interface ThreadMessage {
    * renderer are skipped visually but stay present here.
    */
   uiParts: RawUiPart[];
+  /** Billed usage for the turn — every model call summed, which is what the
+   *  provider charges and what the conversation header totals. A ReAct turn
+   *  re-sends the whole context per call, so this legitimately counts the
+   *  same history several times. */
   tokenUsage?: TokenUsage | null;
+  /** Context size at the end of the turn (#2403) — the anchor the next turn
+   *  subtracts from to work out what it genuinely added. */
+  contextTokens?: number | null;
+  /** What this turn actually ADDED: the new user message, the growth from its
+   *  tool rounds, and the tokens it produced (#2403). This is what the
+   *  per-message badge shows; null when the chain of `contextTokens` is
+   *  broken (Graph agents, pre-#2403 history), where the badge falls back to
+   *  `tokenUsage`. */
+  marginalTokenUsage?: TokenUsage | null;
   hitlChoices?: Array<{ id: string; label: string }>;
   hitlTitle?: string | null;
 }

--- a/apps/frontend/src/rework/utils/traceUtils.ts
+++ b/apps/frontend/src/rework/utils/traceUtils.ts
@@ -20,7 +20,6 @@ import type {
   VectorSearchHit,
 } from "../../slices/runtime/runtimeOpenApi";
 import type { RawUiPart } from "@rework/types/parts";
-import type { TokenUsage } from "@rework/types/conversation";
 
 export const TRACE_CHANNELS: Channel[] = [
   "plan",
@@ -212,19 +211,6 @@ export function toolResultOk(result: ChatMessage): boolean {
 
 export function toolResultLatencyMs(result: ChatMessage): number | null {
   return toolResultPart(result)?.latency_ms ?? null;
-}
-
-// Usage of the model call that decided to make this tool call (TRACE-01) —
-// carried on the tool_call message's metadata, not the result's.
-export function toolCallTokenUsage(call: ChatMessage): TokenUsage | null {
-  const tu = call.metadata?.token_usage;
-  if (!tu) return null;
-  return {
-    input_tokens: tu.input_tokens ?? 0,
-    output_tokens: tu.output_tokens ?? 0,
-    total_tokens: tu.total_tokens ?? 0,
-    cache_read_tokens: tu.cache_read_tokens,
-  };
 }
 
 export function toolResultContent(result: ChatMessage): string {
@@ -499,13 +485,6 @@ export function secondaryTextForEntry(entry: TraceEntry): string {
     return formatLatencyMs(toolResultLatencyMs(entry.result));
   }
   return "";
-}
-
-// Token usage to show alongside the latency (TRACE-01). Only tool steps
-// carry it — reasoning/note/error entries don't have a paired tool_call.
-export function tokenUsageForEntry(entry: TraceEntry): TokenUsage | null {
-  if (entry.kind === "combo") return toolCallTokenUsage(entry.call);
-  return null;
 }
 
 /**

--- a/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
+++ b/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
@@ -588,6 +588,7 @@ export type LinkPart = {
 };
 export type FinalRuntimeEvent = {
   content?: string;
+  context_tokens?: number | null;
   finish_reason?: FinishReason | null;
   kind?: "final";
   model_name?: string | null;
@@ -649,9 +650,6 @@ export type ToolCallRuntimeEvent = {
   call_id: string;
   kind?: "tool_call";
   sequence?: number;
-  token_usage?: {
-    [key: string]: number;
-  } | null;
   tool_name: string;
 };
 export type ToolResultRuntimeEvent = {
@@ -747,6 +745,7 @@ export type ChatTokenUsage = {
 };
 export type ChatMetadata = {
   agent_id?: string | null;
+  context_tokens?: number | null;
   finish_reason?: FinishReason | null;
   latency_ms?: number | null;
   model?: string | null;

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -1287,6 +1287,16 @@
                           "default": "http://localhost:3001",
                           "title": "Host",
                           "type": "string"
+                        },
+                        "capture_content": {
+                          "default": false,
+                          "title": "Capture Content",
+                          "type": "boolean"
+                        },
+                        "max_content_chars": {
+                          "default": 100000,
+                          "title": "Max Content Chars",
+                          "type": "integer"
                         }
                       },
                       "title": "LangfuseObservabilityConfig",

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -4094,3 +4094,104 @@ model rather than guessing one — the same fail-quiet direction
 identity, which the composer displayed as its model label — the root of this
 issue. The control now ships only what it is authoritative about (`default`,
 `effort`).
+
+### 8.57 ✅ Per-tool and per-message token badges report marginal cost, not billed totals — issue #2403 (2026-08-21)
+
+**A tool row claimed a tool had consumed 17 559 tokens when it had consumed
+none.** `ToolCallRuntimeEvent.token_usage` carried the usage of the model call
+that *decided* the tool call, and the trace UI rendered it on the tool's row
+(`toolCallTokenUsage` in `traceUtils.ts`). A tool call costs nothing by itself;
+what the row was actually displaying was the whole prompt of the deciding call.
+The final-answer badge had the mirror problem: it showed the turn total summed
+across every model call, which the conversation header already sums again —
+so the per-message figure repeated the header while being an order of magnitude
+larger than what the turn had added.
+
+Field trace of one 2-tool turn, before the fix:
+
+| model call | input | output | rendered as |
+| --- | --- | --- | --- |
+| 1 (decides tool 1) | 17 550 | 9 | tool row 1: "17 559 tokens" |
+| 2 (decides tool 2) | 19 709 (17 520 cached) | 83 | tool row 2: "19 792 tokens" |
+| 3 (final answer) | 19 942 | 64 | — |
+| turn total | 57 201 | 156 | answer badge: "57 357 tokens" |
+
+**The measurement.** Within a turn the context only grows, so the input size of
+the LAST model call is the context the turn leaves behind — no estimation, no
+tokenizer. `FinalRuntimeEvent` gains one field:
+
+| Field | Meaning |
+| --- | --- |
+| `context_tokens: int \| None` | `input_tokens` of the turn's LAST model call — the context size at turn end |
+
+`ToolCallRuntimeEvent.token_usage` is **removed**, and tool rows now carry no
+token figure at all: a tool call costs nothing by itself, so the row shows
+latency only. (An intermediate version of this work added a
+`tool_context_cost` map attributing each round's context growth per `call_id`;
+it served its diagnostic purpose — proving the tools cost ~2 300 tokens, not
+~17 500 — and was then removed along with its display as UI weight. The
+measurement is recoverable from this issue's history if a per-tool figure is
+ever wanted again.) `token_usage` on `FinalRuntimeEvent` is unchanged and still
+carries the billed total.
+
+**The conversation header sums what the messages display, not the invoice.**
+Summing billed usage there put `72 595` above two messages badged `16 871` and
+`3 136` — the same parts-versus-whole mismatch as the tool rows, one level up.
+`conversationTokenTotals` (`toThreadMessages.ts`) now adds the per-message
+figures, so the thread reconciles with its header; because each turn
+contributes `contextTokens(T) − contextTokens(T−1)`, that sum telescopes to
+`contextTokens(last) + every output` — the tokens the conversation actually
+holds. The billed total is still computed and surfaced, in the header tooltip.
+
+The per-message figure is derived, not transported:
+`new_input(T) = context_tokens(T) − context_tokens(T−1)`.
+`ChatMetadata` gains `context_tokens` (assistant-final rows) so a reloaded
+conversation recomputes identically.
+
+**The anchor is the previous `context_tokens` alone, deliberately not
+`+ output_tokens(T−1)`.** Adding the previous turn's output assumes all of it
+returns in the next prompt, and it does not: reasoning tokens are counted in
+`output_tokens` but dropped from replay (`CheckpointHygieneMiddleware` —
+"reasoning from closed turns is dropped"). That over-subtracted by however much
+the model had reasoned. Observed live: a turn whose two tool rows read `+2254`
+and `+332` displayed `2534` new input tokens — the parts exceeded the whole,
+and the implied question length was −52. Anchoring on `context_tokens` alone is
+fully observed and monotonic. The consequence is that the previous answer
+counts as output when produced and as input when re-sent; both are real costs
+at different rates, so this is not double counting.
+
+**Graph agents do not set it.** The measurement assumes one context growing
+across consecutive calls, which a graph's independent nodes do not share. Their
+badges fall back to the billed total rather than showing a number that does not
+mean what it says.
+
+**What the UI ends up showing.** Header: `Total: <sum of the message badges>`.
+Message: `↑<new input> · ↓<output>`, each arrow titled "N tokens sent" /
+"N tokens received" on hover. Tool row: label, latency, nothing else. No
+tooltip explains the accounting model — how the figure is derived is an
+implementation detail, and an earlier version that spelled it out in three
+tooltips was rejected as noise.
+
+**Consequence worth knowing:** a conversation's FIRST message still shows its
+full prompt as new, because on turn 1 the system prompt and tool schemas
+genuinely are. That makes the fixed base cost a single legible line item
+instead of noise repeated on every turn — relevant while the baseline itself
+stays large (see below).
+
+**Out of scope, measured but deliberately not changed.** The ~16 700-token
+baseline on a bare "Hello" is not history — it is the tool definitions, sent
+twice per model call:
+
+1. Every `FastApiMCP` server in `knowledge-flow-backend/main.py` sets
+   `describe_all_responses=True, describe_full_response_schema=True`, which
+   embeds each route's full JSON response schema in its tool description.
+   Measured: Tabular's 5 tools go 25 505 → 10 323 chars with the flags off,
+   Vector Search's 4 go 22 892 → 9 368; the handwritten docstrings survive
+   intact, only the generated schema dump is dropped.
+2. `build_runtime_tool_prompt_suffix` (`react_tool_binding.py`) then re-emits
+   every tool's description into the system prompt, on top of the `tools` API
+   parameter that already carries it.
+
+Both are real reductions and neither was taken here — this change is display
+and accounting only, kept separate per the consolidation rule against bundling
+a reduction with an unrelated fix.

--- a/docs/swift/platform/ENV_VARIABLES.md
+++ b/docs/swift/platform/ENV_VARIABLES.md
@@ -68,8 +68,10 @@ Note:
 | --------------------- | ------------ | ----------------------------------------------------------------- |
 | `LANGFUSE_PUBLIC_KEY` | agentic      | Langfuse public key.                                              |
 | `LANGFUSE_SECRET_KEY` | agentic      | Langfuse secret key.                                              |
-| `LANGFUSE_HOST`       | agentic      | Langfuse host URL used by current runtime code.                   |
+| `LANGFUSE_HOST`       | agentic      | Langfuse host URL used by current runtime code. Read by the Langfuse SDK itself — when unset the SDK silently defaults to Langfuse Cloud, so a local server receives nothing. |
 | `LANGFUSE_BASE_URL`   | agentic      | Legacy naming in template; current runtime reads `LANGFUSE_HOST`. |
+| `LANGFUSE_CAPTURE_CONTENT` | agentic | **Local debugging only.** Exports prompts, model answers, and tool payloads to Langfuse, overriding `observability.langfuse.capture_content`. Breaks the content exclusion of `OBSERVABILITY-AND-AUDIT.md` §7 — never set on a shared or production deployment. Default off. |
+| `LANGFUSE_MAX_CONTENT_CHARS` | agentic | Total characters exported per payload when content capture is on (default 100000), overriding `observability.langfuse.max_content_chars`. Raise it when traces show `…[truncated N chars]`. Only knob that works when `tracer` is not `langfuse` but credentials are present, since `build_default_tracer` never reads configuration.yaml. |
 
 ## 2) Startup Configuration and Feature-Switch Variables
 

--- a/docs/swift/platform/OBSERVABILITY-AND-AUDIT.md
+++ b/docs/swift/platform/OBSERVABILITY-AND-AUDIT.md
@@ -153,7 +153,7 @@ independently drops any record from that logger by name.
 |---|---|---|
 | Directly identifying | user email, full name | **Nowhere** — Fred uses opaque platform identifiers everywhere an identity reference is needed |
 | Pseudonymous / opaque identity | `user_id`, `session_id`, `team_id` | Product analytics (Stream 2, access-scoped) and the audit trail (Stream 3) — never in operational metrics (Stream 1) |
-| Content | prompts, tool arguments/results, documents, attachments | **Nowhere** in any observability or audit stream — content lives only in the product's own storage, under the product's own access control |
+| Content | prompts, tool arguments/results, documents, attachments | **Nowhere** in any observability or audit stream — content lives only in the product's own storage, under the product's own access control. One deliberate, default-off local exception: `observability.langfuse.capture_content` (see below) |
 | Secrets | tokens, cookies, signed URLs | **Nowhere**, ever |
 | Technical/bounded | tool name, error code, HTTP status, model name | All streams as relevant — none of this is personal data |
 
@@ -162,6 +162,37 @@ Stream 2 (product analytics, itself access-scoped per viewer) and Stream 3 (the 
 entire purpose is to attribute an action to a principal). Stream 1 (what a platform-wide Grafana
 audience can see) is designed to never carry it at all — not filtered as an afterthought, but
 structurally excluded before a metric is ever labeled.
+
+### 7.1 The one content exception: Langfuse local debugging (2026-08-20)
+
+Tracing (the optional `tracer: langfuse` backend) is the one place where a developer can
+deliberately turn the content exclusion off, and only for a Langfuse they run themselves. The
+switch is `observability.langfuse.capture_content` in `configuration.yaml`, overridable per-run by
+the `LANGFUSE_CAPTURE_CONTENT` env var. It is **off by default**, and enabling it exports prompts,
+model answers, and tool arguments/results to Langfuse.
+
+Why this is bounded rather than a hole in the rule:
+
+- **Default-off and structurally enforced.** The switch is exposed as `Tracer.captures_content`
+  (`libs/fred-core/fred_core/portable/observability.py`). Every call site checks it before
+  building a payload, and `Span.set_io` drops the payload again if it is off — so a call site that
+  forgets the check still cannot leak. `Tracer` and `LoggingTracer` both answer `False`
+  permanently, which is what keeps the generic app-log store (§6) and the audit trail (§5) content-
+  free no matter what tracing does.
+- **Never the log store.** `LoggingTracer` records payload *sizes* only, never the payload — the
+  same rule `tracing_kpi.py` has followed since issue #2009 (2026-07-18).
+- **Never Prometheus.** Content and identity both stay out of Stream 1; this exception adds no
+  metric and no label (§3's allow-list is untouched).
+- **Loud at startup.** The pod logs a warning naming the destination host whenever capture is on,
+  so an operator cannot leave it enabled unnoticed.
+
+Enabling it on a shared or production deployment exports user conversations to a system that does
+not enforce Fred's authorization model. It is a laptop-only debugging affordance, not a supported
+deployment mode.
+
+Independently of content, Langfuse traces do carry the pseudonymous identity set (`session_id`,
+`user_id`, `team_id`) in Langfuse's native trace fields — that is the row-2 category above, and it
+is what makes per-conversation and per-user trace analysis possible at all.
 
 ## 8. Cross-classification portability (C1 / C2 / C3)
 

--- a/libs/fred-core/fred_core/history/history_schema.py
+++ b/libs/fred-core/fred_core/history/history_schema.py
@@ -382,6 +382,14 @@ class ChatMetadata(BaseModel):
 
     model: Optional[str] = None
     token_usage: Optional[ChatTokenUsage] = None
+    # Assistant-final rows: size of the context at the end of the turn, i.e.
+    # the input_tokens of the turn's last model call (#2403). Persisted so a
+    # reloaded conversation can recompute each turn's MARGINAL cost the same
+    # way the live stream does — `token_usage` alone only says what was
+    # billed, which re-counts the whole history once per model call.
+    # Absent on runtimes where context growth is not measurable (Graph
+    # agents, whose nodes do not share one growing context).
+    context_tokens: Optional[int] = None
     agent_id: Optional[str] = None
     latency_ms: Optional[int] = None
     finish_reason: Optional[FinishReason] = None
@@ -457,12 +465,14 @@ def make_assistant_final(
     usage: Optional[ChatTokenUsage] = None,
     sources: Optional[List[VectorSearchHit]] = None,
     finish_reason: Optional[str] = None,
+    context_tokens: Optional[int] = None,
 ) -> ChatMessage:
     """
     Build the terminal assistant message for a turn.
 
     How to use it:
     - call after accumulating all assistant delta tokens into ``text``
+    - ``context_tokens``: context size at turn end, see ``ChatMetadata``
     """
     return ChatMessage(
         session_id=session_id,
@@ -475,6 +485,7 @@ def make_assistant_final(
         metadata=ChatMetadata(
             model=model,
             token_usage=usage,
+            context_tokens=context_tokens,
             finish_reason=coerce_finish_reason(finish_reason),
             sources=sources or [],
         ),
@@ -488,16 +499,15 @@ def make_tool_call(
     call_id: str,
     name: str,
     args: Dict[str, Any],
-    *,
-    token_usage: Optional[Dict[str, int]] = None,
 ) -> ChatMessage:
     """
     Build a tool-call record message.
 
     How to use it:
     - call when a ``ToolCallRuntimeEvent`` is received
-    - ``token_usage``: the model call that decided to make this tool call
-      (TRACE-01), same shape as ``ToolCallRuntimeEvent.token_usage``
+    - carries no token figure (#2403): a tool call costs nothing by itself,
+      and the former ``token_usage`` argument carried the deciding model
+      call's whole prompt, making a free tool call look like a 17k one.
     """
     return ChatMessage(
         session_id=session_id,
@@ -507,9 +517,7 @@ def make_tool_call(
         role=Role.assistant,
         channel=Channel.tool_call,
         parts=[ToolCallPart(call_id=call_id, name=name, args=args)],
-        metadata=ChatMetadata(token_usage=ChatTokenUsage(**token_usage))
-        if token_usage
-        else ChatMetadata(),
+        metadata=ChatMetadata(),
     )
 
 

--- a/libs/fred-core/fred_core/portable/observability.py
+++ b/libs/fred-core/fred_core/portable/observability.py
@@ -79,6 +79,55 @@ class Span:
     def set_attribute(self, key: str, value: Any) -> None:
         """Record one key/value attribute on this span."""
 
+    def set_io(self, *, input: Any = None, output: Any = None) -> None:
+        """
+        Record the payload that entered and/or left this unit of work.
+
+        Why this exists:
+        - a trace of an agent turn is only readable end-to-end when each step
+          shows what it received and what it produced (the prompt sent to a
+          model, the arguments handed to a tool, the answer that came back)
+
+        **Content policy.** These payloads ARE content in the sense of
+        `docs/swift/platform/OBSERVABILITY-AND-AUDIT.md` §7, which excludes
+        content from every observability stream. A backend must therefore treat
+        this as opt-in and drop it unless explicitly configured to capture it —
+        which is what `Tracer.captures_content` advertises. The base
+        implementation drops it, and `LoggingTracer` records only sizes, never
+        the payload itself.
+
+        How to use it:
+        - guard the (potentially expensive) serialization behind
+          `tracer.captures_content` so disabled backends cost nothing
+
+        Example:
+        - `if tracer.captures_content: span.set_io(input=messages, output=answer)`
+        """
+
+    def set_usage(
+        self,
+        *,
+        model: str | None = None,
+        usage: Mapping[str, int] | None = None,
+        cost: Mapping[str, float] | None = None,
+    ) -> None:
+        """
+        Attach model identity and token/cost accounting to a model-call span.
+
+        Why this exists:
+        - per-call token counts and cost are the metrics that make a tracing
+          backend useful for supervising spend; unlike `set_io` they are pure
+          technical measurements, so they carry no content-policy caveat
+
+        How to use it:
+        - call once on a model-call span, before `end()`
+        - `usage` keys are backend-defined (`input`, `output`, `total`, and
+          provider extras such as `cache_read_input_tokens`)
+
+        Example:
+        - `span.set_usage(model="gpt-4o", usage={"input": 812, "output": 96})`
+        """
+
     def end(self) -> None:
         """Mark this span as complete."""
 
@@ -95,6 +144,25 @@ class Tracer:
     The base class is a null tracer — override start_span() to add behaviour.
     Use LoggingTracer for structured log output or plug in a Langfuse adapter.
     """
+
+    @property
+    def captures_content(self) -> bool:
+        """
+        Whether this backend actually stores `Span.set_io` payloads.
+
+        Why this exists:
+        - serializing a full message transcript on every model call is real work
+          on the agent hot path; callers must be able to skip it entirely when
+          the backend would only discard the result
+        - it is also the single switch that makes the content exclusion of
+          `OBSERVABILITY-AND-AUDIT.md` §7 auditable: `False` everywhere means no
+          stream can carry content, whatever call sites do
+
+        How to use it:
+        - `if tracer.captures_content: span.set_io(input=..., output=...)`
+        """
+
+        return False
 
     def start_span(
         self,
@@ -176,6 +244,33 @@ class _LoggingSpan(Span):
 
     def set_attribute(self, key: str, value: Any) -> None:
         self._attrs[key] = value
+
+    def set_io(self, *, input: Any = None, output: Any = None) -> None:
+        # This logger feeds the generic app-log store, which carries no content
+        # (OBSERVABILITY-AND-AUDIT.md §7) — hence sizes only, never the payload.
+        # `LoggingTracer.captures_content` stays False so well-behaved callers
+        # never even build these payloads; recording lengths here just means a
+        # caller that ignores that hint still cannot leak content into the store.
+        if input is not None:
+            self._attrs["input_chars"] = len(str(input))
+        if output is not None:
+            self._attrs["output_chars"] = len(str(output))
+
+    def set_usage(
+        self,
+        *,
+        model: str | None = None,
+        usage: Mapping[str, int] | None = None,
+        cost: Mapping[str, float] | None = None,
+    ) -> None:
+        # Token counts and cost are technical measurements, not content — safe
+        # to log in full.
+        if model is not None:
+            self._attrs["model_name"] = model
+        for key, value in (usage or {}).items():
+            self._attrs[f"usage_{key}"] = value
+        for key, value in (cost or {}).items():
+            self._attrs[f"cost_{key}"] = value
 
     def end(self) -> None:
         self.logger.info(

--- a/libs/fred-core/fred_core/tests/portable/test_observability.py
+++ b/libs/fred-core/fred_core/tests/portable/test_observability.py
@@ -50,6 +50,78 @@ def restore_observability_globals() -> Iterator[None]:
         observability.set_metrics_provider(original_metrics)
 
 
+def test_no_tracer_captures_content_by_default() -> None:
+    """
+    The switch that makes the content exclusion of
+    `docs/swift/platform/OBSERVABILITY-AND-AUDIT.md` §7 auditable: with every
+    built-in backend answering False, no stream can carry content whatever the
+    call sites do.
+    """
+
+    assert observability.Tracer().captures_content is False
+    assert observability.LoggingTracer().captures_content is False
+
+
+def test_logging_span_records_content_sizes_but_never_the_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    This logger feeds the generic app-log store, which carries no content.
+    A caller that ignores `captures_content` still must not leak into it.
+    """
+
+    logger = logging.getLogger("fred_core.tests.traces.io")
+    tracer = observability.LoggingTracer(logger=logger)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        span = tracer.start_span("v2.react.model")
+        span.set_io(input="a secret question", output="a secret answer")
+        span.end()
+
+    attributes = cast(
+        dict[str, object],
+        cast(dict[str, object], caplog.records[-1].__dict__["span"])["attributes"],
+    )
+    assert attributes == {"input_chars": 17, "output_chars": 15}
+    assert "secret" not in caplog.text
+
+
+def test_logging_span_records_usage_in_full(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Token counts and cost are measurement, not content — safe to log whole."""
+
+    logger = logging.getLogger("fred_core.tests.traces.usage")
+    tracer = observability.LoggingTracer(logger=logger)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        span = tracer.start_span("v2.react.model")
+        span.set_usage(
+            model="gpt-4o", usage={"input": 812, "output": 96}, cost={"total": 0.02}
+        )
+        span.end()
+
+    attributes = cast(
+        dict[str, object],
+        cast(dict[str, object], caplog.records[-1].__dict__["span"])["attributes"],
+    )
+    assert attributes == {
+        "model_name": "gpt-4o",
+        "usage_input": 812,
+        "usage_output": 96,
+        "cost_total": 0.02,
+    }
+
+
+def test_null_span_accepts_io_and_usage_without_effect() -> None:
+    """Every call site may call these unconditionally against any backend."""
+
+    span = observability.Tracer().start_span("agent.stream")
+    span.set_io(input="x", output="y")
+    span.set_usage(model="m", usage={"input": 1}, cost={"total": 1.0})
+    span.end()
+
+
 def test_logging_tracer_emits_parent_and_runtime_attributes(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -2208,6 +2208,7 @@ async def _write_turn_history(
     final_token_usage: ChatTokenUsage | None = None
     final_model: str | None = None
     final_finish_reason: str | None = None
+    final_context_tokens: int | None = None
 
     for payload in payloads:
         kind = payload.get("kind")
@@ -2221,7 +2222,6 @@ async def _write_turn_history(
                     call_id=payload["call_id"],
                     name=payload["tool_name"],
                     args=payload.get("arguments", {}),
-                    token_usage=payload.get("token_usage"),
                 )
             )
             rank += 1
@@ -2357,6 +2357,9 @@ async def _write_turn_history(
                 )
             final_model = payload.get("model_name")
             final_finish_reason = payload.get("finish_reason")
+            raw_context_tokens = payload.get("context_tokens")
+            if isinstance(raw_context_tokens, (int, float)):
+                final_context_tokens = int(raw_context_tokens)
 
     # 2b. Blocks the stream never closed (truncated turn, crashed node). The live
     # UI closes them itself on `final` so the accordion does not pulse forever
@@ -2378,6 +2381,7 @@ async def _write_turn_history(
                 usage=final_token_usage,
                 sources=final_sources if final_sources else None,
                 finish_reason=final_finish_reason,
+                context_tokens=final_context_tokens,
             )
         )
 

--- a/libs/fred-runtime/fred_runtime/app/config.py
+++ b/libs/fred-runtime/fred_runtime/app/config.py
@@ -211,6 +211,43 @@ class LangfuseObservabilityConfig(BaseModel):
 
     host: str = "http://localhost:3001"
 
+    capture_content: bool = False
+    """
+    Send prompts, model answers, and tool payloads to Langfuse.
+
+    **Off by default, and it must stay off outside a developer's own machine.**
+    `docs/swift/platform/OBSERVABILITY-AND-AUDIT.md` §7 excludes content —
+    prompts, tool arguments/results, documents — from every observability
+    stream; content lives only in the product's own storage under the product's
+    own access control. Turning this on deliberately breaks that rule for a
+    local Langfuse, which is the only setting where it is legitimate: debugging
+    an agent's reasoning, or checking what a model actually received.
+
+    Enabling it in a shared or production deployment exports user conversations
+    to a system that does not enforce Fred's authorization model. Do not.
+
+    The env var `LANGFUSE_CAPTURE_CONTENT` overrides this field, so a developer
+    can flip it per-run without editing configuration.yaml.
+    """
+
+    max_content_chars: int = 100_000
+    """
+    Total character budget per exported payload when `capture_content` is on.
+
+    This is a budget for the payload as a whole, not a per-string cap. A ReAct
+    turn's transcript grows with every tool round and every model call
+    re-exports all of it, so capping each string alone would still leave the
+    payload unbounded in the number of strings. Truncated payloads carry a
+    `…[truncated N chars]` marker so a reader never mistakes a cut payload for
+    a complete one, and the budget is spent most-recent-first so a verbose
+    system prompt cannot blank out the actual question and answer.
+
+    Override per-run with `LANGFUSE_MAX_CONTENT_CHARS`. That env var is the only
+    working knob when the pod reaches Langfuse through `build_default_tracer`
+    (credentials present but `tracer` not set to `langfuse`), since that path
+    never reads this file.
+    """
+
 
 class PodObservabilityConfig(BaseModel):
     """

--- a/libs/fred-runtime/fred_runtime/app/observability_factory.py
+++ b/libs/fred-runtime/fred_runtime/app/observability_factory.py
@@ -131,9 +131,18 @@ def _build_langfuse_tracer(config: PodObservabilityConfig) -> Tracer:
         )
         return LoggingTracer()
     try:
-        from fred_runtime.integrations.v2_runtime.adapters import build_langfuse_tracer
+        from fred_runtime.integrations.v2_runtime.adapters import (
+            build_langfuse_tracer,
+            langfuse_content_capture_enabled,
+        )
 
-        tracer = build_langfuse_tracer()
+        capture_content = langfuse_content_capture_enabled(
+            config.langfuse.capture_content
+        )
+        tracer = build_langfuse_tracer(
+            capture_content=capture_content,
+            max_content_chars=config.langfuse.max_content_chars,
+        )
         if tracer is None:
             logger.warning(
                 "[fred-runtime] Langfuse tracer could not be built — falling back to logging"
@@ -142,6 +151,19 @@ def _build_langfuse_tracer(config: PodObservabilityConfig) -> Tracer:
         logger.info(
             "[fred-runtime] Langfuse tracer initialized (host=%s)", config.langfuse.host
         )
+        if capture_content:
+            # Loud on purpose. This is the one setting that puts user prompts,
+            # model answers, and tool payloads into an external system, against
+            # the content exclusion in OBSERVABILITY-AND-AUDIT.md §7. An
+            # operator who did not mean to enable it must see it at startup.
+            logger.warning(
+                "[fred-runtime] Langfuse CONTENT CAPTURE IS ON — prompts, model"
+                " answers, and tool payloads are exported to %s. This is for local"
+                " debugging only; it violates the content exclusion of"
+                " OBSERVABILITY-AND-AUDIT.md §7 and must never be enabled on a"
+                " shared or production deployment.",
+                config.langfuse.host,
+            )
         return tracer
     except Exception:
         logger.exception(

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -231,10 +231,6 @@ class _GraphNodeExecutionContext:
     # being buffered in _events, so the caller receives tokens in real time.
     _live_emit: Callable[[RuntimeEvent], None] | None = None
     _last_model_name: str | None = None
-    # Usage of the single most recent model call in this node — used for
-    # per-step attribution (TRACE-01: attached to each ToolCallRuntimeEvent
-    # a node emits, so a step shows only the call that triggered it).
-    _last_token_usage: dict[str, int] | None = None
     # Summed across every model call this node makes — a node can call the
     # model more than once (e.g. planning then acting) before invoking a
     # tool, and the node's real total is their sum, not just the last one.
@@ -275,7 +271,6 @@ class _GraphNodeExecutionContext:
         if model_name:
             self._last_model_name = model_name
         if token_usage:
-            self._last_token_usage = token_usage
             self._total_token_usage = sum_token_usage(
                 self._total_token_usage, token_usage
             )
@@ -653,11 +648,6 @@ class _GraphNodeExecutionContext:
                 tool_name=tool_ref,
                 call_id=call_id,
                 arguments=payload,
-                # Usage of the most recent model call recorded on this node
-                # (TRACE-01) — the same value `last_model_metadata` reads, not
-                # necessarily this specific call's own usage: a graph node can
-                # invoke several models before invoking a tool.
-                token_usage=self._last_token_usage,
             )
         )
         span = _start_runtime_span(
@@ -732,8 +722,6 @@ class _GraphNodeExecutionContext:
                 tool_name=tool_name,
                 call_id=call_id,
                 arguments=arguments,
-                # See invoke_tool() above — same caveat applies.
-                token_usage=self._last_token_usage,
             )
         )
         span = _start_runtime_span(

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -100,6 +100,11 @@ from fred_runtime.runtime_support.checkpoints import (
     AsyncCheckpointWriter,
     checkpoint_namespace,
 )
+from fred_runtime.runtime_support.trace_payloads import (
+    serialize_messages,
+    serialize_model_output,
+    to_langfuse_usage,
+)
 from fred_runtime.runtime_support.model_metadata import (
     runtime_metadata_from_message,
     sum_token_usage,
@@ -527,6 +532,20 @@ class _GraphNodeExecutionContext:
                 )
                 if span is not None:
                     span.set_attribute("status", "ok")
+                    span.set_usage(
+                        model=captured_model_name,
+                        usage=to_langfuse_usage(captured_token_usage),
+                    )
+                    tracer = self.services.tracer
+                    if tracer is not None and tracer.captures_content:
+                        span.set_io(
+                            input=serialize_messages(messages),
+                            output=serialize_model_output(
+                                [accumulated]
+                                if isinstance(accumulated, BaseMessage)
+                                else []
+                            ),
+                        )
                 return accumulated
             except Exception:
                 if span is not None:

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -100,14 +100,14 @@ from fred_runtime.runtime_support.checkpoints import (
     AsyncCheckpointWriter,
     checkpoint_namespace,
 )
+from fred_runtime.runtime_support.model_metadata import (
+    runtime_metadata_from_message,
+    sum_token_usage,
+)
 from fred_runtime.runtime_support.trace_payloads import (
     serialize_messages,
     serialize_model_output,
     to_langfuse_usage,
-)
-from fred_runtime.runtime_support.model_metadata import (
-    runtime_metadata_from_message,
-    sum_token_usage,
 )
 
 logger = logging.getLogger(__name__)

--- a/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
+++ b/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
@@ -40,7 +40,7 @@ import os
 import re
 from collections.abc import Awaitable, Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Protocol, TypedDict, cast
+from typing import Any, Protocol, TypedDict, cast
 
 import httpx
 from fred_core.common import OwnerFilter
@@ -126,19 +126,170 @@ _TRACE_AWAIT_HUMAN_SPAN_NAMES = frozenset({"v2.graph.await_human"})
 _TRACE_TOOL_SPAN_NAMES = frozenset(
     {"v2.graph.tool", "v2.graph.runtime_tool", "tool.invoke"}
 )
+_TRACE_AGENT_SPAN_NAMES = frozenset({"agent.invoke", "agent.stream"})
+# Tool-shaped spans that are not the generic tool invoker.
+_TRACE_EXTRA_TOOL_SPAN_NAMES = frozenset({"artifact.publish", "resource.fetch"})
+
+# Langfuse renders an observation according to its declared type: only a
+# `generation` shows model/tokens/cost columns, only `tool` and `agent` get
+# their dedicated icons and the agent-graph view. Fred's runtime tracing
+# contract is backend-agnostic and knows nothing about those types, so the
+# mapping lives here, keyed by the span names the runtime already emits —
+# the same names `_extract_interesting_spans` reads back when summarizing a
+# conversation.
+_LANGFUSE_OBSERVATION_TYPE_BY_SPAN_NAME: dict[str, str] = {
+    **{name: "generation" for name in _TRACE_MODEL_SPAN_NAMES},
+    **{name: "tool" for name in _TRACE_TOOL_SPAN_NAMES},
+    **{name: "tool" for name in _TRACE_EXTRA_TOOL_SPAN_NAMES},
+    **{name: "agent" for name in _TRACE_AGENT_SPAN_NAMES},
+}
+
+# Observation types on which Langfuse keeps model/usage/cost. Mirrors
+# `langfuse._client.constants.ObservationTypeGenerationLike`; every other type
+# discards those fields without warning (see `LangfuseSpanAdapter.end`).
+_LANGFUSE_GENERATION_LIKE_TYPES = frozenset({"generation", "embedding"})
+
+# Total characters exported per payload when content capture is on. Generous
+# on purpose: content capture is a laptop-only debugging affordance, and one
+# agent's tool schemas alone can run past 20k characters — a budget that cuts
+# them defeats the reason the developer turned it on. Its job is to stop a
+# pathological multi-MB payload, not to be stingy.
+DEFAULT_MAX_CONTENT_CHARS = 100_000
+
+# OpenTelemetry attribute names Langfuse promotes to trace-level fields.
+# `propagate_attributes()` — the SDK's public helper — ultimately just sets
+# these on every span in its context (see langfuse/_client/propagation.py).
+# Fred cannot use that helper: it is a context manager backed by contextvars,
+# and Fred's spans are started and ended explicitly across await boundaries,
+# so the enter/exit pair would not bracket a span's real lifetime. Setting the
+# attributes directly on each span is the same operation without that
+# constraint, and it keeps every span of a turn attributable, which is what
+# Langfuse's per-session and per-user aggregations require.
+_OTEL_TRACE_SESSION_ID = "session.id"
+_OTEL_TRACE_USER_ID = "user.id"
+_OTEL_TRACE_NAME = "langfuse.trace.name"
+_OTEL_TRACE_TAGS = "langfuse.trace.tags"
+_OTEL_TRACE_INPUT = "langfuse.trace.input"
+_OTEL_TRACE_OUTPUT = "langfuse.trace.output"
+
+
+# Strings at or below this length are never truncated — see `_truncate_payload`.
+# Sized to hold the structural fields of a trace payload (roles, tool names,
+# tool-call ids) plus a short answer, without being large enough for a handful
+# of them to matter against the budget.
+_MIN_TRUNCATABLE_CHARS = 64
+
+
+def _truncate_payload(value: object, limit: int) -> object:
+    """
+    Bound a trace payload to `limit` characters **in total**, not per string.
+
+    Why the total matters, not just each string:
+    - a ReAct turn's transcript grows with every tool round, and every model
+      call of that turn re-exports the whole transcript. Capping each string
+      alone leaves the payload unbounded in the number of strings: twenty tool
+      results just under the cap is still hundreds of KB per model call, walked
+      and JSON-serialized on the event loop each time
+    - truncating the serialized JSON instead would produce invalid JSON, so the
+      structure is preserved and the budget is spent string by string
+
+    Once the budget is exhausted the remaining strings collapse to a marker
+    rather than being dropped, so a reader can see the payload was cut and
+    never mistakes it for a complete one.
+
+    **Lists spend the budget from the end backwards** (output order is
+    unchanged). A message list starts with the system prompt, which in an agent
+    with several tools carries every tool's JSON schema and can run to tens of
+    thousands of characters. Spending front-to-back let that boilerplate eat the
+    whole budget and blank out the actual question and answer — the two things
+    anyone opening a trace is looking for. Recency wins instead.
+    """
+
+    remaining = max(limit, 0)
+
+    def _walk(value: object) -> object:
+        nonlocal remaining
+        if isinstance(value, str):
+            if not value:
+                return value
+            # Short strings are emitted verbatim even past the budget. They are
+            # the payload's structure — roles, tool names, ids, call ids — and
+            # replacing one with a ~24-character marker makes the payload BIGGER
+            # while destroying the field's meaning (`"system"` became
+            # `"sys…[truncated 3 chars]"`). Truncation only ever applies where it
+            # actually saves space. They still consume budget, so the bound holds.
+            if len(value) <= _MIN_TRUNCATABLE_CHARS:
+                remaining = max(remaining - len(value), 0)
+                return value
+            if remaining <= 0:
+                return f"…[truncated {len(value)} chars]"
+            if len(value) <= remaining:
+                remaining -= len(value)
+                return value
+            kept, cut = value[:remaining], len(value) - remaining
+            remaining = 0
+            return f"{kept}…[truncated {cut} chars]"
+        if isinstance(value, dict):
+            return {key: _walk(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            items = list(value)
+            walked: list[object] = [None] * len(items)
+            for index in range(len(items) - 1, -1, -1):
+                walked[index] = _walk(items[index])
+            return walked
+        return value
+
+    return _walk(value)
+
+
+def _serialize_trace_attribute(value: object) -> str:
+    """
+    Render a payload as the JSON string an OTel attribute can carry.
+
+    OpenTelemetry attributes accept only scalars and sequences of scalars, so
+    trace-level input/output must be serialized before being set. `default=str`
+    keeps a stray non-JSON value (a datetime, a Pydantic model) from raising on
+    the tracing path.
+    """
+
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)
 
 
 class LangfuseSpanAdapter(SpanPort):
     """
     Thin `SpanPort` adapter over a Langfuse span.
 
-    Attributes are buffered and flushed as metadata updates to keep the runtime
-    tracing contract generic and side-effect free.
+    Everything a caller records is buffered and flushed in a single `update()`
+    at `end()`. One flush per span keeps the runtime tracing contract generic
+    and side-effect free, and costs one SDK call per span instead of one per
+    attribute on the agent hot path.
     """
 
-    def __init__(self, span: "_LangfuseSpanLike"):
+    def __init__(
+        self,
+        span: "_LangfuseSpanLike",
+        *,
+        capture_content: bool = False,
+        max_content_chars: int = DEFAULT_MAX_CONTENT_CHARS,
+        is_root: bool = False,
+        observation_type: str = "span",
+    ):
         self._span = span
         self._metadata: dict[str, object] = {}
+        self._capture_content = capture_content
+        self._max_content_chars = max_content_chars
+        self._is_root = is_root
+        self._observation_type = observation_type
+        self._input: object | None = None
+        self._output: object | None = None
+        self._model: str | None = None
+        self._usage: dict[str, int] | None = None
+        self._cost: dict[str, float] | None = None
         self._ended = False
 
     @property
@@ -150,24 +301,161 @@ class LangfuseSpanAdapter(SpanPort):
             return
         self._metadata[key] = value
 
+    def set_io(self, *, input: object = None, output: object = None) -> None:
+        # Dropped unless the pod explicitly opted into content capture
+        # (OBSERVABILITY-AND-AUDIT.md §7). Callers are expected to check
+        # `tracer.captures_content` first and skip building the payload at all;
+        # this second check makes the guarantee hold even if one does not.
+        if self._ended or not self._capture_content:
+            return
+        if input is not None:
+            self._input = _truncate_payload(input, self._max_content_chars)
+        if output is not None:
+            self._output = _truncate_payload(output, self._max_content_chars)
+
+    @property
+    def _is_generation_like(self) -> bool:
+        """
+        Whether Langfuse will keep model/usage/cost on this observation.
+
+        Only `generation` and `embedding` are generation-like
+        (`langfuse._client.constants.ObservationTypeGenerationLike`); every
+        other type silently discards those fields on `update()`.
+        """
+
+        return self._observation_type in _LANGFUSE_GENERATION_LIKE_TYPES
+
+    def set_usage(
+        self,
+        *,
+        model: str | None = None,
+        usage: Mapping[str, int] | None = None,
+        cost: Mapping[str, float] | None = None,
+    ) -> None:
+        if self._ended:
+            return
+        if model is not None:
+            self._model = model
+        if usage:
+            self._usage = dict(usage)
+        if cost:
+            self._cost = dict(cost)
+
     def end(self) -> None:
         if self._ended:
             return
+        # The two steps are guarded separately and `end()` runs in a `finally`:
+        # if flushing the payload fails — a Langfuse outage, a payload the
+        # exporter rejects, an SDK signature change — the span must still be
+        # closed. Sharing one try block would leave it open forever, which
+        # renders as a turn that never finished and skews every duration in the
+        # trace. Tracing degrades the trace, never the agent turn.
         try:
-            if self._metadata:
-                self._span.update(metadata=dict(self._metadata))
-            self._span.end()
+            update: dict[str, object] = {}
+            metadata = dict(self._metadata)
+            # Langfuse keeps `model`/`usage_details`/`cost_details` ONLY on
+            # generation-like observations; on a span-like one (`agent`, `tool`,
+            # `span`) `update()` routes through `create_span_attributes` and
+            # drops them without a warning. A turn total recorded on the
+            # `agent.stream` root therefore vanished silently. Rather than let
+            # `set_usage` be a no-op on those spans, fall back to metadata so
+            # the numbers stay readable. Langfuse still computes the trace's own
+            # token and cost totals by aggregating the child generations, which
+            # is where the authoritative per-call usage lives.
+            if self._is_generation_like:
+                if self._model is not None:
+                    update["model"] = self._model
+                if self._usage is not None:
+                    update["usage_details"] = self._usage
+                if self._cost is not None:
+                    update["cost_details"] = self._cost
+            else:
+                if self._model is not None:
+                    metadata.setdefault("model_name", self._model)
+                for key, value in (self._usage or {}).items():
+                    metadata[f"usage_{key}"] = value
+                for key, value in (self._cost or {}).items():
+                    metadata[f"cost_{key}"] = value
+            if metadata:
+                update["metadata"] = metadata
+            if self._input is not None:
+                update["input"] = self._input
+            if self._output is not None:
+                update["output"] = self._output
+            # Surface failures as Langfuse's own error level so a broken turn is
+            # visible in the trace list without opening every span. The runtime
+            # records status as a plain attribute; only this adapter knows what
+            # the backend does with it.
+            if self._metadata.get("status") == "error":
+                update["level"] = "ERROR"
+            if update:
+                self._span.update(**update)
+            # The trace row in Langfuse's list view shows the trace-level
+            # input/output, not the root span's. Mirroring them here is what
+            # makes a conversation scannable: question in, answer out, without
+            # drilling into the span tree.
+            if self._is_root and (self._input is not None or self._output is not None):
+                self._set_trace_io()
+        except Exception:
+            logger.warning(
+                "[V2][TRACING] Failed to flush Langfuse span payload.", exc_info=True
+            )
         finally:
+            try:
+                self._span.end()
+            except Exception:
+                logger.warning(
+                    "[V2][TRACING] Failed to end Langfuse span.", exc_info=True
+                )
             self._ended = True
+
+    def _set_trace_io(self) -> None:
+        otel_span = getattr(self._span, "_otel_span", None)
+        if otel_span is None:
+            return
+        attributes: dict[str, str] = {}
+        if self._input is not None:
+            attributes[_OTEL_TRACE_INPUT] = _serialize_trace_attribute(self._input)
+        if self._output is not None:
+            attributes[_OTEL_TRACE_OUTPUT] = _serialize_trace_attribute(self._output)
+        if attributes:
+            otel_span.set_attributes(attributes)
 
 
 class LangfuseTracerAdapter(TracerPort):
     """
     Langfuse-backed implementation of the v2 runtime tracing port.
+
+    Trace shape produced here:
+    - **one trace per turn**, seeded on `exchange_id` so every span of one
+      user message shares it, and so a HITL resume rejoins the trace of the
+      exchange it resumes instead of starting an orphan
+    - **grouped into a session** through Langfuse's native `session.id`, which
+      is what makes its Sessions view show a conversation as a whole rather
+      than a pile of unrelated traces
+    - **attributed to a user** through the native `user.id`, enabling per-user
+      cost and latency aggregation
+    - **typed observations**: model calls become `generation` (model, tokens,
+      cost), tool calls become `tool`, the turn's root becomes `agent`
+
+    Identity metadata stays on every span as before, so the read-back path in
+    `_summarize_langfuse_conversation` keeps working unchanged.
     """
 
-    def __init__(self, client: Langfuse):
+    def __init__(
+        self,
+        client: Langfuse,
+        *,
+        capture_content: bool = False,
+        max_content_chars: int = 20000,
+    ):
         self._client = client
+        self._capture_content = capture_content
+        self._max_content_chars = max_content_chars
+
+    @property
+    def captures_content(self) -> bool:
+        return self._capture_content
 
     @property
     def propagator(self):  # type: ignore[override]
@@ -220,8 +508,17 @@ class LangfuseTracerAdapter(TracerPort):
                 environment=PortableEnvironment.DEV,
             )
         )
+        # `exchange_id` comes first so one trace covers one user turn end to
+        # end. It is the only seed that survives a HITL resume: the resume is a
+        # new request with a fresh `request_id` but the same exchange, and
+        # seeding on `request_id` (the previous first choice after `trace_id`)
+        # split it into a second, parentless trace. Seeding on `session_id`
+        # would go too far the other way and collapse a whole conversation into
+        # a single unreadable trace — sessions are grouped by `session.id`
+        # below, which is what Langfuse's Sessions view is built on.
         trace_seed = (
             portable_context.trace_id
+            or portable_context.baggage.get("exchange_id")
             or portable_context.request_id
             or portable_context.correlation_id
             or portable_context.session_id
@@ -258,16 +555,80 @@ class LangfuseTracerAdapter(TracerPort):
         parent_span_id = parent.span_id if parent is not None else None
         if parent_span_id is not None:
             trace_context["parent_span_id"] = parent_span_id
+        observation_type = _LANGFUSE_OBSERVATION_TYPE_BY_SPAN_NAME.get(name, "span")
         span = cast(
             "_LangfuseSpanLike",
             self._client.start_observation(
                 name=name,
-                as_type="span",
+                as_type=cast(Any, observation_type),
                 trace_context=trace_context,
                 metadata=metadata,
             ),
         )
-        return LangfuseSpanAdapter(span)
+        self._apply_trace_attributes(
+            span, portable_context=portable_context, span_name=name
+        )
+        return LangfuseSpanAdapter(
+            span,
+            capture_content=self._capture_content,
+            max_content_chars=self._max_content_chars,
+            is_root=parent_span_id is None,
+            observation_type=observation_type,
+        )
+
+    def _apply_trace_attributes(
+        self,
+        span: "_LangfuseSpanLike",
+        *,
+        portable_context: PortableContext,
+        span_name: str,
+    ) -> None:
+        """
+        Promote Fred's session/user identity to Langfuse's native trace fields.
+
+        Without this, `session_id` and `user_id` reach Langfuse only as
+        free-form metadata: the Sessions and Users views stay empty and a
+        conversation cannot be reassembled from its individual turns. These are
+        opaque platform identifiers, not content — the category
+        `OBSERVABILITY-AND-AUDIT.md` §7 explicitly allows in an identity-bearing
+        stream — so they are set unconditionally, independently of
+        `capture_content`.
+        """
+
+        otel_span = getattr(span, "_otel_span", None)
+        if otel_span is None:
+            return
+        attributes: dict[str, object] = {}
+        if portable_context.session_id:
+            attributes[_OTEL_TRACE_SESSION_ID] = portable_context.session_id
+        if portable_context.user_id:
+            attributes[_OTEL_TRACE_USER_ID] = portable_context.user_id
+        # Name the trace after the agent rather than after whichever span
+        # happened to open it, so the Langfuse trace list reads as a list of
+        # agent turns.
+        agent_label = portable_context.agent_name or portable_context.agent_id
+        if agent_label and span_name in _TRACE_AGENT_SPAN_NAMES:
+            attributes[_OTEL_TRACE_NAME] = agent_label
+            tags = [
+                tag
+                for tag in (
+                    portable_context.team_id,
+                    portable_context.baggage.get("execution_action"),
+                    portable_context.environment.value,
+                )
+                if tag
+            ]
+            if tags:
+                attributes[_OTEL_TRACE_TAGS] = tags
+        if not attributes:
+            return
+        try:
+            otel_span.set_attributes(attributes)
+        except Exception:
+            # Never let a tracing detail break a turn.
+            logger.debug(
+                "[V2][TRACING] Could not set Langfuse trace attributes.", exc_info=True
+            )
 
 
 _LANGFUSE_TRACER: TracerPort | None | bool = False
@@ -276,18 +637,82 @@ _LANGFUSE_TRACER: TracerPort | None | bool = False
 class _LangfuseSpanLike(Protocol):
     id: str
 
-    def update(
-        self, *, metadata: Mapping[str, object] | None = None, **kwargs
-    ) -> object:
+    # Kept fully open (`**kwargs`) because the adapter flushes a span in one
+    # call whose keys depend on what the caller recorded — metadata, input,
+    # output, model, usage_details, cost_details, level. Naming a subset here
+    # only forces a cast at the single call site without adding safety.
+    def update(self, **kwargs: Any) -> object:
         pass
 
     def end(self, *, end_time: int | None = None) -> object:
         pass
 
 
-def build_langfuse_tracer() -> TracerPort | None:
+def langfuse_content_capture_enabled(default: bool = False) -> bool:
+    """
+    Resolve whether prompts and answers may be exported to Langfuse.
+
+    `LANGFUSE_CAPTURE_CONTENT` overrides the configuration.yaml value so a
+    developer can flip content capture for one local run without editing
+    committed config — the only setting where enabling it is legitimate (see
+    `LangfuseObservabilityConfig.capture_content`).
+    """
+
+    raw = os.getenv("LANGFUSE_CAPTURE_CONTENT")
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def langfuse_max_content_chars(default: int = DEFAULT_MAX_CONTENT_CHARS) -> int:
+    """
+    Resolve the per-payload export budget, with an env override.
+
+    Why the env var matters more than it looks: `build_default_tracer` builds
+    the Langfuse tracer whenever credentials exist, even when
+    `observability.tracer` is not `langfuse` — and that path never sees
+    configuration.yaml. On a pod configured with `tracer: logging` plus Langfuse
+    keys in `.env` (the common local setup), the env var is the ONLY way to
+    change this budget.
+
+    A non-numeric or non-positive value falls back to the default rather than
+    disabling truncation, so a typo cannot turn a debugging knob into an
+    unbounded export.
+    """
+
+    raw = os.getenv("LANGFUSE_MAX_CONTENT_CHARS")
+    if raw is None:
+        return default
+    try:
+        parsed = int(raw.strip())
+    except ValueError:
+        logger.warning(
+            "[V2][TRACING] LANGFUSE_MAX_CONTENT_CHARS=%r is not an integer — using %d.",
+            raw,
+            default,
+        )
+        return default
+    if parsed <= 0:
+        logger.warning(
+            "[V2][TRACING] LANGFUSE_MAX_CONTENT_CHARS must be positive — using %d.",
+            default,
+        )
+        return default
+    return parsed
+
+
+def build_langfuse_tracer(
+    *,
+    capture_content: bool = False,
+    max_content_chars: int = DEFAULT_MAX_CONTENT_CHARS,
+) -> TracerPort | None:
     """
     Return a shared Langfuse tracer when credentials are configured.
+
+    The instance is memoized: `bootstrap_observability` builds it first, with
+    the pod's configuration, so later argument-less calls from
+    `build_default_tracer` reuse that configured tracer rather than silently
+    rebuilding a default-configured one.
     """
 
     global _LANGFUSE_TRACER
@@ -298,7 +723,11 @@ def build_langfuse_tracer() -> TracerPort | None:
     has_secret = bool(os.getenv("LANGFUSE_SECRET_KEY"))
     if has_public and has_secret:
         try:
-            _LANGFUSE_TRACER = LangfuseTracerAdapter(Langfuse())
+            _LANGFUSE_TRACER = LangfuseTracerAdapter(
+                Langfuse(),
+                capture_content=langfuse_content_capture_enabled(capture_content),
+                max_content_chars=langfuse_max_content_chars(max_content_chars),
+            )
         except Exception:
             logger.exception("[V2][TRACING] Failed to initialize Langfuse tracer.")
             _LANGFUSE_TRACER = None

--- a/libs/fred-runtime/fred_runtime/react/middleware/tracing_kpi.py
+++ b/libs/fred-runtime/fred_runtime/react/middleware/tracing_kpi.py
@@ -23,10 +23,18 @@ from typing import cast
 
 from fred_core.kpi import BaseKPIWriter, KPIActor
 from fred_sdk.contracts.context import BoundRuntimeContext
-from fred_sdk.contracts.runtime import TracerPort
+from fred_sdk.contracts.runtime import SpanPort, TracerPort
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+from fred_runtime.runtime_support.model_metadata import runtime_metadata_from_message
+from fred_runtime.runtime_support.trace_payloads import (
+    final_assistant_message,
+    serialize_messages,
+    serialize_model_output,
+    to_langfuse_usage,
+)
 
 from ..react_model_adapter import (
     TRACE_MODEL_SPAN_NAME,
@@ -88,6 +96,15 @@ class TracingKpiMiddleware(AgentMiddleware):
                 attributes=cast(dict[str, str | int | float | bool | None], attributes),
                 parent=active_agent_span.get(),
             )
+            # Serializing a full transcript is real work on the per-turn hot
+            # path, so it happens only when a backend will actually store it.
+            if self._tracer.captures_content:
+                span.set_io(
+                    input=serialize_messages(
+                        list(request.messages),
+                        system_prompt=request.system_prompt,
+                    )
+                )
 
         kpi_dims: dict[str, str | None] = {
             "agent_id": self._binding.portable_context.agent_name
@@ -116,6 +133,9 @@ class TracingKpiMiddleware(AgentMiddleware):
                     )
                     if response_model_name is not None:
                         span.set_attribute("model_name", response_model_name)
+                    self._record_model_response(
+                        span, response, model_name=response_model_name or model_name
+                    )
                 self._log_model_response(response)
                 return response
             except Exception:
@@ -125,6 +145,46 @@ class TracingKpiMiddleware(AgentMiddleware):
             finally:
                 if span is not None:
                     span.end()
+
+    def _record_model_response(
+        self,
+        span: SpanPort,
+        response: ModelResponse,
+        *,
+        model_name: str | None,
+    ) -> None:
+        """
+        Attach the answer and the token accounting to the model-call span.
+
+        Why this exists:
+        - token counts and cost per call are the whole point of tracing an LLM
+          call; without `set_usage` a tracing backend can only show latency
+        - usage is technical measurement, so it is always recorded; the answer
+          text is content and follows `captures_content` (§7)
+
+        How to use:
+        - called once per successful model call, before the span ends
+        """
+
+        messages = [
+            message for message in response.result if isinstance(message, BaseMessage)
+        ]
+        if not messages:
+            return
+
+        assistant_message = final_assistant_message(messages)
+        if assistant_message is not None:
+            _, token_usage, finish_reason = runtime_metadata_from_message(
+                assistant_message
+            )
+            usage = to_langfuse_usage(token_usage)
+            if usage is not None or model_name is not None:
+                span.set_usage(model=model_name, usage=usage)
+            if finish_reason is not None:
+                span.set_attribute("finish_reason", str(finish_reason))
+
+        if self._tracer is not None and self._tracer.captures_content:
+            span.set_io(output=serialize_model_output(messages))
 
     @staticmethod
     def _log_model_call(request: ModelRequest) -> None:

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -81,6 +81,7 @@ from langgraph.types import Checkpointer
 
 from fred_runtime.capabilities.assembly import CapabilityAgentBlock
 from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
+from fred_runtime.runtime_support.trace_payloads import to_langfuse_usage
 
 # Everything imported from `react_langchain_adapter` below is SDK-bound glue.
 # Read it as one boundary:
@@ -172,6 +173,30 @@ def _format_invocation_turns(turns: tuple[ConversationTurn, ...]) -> str:
             f"User: {turn.user_message}\nAssistant{speaker}: {turn.agent_response}"
         )
     return "\n\n".join(parts)
+
+
+def _trace_input_payload(input_model: ReActInput) -> object:
+    """
+    Render the turn's input for the trace-level `input` of a tracing backend.
+
+    A turn's transcript can be long, but what identifies the turn in a trace
+    list is the message that opened it — so a single trailing user message
+    collapses to its bare text, and anything else keeps the full role/content
+    list.
+
+    Only ever called behind `tracer.captures_content` — this is content in the
+    sense of `OBSERVABILITY-AND-AUDIT.md` §7.
+    """
+
+    messages = list(input_model.messages)
+    if not messages:
+        return ""
+    last = messages[-1]
+    if last.role == ReActMessageRole.USER:
+        return last.content
+    return [
+        {"role": message.role.value, "content": message.content} for message in messages
+    ]
 
 
 def _graph_input(
@@ -268,6 +293,8 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                 context=self._binding.portable_context,
                 attributes={"agent_id": self._binding.portable_context.agent_id or ""},
             )
+            if self._services.tracer.captures_content:
+                span.set_io(input=_trace_input_payload(input_model))
             span_token = active_agent_span.set(span)
         try:
             result = await self._compiled_agent.ainvoke(
@@ -289,6 +316,9 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                 result["messages"],
                 sanitize_tool_name=_sanitize_tool_name,
             )
+            if span is not None and self._services.tracer is not None:
+                if self._services.tracer.captures_content:
+                    span.set_io(output=final_message.content)
             return ReActOutput(final_message=final_message, transcript=transcript)
         finally:
             if span_token is not None:
@@ -312,6 +342,11 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                 context=self._binding.portable_context,
                 attributes={"agent_id": self._binding.portable_context.agent_id or ""},
             )
+            # The turn's root span carries the trace-level input/output, which
+            # is what the Langfuse trace list shows for a conversation: the
+            # question that opened the turn and the answer that closed it.
+            if self._services.tracer.captures_content:
+                span.set_io(input=_trace_input_payload(input_model))
             span_token = active_agent_span.set(span)
 
         metrics = self._services.metrics
@@ -618,7 +653,23 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                     token_usage=total_token_usage,
                     finish_reason=last_finish_reason,
                 )
+                if span is not None and self._services.tracer is not None:
+                    # Turn-level totals, summed across every model call of the
+                    # turn — the per-call breakdown already lives on the child
+                    # generation spans.
+                    span.set_usage(
+                        model=last_model_name,
+                        usage=to_langfuse_usage(total_token_usage),
+                    )
+                    if last_finish_reason is not None:
+                        span.set_attribute("finish_reason", str(last_finish_reason))
+                    if self._services.tracer.captures_content:
+                        span.set_io(output=final_content)
         except Exception:
+            # Mark the turn failed so the trace list shows it as an error
+            # instead of a turn that merely produced no answer.
+            if span is not None:
+                span.set_attribute("status", "error")
             # Close every pending tool call / thought pair so neither the
             # tool-call row nor the thought row spins forever in the frontend.
             for call_id, thought_id in active_thought_ids.items():

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -379,6 +379,13 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         # per-call, not cumulative (TRACE-01 follow-up: the previous
         # last-write-wins variable silently undercounted any multi-call turn).
         total_token_usage: dict[str, int] | None = None
+        # Marginal context accounting (#2403), distinct from the billed total
+        # above: `context_tokens` trails the most recent model call's input
+        # size, so at the end of the turn it is the size of the context the
+        # turn leaves behind. The chat UI diffs it against the previous turn's
+        # to show what a message genuinely added, rather than the billed sum
+        # which re-counts the history once per model call.
+        context_tokens: int | None = None
         last_finish_reason: str | None = None
         # When a whole round of tool calls fails (every call errored, no
         # success anywhere in the batch), the error is surfaced directly as the
@@ -411,6 +418,23 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         # closed before the first answer delta and before the run ends.
         model_native_thought_id: str | None = None
         model_native_thought_started_at: float | None = None
+
+        def observe_model_call(call_usage: dict[str, int] | None) -> None:
+            """
+            Track the context size across the turn's model calls (#2403).
+
+            Called once per model call, in stream order, so that when the turn
+            ends `context_tokens` holds the last call's input — the context the
+            turn leaves behind. A provider that reports no input count resets
+            it to None rather than leaving a stale value: the UI treats None as
+            "unknown" and falls back to the billed total, which is honest,
+            whereas a stale anchor would silently misreport the next turn.
+            """
+
+            nonlocal context_tokens
+
+            context_tokens = (call_usage or {}).get("input_tokens")
+
         phase_timer_ctx.__enter__()
         try:
             async for raw_event in self._compiled_agent.astream(
@@ -568,21 +592,18 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                         # response back to the LLM's synthesis.
                         round_had_tool_success = False
                         # The usage of the model call that decided to make these
-                        # tool calls — attached per-call to ToolCallRuntimeEvent
-                        # (TRACE-01) so the trace UI can show tokens per step,
-                        # AND folded into the turn's running total. When one
-                        # AIMessage requests several tools in parallel, every
-                        # one of them gets this same per-step total (it is the
-                        # cost of the one decision that produced them, not a
-                        # per-tool split — providers don't expose that
-                        # breakdown), but it is only added to the turn total
-                        # once, here, not once per parallel tool call.
+                        # tool calls, folded into the turn's billed total once
+                        # here — not once per parallel tool call. It is NOT
+                        # attached to the individual ToolCallRuntimeEvents any
+                        # more (#2403): showing a decision's whole prompt on a
+                        # tool row read as if the tool had consumed it.
                         _, tool_call_token_usage, _ = _runtime_metadata_from_message(
                             message
                         )
                         total_token_usage = _sum_token_usage(
                             total_token_usage, tool_call_token_usage
                         )
+                        observe_model_call(tool_call_token_usage)
                         for tool_call in message.tool_calls:
                             name = str(tool_call.get("name") or "")
                             call_id = str(tool_call.get("id") or "")
@@ -603,7 +624,6 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                                 arguments=cast(
                                     dict[str, object], tool_call.get("args") or {}
                                 ),
-                                token_usage=tool_call_token_usage,
                             )
                             sequence += 1
                         continue
@@ -617,6 +637,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                         total_token_usage = _sum_token_usage(
                             total_token_usage, token_usage
                         )
+                        observe_model_call(token_usage)
                         if finish_reason is not None:
                             last_finish_reason = finish_reason
                         last_assistant_message = _from_langchain_message_adapter(
@@ -651,6 +672,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
                     ui_parts=collected_ui_parts,
                     model_name=last_model_name,
                     token_usage=total_token_usage,
+                    context_tokens=context_tokens,
                     finish_reason=last_finish_reason,
                 )
                 if span is not None and self._services.tracer is not None:

--- a/libs/fred-runtime/fred_runtime/react/react_tool_binding.py
+++ b/libs/fred-runtime/fred_runtime/react/react_tool_binding.py
@@ -234,14 +234,23 @@ class ReActToolBinder:
                     attributes=attributes,
                     parent=active_agent_span.get(),
                 )
+                # A tool span without its arguments and result shows only that
+                # a tool ran and how long it took — not enough to tell a bad
+                # retrieval from a bad answer, which is the usual reason for
+                # opening a trace at all.
+                if self._tracer.captures_content:
+                    span.set_io(input=normalized_payload)
             try:
                 rendered_result, artifact = await spec.invoke(normalized_payload)
                 if span is not None:
                     span.set_attribute("status", "ok")
+                    if self._tracer is not None and self._tracer.captures_content:
+                        span.set_io(output=rendered_result)
                 return (rendered_result, artifact)
-            except Exception:
+            except Exception as exc:
                 if span is not None:
                     span.set_attribute("status", "error")
+                    span.set_attribute("error_type", type(exc).__name__)
                 raise
             finally:
                 if span is not None:

--- a/libs/fred-runtime/fred_runtime/runtime_support/trace_payloads.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/trace_payloads.py
@@ -1,0 +1,228 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Trace payload shaping for a content-capturing tracing backend.
+
+Why this module exists:
+- a tracing backend that shows what a model received and produced needs those
+  payloads as plain, JSON-serializable structures; LangChain message objects
+  are neither plain nor stable across providers
+- the conversion is shared by the ReAct middleware, the tool binding, and the
+  Graph runtime, and none of them should grow its own variant
+
+**Content policy.** Everything this module produces IS content in the sense of
+`docs/swift/platform/OBSERVABILITY-AND-AUDIT.md` §7, which excludes content
+from every observability stream. These helpers are therefore only ever called
+behind `tracer.captures_content`, which is off unless a developer explicitly
+turned it on for a local Langfuse. Nothing here may be routed to the generic
+app-log store, KPI rows, or the audit trail.
+
+How to use:
+- `if tracer.captures_content: span.set_io(input=serialize_messages(msgs))`
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage
+
+# Fred's normalized usage keys (`normalize_token_usage`) mapped onto the names
+# Langfuse recognizes. `input`/`output`/`total` are the canonical trio it uses
+# for cost inference; the cache keys follow its documented provider extras.
+_USAGE_KEY_MAP = {
+    "input_tokens": "input",
+    "output_tokens": "output",
+    "total_tokens": "total",
+    "cache_read_tokens": "cache_read_input_tokens",
+    "cache_creation_tokens": "cache_creation_input_tokens",
+}
+
+
+def to_langfuse_usage(token_usage: Mapping[str, int] | None) -> dict[str, int] | None:
+    """
+    Translate a normalized Fred token-usage map to Langfuse `usage_details`.
+
+    Zero-valued entries are dropped: a provider that reports no cache usage
+    sends zeros, and rendering "0 cache read tokens" on every generation adds
+    noise without information.
+
+    Example:
+    - `to_langfuse_usage({"input_tokens": 812, "output_tokens": 96, ...})`
+    """
+
+    if not token_usage:
+        return None
+    usage = {
+        _USAGE_KEY_MAP[key]: int(value)
+        for key, value in token_usage.items()
+        if key in _USAGE_KEY_MAP and isinstance(value, int) and value > 0
+    }
+    return usage or None
+
+
+def _content_to_text(content: object) -> str:
+    """
+    Flatten a LangChain message content field to plain text.
+
+    Content is a string for most providers but a list of typed blocks for
+    multimodal ones (Anthropic, OpenAI vision). Non-text blocks are reduced to
+    their type name rather than dumped whole — a base64 image would blow the
+    payload budget and tells a trace reader nothing.
+    """
+
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                else:
+                    parts.append(f"[{block.get('type') or 'block'}]")
+        return "".join(parts)
+    return str(content)
+
+
+def _tool_calls_of(message: BaseMessage) -> list[dict[str, Any]]:
+    raw_tool_calls = getattr(message, "tool_calls", None) or []
+    tool_calls: list[dict[str, Any]] = []
+    for tool_call in raw_tool_calls:
+        if isinstance(tool_call, dict):
+            tool_calls.append(
+                {
+                    "name": tool_call.get("name"),
+                    "args": tool_call.get("args") or {},
+                    "id": tool_call.get("id"),
+                }
+            )
+        else:
+            tool_calls.append(
+                {
+                    "name": getattr(tool_call, "name", None),
+                    "args": getattr(tool_call, "args", {}) or {},
+                    "id": getattr(tool_call, "id", None),
+                }
+            )
+    return tool_calls
+
+
+_ROLE_BY_MESSAGE_TYPE = {
+    "human": "user",
+    "ai": "assistant",
+    "system": "system",
+    "tool": "tool",
+}
+
+
+def serialize_message(message: BaseMessage) -> dict[str, Any]:
+    """
+    Render one LangChain message as a plain `{role, content, ...}` dict.
+
+    The role vocabulary is the chat-completion one Langfuse's message viewer
+    understands, so a captured prompt renders as a conversation rather than as
+    an opaque object dump.
+
+    Example:
+    - `serialize_message(HumanMessage(content="hello"))`
+    """
+
+    message_type = getattr(message, "type", "") or ""
+    payload: dict[str, Any] = {
+        "role": _ROLE_BY_MESSAGE_TYPE.get(message_type, message_type or "unknown"),
+        "content": _content_to_text(getattr(message, "content", "")),
+    }
+    tool_calls = _tool_calls_of(message)
+    if tool_calls:
+        payload["tool_calls"] = tool_calls
+    tool_call_id = getattr(message, "tool_call_id", None)
+    if isinstance(tool_call_id, str) and tool_call_id:
+        payload["tool_call_id"] = tool_call_id
+    name = getattr(message, "name", None)
+    if isinstance(name, str) and name:
+        payload["name"] = name
+    return payload
+
+
+def serialize_messages(
+    messages: Sequence[BaseMessage],
+    *,
+    system_prompt: str | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Render a message list as the prompt payload of a generation span.
+
+    `system_prompt` is prepended when the caller holds it separately from the
+    transcript — LangChain's middleware surfaces it on the request rather than
+    as a message, and a captured prompt that omits it misrepresents what the
+    model actually received.
+
+    Example:
+    - `serialize_messages(request.messages, system_prompt=request.system_prompt)`
+    """
+
+    payload: list[dict[str, Any]] = []
+    if system_prompt:
+        payload.append({"role": "system", "content": system_prompt})
+    payload.extend(
+        serialize_message(message)
+        for message in messages
+        if isinstance(message, BaseMessage)
+    )
+    return payload
+
+
+def serialize_model_output(messages: Sequence[BaseMessage]) -> object:
+    """
+    Render a model response as the output payload of a generation span.
+
+    A single assistant message with no tool calls collapses to its bare text —
+    that is the common case, and a one-element list of dicts around a sentence
+    only makes the trace harder to read. Anything else keeps the full list.
+
+    Example:
+    - `serialize_model_output(response.result)`
+    """
+
+    serialized = [
+        serialize_message(message)
+        for message in messages
+        if isinstance(message, BaseMessage)
+    ]
+    if (
+        len(serialized) == 1
+        and serialized[0].get("role") == "assistant"
+        and "tool_calls" not in serialized[0]
+    ):
+        return serialized[0]["content"]
+    return serialized
+
+
+def final_assistant_message(messages: Sequence[BaseMessage]) -> AIMessage | None:
+    """
+    Return the last assistant message of a model response, if any.
+
+    Example:
+    - `final_assistant_message(response.result)`
+    """
+
+    return next(
+        (message for message in reversed(messages) if isinstance(message, AIMessage)),
+        None,
+    )

--- a/libs/fred-runtime/tests/test_graph_runtime_token_usage_totals.py
+++ b/libs/fred-runtime/tests/test_graph_runtime_token_usage_totals.py
@@ -17,9 +17,12 @@ follow-up) — the same bug as react_runtime.py's, at the node level: a node
 that calls the model more than once before invoking a tool must report the
 *sum* of those calls as its contribution to the turn total, not just the
 last one. `last_model_metadata` (what the executor folds into the turn
-total) must carry that sum, while the per-step attribution used by
-`ToolCallRuntimeEvent` (TRACE-01) must keep showing only the most recent
-individual call, not a running total.
+total) must carry that sum.
+
+Graph nodes carry no per-step token figure at all (#2403): the marginal
+measurement the ReAct runtime uses relies on one context growing across
+consecutive calls, which a graph's independent nodes do not share. Reporting
+an unmeasurable number there would be worse than reporting none.
 """
 
 from __future__ import annotations
@@ -101,13 +104,11 @@ def test_last_model_metadata_sums_every_call_the_node_made() -> None:
     assert finish_reason == "stop"
 
 
-def test_tool_call_event_keeps_only_the_most_recent_call_not_the_running_total() -> (
-    None
-):
+def test_graph_tool_call_event_carries_no_token_figure() -> None:
     """
-    TRACE-01 per-step display must not regress into showing a node-level
-    running total: a tool call right after the node's *second* model call
-    should show only that call's usage, not the sum of both.
+    A graph node's tool row must not resurrect the old per-step display
+    (#2403). The node's model calls still feed the turn's billed total —
+    that is asserted above — but nothing per-step is claimed.
     """
 
     ctx = _node_context({"noop_probe": _noop_probe})
@@ -117,17 +118,16 @@ def test_tool_call_event_keeps_only_the_most_recent_call_not_the_running_total()
         token_usage={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
         finish_reason=None,
     )
-    ctx.record_model_metadata(
-        model_name="gpt-4o",
-        token_usage={"input_tokens": 5, "output_tokens": 1, "total_tokens": 6},
-        finish_reason=None,
-    )
 
     asyncio.run(ctx.invoke_runtime_tool("noop_probe", {"x": "y"}))
 
     (event,) = [e for e in ctx.events if isinstance(e, ToolCallRuntimeEvent)]
-    assert event.token_usage == {
-        "input_tokens": 5,
-        "output_tokens": 1,
-        "total_tokens": 6,
+    assert not hasattr(event, "token_usage")
+    # The node still contributes its usage to the turn total.
+    assert ctx.last_model_metadata[1] == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "total_tokens": 120,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
     }

--- a/libs/fred-runtime/tests/test_history.py
+++ b/libs/fred-runtime/tests/test_history.py
@@ -170,7 +170,6 @@ def test_write_turn_history_maps_react_turn_to_chat_messages() -> None:
             "call_id": "c1",
             "tool_name": "demo.echo",
             "arguments": {"text": "hi"},
-            "token_usage": {"input_tokens": 20, "output_tokens": 3, "total_tokens": 23},
         },
         {
             "kind": "tool_result",
@@ -183,6 +182,7 @@ def test_write_turn_history_maps_react_turn_to_chat_messages() -> None:
             "content": "Done.",
             "model_name": "gpt-4o",
             "token_usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            "context_tokens": 9,
             "finish_reason": "stop",
         },
     ]
@@ -213,12 +213,10 @@ def test_write_turn_history_maps_react_turn_to_chat_messages() -> None:
     assert messages[1].channel == Channel.tool_call
     assert messages[1].parts[0].name == "demo.echo"
     assert messages[1].rank == 1
-    # TRACE-01: usage of the model call that decided this tool call must
-    # survive into the persisted record, not just the live SSE payload —
-    # otherwise the chat trace loses its per-step token figure on reload.
-    assert messages[1].metadata.token_usage.input_tokens == 20
-    assert messages[1].metadata.token_usage.output_tokens == 3
-    assert messages[1].metadata.token_usage.total_tokens == 23
+    # #2403: a tool-call row carries no token figure at all. The former
+    # `token_usage` here was the deciding model call's whole prompt, which the
+    # trace rendered as if the tool had consumed it.
+    assert messages[1].metadata.token_usage is None
 
     # Row 2 — tool result record
     assert messages[2].role == Role.tool
@@ -232,6 +230,9 @@ def test_write_turn_history_maps_react_turn_to_chat_messages() -> None:
     assert messages[3].parts[0].text == "Done."
     assert messages[3].metadata.model == "gpt-4o"
     assert messages[3].rank == 3
+    # The anchor a reloaded conversation needs to recompute each turn's
+    # marginal cost the same way the live stream did (#2403).
+    assert messages[3].metadata.context_tokens == 9
 
 
 def test_write_turn_history_skips_save_when_no_content() -> None:

--- a/libs/fred-runtime/tests/test_langfuse_tracing.py
+++ b/libs/fred-runtime/tests/test_langfuse_tracing.py
@@ -1,0 +1,507 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Langfuse trace shape: session grouping, typed observations, and the content gate.
+
+The rule under test that matters most is the last one: content capture is off
+unless explicitly enabled, because `OBSERVABILITY-AND-AUDIT.md` §7 excludes
+prompts and tool payloads from every observability stream.
+"""
+
+from typing import Any, cast
+
+from fred_runtime.integrations.v2_runtime.adapters import (
+    LangfuseTracerAdapter,
+    langfuse_content_capture_enabled,
+    langfuse_max_content_chars,
+)
+from fred_sdk.contracts.context import PortableContext, PortableEnvironment
+
+
+class _FakeOtelSpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, Any] = {}
+
+    def set_attributes(self, attributes: dict[str, Any]) -> None:
+        self.attributes.update(attributes)
+
+
+class _FakeObservation:
+    def __init__(self) -> None:
+        self.id = "obs-1"
+        self.updates: list[dict[str, Any]] = []
+        self.ended = False
+        self._otel_span = _FakeOtelSpan()
+
+    def update(self, **kwargs: Any) -> None:
+        self.updates.append(kwargs)
+
+    def end(self, *, end_time: int | None = None) -> None:
+        self.ended = True
+
+
+class _FakeLangfuse:
+    def __init__(self) -> None:
+        self.seeds: list[str] = []
+        self.observations: list[_FakeObservation] = []
+        self.start_kwargs: list[dict[str, Any]] = []
+
+    def create_trace_id(self, seed: str) -> str:
+        self.seeds.append(seed)
+        return f"trace-{seed}"
+
+    def start_observation(self, **kwargs: Any) -> _FakeObservation:
+        self.start_kwargs.append(kwargs)
+        observation = _FakeObservation()
+        self.observations.append(observation)
+        return observation
+
+
+def _context(**overrides: Any) -> PortableContext:
+    base: dict[str, Any] = {
+        "request_id": "req-1",
+        "correlation_id": "corr-1",
+        "actor": "alice",
+        "tenant": "fred",
+        "environment": PortableEnvironment.DEV,
+        "agent_id": "rag-agent",
+        "agent_name": "rag-agent",
+        "session_id": "sess-42",
+        "user_id": "user-7",
+        "team_id": "team-red",
+        "baggage": {"exchange_id": "exch-9", "execution_action": "execute"},
+    }
+    base.update(overrides)
+    return PortableContext(**base)
+
+
+def _tracer(**kwargs: Any) -> tuple[LangfuseTracerAdapter, _FakeLangfuse]:
+    fake = _FakeLangfuse()
+    return LangfuseTracerAdapter(cast(Any, fake), **kwargs), fake
+
+
+# ---------------------------------------------------------------------------
+# Session grouping
+# ---------------------------------------------------------------------------
+
+
+def test_session_and_user_reach_langfuse_native_trace_fields() -> None:
+    """Without these, Langfuse's Sessions and Users views stay empty."""
+
+    tracer, fake = _tracer()
+    tracer.start_span("agent.stream", context=_context())
+
+    attributes = fake.observations[0]._otel_span.attributes
+    assert attributes["session.id"] == "sess-42"
+    assert attributes["user.id"] == "user-7"
+
+
+def test_trace_is_named_after_the_agent_and_tagged() -> None:
+    tracer, fake = _tracer()
+    tracer.start_span("agent.stream", context=_context())
+
+    attributes = fake.observations[0]._otel_span.attributes
+    assert attributes["langfuse.trace.name"] == "rag-agent"
+    assert attributes["langfuse.trace.tags"] == ["team-red", "execute", "dev"]
+
+
+def test_only_the_turn_root_names_the_trace() -> None:
+    """A model call must not rename the trace it belongs to."""
+
+    tracer, fake = _tracer()
+    tracer.start_span("v2.react.model", context=_context())
+
+    attributes = fake.observations[0]._otel_span.attributes
+    assert "langfuse.trace.name" not in attributes
+    # Identity still propagates, so per-session aggregation covers every span.
+    assert attributes["session.id"] == "sess-42"
+
+
+def test_every_span_of_one_turn_shares_one_trace() -> None:
+    tracer, fake = _tracer()
+    context = _context()
+    tracer.start_span("agent.stream", context=context)
+    tracer.start_span("v2.react.model", context=context)
+    tracer.start_span("tool.invoke", context=context)
+
+    assert len(set(fake.seeds)) == 1
+
+
+def test_a_resume_rejoins_the_trace_of_the_exchange_it_resumes() -> None:
+    """
+    A HITL resume is a new request with a fresh `request_id` but the same
+    exchange. Seeding on `request_id` split it into a second, parentless trace.
+    """
+
+    tracer, fake = _tracer()
+    tracer.start_span("agent.stream", context=_context(request_id="req-1"))
+    tracer.start_span(
+        "agent.stream",
+        context=_context(
+            request_id="req-2",
+            baggage={"exchange_id": "exch-9", "execution_action": "resume"},
+        ),
+    )
+
+    assert fake.seeds[0] == fake.seeds[1] == "exch-9"
+
+
+def test_two_turns_of_one_session_are_two_traces() -> None:
+    """Collapsing a whole conversation into one trace makes it unreadable."""
+
+    tracer, fake = _tracer()
+    tracer.start_span("agent.stream", context=_context(baggage={"exchange_id": "e1"}))
+    tracer.start_span("agent.stream", context=_context(baggage={"exchange_id": "e2"}))
+
+    assert fake.seeds[0] != fake.seeds[1]
+    for observation in fake.observations:
+        assert observation._otel_span.attributes["session.id"] == "sess-42"
+
+
+def test_an_upstream_trace_id_still_wins() -> None:
+    tracer, fake = _tracer()
+    tracer.start_span("agent.stream", context=_context(trace_id="trace-upstream"))
+
+    assert fake.seeds == ["trace-upstream"]
+
+
+# ---------------------------------------------------------------------------
+# Observation typing
+# ---------------------------------------------------------------------------
+
+
+def test_span_names_map_to_langfuse_observation_types() -> None:
+    """Only a `generation` renders model, token, and cost columns."""
+
+    tracer, fake = _tracer()
+    for name in (
+        "agent.stream",
+        "v2.react.model",
+        "tool.invoke",
+        "v2.graph.await_human",
+    ):
+        tracer.start_span(name, context=_context())
+
+    assert [kwargs["as_type"] for kwargs in fake.start_kwargs] == [
+        "agent",
+        "generation",
+        "tool",
+        "span",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Content gate (OBSERVABILITY-AND-AUDIT.md §7)
+# ---------------------------------------------------------------------------
+
+
+def test_content_capture_is_off_by_default() -> None:
+    tracer, _ = _tracer()
+    assert tracer.captures_content is False
+
+
+def test_content_is_dropped_when_capture_is_disabled() -> None:
+    tracer, fake = _tracer()
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_io(input=[{"role": "user", "content": "my private question"}])
+    span.set_io(output="the private answer")
+    span.end()
+
+    flushed = fake.observations[0].updates
+    assert all("input" not in update for update in flushed)
+    assert all("output" not in update for update in flushed)
+
+
+def test_content_is_exported_when_capture_is_enabled() -> None:
+    tracer, fake = _tracer(capture_content=True)
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_io(input=[{"role": "user", "content": "question"}], output="answer")
+    span.end()
+
+    update = fake.observations[0].updates[0]
+    assert update["input"] == [{"role": "user", "content": "question"}]
+    assert update["output"] == "answer"
+
+
+def test_long_payloads_are_truncated_with_a_visible_marker() -> None:
+    tracer, fake = _tracer(capture_content=True, max_content_chars=100)
+    span = tracer.start_span("tool.invoke", context=_context())
+    span.set_io(output={"hits": ["x" * 500]})
+    span.end()
+
+    output = cast(dict[str, Any], fake.observations[0].updates[0]["output"])
+    assert output["hits"][0] == "x" * 100 + "…[truncated 400 chars]"
+
+
+def test_the_budget_bounds_the_whole_payload_not_each_string() -> None:
+    """
+    Every model call of a ReAct turn re-exports the whole transcript, which
+    grows with each tool round. A per-string cap alone leaves the payload
+    unbounded in the number of strings.
+    """
+
+    tracer, fake = _tracer(capture_content=True, max_content_chars=200)
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_io(
+        input=[
+            {"content": "a" * 150},
+            {"content": "b" * 150},
+            {"content": "c" * 150},
+        ]
+    )
+    span.end()
+
+    payload = cast(list[dict[str, Any]], fake.observations[0].updates[0]["input"])
+    # Spent newest-first: the last message is whole, the middle one is cut at
+    # the remaining 50, and the oldest is past the budget entirely.
+    assert payload[2]["content"] == "c" * 150
+    assert payload[1]["content"] == "b" * 50 + "…[truncated 100 chars]"
+    assert payload[0]["content"] == "…[truncated 150 chars]"
+
+
+def test_short_structural_strings_are_never_mangled() -> None:
+    """
+    Replacing `"system"` with a 24-character marker grows the payload while
+    destroying the field's meaning.
+    """
+
+    tracer, fake = _tracer(capture_content=True, max_content_chars=1)
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_io(input=[{"role": "system", "name": "search", "content": "x" * 500}])
+    span.end()
+
+    payload = cast(list[dict[str, Any]], fake.observations[0].updates[0]["input"])
+    assert payload[0]["role"] == "system"
+    assert payload[0]["name"] == "search"
+    assert payload[0]["content"].endswith("…[truncated 500 chars]")
+
+
+def test_a_verbose_system_prompt_cannot_blank_out_the_question() -> None:
+    """
+    A message list starts with the system prompt, which carries every tool's
+    JSON schema. Spending the budget front-to-back let that boilerplate eat it
+    all and truncate away the two things a trace reader actually wants.
+    """
+
+    tracer, fake = _tracer(capture_content=True, max_content_chars=20)
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_io(
+        input=[
+            {"role": "system", "content": "S" * 5000},
+            {"role": "user", "content": "what is fred?"},
+        ]
+    )
+    span.end()
+
+    payload = cast(list[dict[str, Any]], fake.observations[0].updates[0]["input"])
+    # Order is preserved; the budget went to the most recent message.
+    assert payload[0]["role"] == "system"
+    assert payload[1]["content"] == "what is fred?"
+    assert payload[0]["content"].startswith("…[truncated")
+
+
+def test_the_env_var_overrides_the_budget() -> None:
+    """
+    `build_default_tracer` never reads configuration.yaml, so on a pod with
+    `tracer: logging` plus Langfuse keys this env var is the only knob.
+    """
+
+    assert langfuse_max_content_chars(1234) == 1234
+
+
+def test_a_bad_budget_env_value_falls_back_instead_of_disabling_truncation(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("LANGFUSE_MAX_CONTENT_CHARS", "not-a-number")
+    assert langfuse_max_content_chars(999) == 999
+    monkeypatch.setenv("LANGFUSE_MAX_CONTENT_CHARS", "0")
+    assert langfuse_max_content_chars(999) == 999
+    monkeypatch.setenv("LANGFUSE_MAX_CONTENT_CHARS", "-5")
+    assert langfuse_max_content_chars(999) == 999
+    monkeypatch.setenv("LANGFUSE_MAX_CONTENT_CHARS", "250000")
+    assert langfuse_max_content_chars(999) == 250000
+
+
+def test_structure_survives_truncation() -> None:
+    """Cutting the serialized JSON instead would produce invalid JSON."""
+
+    tracer, fake = _tracer(capture_content=True, max_content_chars=1)
+    span = tracer.start_span("tool.invoke", context=_context())
+    span.set_io(input={"query": "hello", "top_k": 8, "flags": [True, None]})
+    span.end()
+
+    payload = cast(dict[str, Any], fake.observations[0].updates[0]["input"])
+    assert payload["top_k"] == 8
+    assert payload["flags"] == [True, None]
+    assert payload["query"].startswith("h")
+
+
+def test_env_var_overrides_the_configured_default() -> None:
+    assert langfuse_content_capture_enabled(False) is False
+    assert langfuse_content_capture_enabled(True) is True
+
+
+def test_env_var_parsing(monkeypatch: Any) -> None:
+    monkeypatch.setenv("LANGFUSE_CAPTURE_CONTENT", "true")
+    assert langfuse_content_capture_enabled(False) is True
+    monkeypatch.setenv("LANGFUSE_CAPTURE_CONTENT", "false")
+    assert langfuse_content_capture_enabled(True) is False
+
+
+# ---------------------------------------------------------------------------
+# Usage, errors, flush behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_usage_is_recorded_even_when_content_capture_is_off() -> None:
+    """Token counts are technical measurement, not content — always exported."""
+
+    tracer, fake = _tracer()
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_usage(model="gpt-4o", usage={"input": 812, "output": 96})
+    span.end()
+
+    update = fake.observations[0].updates[0]
+    assert update["model"] == "gpt-4o"
+    assert update["usage_details"] == {"input": 812, "output": 96}
+
+
+def test_usage_on_a_span_like_observation_falls_back_to_metadata() -> None:
+    """
+    Langfuse keeps model/usage/cost only on generation-like observations; on an
+    `agent`/`tool`/`span` it drops them without warning, so a turn total
+    recorded on the `agent.stream` root vanished silently.
+    """
+
+    tracer, fake = _tracer()
+    span = tracer.start_span("agent.stream", context=_context())
+    span.set_usage(
+        model="mistral-small-latest", usage={"input": 812, "output": 96, "total": 908}
+    )
+    span.end()
+
+    update = fake.observations[0].updates[0]
+    # Not sent as fields Langfuse would discard...
+    assert "usage_details" not in update
+    assert "model" not in update
+    # ...but still readable on the span.
+    metadata = cast(dict[str, Any], update["metadata"])
+    assert metadata["usage_input"] == 812
+    assert metadata["usage_output"] == 96
+    assert metadata["usage_total"] == 908
+    assert metadata["model_name"] == "mistral-small-latest"
+
+
+def test_a_generation_keeps_usage_as_first_class_fields() -> None:
+    """The per-call generation is where Langfuse aggregates trace totals from."""
+
+    tracer, fake = _tracer()
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_usage(model="mistral-small-latest", usage={"input": 812})
+    span.end()
+
+    update = fake.observations[0].updates[0]
+    assert update["usage_details"] == {"input": 812}
+    assert update["model"] == "mistral-small-latest"
+
+
+def test_error_status_becomes_a_langfuse_error_level() -> None:
+    tracer, fake = _tracer()
+    span = tracer.start_span("tool.invoke", context=_context())
+    span.set_attribute("status", "error")
+    span.end()
+
+    assert fake.observations[0].updates[0]["level"] == "ERROR"
+
+
+def test_a_successful_span_carries_no_error_level() -> None:
+    tracer, fake = _tracer()
+    span = tracer.start_span("tool.invoke", context=_context())
+    span.set_attribute("status", "ok")
+    span.end()
+
+    assert "level" not in fake.observations[0].updates[0]
+
+
+def test_a_span_flushes_once_and_ends_once() -> None:
+    """One SDK call per span, not one per recorded attribute."""
+
+    tracer, fake = _tracer(capture_content=True)
+    span = tracer.start_span("v2.react.model", context=_context())
+    span.set_attribute("status", "ok")
+    span.set_attribute("finish_reason", "stop")
+    span.set_io(input="in", output="out")
+    span.set_usage(model="gpt-4o", usage={"input": 1})
+    span.end()
+    span.end()
+
+    observation = fake.observations[0]
+    assert len(observation.updates) == 1
+    assert observation.ended is True
+
+
+def test_the_turn_root_mirrors_io_to_the_trace_row() -> None:
+    """The Langfuse trace list shows trace-level io, not the root span's."""
+
+    tracer, fake = _tracer(capture_content=True)
+    span = tracer.start_span("agent.stream", context=_context())
+    span.set_io(input="what is fred?", output="a platform.")
+    span.end()
+
+    attributes = fake.observations[0]._otel_span.attributes
+    assert attributes["langfuse.trace.input"] == "what is fred?"
+    assert attributes["langfuse.trace.output"] == "a platform."
+
+
+def test_a_child_span_does_not_overwrite_the_trace_row() -> None:
+    tracer, fake = _tracer(capture_content=True)
+    root = tracer.start_span("agent.stream", context=_context())
+    child = tracer.start_span("v2.react.model", context=_context(), parent=root)
+    child.set_io(input="inner prompt", output="inner answer")
+    child.end()
+
+    attributes = fake.observations[1]._otel_span.attributes
+    assert "langfuse.trace.input" not in attributes
+    assert "langfuse.trace.output" not in attributes
+
+
+def test_a_failed_flush_still_closes_the_span() -> None:
+    """
+    Tracing degrades the trace, never the agent — and a span left open renders
+    as a turn that never finished, skewing every duration in the trace.
+    """
+
+    tracer, fake = _tracer()
+    span = tracer.start_span("v2.react.model", context=_context())
+
+    def _boom(**kwargs: Any) -> None:
+        raise RuntimeError("langfuse is down")
+
+    fake.observations[0].update = _boom  # type: ignore[method-assign]
+    span.set_attribute("status", "ok")
+    span.end()  # must not raise
+
+    assert fake.observations[0].ended is True
+
+
+def test_a_failure_to_end_is_swallowed_too() -> None:
+    tracer, fake = _tracer()
+    span = tracer.start_span("v2.react.model", context=_context())
+
+    def _boom(**kwargs: Any) -> None:
+        raise RuntimeError("langfuse is down")
+
+    fake.observations[0].end = _boom  # type: ignore[method-assign]
+    span.end()  # must not raise

--- a/libs/fred-runtime/tests/test_react_token_usage_totals.py
+++ b/libs/fred-runtime/tests/test_react_token_usage_totals.py
@@ -23,9 +23,11 @@ Why this exists:
   (spotted live: summing the trace's per-step token figures gave a larger
   total than the chat top-bar badge, which sums FinalRuntimeEvent.token_usage
   per exchange)
-- ToolCallRuntimeEvent.token_usage (TRACE-01 per-step display) must NOT
-  become a running total in the same fix — each step should keep showing
-  only the usage of the model call that decided that specific step
+- tool rows carry no token figure at all (#2403): a tool call costs nothing by
+  itself, and the deciding call's whole prompt on a tool row read as if a free
+  call had consumed 17k tokens
+- `context_tokens` is the size of the context the turn leaves behind, which the
+  chat UI diffs against the previous turn to show what a message really added
 """
 
 from __future__ import annotations
@@ -177,52 +179,110 @@ async def test_final_token_usage_carries_cache_detail_through_the_pipeline() -> 
     }
 
 
-@pytest.mark.asyncio
-async def test_tool_call_event_keeps_only_its_own_triggering_call_usage() -> None:
-    """
-    The turn-total fix must not turn the per-step (TRACE-01) figure into a
-    running total: each ToolCallRuntimeEvent should show only the usage of
-    the model call that decided that one step, even once a later step's
-    usage has been folded into the turn total.
-    """
+def _tool_call(call_id: str, input_tokens: int, output_tokens: int = 1) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"id": call_id, "name": "read_query", "args": {}}],
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    )
 
-    first_call = AIMessage(
-        content="",
-        tool_calls=[{"id": "call-1", "name": "read_query", "args": {}}],
-        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
-    )
-    first_result = ToolMessage(content="ok", tool_call_id="call-1", name="read_query")
-    second_call = AIMessage(
-        content="",
-        tool_calls=[{"id": "call-2", "name": "read_query", "args": {}}],
-        usage_metadata={"input_tokens": 5, "output_tokens": 1, "total_tokens": 6},
-    )
-    second_result = ToolMessage(content="ok", tool_call_id="call-2", name="read_query")
-    final_message = AIMessage(content="done")
+
+@pytest.mark.asyncio
+async def test_tool_call_event_no_longer_carries_the_deciding_calls_prompt() -> None:
+    """
+    The misleading field is gone from the contract, not merely unused: a tool
+    row must have no way to render the deciding call's whole prompt again.
+    """
 
     events = [
-        ("updates", {"agent": {"messages": [first_call]}}),
-        ("updates", {"tools": {"messages": [first_result]}}),
-        ("updates", {"agent": {"messages": [second_call]}}),
-        ("updates", {"tools": {"messages": [second_result]}}),
-        ("updates", {"agent": {"messages": [final_message]}}),
+        ("updates", {"agent": {"messages": [_tool_call("call-1", 17550)]}}),
+        (
+            "updates",
+            {"tools": {"messages": [ToolMessage(content="ok", tool_call_id="call-1")]}},
+        ),
+        ("updates", {"agent": {"messages": [AIMessage(content="done")]}}),
     ]
 
-    collected = await _run_stream(events)
+    (tool_call,) = [
+        e for e in await _run_stream(events) if isinstance(e, ToolCallRuntimeEvent)
+    ]
+    assert not hasattr(tool_call, "token_usage")
 
-    tool_calls = [e for e in collected if isinstance(e, ToolCallRuntimeEvent)]
-    assert len(tool_calls) == 2
-    assert tool_calls[0].token_usage == {
-        "input_tokens": 100,
-        "output_tokens": 20,
-        "total_tokens": 120,
-        "cache_read_tokens": 0,
-        "cache_creation_tokens": 0,
-    }
-    assert tool_calls[1].token_usage == {
-        "input_tokens": 5,
-        "output_tokens": 1,
-        "total_tokens": 6,
-        "cache_read_tokens": 0,
-        "cache_creation_tokens": 0,
-    }
+
+@pytest.mark.asyncio
+async def test_context_tokens_is_the_last_calls_input_even_after_trimming() -> None:
+    """
+    History trimming (`CheckpointHygieneMiddleware`) can shrink the context
+    between two calls. `context_tokens` must still report what the LAST call
+    actually sent, so the UI diffs against reality rather than a high-water
+    mark it can never reach again.
+    """
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_call("call-1", 90_000)]}}),
+        (
+            "updates",
+            {"tools": {"messages": [ToolMessage(content="ok", tool_call_id="call-1")]}},
+        ),
+        (
+            "updates",
+            {
+                "agent": {
+                    "messages": [
+                        AIMessage(
+                            content="done",
+                            usage_metadata={
+                                "input_tokens": 40_000,
+                                "output_tokens": 10,
+                                "total_tokens": 40_010,
+                            },
+                        )
+                    ]
+                }
+            },
+        ),
+    ]
+
+    (final,) = [
+        e for e in await _run_stream(events) if isinstance(e, FinalRuntimeEvent)
+    ]
+
+    assert final.context_tokens == 40_000
+
+
+@pytest.mark.asyncio
+async def test_a_turn_cut_short_by_a_tool_error_still_reports_its_context() -> None:
+    """
+    When a whole round of tool calls fails, the error is surfaced directly as
+    the final response and the LLM is never called again. The turn still
+    reports the context of the one call it did make.
+    """
+
+    events = [
+        ("updates", {"agent": {"messages": [_tool_call("call-1", 500)]}}),
+        (
+            "updates",
+            {
+                "tools": {
+                    "messages": [
+                        ToolMessage(
+                            content="Tool error:\nboom",
+                            tool_call_id="call-1",
+                            name="t",
+                            artifact={"tool_ref": "t", "is_error": True},
+                        )
+                    ]
+                }
+            },
+        ),
+    ]
+
+    (final,) = [
+        e for e in await _run_stream(events) if isinstance(e, FinalRuntimeEvent)
+    ]
+
+    assert final.context_tokens == 500

--- a/libs/fred-runtime/tests/test_trace_payloads.py
+++ b/libs/fred-runtime/tests/test_trace_payloads.py
@@ -24,7 +24,6 @@ from fred_runtime.runtime_support.trace_payloads import (
 )
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-
 # ---------------------------------------------------------------------------
 # Token usage
 # ---------------------------------------------------------------------------

--- a/libs/fred-runtime/tests/test_trace_payloads.py
+++ b/libs/fred-runtime/tests/test_trace_payloads.py
@@ -1,0 +1,239 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shaping of trace payloads: prompt rendering and token-usage translation."""
+
+from fred_runtime.runtime_support.model_metadata import runtime_metadata_from_message
+from fred_runtime.runtime_support.trace_payloads import (
+    final_assistant_message,
+    serialize_message,
+    serialize_messages,
+    serialize_model_output,
+    to_langfuse_usage,
+)
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+
+# ---------------------------------------------------------------------------
+# Token usage
+# ---------------------------------------------------------------------------
+
+
+def test_fred_usage_keys_map_to_langfuse_names() -> None:
+    usage = to_langfuse_usage(
+        {
+            "input_tokens": 812,
+            "output_tokens": 96,
+            "total_tokens": 908,
+            "cache_read_tokens": 400,
+            "cache_creation_tokens": 0,
+        }
+    )
+
+    assert usage == {
+        "input": 812,
+        "output": 96,
+        "total": 908,
+        "cache_read_input_tokens": 400,
+    }
+
+
+def test_zero_valued_entries_are_dropped() -> None:
+    """A provider reporting no cache usage sends zeros; rendering them is noise."""
+
+    assert to_langfuse_usage(
+        {"input_tokens": 5, "output_tokens": 0, "cache_read_tokens": 0}
+    ) == {"input": 5}
+
+
+def test_absent_or_empty_usage_is_none() -> None:
+    assert to_langfuse_usage(None) is None
+    assert to_langfuse_usage({}) is None
+    assert to_langfuse_usage({"input_tokens": 0}) is None
+
+
+# ---------------------------------------------------------------------------
+# Provider coverage — the "works with any model" guarantee
+# ---------------------------------------------------------------------------
+#
+# Providers do not agree on where token usage lives. `runtime_metadata_from_message`
+# already normalizes ~a dozen conventions; these cases pin the end-to-end chain
+# (provider payload → Fred shape → Langfuse `usage_details`) for the shapes Fred
+# actually meets, so a new provider that reports usage at all lands in a trace
+# without touching the tracing code.
+
+
+def _usage_of(message: AIMessage) -> dict[str, int] | None:
+    _, token_usage, _ = runtime_metadata_from_message(message)
+    return to_langfuse_usage(token_usage)
+
+
+def test_langchain_standard_usage_metadata_reaches_langfuse() -> None:
+    message = AIMessage(
+        content="hi",
+        usage_metadata={"input_tokens": 812, "output_tokens": 96, "total_tokens": 908},
+    )
+
+    assert _usage_of(message) == {"input": 812, "output": 96, "total": 908}
+
+
+def test_openai_compatible_token_usage_reaches_langfuse() -> None:
+    """Mistral, and any gateway Fred reaches through the OpenAI wrapper."""
+
+    message = AIMessage(
+        content="hi",
+        response_metadata={
+            "model_name": "mistral-small-latest",
+            "token_usage": {
+                "prompt_tokens": 812,
+                "completion_tokens": 96,
+                "total_tokens": 908,
+            },
+        },
+    )
+
+    assert _usage_of(message) == {"input": 812, "output": 96, "total": 908}
+
+
+def test_anthropic_style_usage_reaches_langfuse() -> None:
+    message = AIMessage(
+        content="hi",
+        response_metadata={"usage": {"input_tokens": 812, "output_tokens": 96}},
+    )
+
+    # No total reported by the provider — derived rather than left missing.
+    assert _usage_of(message) == {"input": 812, "output": 96, "total": 908}
+
+
+def test_ollama_style_counters_reach_langfuse() -> None:
+    message = AIMessage(
+        content="hi",
+        response_metadata={
+            "usage": {"prompt_eval_count": 812, "eval_count": 96},
+        },
+    )
+
+    assert _usage_of(message) == {"input": 812, "output": 96, "total": 908}
+
+
+def test_prompt_cache_hits_are_reported_separately() -> None:
+    message = AIMessage(
+        content="hi",
+        usage_metadata={
+            "input_tokens": 812,
+            "output_tokens": 96,
+            "total_tokens": 908,
+            "input_token_details": {"cache_read": 400},
+        },
+    )
+
+    usage = _usage_of(message)
+    assert usage is not None
+    assert usage["cache_read_input_tokens"] == 400
+
+
+def test_a_provider_reporting_nothing_yields_no_usage() -> None:
+    """A silent provider leaves the generation without tokens — visibly, not wrongly."""
+
+    assert _usage_of(AIMessage(content="hi")) is None
+    assert _usage_of(AIMessage(content="hi", response_metadata={"model": "x"})) is None
+
+
+# ---------------------------------------------------------------------------
+# Message rendering
+# ---------------------------------------------------------------------------
+
+
+def test_roles_use_the_chat_completion_vocabulary() -> None:
+    """Langfuse's message viewer renders these roles as a conversation."""
+
+    assert serialize_message(HumanMessage(content="hi"))["role"] == "user"
+    assert serialize_message(AIMessage(content="yo"))["role"] == "assistant"
+    assert serialize_message(SystemMessage(content="be nice"))["role"] == "system"
+    assert (
+        serialize_message(ToolMessage(content="42", tool_call_id="c1"))["role"]
+        == "tool"
+    )
+
+
+def test_a_separately_held_system_prompt_is_prepended() -> None:
+    """Omitting it misrepresents what the model actually received."""
+
+    payload = serialize_messages(
+        [HumanMessage(content="hello")], system_prompt="you are fred"
+    )
+
+    assert payload == [
+        {"role": "system", "content": "you are fred"},
+        {"role": "user", "content": "hello"},
+    ]
+
+
+def test_tool_calls_are_kept_with_their_arguments() -> None:
+    message = AIMessage(
+        content="",
+        tool_calls=[{"name": "search", "args": {"query": "fred"}, "id": "call-1"}],
+    )
+
+    assert serialize_message(message)["tool_calls"] == [
+        {"name": "search", "args": {"query": "fred"}, "id": "call-1"}
+    ]
+
+
+def test_multimodal_blocks_are_reduced_to_text_and_type_names() -> None:
+    """A base64 image would blow the payload budget and tell a reader nothing."""
+
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "describe this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+    )
+
+    assert serialize_message(message)["content"] == "describe this[image_url]"
+
+
+def test_a_lone_plain_answer_collapses_to_its_text() -> None:
+    """A one-element list of dicts around a sentence only hurts readability."""
+
+    assert serialize_model_output([AIMessage(content="the answer")]) == "the answer"
+
+
+def test_a_tool_calling_answer_keeps_its_structure() -> None:
+    output = serialize_model_output(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "search", "args": {}, "id": "c1"}],
+            )
+        ]
+    )
+
+    assert isinstance(output, list)
+    assert output[0]["tool_calls"][0]["name"] == "search"
+
+
+def test_the_final_assistant_message_is_the_last_one() -> None:
+    messages = [
+        AIMessage(content="first"),
+        ToolMessage(content="result", tool_call_id="c1"),
+        AIMessage(content="last"),
+    ]
+
+    found = final_assistant_message(messages)
+    assert found is not None and found.content == "last"
+
+
+def test_no_assistant_message_yields_none() -> None:
+    assert final_assistant_message([HumanMessage(content="hi")]) is None

--- a/libs/fred-sdk/fred_sdk/contracts/runtime.py
+++ b/libs/fred-sdk/fred_sdk/contracts/runtime.py
@@ -194,10 +194,11 @@ class ToolCallRuntimeEvent(RuntimeEventBase):
     tool_name: str = Field(..., min_length=1)
     call_id: str = Field(..., min_length=1)
     arguments: dict[str, object] = Field(default_factory=dict)
-    # Usage of the model call that decided to make this tool call — the
-    # runtime's per-call `usage_metadata`, captured just before this event is
-    # emitted. None when the provider didn't report usage for that call.
-    token_usage: dict[str, int] | None = None
+    # NOTE (#2403): this event carries no token usage on purpose. It used to
+    # carry the usage of the model call that DECIDED the call, which the trace
+    # UI rendered on the tool row — reading as if the tool had consumed the
+    # whole prompt (17.5k tokens for a call that consumes none). A tool call
+    # costs nothing by itself, so the row shows latency only.
 
 
 class ToolResultRuntimeEvent(RuntimeEventBase):
@@ -310,7 +311,16 @@ class FinalRuntimeEvent(RuntimeEventBase):
     sources: tuple[VectorSearchHit, ...] = ()
     ui_parts: tuple[UiPart, ...] = ()
     model_name: str | None = None
+    # Billed usage, summed across every model call of the turn. This is what
+    # the provider charges: a ReAct turn re-sends the whole context on each
+    # call, so the same history is legitimately counted once per call.
     token_usage: dict[str, int] | None = None
+    # Size of the context at the end of the turn — the `input_tokens` of the
+    # turn's LAST model call (#2403). Together with the previous turn's value
+    # this yields what a turn genuinely ADDED, as opposed to what it was
+    # billed: `new_input(T) = context_tokens(T) - (context_tokens(T-1) +
+    # output_tokens(T-1))`. None when no model call reported an input count.
+    context_tokens: int | None = None
     finish_reason: FinishReason | None = None
 
     # Same tolerant coercion as `ChatMetadata.finish_reason` (fred-core): a raw


### PR DESCRIPTION
# Pull Request

## 1. What problem does this solve — and where is it tracked?

**Issue:** #2403 (token accounting). The second commit — Langfuse content
capture — has **no issue**: it is local-debugging instrumentation that grew out
of investigating #2403 (you cannot see which prompt produced a 17.5k input
count without reading the prompt). Flagging it rather than retro-fitting an
issue: see the scope note at the end of §3.

**Problem in one sentence:** Tool rows and per-message badges reported the
*billed* token totals of the model call that decided them, so a zero-token tool
call displayed `17559 tokens` and the per-message badge duplicated the figure
the conversation header already showed.

**Backlog ref:** n/a — `docs/swift/backlog/BACKLOG.md` is frozen (2026-07-16).
GitHub issue #2403 (milestone `swift-v2.2`, `Priority: Critical`) is the
tracking unit.

---

## 2. Before you wrote a single line of code

**RFC written?**

Not required — no new architecture, endpoint family, or migration direction.
The change adds one optional field to an existing frozen contract type
(`FinalRuntimeEvent.context_tokens`) and removes one
(`ToolCallRuntimeEvent.token_usage`); issue #2403 carries the full design
(problem, measured numbers, approach, edge cases, out-of-scope) and served as
the design record. The contract change is recorded in
`RUNTIME-EXECUTION-CONTRACT.md` per the Step 6 checklist.

**Plan presented to the team before implementation?**

Yes — issue #2403 states the approach, the two new fields, the frontend
formula, and the edge cases (parallel calls, negative delta, no following model
call) before any code was written.

**Confirmation received?**

The issue was filed and prioritised `Priority: Critical` into milestone
`swift-v2.2`. I do not have a written "go ahead" to quote beyond that.

---

## 3. What you built

**Marginal token accounting (#2403).**
`ToolCallRuntimeEvent.token_usage` is removed — a tool call consumes no tokens
of its own, so tool rows in `ThoughtTrace`/`TraceEntryRow` now show latency
only. `FinalRuntimeEvent` and `ChatMetadata` gain `context_tokens` (the input
size of the turn's last model call), persisted so reloaded history recomputes
identically instead of drifting from a live turn. The per-message
`TokenUsageBadge` shows `context_tokens(T) - (context_tokens(T-1) +
output(T-1))` plus this turn's output — the tokens genuinely new this turn —
and the conversation header now sums those message badges rather than the
provider's per-call usage. Trace arrows carry `N tokens sent` / `N tokens
received` on hover, locale-grouped.

**Divergence from the issue, deliberate:** issue #2403 proposed a second field
`tool_context_cost: dict[str, int]` splitting each round's delta across
parallel tool calls *proportionally by result length*. That is not implemented.
The split is a heuristic no provider backs (the issue says so itself), and it
would have put an invented per-tool number back on exactly the rows this PR is
removing an invented number from. Tool rows show latency only; the round's real
cost stays visible in the message badge. Raising it here rather than silently
shipping a narrower change than the issue describes — if the per-tool
breakdown is genuinely wanted, it should be its own issue.

**Langfuse content capture (OBSERV, no issue).**
Adds `capture_content` / `max_content_chars` to the Langfuse observability
config and wires trace-level input/output plus per-span usage on both the ReAct
and Graph runtimes. **Off by default** — it deliberately breaks the content
exclusion of `OBSERVABILITY-AND-AUDIT.md` §7 and is intended for a local
Langfuse only; the doc is updated to say so. Also regenerates the fred-agents
config JSON schema and the Helm chart values schema, which had drifted since
those two fields were added to the Pydantic model
(`make check-config-schema-drift` was failing).

**Scope note:** these are two separable concerns in one PR, which cuts against
the consolidation phase's scope-discipline rule. They are two clean commits and
touch disjoint files, so they can be split into two PRs on request — say the
word and I will.

---

## 4. Proof of quality

**Tests added or updated:**

| Test | File | What it covers |
| ---- | ---- | -------------- |
| 11 cases, incl. `subtracts the context the previous turn ended on`, `never lets the tool rows exceed the turn's own new-input figure`, `chains each turn's anchor to the previous one` | `apps/frontend/.../ManagedChatPage/marginalTokenUsage.test.ts` | The marginal formula end to end: first-turn prompt, chaining, header telescoping |
| `clamps to zero when trimming left a smaller context than before`, `reports nothing when the previous anchor is unknown`, `reports nothing when the turn itself has no context anchor`, `falls back to the billed total after a turn with no anchor` | same file | The three edge cases named in #2403 (negative delta, missing anchor, no following model call) |
| 2 cases | `apps/frontend/src/locales/tokenCountFormat.test.ts` | Locale grouping of the token figure; that the format specifier does not break plural selection |
| 30 cases | `libs/fred-runtime/tests/test_langfuse_tracing.py` | Trace/session identity, `content_capture_is_off_by_default`, truncation budget bounds the whole payload, env-var override + bad-value fallback, span flush/end once, failed flush still closes |
| 17 cases | `libs/fred-runtime/tests/test_trace_payloads.py` | Usage-key mapping across LangChain / OpenAI / Anthropic / Ollama shapes, cache-hit reporting, multimodal reduction, tool-call structure |
| updated | `test_react_token_usage_totals.py`, `test_graph_runtime_token_usage_totals.py`, `test_history.py`, `fred_core/tests/portable/test_observability.py` | Adjusted to the removed `ToolCallRuntimeEvent.token_usage` and the new `context_tokens` |

**`make code-quality` output:**

```
************ All code quality checks completed ************
(ruff + format, bandit 0 high, detect-secrets, basedpyright 0 errors;
 frontend: tsc --noEmit, prettier --check, eslint — all clean)
```

**Raw `basedpyright` output:**

```
0 errors, 0 warnings, 0 notes
```

**`make test` output (one block per touched package):**

```
libs/fred-core     520 passed, 25 deselected, 4 warnings in 35.64s
libs/fred-sdk      338 passed, 3 skipped in 9.73s
libs/fred-runtime  984 passed, 2 deselected, 17 warnings in 80.44s
apps/frontend      Test Files 141 passed | 1 skipped (142)
                   Tests 1386 passed | 2 skipped (1388)
```

---

## 5. Docs updated

| What changed | File updated |
| ------------ | ------------ |
| Backlog `[ ]` item is now done | n/a — `BACKLOG.md` frozen 2026-07-16; GitHub issue #2403 is the tracking unit |
| New behaviour, API field, or contract change | `docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md` |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | `docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md` — dated §8 entry (`agent_app.py`, `fred_sdk/contracts/runtime.py` and `runtimeOpenApi.ts` all touched) |
| UX component implemented or visual status changed | **Gap, called out:** `TokenUsageBadge` has no `COMPONENT-UX.md` entry at all — pre-existing, not introduced here. Its rendering changes in this PR. Happy to add the entry in this PR if wanted. |
| Phase progress row exists for this area | n/a — no phase table covers runtime token accounting |
| WORKPLAN sprint item finished | n/a — `WORKPLAN.md` frozen 2026-07-16 |
| Code and a design doc now diverge | None outstanding. `ENV_VARIABLES.md` and `OBSERVABILITY-AND-AUDIT.md` updated for the two new Langfuse settings and the §7 content-exclusion carve-out. |

---

## 6. Close-out statement

```
## Task close-out
- Code: tool rows drop the decider call's token_usage and show latency only;
  FinalRuntimeEvent/ChatMetadata gain context_tokens so per-message badges show
  marginal (new-this-turn) cost and the header sums them. Separately, Langfuse
  gains opt-in content capture (capture_content / max_content_chars) with
  per-span usage on the ReAct and Graph runtimes, plus the two regenerated
  config schemas that had drifted.
- Tests: pass — 4 new test files (60 cases), 4 updated; 520 / 338 / 984 backend,
  1386 frontend, 0 failures.
- Docs updated: RUNTIME-EXECUTION-CONTRACT.md, ENV_VARIABLES.md,
  OBSERVABILITY-AND-AUDIT.md. COMPONENT-UX.md deliberately not touched — see §5.
- Tracking: #2403 (to close on merge). Langfuse commit untracked — see §1.
- Skipped steps: Step 1 RFC — not required, #2403 carries the design and no new
  architecture is introduced. The per-tool `tool_context_cost` split from the
  issue is deliberately NOT implemented — see §3.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** Display and accounting only — no change to
what is sent to a provider or to what is billed. The header keeps the true
billed total, so a bug in the marginal formula makes badges misleading, not the
totals wrong. `ToolCallRuntimeEvent.token_usage` is a **removed contract
field**: any consumer outside this repo reading it breaks. Content capture is
off by default; enabling it exports prompts and tool payloads to Langfuse, so
it must stay off anywhere but a local instance.

**How do we roll back?** Revert the two commits independently — they touch
disjoint files. For content capture alone, no revert is needed: unset
`capture_content` (or the env override) and nothing is exported.
