### PR TITLE
fix(#2407): Document name updated in-place after a rename in the Resources tab

### DIFF
--- a/apps/frontend/src/components/documents/common/useDocumentCommands.rename.test.tsx
+++ b/apps/frontend/src/components/documents/common/useDocumentCommands.rename.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage for #2407: renaming a document from the Resources tab
+// hit the backend correctly but the row kept showing the old name, because
+// renameDocument called refresh() with no tag id - and DocumentWorkspace's
+// refetchDocs callback is a no-op without one, so the folder page was never
+// reloaded. renameDocument must forward the caller's tag id, the way
+// removeFromLibrary already does.
+//
+// Second case: a failed rename must surface a toast, must NOT reload the
+// folder page, and must rethrow - RenameModal relies on the rejection to keep
+// itself open with the typed name still in the input.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DocumentMetadata } from "../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renameMutation = vi.fn();
+const refetchTags = vi.fn(async () => undefined);
+const refetchDocs = vi.fn(async (_tagId?: string) => undefined);
+const showError = vi.fn();
+const showSuccess = vi.fn();
+const showInfo = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({ showSuccess, showError, showInfo }),
+}));
+vi.mock("../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
+  useRenameDocumentKnowledgeFlowV1DocumentMetadataDocumentUidNamePutMutation: () => [renameMutation],
+  useUpdateTagKnowledgeFlowV1TagsTagIdPutMutation: () => [vi.fn()],
+  useSearchDocumentMetadataKnowledgeFlowV1DocumentsMetadataSearchPostMutation: () => [vi.fn()],
+  useUpdateDocumentMetadataRetrievableKnowledgeFlowV1DocumentMetadataDocumentUidPutMutation: () => [vi.fn()],
+  useMutateDocumentLabelsMutation: () => [vi.fn()],
+}));
+vi.mock("../../../slices/knowledgeFlow/knowledgeFlowApi.blob", () => ({
+  useLazyDownloadRawContentBlobQuery: () => [vi.fn()],
+}));
+
+import { useDocumentCommands } from "./useDocumentCommands";
+
+const doc = {
+  identity: { document_uid: "uid-1", document_name: "report.pdf", title: null },
+  source: { retrievable: true },
+} as unknown as DocumentMetadata;
+
+function Harness({ onRender }: { onRender: (commands: ReturnType<typeof useDocumentCommands>) => void }) {
+  onRender(useDocumentCommands({ refetchTags, refetchDocs }));
+  return null;
+}
+
+describe("useDocumentCommands.renameDocument (#2407)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let commands: ReturnType<typeof useDocumentCommands>;
+
+  beforeEach(() => {
+    renameMutation.mockReset();
+    refetchTags.mockClear();
+    refetchDocs.mockClear();
+    showError.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<Harness onRender={(c) => (commands = c)} />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("reloads the caller's folder page after the rename succeeds", async () => {
+    renameMutation.mockReturnValue({ unwrap: async () => undefined });
+
+    await act(async () => {
+      await commands.renameDocument(doc, "Q3-Final.pdf", "tag-1");
+    });
+
+    expect(renameMutation).toHaveBeenCalledWith({
+      documentUid: "uid-1",
+      bodyRenameDocumentKnowledgeFlowV1DocumentMetadataDocumentUidNamePut: { name: "Q3-Final.pdf" },
+    });
+    // The whole point of the fix: the tag id reaches refetchDocs, so the
+    // folder page reloads and the row picks up its new name.
+    expect(refetchDocs).toHaveBeenCalledWith("tag-1");
+    expect(refetchTags).toHaveBeenCalledTimes(1);
+  });
+
+  it("toasts, skips the reload and rethrows when the rename fails", async () => {
+    renameMutation.mockReturnValue({
+      unwrap: async () => {
+        throw { data: { detail: "name already taken" } };
+      },
+    });
+
+    await act(async () => {
+      await expect(commands.renameDocument(doc, "Q3-Final.pdf", "tag-1")).rejects.toBeDefined();
+    });
+
+    expect(showError).toHaveBeenCalledWith(expect.objectContaining({ detail: "name already taken" }));
+    expect(refetchDocs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
+++ b/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
@@ -18,7 +18,6 @@ import {
   useSearchDocumentMetadataKnowledgeFlowV1DocumentsMetadataSearchPostMutation,
   TagWithItemsId,
   DocumentMetadata,
-  useLazyGetTagKnowledgeFlowV1TagsTagIdGetQuery,
   useUpdateDocumentMetadataRetrievableKnowledgeFlowV1DocumentMetadataDocumentUidPutMutation,
   useRenameDocumentKnowledgeFlowV1DocumentMetadataDocumentUidNamePutMutation,
   useMutateDocumentLabelsMutation,
@@ -41,7 +40,6 @@ export interface DocumentPreviewTarget {
 export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefreshers = {}) {
   const { t } = useTranslation();
   const { showSuccess, showError, showInfo } = useToast();
-  const [] = useLazyGetTagKnowledgeFlowV1TagsTagIdGetQuery();
 
   const [updateTag] = useUpdateTagKnowledgeFlowV1TagsTagIdPutMutation();
   const [updateRetrievable] =
@@ -239,14 +237,18 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
   // index and the content-store filename lookup. Supersedes the earlier
   // cosmetic title-only rename (identity.title, browser-display only) for
   // the Corpus "Renommer" action.
+  // `tagId` is the folder currently being viewed: callers must pass it (like
+  // removeFromLibrary does) so `refresh` reloads that folder's page and the
+  // renamed row shows its new name. Without it refetchDocs is a no-op and the
+  // rename succeeds server-side while the UI keeps showing the old name.
   const renameDocument = useCallback(
-    async (doc: DocumentMetadata, newName: string) => {
+    async (doc: DocumentMetadata, newName: string, tagId?: string) => {
       try {
         await renameDocumentMutation({
           documentUid: doc.identity.document_uid,
           bodyRenameDocumentKnowledgeFlowV1DocumentMetadataDocumentUidNamePut: { name: newName },
         }).unwrap();
-        await refresh();
+        await refresh(tagId);
       } catch (e: any) {
         showError?.({
           summary: t("validation.error"),

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.rename.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.rename.test.tsx
@@ -180,9 +180,17 @@ describe("DocumentWorkspace — rename a document", () => {
     await clickSave();
 
     expect(renameDocument).toHaveBeenCalledTimes(1);
-    const [doc, newName] = renameDocument.mock.calls[0] as [{ identity: { document_uid: string } }, string];
+    const [doc, newName, tagId] = renameDocument.mock.calls[0] as [
+      { identity: { document_uid: string } },
+      string,
+      string | undefined,
+    ];
     expect(doc.identity.document_uid).toBe("uid-1");
     expect(newName).toBe("Q3-Final.pdf");
+    // #2407: the folder being viewed must be passed through - without it the
+    // command's refresh() cannot reload this page and the row keeps the old
+    // name even though the rename succeeded server-side.
+    expect(tagId).toBe("tag-cir");
   });
 
   it("does not select the row when clicking a 'more' menu item — the menu portals to document.body, and React bubbles portal clicks through the React tree, not the DOM tree, so the row's own click-to-select guard can't see them via target.closest()", () => {

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
@@ -1630,7 +1630,7 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
               const tag = renameTarget.node.tagsHere[0];
               if (tag) await commands.renameTag(tag as unknown as TagWithItemsId, newName);
             } else {
-              await commands.renameDocument(renameTarget.doc, newName);
+              await commands.renameDocument(renameTarget.doc, newName, currentTag?.id);
             }
           }}
         />


### PR DESCRIPTION
## Problem

Renaming a document from the Resources tab did nothing visible: the modal
closed, no error appeared, and the row kept its old name. The rename actually
succeeded server-side - a manual page reload showed the new name - so the
backend endpoint (#1864) and the UI action (#2128) were both fine. Only the
refresh was broken.

## Root cause

`renameDocument` in `useDocumentCommands.tsx` called `await refresh()` with no
tag id. `refresh` forwards to the `refetchDocs` callback supplied by
`DocumentWorkspace`, and that callback is `async (tagId?) => { if (tagId) await
loadTagPage(...) }` - a no-op when `tagId` is undefined. The visible rows come
from `perTag[currentTagId].docs`, which only `loadTagPage` populates, so nothing
on screen ever changed.

`removeFromLibrary` in the same hook already does this correctly with
`await refresh(tag.id)`.

## Fix

- `renameDocument(doc, newName, tagId?)` - new optional third parameter, passed
  straight to `refresh(tagId)`, mirroring `removeFromLibrary`.
- `DocumentWorkspace`'s RenameModal submit passes `currentTag?.id`, the folder
  being viewed.
- Removed the dead `useLazyGetTagKnowledgeFlowV1TagsTagIdGetQuery()` call in the
  same hook (it destructured nothing) and its now-unused import.

No backend change and no API client regeneration: the endpoint, the service and
the generated RTK hook were all already correct.

## Tests

- `useDocumentCommands.rename.test.tsx` (new): the hook had no test file. Covers
  the regression - a successful rename calls the mutation with the right body
  and then `refetchDocs("tag-1")` plus `refetchTags()` - and the failure path -
  a rejected mutation toasts the error, skips the reload, and rethrows so
  RenameModal stays open.
- `DocumentWorkspace.rename.test.tsx`: the existing call-site test now asserts
  the third argument is the folder id, locking the contract that broke.

Both new assertions were verified to fail against the pre-fix code. Frontend
suite: 1363 passed, 2 skipped (141 files). `make code-quality` clean (tsc,
prettier, eslint).

Closes #2407
