### PR TITLE
fix(#2415): isolate agent checkpoints within shared sessions + namespace HITL resume checkpoints

### DIFF
--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -142,7 +142,10 @@ from fred_runtime.capabilities.errors import (
 from fred_runtime.common.kf_markdown_media_client import KfMarkdownMediaClient
 from fred_runtime.graph.graph_runtime import GraphRuntime
 from fred_runtime.react.react_runtime import ReActRuntime
-from fred_runtime.runtime_support.checkpoints import load_checkpoint
+from fred_runtime.runtime_support.checkpoints import (
+    checkpoint_namespace,
+    load_checkpoint,
+)
 from fred_runtime.runtime_support.sql_checkpointer import FredSqlCheckpointer
 
 from ..common.structures import AgentSettingsLike
@@ -1948,10 +1951,16 @@ async def _validate_session_checkpoint_access(
     if checkpointer is None:
         return
 
+    checkpoint_ns = checkpoint_namespace(
+        agent_instance_id=request.agent_instance_id,
+        agent_id=request.agent_id or request.agent_instance_id or "",
+    )
+
     loaded = await load_checkpoint(
         checkpointer,
         thread_id=session_id,
         checkpoint_id=request.checkpoint_id,
+        checkpoint_ns=checkpoint_ns,
     )
     if (
         loaded is None
@@ -1968,7 +1977,11 @@ async def _validate_session_checkpoint_access(
         # recovery path (a clean "does not match pending" 409 instead of a
         # blunt "unknown checkpoint" one), preserving its exact prior
         # behavior.
-        loaded = await load_checkpoint(checkpointer, thread_id=session_id)
+        loaded = await load_checkpoint(
+            checkpointer,
+            thread_id=session_id,
+            checkpoint_ns=checkpoint_ns,
+        )
 
     if loaded is None:
         detail = (
@@ -3014,20 +3027,24 @@ class _HitlResumeClaim:
 
     _checkpointer: FredSqlCheckpointer
     _thread_id: str
+    _checkpoint_ns: str
     _interrupt_id: str
     _claim_token: str
 
     async def consume(self) -> None:
         await self._checkpointer.aconsume_hitl_resume(
             thread_id=self._thread_id,
-            checkpoint_ns="",
+            checkpoint_ns=self._checkpoint_ns,
             interrupt_id=self._interrupt_id,
             claim_token=self._claim_token,
         )
 
 
 async def _claim_hitl_resume_before_invocation(
-    *, session_id: str | None, interrupt_id: str
+    *,
+    session_id: str | None,
+    checkpoint_ns: str,
+    interrupt_id: str,
 ) -> _HitlResumeClaim | None:
     """
     Acquire and confirm the durable single-use HITL resume claim,
@@ -3086,14 +3103,14 @@ async def _claim_hitl_resume_before_invocation(
         )
         return None
     claim_token = await checkpointer.aclaim_hitl_resume(
-        thread_id=session_id, checkpoint_ns="", interrupt_id=interrupt_id
+        thread_id=session_id, checkpoint_ns=checkpoint_ns, interrupt_id=interrupt_id
     )
     if claim_token is None:
         raise RuntimeError("This HITL request is already being resumed.")
     try:
         started = await checkpointer.astart_hitl_resume(
             thread_id=session_id,
-            checkpoint_ns="",
+            checkpoint_ns=checkpoint_ns,
             interrupt_id=interrupt_id,
             claim_token=claim_token,
         )
@@ -3105,7 +3122,7 @@ async def _claim_hitl_resume_before_invocation(
         # longer matches). Either way, re-raise: this attempt still fails.
         await checkpointer.arelease_hitl_resume(
             thread_id=session_id,
-            checkpoint_ns="",
+            checkpoint_ns=checkpoint_ns,
             interrupt_id=interrupt_id,
             claim_token=claim_token,
         )
@@ -3118,7 +3135,7 @@ async def _claim_hitl_resume_before_invocation(
         # still-legitimate claim doesn't wait out the TTL either.
         await checkpointer.arelease_hitl_resume(
             thread_id=session_id,
-            checkpoint_ns="",
+            checkpoint_ns=checkpoint_ns,
             interrupt_id=interrupt_id,
             claim_token=claim_token,
         )
@@ -3129,6 +3146,7 @@ async def _claim_hitl_resume_before_invocation(
     return _HitlResumeClaim(
         _checkpointer=checkpointer,
         _thread_id=session_id,
+        _checkpoint_ns=checkpoint_ns,
         _interrupt_id=interrupt_id,
         _claim_token=claim_token,
     )
@@ -3430,9 +3448,14 @@ async def _iterate_runtime_event_payloads(
             # docstring for the full claimed → started lifecycle and the
             # guarantees it does and does not provide.
             hitl_claim: _HitlResumeClaim | None = None
+            hitl_checkpoint_ns = checkpoint_namespace(
+                agent_instance_id=portable_context.baggage.get("agent_instance_id"),
+                agent_id=definition.agent_id,
+            )
             if request.resume_payload is not None and request.interrupt_id:
                 hitl_claim = await _claim_hitl_resume_before_invocation(
                     session_id=ctx.get("session_id"),
+                    checkpoint_ns=hitl_checkpoint_ns,
                     interrupt_id=request.interrupt_id,
                 )
 

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -1768,7 +1768,12 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         if checkpointer is None:
             return None
         checkpoint_tuple = await self._get_checkpoint_tuple(
-            config={"configurable": {"thread_id": checkpoint_key, "checkpoint_ns": self._checkpoint_ns}}
+            config={
+                "configurable": {
+                    "thread_id": checkpoint_key,
+                    "checkpoint_ns": self._checkpoint_ns,
+                }
+            }
         )
         if checkpoint_tuple is None:
             return None

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -103,6 +103,7 @@ from fred_runtime.runtime_support.model_metadata import (
     runtime_metadata_from_message,
     sum_token_usage,
 )
+from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -1029,6 +1030,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         model: BaseChatModel | None,
         runtime_tools: tuple[BaseTool, ...],
         pending_checkpoints: dict[str, _PendingGraphCheckpoint],
+        checkpoint_ns: str,
     ) -> None:
         self._definition = definition
         self._binding = binding
@@ -1055,6 +1057,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         self._total_token_usage: dict[str, int] | None = None
         self._last_finish_reason: str | None = None
         self._thought_records: list[ThoughtRecord] = []
+        self._checkpoint_ns = checkpoint_ns
 
     def _reset_model_metadata(self) -> None:
         """
@@ -1588,7 +1591,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
             config={
                 "configurable": {
                     "thread_id": checkpoint_key,
-                    "checkpoint_ns": "",
+                    "checkpoint_ns": self._checkpoint_ns,
                     **(
                         {"checkpoint_id": config.checkpoint_id}
                         if config.checkpoint_id
@@ -1635,7 +1638,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
             config={
                 "configurable": {
                     "thread_id": checkpoint_key,
-                    "checkpoint_ns": "",
+                    "checkpoint_ns": self._checkpoint_ns,
                 }
             }
         )
@@ -1745,7 +1748,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
             config={
                 "configurable": {
                     "thread_id": checkpoint_key,
-                    "checkpoint_ns": "",
+                    "checkpoint_ns": self._checkpoint_ns,
                     **(
                         {"checkpoint_id": config.checkpoint_id}
                         if config.checkpoint_id
@@ -1765,7 +1768,7 @@ class _DeterministicGraphExecutor(Executor[BaseModel, BaseModel]):
         if checkpointer is None:
             return None
         checkpoint_tuple = await self._get_checkpoint_tuple(
-            config={"configurable": {"thread_id": checkpoint_key, "checkpoint_ns": ""}}
+            config={"configurable": {"thread_id": checkpoint_key, "checkpoint_ns": self._checkpoint_ns}}
         )
         if checkpoint_tuple is None:
             return None
@@ -1903,6 +1906,11 @@ class GraphRuntime(AgentRuntime[GraphAgentDefinition, BaseModel, BaseModel]):
             self._capability_block,
             mcp_tool_names={tool.name for tool in mcp_tools},
         )
+        portable = binding.portable_context
+        graph_checkpoint_ns = checkpoint_namespace(
+            agent_instance_id=portable.baggage.get("agent_instance_id"),
+            agent_id=self.definition.agent_id,
+        )
         return _DeterministicGraphExecutor(
             definition=self.definition,
             binding=binding,
@@ -1910,6 +1918,7 @@ class GraphRuntime(AgentRuntime[GraphAgentDefinition, BaseModel, BaseModel]):
             model=self._model,
             runtime_tools=mcp_tools + capability_tools,
             pending_checkpoints=self._pending_checkpoints,
+            checkpoint_ns=graph_checkpoint_ns,
         )
 
     async def on_dispose(self) -> None:

--- a/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
+++ b/libs/fred-runtime/fred_runtime/graph/graph_runtime.py
@@ -98,12 +98,12 @@ from fred_runtime.capabilities.errors import CapabilityAssemblyError
 from fred_runtime.runtime_support.checkpoints import (
     AsyncCheckpointReader,
     AsyncCheckpointWriter,
+    checkpoint_namespace,
 )
 from fred_runtime.runtime_support.model_metadata import (
     runtime_metadata_from_message,
     sum_token_usage,
 )
-from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
 
 logger = logging.getLogger(__name__)
 

--- a/libs/fred-runtime/fred_runtime/react/react_message_codec.py
+++ b/libs/fred-runtime/fred_runtime/react/react_message_codec.py
@@ -204,7 +204,7 @@ def final_assistant_message(
     raise RuntimeError("ReAct execution completed without an assistant message.")
 
 
-def to_runnable_config(config: ExecutionConfig) -> Mapping[str, object] | None:
+def to_runnable_config(config: ExecutionConfig,*,checkpoint_ns: str | None = None,) -> Mapping[str, object] | None:
     """
     Convert Fred execution config to LangChain runnable config.
 
@@ -228,6 +228,9 @@ def to_runnable_config(config: ExecutionConfig) -> Mapping[str, object] | None:
     if config.session_id is not None:
         # session_id is Fred's public identity; thread_id is LangGraph's internal key.
         configurable["thread_id"] = config.session_id
+
+    if checkpoint_ns is not None:
+        configurable["checkpoint_ns"] = checkpoint_ns
 
     if configurable:
         merged["configurable"] = configurable

--- a/libs/fred-runtime/fred_runtime/react/react_message_codec.py
+++ b/libs/fred-runtime/fred_runtime/react/react_message_codec.py
@@ -204,7 +204,11 @@ def final_assistant_message(
     raise RuntimeError("ReAct execution completed without an assistant message.")
 
 
-def to_runnable_config(config: ExecutionConfig,*,checkpoint_ns: str | None = None,) -> Mapping[str, object] | None:
+def to_runnable_config(
+    config: ExecutionConfig,
+    *,
+    checkpoint_ns: str | None = None,
+) -> Mapping[str, object] | None:
     """
     Convert Fred execution config to LangChain runnable config.
 

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -80,6 +80,7 @@ from langchain_core.tools import BaseTool
 from langgraph.types import Checkpointer
 
 from fred_runtime.capabilities.assembly import CapabilityAgentBlock
+from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
 
 # Everything imported from `react_langchain_adapter` below is SDK-bound glue.
 # Read it as one boundary:
@@ -244,10 +245,12 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         compiled_agent: _CompiledReActAgent,
         binding: BoundRuntimeContext,
         services: RuntimeServices,
+        checkpoint_ns: str = "",
     ) -> None:
         self._compiled_agent = compiled_agent
         self._binding = binding
         self._services = services
+        self._checkpoint_ns = checkpoint_ns
 
     async def invoke(
         self, input_model: ReActInput, config: ExecutionConfig
@@ -269,7 +272,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         try:
             result = await self._compiled_agent.ainvoke(
                 _graph_input(input_model, config),
-                config=_to_runnable_config(config),
+                config=_to_runnable_config(config,checkpoint_ns=self._checkpoint_ns,),
             )
             transcript = tuple(
                 _from_langchain_message_adapter(
@@ -374,7 +377,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         try:
             async for raw_event in self._compiled_agent.astream(
                 _graph_input(input_model, config),
-                config=_to_runnable_config(config),
+                config=_to_runnable_config(config,checkpoint_ns=self._checkpoint_ns,),
                 stream_mode=["messages", "updates"],
             ):
                 mode, update = _split_stream_event_mode(raw_event)
@@ -790,10 +793,18 @@ class ReActRuntime(AgentRuntime[ReActAgentDefinition, ReActInput, ReActOutput]):
             max_tool_calls_per_turn=policy.tool_selection.max_tool_calls_per_turn,
             capability_block=self._capability_block,
         )
+
+        portable = binding.portable_context
+        react_checkpoint_ns = checkpoint_namespace(
+            agent_instance_id=portable.baggage.get("agent_instance_id"),
+            agent_id=self.definition.agent_id,
+        )
+        
         return _TransportBackedReActExecutor(
             compiled_agent=compiled_agent,
             binding=binding,
             services=self.services,
+            checkpoint_ns=react_checkpoint_ns,
         )
 
     async def on_dispose(self) -> None:

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -272,7 +272,10 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         try:
             result = await self._compiled_agent.ainvoke(
                 _graph_input(input_model, config),
-                config=_to_runnable_config(config,checkpoint_ns=self._checkpoint_ns,),
+                config=_to_runnable_config(
+                    config,
+                    checkpoint_ns=self._checkpoint_ns,
+                ),
             )
             transcript = tuple(
                 _from_langchain_message_adapter(
@@ -377,7 +380,10 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         try:
             async for raw_event in self._compiled_agent.astream(
                 _graph_input(input_model, config),
-                config=_to_runnable_config(config,checkpoint_ns=self._checkpoint_ns,),
+                config=_to_runnable_config(
+                    config,
+                    checkpoint_ns=self._checkpoint_ns,
+                ),
                 stream_mode=["messages", "updates"],
             ):
                 mode, update = _split_stream_event_mode(raw_event)
@@ -799,7 +805,7 @@ class ReActRuntime(AgentRuntime[ReActAgentDefinition, ReActInput, ReActOutput]):
             agent_instance_id=portable.baggage.get("agent_instance_id"),
             agent_id=self.definition.agent_id,
         )
-        
+
         return _TransportBackedReActExecutor(
             compiled_agent=compiled_agent,
             binding=binding,

--- a/libs/fred-runtime/fred_runtime/runtime_support/checkpoints.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/checkpoints.py
@@ -65,6 +65,7 @@ def checkpoint_config(
         configurable["checkpoint_id"] = checkpoint_id
     return cast(RunnableConfig, {"configurable": configurable})
 
+
 def checkpoint_namespace(
     *,
     agent_instance_id: str | None,
@@ -77,6 +78,7 @@ def checkpoint_namespace(
     SDK-defined agents fall back to their stable agent id.
     """
     return agent_instance_id or agent_id
+
 
 async def load_checkpoint(
     checkpointer: AsyncCheckpointReader | None,

--- a/libs/fred-runtime/fred_runtime/runtime_support/checkpoints.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/checkpoints.py
@@ -65,6 +65,18 @@ def checkpoint_config(
         configurable["checkpoint_id"] = checkpoint_id
     return cast(RunnableConfig, {"configurable": configurable})
 
+def checkpoint_namespace(
+    *,
+    agent_instance_id: str | None,
+    agent_id: str,
+) -> str:
+    """
+    Return the LangGraph checkpoint namespace for one executing agent.
+
+    Managed agent instances are isolated by their concrete instance id.
+    SDK-defined agents fall back to their stable agent id.
+    """
+    return agent_instance_id or agent_id
 
 async def load_checkpoint(
     checkpointer: AsyncCheckpointReader | None,

--- a/libs/fred-runtime/tests/test_agent_app.py
+++ b/libs/fred-runtime/tests/test_agent_app.py
@@ -2400,6 +2400,7 @@ def test_local_registry_invoker_reuses_runtime_execute_projection(monkeypatch) -
     assert context["execution_action"] == "execute"
 
 
+
 def test_local_registry_invoker_applies_invocation_scope(monkeypatch) -> None:
     """
     RFC AGENT-INVOKE: a per-call ``InvocationScope`` narrows the callee's retrieval.
@@ -2872,7 +2873,11 @@ def test_resume_rejects_non_pending_checkpoint(monkeypatch, tmp_path) -> None:
 
 
 async def _write_react_v2_checkpoint(
-    checkpointer, *, thread_id: str, channel_values: dict[str, Any]
+    checkpointer,
+    *,
+    thread_id: str,
+    checkpoint_ns: str = "",
+    channel_values: dict[str, Any],
 ):
     """
     Write one ReAct-V2-shaped checkpoint through the real `FredSqlCheckpointer`
@@ -2886,7 +2891,10 @@ async def _write_react_v2_checkpoint(
     checkpoint["channel_values"] = channel_values
     checkpoint["channel_versions"] = {key: checkpoint_id for key in channel_values}
     return await checkpointer.aput(
-        checkpoint_config(thread_id=thread_id),
+        checkpoint_config(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+        ),
         checkpoint,
         {"source": "update", "step": 0, "parents": {}},
         dict(checkpoint["channel_versions"]),
@@ -2898,6 +2906,7 @@ async def _write_react_v2_interrupt(
     *,
     thread_id: str,
     interrupt_id: str,
+    checkpoint_ns: str = "",
     task_id: str = "task-1",
     channel_values: dict[str, Any] | None = None,
 ):
@@ -2914,6 +2923,7 @@ async def _write_react_v2_interrupt(
     stored_config = await _write_react_v2_checkpoint(
         checkpointer,
         thread_id=thread_id,
+        checkpoint_ns=checkpoint_ns,
         channel_values=channel_values or {"messages": []},
     )
     await checkpointer.aput_writes(
@@ -2991,6 +3001,7 @@ def test_resume_accepts_react_v2_checkpoint_via_pending_interrupt_write(
                 checkpointer,
                 thread_id="session-react-v2",
                 interrupt_id="xxh3-routing-hash-not-a-real-checkpoint-id",
+                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3041,6 +3052,7 @@ def test_resume_rejects_react_v2_checkpoint_without_pending_interrupt(
             _write_react_v2_checkpoint(
                 checkpointer,
                 thread_id="session-react-v2-done",
+                checkpoint_ns=definition.agent_id,
                 channel_values={"messages": []},
             )
         )
@@ -3143,6 +3155,7 @@ def test_resume_builds_react_input_without_raising(monkeypatch, tmp_path) -> Non
                 checkpointer,
                 thread_id="session-react-input-resume",
                 interrupt_id="xxh3-routing-hash-not-a-real-checkpoint-id",
+                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3286,6 +3299,7 @@ def test_resume_reuses_exchange_id_from_the_interrupted_turn(
                 checkpointer,
                 thread_id="session-exchange-continuity",
                 interrupt_id="xxh3-routing-hash-not-a-real-checkpoint-id",
+                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3425,7 +3439,10 @@ def test_resume_stale_response_cannot_approve_a_later_interrupt(
         # 1. interrupt A is pending; resume it with its own id.
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id=session_id, interrupt_id="interrupt-a"
+                checkpointer,
+                thread_id=session_id,
+                interrupt_id="interrupt-a",
+                checkpoint_ns=definition.agent_id,
             )
         )
         resume_a = client.post(
@@ -3445,7 +3462,10 @@ def test_resume_stale_response_cannot_approve_a_later_interrupt(
         # 2. the thread later reaches interrupt B — a different id.
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id=session_id, interrupt_id="interrupt-b"
+                checkpointer,
+                thread_id=session_id,
+                interrupt_id="interrupt-b",
+                checkpoint_ns=definition.agent_id,
             )
         )
         assert "interrupt-a" != "interrupt-b"
@@ -3526,7 +3546,10 @@ def test_resume_replay_after_success_does_not_execute_again(
         assert checkpointer is not None
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id=session_id, interrupt_id="interrupt-a"
+                checkpointer,
+                thread_id=session_id,
+                interrupt_id="interrupt-a",
+                checkpoint_ns=definition.agent_id,
             )
         )
         payload = {
@@ -3587,7 +3610,10 @@ def test_resume_rejects_non_matching_interrupt_id_variants(
         assert checkpointer is not None
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id=session_id, interrupt_id="interrupt-real"
+                checkpointer,
+                thread_id=session_id,
+                interrupt_id="interrupt-real",
+                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3632,12 +3658,18 @@ def test_resume_rejects_token_belonging_to_another_thread(
         assert checkpointer is not None
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id="session-thread-a", interrupt_id="interrupt-a"
+                checkpointer,
+                thread_id="session-thread-a",
+                interrupt_id="interrupt-a",
+                checkpoint_ns=definition.agent_id,
             )
         )
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id="session-thread-b", interrupt_id="interrupt-b"
+                checkpointer,
+                thread_id="session-thread-b",
+                interrupt_id="interrupt-b",
+                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3685,13 +3717,18 @@ async def test_concurrent_duplicate_resumes_have_exactly_one_winner(
         checkpointer = get_runtime_context().config.checkpointer
         assert checkpointer is not None
         await _write_react_v2_interrupt(
-            checkpointer, thread_id="session-concurrent", interrupt_id="interrupt-a"
+            checkpointer,
+            thread_id="session-concurrent",
+            interrupt_id="interrupt-a",
+            checkpoint_ns=definition.agent_id,
         )
 
         async def _attempt():
             try:
                 claim = await agent_app_module._claim_hitl_resume_before_invocation(
-                    session_id="session-concurrent", interrupt_id="interrupt-a"
+                    session_id="session-concurrent",
+                    checkpoint_ns=definition.agent_id,
+                    interrupt_id="interrupt-a",
                 )
                 return "ok" if claim is not None else "none"
             except RuntimeError:
@@ -3740,7 +3777,10 @@ async def test_concurrent_duplicate_resumes_execute_the_tool_at_most_once(
         checkpointer = get_runtime_context().config.checkpointer
         assert checkpointer is not None
         await _write_react_v2_interrupt(
-            checkpointer, thread_id=session_id, interrupt_id="interrupt-a"
+            checkpointer,
+            thread_id=session_id,
+            interrupt_id="interrupt-a",
+            checkpoint_ns=definition.agent_id,
         )
 
         payload = {
@@ -3826,7 +3866,10 @@ def test_resume_runtime_setup_failure_leaves_no_claim_and_retry_succeeds(
         assert checkpointer is not None
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id=session_id, interrupt_id="interrupt-a"
+                checkpointer,
+                thread_id=session_id,
+                interrupt_id="interrupt-a",
+                checkpoint_ns=definition.agent_id,
             )
         )
         payload = {
@@ -3900,7 +3943,10 @@ def test_resume_start_failure_releases_the_claim_for_a_retry(
         assert checkpointer is not None
         asyncio.run(
             _write_react_v2_interrupt(
-                checkpointer, thread_id=session_id, interrupt_id="interrupt-a"
+                checkpointer,
+                thread_id=session_id,
+                interrupt_id="interrupt-a",
+                checkpoint_ns=definition.agent_id,
             )
         )
         payload = {
@@ -4003,7 +4049,10 @@ async def test_cancellation_after_start_leaves_the_claim_stuck_not_released(
         checkpointer = get_runtime_context().config.checkpointer
         assert checkpointer is not None
         await _write_react_v2_interrupt(
-            checkpointer, thread_id=session_id, interrupt_id="interrupt-a"
+            checkpointer,
+            thread_id=session_id,
+            interrupt_id="interrupt-a",
+            checkpoint_ns=definition.agent_id,
         )
         payload = {
             "agent_id": "rags.sample.echo",

--- a/libs/fred-runtime/tests/test_agent_app.py
+++ b/libs/fred-runtime/tests/test_agent_app.py
@@ -2400,7 +2400,6 @@ def test_local_registry_invoker_reuses_runtime_execute_projection(monkeypatch) -
     assert context["execution_action"] == "execute"
 
 
-
 def test_local_registry_invoker_applies_invocation_scope(monkeypatch) -> None:
     """
     RFC AGENT-INVOKE: a per-call ``InvocationScope`` narrows the callee's retrieval.

--- a/libs/fred-runtime/tests/test_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_checkpoint_namespace.py
@@ -1,0 +1,21 @@
+from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
+
+
+def test_checkpoint_namespace_prefers_agent_instance_id() -> None:
+    assert (
+        checkpoint_namespace(
+            agent_instance_id="instance-123",
+            agent_id="agent.template",
+        )
+        == "instance-123"
+    )
+
+
+def test_checkpoint_namespace_falls_back_to_agent_id() -> None:
+    assert (
+        checkpoint_namespace(
+            agent_instance_id=None,
+            agent_id="agent.template",
+        )
+        == "agent.template"
+    )

--- a/libs/fred-runtime/tests/test_graph_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_graph_checkpoint_namespace.py
@@ -97,8 +97,11 @@ def _binding(*, agent_instance_id: str | None = None) -> BoundRuntimeContext:
         ),
     )
 
+
 @pytest.mark.asyncio
-async def test_graph_agents_with_same_session_do_not_share_completed_state(tmp_path) -> None:
+async def test_graph_agents_with_same_session_do_not_share_completed_state(
+    tmp_path,
+) -> None:
     db = tmp_path / "graph-memory.sqlite3"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db}")
 
@@ -116,6 +119,7 @@ async def test_graph_agents_with_same_session_do_not_share_completed_state(tmp_p
             _Input(message="from-a"),
             ExecutionConfig(session_id="shared-session"),
         )
+        assert isinstance(result_a, _Input)
         assert result_a.message == "from-a"
 
         agent_b = _GraphAgent(agent_id="test.graph.memory.b")
@@ -127,9 +131,11 @@ async def test_graph_agents_with_same_session_do_not_share_completed_state(tmp_p
             ExecutionConfig(session_id="shared-session"),
         )
 
+        assert isinstance(result_b, _Input)
         assert result_b.message == "from-b"
     finally:
         await engine.dispose()
+
 
 @pytest.mark.asyncio
 async def test_graph_managed_instances_with_same_agent_and_session_do_not_share_state(
@@ -154,6 +160,7 @@ async def test_graph_managed_instances_with_same_agent_and_session_do_not_share_
             _Input(message="from-instance-a"),
             ExecutionConfig(session_id="shared-session"),
         )
+        assert isinstance(result_a, _Input)
         assert result_a.message == "from-instance-a"
 
         runtime_b = GraphRuntime(definition=definition, services=services)
@@ -166,9 +173,11 @@ async def test_graph_managed_instances_with_same_agent_and_session_do_not_share_
             ExecutionConfig(session_id="shared-session"),
         )
 
+        assert isinstance(result_b, _Input)
         assert result_b.message == "from-instance-b"
     finally:
         await engine.dispose()
+
 
 @pytest.mark.asyncio
 async def test_graph_same_agent_and_session_preserves_its_own_completed_state(
@@ -191,6 +200,7 @@ async def test_graph_same_agent_and_session_preserves_its_own_completed_state(
             _Input(message="remember-me"),
             ExecutionConfig(session_id="shared-session"),
         )
+        assert isinstance(result_first, _Input)
         assert result_first.message == "remember-me"
 
         runtime_second = GraphRuntime(definition=definition, services=services)
@@ -201,6 +211,7 @@ async def test_graph_same_agent_and_session_preserves_its_own_completed_state(
             ExecutionConfig(session_id="shared-session"),
         )
 
+        assert isinstance(result_second, _Input)
         assert result_second.message == "remember-me"
     finally:
         await engine.dispose()

--- a/libs/fred-runtime/tests/test_graph_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_graph_checkpoint_namespace.py
@@ -1,11 +1,8 @@
-import pytest
-
-from fred_runtime.graph.graph_runtime import GraphRuntime
-from fred_runtime.runtime_support.sql_checkpointer import FredSqlCheckpointer
-from fred_sdk.contracts.runtime import ExecutionConfig, RuntimeServices
-from sqlalchemy.ext.asyncio import create_async_engine
 from collections.abc import Mapping
 
+import pytest
+from fred_runtime.graph.graph_runtime import GraphRuntime
+from fred_runtime.runtime_support.sql_checkpointer import FredSqlCheckpointer
 from fred_sdk.contracts.context import (
     BoundRuntimeContext,
     PortableContext,
@@ -17,8 +14,10 @@ from fred_sdk.contracts.models import (
     GraphDefinition,
     GraphNodeDefinition,
 )
+from fred_sdk.contracts.runtime import ExecutionConfig, RuntimeServices
 from fred_sdk.graph.runtime import GraphNodeResult
 from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import create_async_engine
 
 
 class _Input(BaseModel):

--- a/libs/fred-runtime/tests/test_graph_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_graph_checkpoint_namespace.py
@@ -1,0 +1,206 @@
+import pytest
+
+from fred_runtime.graph.graph_runtime import GraphRuntime
+from fred_runtime.runtime_support.sql_checkpointer import FredSqlCheckpointer
+from fred_sdk.contracts.runtime import ExecutionConfig, RuntimeServices
+from sqlalchemy.ext.asyncio import create_async_engine
+from collections.abc import Mapping
+
+from fred_sdk.contracts.context import (
+    BoundRuntimeContext,
+    PortableContext,
+    PortableEnvironment,
+    RuntimeContext,
+)
+from fred_sdk.contracts.models import (
+    GraphAgentDefinition,
+    GraphDefinition,
+    GraphNodeDefinition,
+)
+from fred_sdk.graph.runtime import GraphNodeResult
+from pydantic import BaseModel
+
+
+class _Input(BaseModel):
+    message: str = ""
+
+
+class _State(BaseModel):
+    remembered: str = ""
+
+
+class _GraphAgent(GraphAgentDefinition):
+    agent_id: str = "test.graph.memory"
+
+    role: str = "test"
+    description: str = "test"
+
+    def build_graph(self) -> GraphDefinition:
+        return GraphDefinition(
+            state_model_name="State",
+            entry_node="n",
+            nodes=(GraphNodeDefinition(node_id="n", title="N"),),
+        )
+
+    def input_model(self) -> type[BaseModel]:
+        return _Input
+
+    def state_model(self) -> type[BaseModel]:
+        return _State
+
+    def output_model(self) -> type[BaseModel]:
+        return _Input
+
+    def _turn_carry_fields(self) -> frozenset[str]:
+        return frozenset({"remembered"})
+
+    def build_initial_state(
+        self,
+        input_model: BaseModel,
+        binding: BoundRuntimeContext,
+    ) -> BaseModel:
+        del binding
+        return _State(remembered=getattr(input_model, "message", ""))
+
+    def node_handlers(self) -> Mapping[str, object]:
+        async def _n(state: BaseModel, ctx: object) -> GraphNodeResult:
+            del state, ctx
+            return GraphNodeResult()
+
+        return {"n": _n}
+
+    def build_output(self, state: BaseModel) -> BaseModel:
+        return _Input(message=getattr(state, "remembered", ""))
+
+
+def _binding(*, agent_instance_id: str | None = None) -> BoundRuntimeContext:
+    baggage = {}
+    if agent_instance_id is not None:
+        baggage["agent_instance_id"] = agent_instance_id
+
+    return BoundRuntimeContext(
+        runtime_context=RuntimeContext(
+            session_id="shared-session",
+            user_id="u",
+            team_id="t",
+        ),
+        portable_context=PortableContext(
+            request_id="r",
+            correlation_id="c",
+            actor="u",
+            tenant="t",
+            environment=PortableEnvironment.DEV,
+            session_id="shared-session",
+            user_id="u",
+            team_id="t",
+            baggage=baggage,
+        ),
+    )
+
+@pytest.mark.asyncio
+async def test_graph_agents_with_same_session_do_not_share_completed_state(tmp_path) -> None:
+    db = tmp_path / "graph-memory.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db}")
+
+    try:
+        checkpointer = FredSqlCheckpointer(engine, prefix="v2_")
+        await checkpointer._ensure_tables()
+
+        services = RuntimeServices(checkpointer=checkpointer)
+
+        agent_a = _GraphAgent(agent_id="test.graph.memory.a")
+        runtime_a = GraphRuntime(definition=agent_a, services=services)
+        executor_a = await runtime_a.build_executor(_binding())
+
+        result_a = await executor_a.invoke(
+            _Input(message="from-a"),
+            ExecutionConfig(session_id="shared-session"),
+        )
+        assert result_a.message == "from-a"
+
+        agent_b = _GraphAgent(agent_id="test.graph.memory.b")
+        runtime_b = GraphRuntime(definition=agent_b, services=services)
+        executor_b = await runtime_b.build_executor(_binding())
+
+        result_b = await executor_b.invoke(
+            _Input(message="from-b"),
+            ExecutionConfig(session_id="shared-session"),
+        )
+
+        assert result_b.message == "from-b"
+    finally:
+        await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_graph_managed_instances_with_same_agent_and_session_do_not_share_state(
+    tmp_path,
+) -> None:
+    db = tmp_path / "graph-managed-memory.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db}")
+
+    try:
+        checkpointer = FredSqlCheckpointer(engine, prefix="v2_")
+        await checkpointer._ensure_tables()
+
+        services = RuntimeServices(checkpointer=checkpointer)
+        definition = _GraphAgent(agent_id="test.graph.memory")
+
+        runtime_a = GraphRuntime(definition=definition, services=services)
+        executor_a = await runtime_a.build_executor(
+            _binding(agent_instance_id="instance-a")
+        )
+
+        result_a = await executor_a.invoke(
+            _Input(message="from-instance-a"),
+            ExecutionConfig(session_id="shared-session"),
+        )
+        assert result_a.message == "from-instance-a"
+
+        runtime_b = GraphRuntime(definition=definition, services=services)
+        executor_b = await runtime_b.build_executor(
+            _binding(agent_instance_id="instance-b")
+        )
+
+        result_b = await executor_b.invoke(
+            _Input(message="from-instance-b"),
+            ExecutionConfig(session_id="shared-session"),
+        )
+
+        assert result_b.message == "from-instance-b"
+    finally:
+        await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_graph_same_agent_and_session_preserves_its_own_completed_state(
+    tmp_path,
+) -> None:
+    db = tmp_path / "graph-own-memory.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db}")
+
+    try:
+        checkpointer = FredSqlCheckpointer(engine, prefix="v2_")
+        await checkpointer._ensure_tables()
+
+        services = RuntimeServices(checkpointer=checkpointer)
+        definition = _GraphAgent(agent_id="test.graph.memory")
+
+        runtime_first = GraphRuntime(definition=definition, services=services)
+        executor_first = await runtime_first.build_executor(_binding())
+
+        result_first = await executor_first.invoke(
+            _Input(message="remember-me"),
+            ExecutionConfig(session_id="shared-session"),
+        )
+        assert result_first.message == "remember-me"
+
+        runtime_second = GraphRuntime(definition=definition, services=services)
+        executor_second = await runtime_second.build_executor(_binding())
+
+        result_second = await executor_second.invoke(
+            _Input(message="new-input"),
+            ExecutionConfig(session_id="shared-session"),
+        )
+
+        assert result_second.message == "remember-me"
+    finally:
+        await engine.dispose()

--- a/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
@@ -1,10 +1,9 @@
 import pytest
-
-from fred_sdk.contracts.react_contract import ReActInput, ReActMessage, ReActMessageRole
-from fred_runtime.react.react_runtime import _TransportBackedReActExecutor
-from fred_sdk.contracts.runtime import ExecutionConfig
 from fred_runtime.react.react_message_codec import to_runnable_config
+from fred_runtime.react.react_runtime import _TransportBackedReActExecutor
 from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
+from fred_sdk.contracts.react_contract import ReActInput, ReActMessage, ReActMessageRole
+from fred_sdk.contracts.runtime import ExecutionConfig
 
 
 class _FakePortable:

--- a/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
@@ -6,6 +6,7 @@ from fred_sdk.contracts.runtime import ExecutionConfig
 from fred_runtime.react.react_message_codec import to_runnable_config
 from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
 
+
 class _FakePortable:
     agent_id = "react.agent"
     session_id = "session-1"
@@ -31,7 +32,9 @@ class _RecordingCompiledAgent:
     def __init__(self) -> None:
         self.config: object = None
 
-    async def ainvoke(self, graph_input: object, *, config: object = None) -> dict[str, object]:
+    async def ainvoke(
+        self, graph_input: object, *, config: object = None
+    ) -> dict[str, object]:
         self.config = config
         return {
             "messages": [
@@ -66,6 +69,7 @@ async def test_react_executor_passes_checkpoint_namespace_to_langgraph() -> None
         }
     }
 
+
 def test_react_checkpoint_namespace_uses_managed_instance_when_available() -> None:
     assert (
         checkpoint_namespace(
@@ -74,6 +78,7 @@ def test_react_checkpoint_namespace_uses_managed_instance_when_available() -> No
         )
         == "managed-456"
     )
+
 
 def test_to_runnable_config_adds_agent_checkpoint_namespace() -> None:
     config = ExecutionConfig(session_id="session-1")
@@ -84,5 +89,7 @@ def test_to_runnable_config_adds_agent_checkpoint_namespace() -> None:
     )
 
     assert runnable is not None
-    assert runnable["configurable"]["thread_id"] == "session-1"
-    assert runnable["configurable"]["checkpoint_ns"] == "instance-123"
+    configurable = runnable["configurable"]
+    assert isinstance(configurable, dict)
+    assert configurable["thread_id"] == "session-1"
+    assert configurable["checkpoint_ns"] == "instance-123"

--- a/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
@@ -1,0 +1,88 @@
+import pytest
+
+from fred_sdk.contracts.react_contract import ReActInput, ReActMessage, ReActMessageRole
+from fred_runtime.react.react_runtime import _TransportBackedReActExecutor
+from fred_sdk.contracts.runtime import ExecutionConfig
+from fred_runtime.react.react_message_codec import to_runnable_config
+from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
+
+class _FakePortable:
+    agent_id = "react.agent"
+    session_id = "session-1"
+    team_id = "personal"
+    baggage: dict[str, object] = {}
+
+
+class _FakeRuntimeContext:
+    pass
+
+
+class _FakeBinding:
+    portable_context = _FakePortable()
+    runtime_context = _FakeRuntimeContext()
+
+
+class _FakeServices:
+    tracer = None
+    metrics = None
+
+
+class _RecordingCompiledAgent:
+    def __init__(self) -> None:
+        self.config: object = None
+
+    async def ainvoke(self, graph_input: object, *, config: object = None) -> dict[str, object]:
+        self.config = config
+        return {
+            "messages": [
+                __import__("langchain_core.messages").messages.AIMessage(content="ok")
+            ]
+        }
+
+
+@pytest.mark.asyncio
+async def test_react_executor_passes_checkpoint_namespace_to_langgraph() -> None:
+    compiled = _RecordingCompiledAgent()
+    executor = _TransportBackedReActExecutor(
+        compiled_agent=compiled,  # type: ignore[arg-type]
+        binding=_FakeBinding(),  # type: ignore[arg-type]
+        services=_FakeServices(),  # type: ignore[arg-type]
+        checkpoint_ns="instance-123",
+    )
+
+    input_model = ReActInput(
+        messages=(ReActMessage(role=ReActMessageRole.USER, content="hi"),)
+    )
+
+    await executor.invoke(
+        input_model,
+        ExecutionConfig(session_id="session-1"),
+    )
+
+    assert compiled.config == {
+        "configurable": {
+            "thread_id": "session-1",
+            "checkpoint_ns": "instance-123",
+        }
+    }
+
+def test_react_checkpoint_namespace_uses_managed_instance_when_available() -> None:
+    assert (
+        checkpoint_namespace(
+            agent_instance_id="managed-456",
+            agent_id="react.agent",
+        )
+        == "managed-456"
+    )
+
+def test_to_runnable_config_adds_agent_checkpoint_namespace() -> None:
+    config = ExecutionConfig(session_id="session-1")
+
+    runnable = to_runnable_config(
+        config,
+        checkpoint_ns="instance-123",
+    )
+
+    assert runnable is not None
+    assert runnable["configurable"]["thread_id"] == "session-1"
+    assert runnable["configurable"]["checkpoint_ns"] == "instance-123"

--- a/libs/fred-runtime/tests/test_sql_checkpointer_owner.py
+++ b/libs/fred-runtime/tests/test_sql_checkpointer_owner.py
@@ -210,6 +210,43 @@ async def test_adelete_thread_returns_checkpoint_row_count(checkpointer):
 
 
 @pytest.mark.asyncio
+async def test_adelete_thread_purges_all_checkpoint_namespaces(checkpointer):
+    """Deleting one thread must erase every agent namespace in that session."""
+    await _put(checkpointer, "thread-multi-ns", checkpoint_ns="agent-a")
+    await _put(checkpointer, "thread-multi-ns", checkpoint_ns="agent-b")
+
+    assert (
+        await checkpointer.aget_tuple(
+            _config("thread-multi-ns", checkpoint_ns="agent-a")
+        )
+        is not None
+    )
+    assert (
+        await checkpointer.aget_tuple(
+            _config("thread-multi-ns", checkpoint_ns="agent-b")
+        )
+        is not None
+    )
+
+    deleted = await checkpointer.adelete_thread("thread-multi-ns")
+
+    assert deleted == 2
+    assert (
+        await checkpointer.aget_tuple(
+            _config("thread-multi-ns", checkpoint_ns="agent-a")
+        )
+        is None
+    )
+    assert (
+        await checkpointer.aget_tuple(
+            _config("thread-multi-ns", checkpoint_ns="agent-b")
+        )
+        is None
+    )
+    assert await _owner_rows(checkpointer) == []
+
+
+@pytest.mark.asyncio
 async def test_adelete_thread_returns_zero_for_unknown_thread(checkpointer):
     assert await checkpointer.adelete_thread("no-such-thread") == 0
 


### PR DESCRIPTION
Closes #2415

Cherry-picks two checkpoint-isolation fixes from `mvp/rags-support` (author: Marc, authorship preserved):

- 2b0a5cb99b47d6240cf385cf3a3bf25106de621c - fix(runtime): namespace HITL resume checkpoints
- f188712e0069778fc1978d28166c5dc87379533e - fix(runtime): isolate agent checkpoints within shared sessions

Plus one adaptation commit on top so the branch passes swift's `make code-quality`: ruff format on the 7 touched files and a few pyright narrowing asserts in the new tests. No behavior change in that commit.

Cherry-pick note: the conflict in `tests/test_agent_app.py` came from two neighboring tests that exist only on `mvp/rags-support`; resolved by keeping the swift side, the commit's real changes (the `checkpoint_ns` plumbing in the resume tests) applied cleanly.

Verification: `make code-quality` 0 errors, `make test` 944 passed in `libs/fred-runtime`.