### PR TITLE
feat(#2409): rename general-purpose assistant + less technical agent descriptions

### DIFF
--- a/apps/fred-agents/fred_agents/deep_assistant.py
+++ b/apps/fred-agents/fred_agents/deep_assistant.py
@@ -104,18 +104,18 @@ class DeepAssistantDefinition(DeepAgentDefinition):
     """
 
     agent_id: str = "fred.github.deep_assistant"
-    role: str = "General-purpose deep assistant"
+    role: str = "Custom planning assistant"
     description: str = (
-        "Blank-slate planning assistant (LangGraph deep-agent runtime). "
-        "Plans multi-step tasks before executing them. Select the tools you "
-        "need at enrollment, write your own prompt."
+        "An assistant that plans before it acts: it breaks complex requests "
+        "into steps and checks its intermediate results. Choose the tools it "
+        "can use and describe its role in your own words."
     )
     description_by_lang: dict[str, str] | None = {
         "fr": (
-            "Assistant généraliste planificateur (moteur deep-agent LangGraph). "
-            "Planifie les tâches à plusieurs étapes avant de les exécuter. "
-            "Sélectionnez les outils dont vous avez besoin à l'enrôlement, "
-            "rédigez votre propre prompt."
+            "Un assistant qui planifie avant d'agir : il découpe les demandes "
+            "complexes en étapes et vérifie ses résultats intermédiaires. "
+            "Choisissez les outils qu'il peut utiliser et décrivez son rôle "
+            "avec vos propres mots."
         )
     }
     tags: tuple[str, ...] = ("general", "deep")

--- a/apps/fred-agents/fred_agents/general_assistant.py
+++ b/apps/fred-agents/fred_agents/general_assistant.py
@@ -114,17 +114,18 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
     """
 
     agent_id: str = "fred.github.assistant"
-    role: str = "General-purpose assistant"
+    role: str = "Custom assistant"
     description: str = (
-        "Blank-slate assistant with access to all pod MCP tools. "
-        "Select the tools you need at enrollment, write your own prompt, "
-        "and build the agent that fits your use case."
+        "Build your own assistant: choose the tools it can use — document "
+        "search, data analysis, and more — and describe its role in your own "
+        "words. The best starting point for most use cases."
     )
     description_by_lang: dict[str, str] | None = {
         "fr": (
-            "Assistant généraliste avec accès à tous les outils MCP du pod. "
-            "Sélectionnez les outils dont vous avez besoin à l'enrôlement, "
-            "rédigez votre propre prompt et créez l'assistant adapté à votre cas d'usage."
+            "Créez votre propre assistant : choisissez les outils qu'il peut "
+            "utiliser — recherche documentaire, analyse de données, etc. — et "
+            "décrivez son rôle avec vos propres mots. Le meilleur point de "
+            "départ pour la plupart des cas d'usage."
         )
     }
     tags: tuple[str, ...] = ("general", "react")
@@ -163,12 +164,12 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
             title="System prompt",
             description=(
                 "Instructions that define the assistant's role and focus. "
-                "Leave blank to use the default general-purpose prompt."
+                "Leave blank to use the built-in default prompt."
             ),
             description_by_lang={
                 "fr": (
                     "Instructions définissant le rôle et le périmètre de l'assistant. "
-                    "Laissez vide pour utiliser le prompt généraliste par défaut."
+                    "Laissez vide pour utiliser le prompt par défaut."
                 )
             },
             required=False,

--- a/apps/fred-agents/fred_agents/general_assistant.py
+++ b/apps/fred-agents/fred_agents/general_assistant.py
@@ -116,14 +116,14 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
     agent_id: str = "fred.github.assistant"
     role: str = "Custom assistant"
     description: str = (
-        "Build your own assistant: choose the tools it can use — document "
-        "search, data analysis, and more — and describe its role in your own "
+        "Build your own assistant: choose the tools it can use - document "
+        "search, data analysis, and more - and describe its role in your own "
         "words. The best starting point for most use cases."
     )
     description_by_lang: dict[str, str] | None = {
         "fr": (
             "Créez votre propre assistant : choisissez les outils qu'il peut "
-            "utiliser — recherche documentaire, analyse de données, etc. — et "
+            "utiliser - recherche documentaire, analyse de données, etc. - et "
             "décrivez son rôle avec vos propres mots. Le meilleur point de "
             "départ pour la plupart des cas d'usage."
         )

--- a/apps/fred-agents/fred_agents/general_assistant.py
+++ b/apps/fred-agents/fred_agents/general_assistant.py
@@ -116,16 +116,16 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
     agent_id: str = "fred.github.assistant"
     role: str = "Custom assistant"
     description: str = (
-        "Build your own assistant: choose the tools it can use - document "
-        "search, data analysis, and more - and describe its role in your own "
-        "words. The best starting point for most use cases."
+        "Build your own assistant: choose the tools it can use, like document "
+        "search or data analysis, and describe its role in your own words. "
+        "The best starting point for most use cases."
     )
     description_by_lang: dict[str, str] | None = {
         "fr": (
             "Créez votre propre assistant : choisissez les outils qu'il peut "
-            "utiliser - recherche documentaire, analyse de données, etc. - et "
-            "décrivez son rôle avec vos propres mots. Le meilleur point de "
-            "départ pour la plupart des cas d'usage."
+            "utiliser, comme la recherche documentaire ou l'analyse de "
+            "données, et décrivez son rôle avec vos propres mots. Le meilleur "
+            "point de départ pour la plupart des cas d'usage."
         )
     }
     tags: tuple[str, ...] = ("general", "react")


### PR DESCRIPTION
Closes #2409.

## Proposed wording (to validate with the team — acceptance criterion of #2409)

| Agent | Before | After |
|---|---|---|
| `fred.github.assistant` | General-purpose assistant | **Custom assistant** |
| `fred.github.deep_assistant` | General-purpose deep assistant | **Custom planning assistant** |

Descriptions (EN + FR) now speak in terms of **tools and capabilities** — document search, data analysis, "describe its role in your own words" — instead of implementation details ("blank-slate", "pod MCP tools", "LangGraph deep-agent runtime", "enrollment"). The system-prompt field hint no longer echoes the old name either.

## Scope notes

- Display wording only: `agent_id`s, the runtime contract, and the OpenAPI spec are untouched (the catalog `display_name` is derived from `definition.role`), so **no client regeneration** and no migration.
- The catalog card, the agent form (template picker), and the default instance name at enrollment all read these same fields — one source, consistent everywhere per the acceptance criteria. Already-enrolled instances keep their operator-chosen names.
- Renaming the deep assistant's role goes slightly beyond the ticket's letter (it only mandated renaming the general one), but "General-purpose **deep** assistant" would otherwise keep both the old name and the jargon.
- No doc updates needed: nothing under `docs/` or the frontend i18n references the old name.

## Verification

- `make code-quality` from the monorepo root: pass (all modules).
- `apps/fred-agents` `make test`: 40 passed.