### PR TITLE
feat(#2410): seed personal teams with the prompt starter kit on first access

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/product/prompt_starter_kit.py
+++ b/apps/control-plane-backend/control_plane_backend/product/prompt_starter_kit.py
@@ -1,6 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+from uuid import uuid4
+
+from fred_core.common import TeamId
+
+from control_plane_backend.prompts.category_store import (
+    PromptCategoryAlreadyExistsError,
+    PromptCategoryRecord,
+    PromptCategoryStore,
+)
+from control_plane_backend.prompts.store import (
+    PromptAlreadyExistsError,
+    PromptRecord,
+    PromptStore,
+)
 
 
 @dataclass(frozen=True)
@@ -106,3 +121,72 @@ STARTER_PROMPTS: list[StarterPromptSpec] = [
         ),
     ),
 ]
+
+
+async def seed_starter_kit(
+    team_id: TeamId,
+    *,
+    prompt_store: PromptStore,
+    category_store: PromptCategoryStore,
+) -> None:
+    """Write the starter categories + prompts into one team's prompt library.
+
+    Why this function exists:
+    - two call sites need the exact same content and linkage: `create_team`
+      (PROMPT-09, collaborative teams) and the lazy personal-space seeding in
+      `product.service` (#2410, personal teams are virtual and never go
+      through `create_team`)
+
+    Convergent by design: each category and each prompt is created by
+    `(team_id, name)`, and a duplicate hitting the store's unique constraint
+    is swallowed for that item alone. Calling this twice - or concurrently
+    from two requests of the same user - therefore converges on one starter
+    kit instead of raising or duplicating rows.
+
+    Not best-effort on its own: a non-duplicate failure propagates, and each
+    caller decides how to degrade (both currently log and swallow, because an
+    empty prompt library is degraded but not unsafe).
+    """
+
+    async def _ensure_category(name: str) -> tuple[str, str | None]:
+        try:
+            record = await category_store.create(
+                PromptCategoryRecord(
+                    category_id=str(uuid4()), team_id=team_id, name=name
+                )
+            )
+            return name, record.category_id
+        except PromptCategoryAlreadyExistsError:
+            return name, None
+
+    # Each category is independent of its siblings - only the prompt phase
+    # below depends on this one having finished (it needs every category_id
+    # to link prompts to their category).
+    pairs = await asyncio.gather(*(_ensure_category(n) for n in STARTER_CATEGORY_NAMES))
+    category_id_by_name = {name: cid for name, cid in pairs if cid is not None}
+    if len(category_id_by_name) < len(STARTER_CATEGORY_NAMES):
+        # At least one name was already taken (a pre-existing category, or a
+        # concurrent seeding that won the race): re-read the team's rows so
+        # the prompts below still link to a real category id.
+        for record in await category_store.list_by_team(team_id):
+            category_id_by_name.setdefault(record.name, record.category_id)
+
+    async def _ensure_prompt(spec: StarterPromptSpec) -> None:
+        try:
+            await prompt_store.create(
+                PromptRecord(
+                    prompt_id=str(uuid4()),
+                    team_id=team_id,
+                    name=spec.name,
+                    description=spec.description,
+                    category_id=category_id_by_name.get(spec.category_name),
+                    text=spec.text,
+                    created_by=None,
+                )
+            )
+        except PromptAlreadyExistsError:
+            pass
+
+    # Independent of each other too - each prompt only needs its own
+    # (already-resolved) category id, not any sibling prompt.
+    await asyncio.gather(*(_ensure_prompt(s) for s in STARTER_PROMPTS))

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -57,6 +57,7 @@ from control_plane_backend.config.models import (
     ManagedAgentTuning,
 )
 from control_plane_backend.product.dependencies import ProductServiceDependencies
+from control_plane_backend.product.prompt_starter_kit import seed_starter_kit
 from control_plane_backend.product.schemas import (
     AgentTemplateSummary,
     ContextPromptSummary,
@@ -3524,6 +3525,56 @@ async def create_prompt(
     return _prompt_record_to_summary(created)
 
 
+async def _ensure_personal_starter_kit(
+    team_id: TeamId, deps: ProductServiceDependencies
+) -> None:
+    """Give a personal space the same starter prompt kit collaborative teams get (#2410).
+
+    Why this function exists:
+    - personal teams are *virtual* (`teams/system.py::build_personal_team`
+      synthesizes `personal-<uid>` on the fly): they never go through
+      `create_team` and own no `teammetadata` row, so neither PROMPT-09's
+      creation-time seeding nor its backfill migration could ever reach them
+      and a new user's personal prompt library started empty
+    - seeding on first read *is* the backfill: there is no reliable way to
+      enumerate the personal teams that already exist, so there is no
+      migration - each pristine personal space heals itself on next visit
+
+    Only a **pristine** library is seeded (zero prompts *and* zero
+    categories), so a user who curated their own personal space is never
+    given content they did not ask for. Best-effort: a failure here must
+    never break the listing surface it is called from.
+
+    Two consequences of using "library is empty" as the proxy for "never
+    seeded" (no marker row exists for a virtual team), both accepted
+    knowingly rather than overlooked:
+    - a user who deletes *every* prompt **and** every category gets the kit
+      back on the next visit
+    - a seeding run that fails halfway leaves the space non-pristine, so it
+      is not retried; the user keeps whatever landed and can edit from there
+    """
+
+    if not is_personal_team_id(team_id):
+        return
+    try:
+        prompt_store = deps.get_prompt_store()
+        if await prompt_store.list_by_team(team_id, limit=1):
+            return
+        category_store = deps.get_prompt_category_store()
+        if await category_store.list_by_team(team_id):
+            return
+        await seed_starter_kit(
+            team_id, prompt_store=prompt_store, category_store=category_store
+        )
+    except Exception:
+        logger.warning(
+            "Failed to seed the starter prompt kit for personal space %s - "
+            "continuing with an empty prompt library.",
+            team_id,
+            exc_info=True,
+        )
+
+
 async def list_prompts(
     team_id: TeamId,
     deps: ProductServiceDependencies,
@@ -3547,6 +3598,7 @@ async def list_prompts(
     - `prompts = await list_prompts(team_id, deps)`
     """
 
+    await _ensure_personal_starter_kit(team_id, deps)
     store = deps.get_prompt_store()
     records = await store.list_by_team(team_id, limit=limit)
     return sorted(
@@ -3677,6 +3729,7 @@ async def list_context_prompts(
     session_count DESC (most-used first).
     """
 
+    await _ensure_personal_starter_kit(team_id, deps)
     store = deps.get_prompt_store()
     records = await store.list_context_prompts(personal_team_id(user.uid), team_id)
     return [
@@ -3961,6 +4014,7 @@ async def list_prompt_categories(
 ) -> list[PromptCategorySummary]:
     """List one team's prompt categories, alphabetically."""
 
+    await _ensure_personal_starter_kit(team_id, deps)
     records = await deps.get_prompt_category_store().list_by_team(team_id)
     return [_category_record_to_summary(r) for r in records]
 

--- a/apps/control-plane-backend/control_plane_backend/teams/service.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/service.py
@@ -35,12 +35,7 @@ from fred_core.store import ContentStore
 from fred_core.teams.metadata_store import TeamMetadata, TeamMetadataPatch
 from sqlalchemy.exc import IntegrityError
 
-from control_plane_backend.product.prompt_starter_kit import (
-    STARTER_CATEGORY_NAMES,
-    STARTER_PROMPTS,
-)
-from control_plane_backend.prompts.category_store import PromptCategoryRecord
-from control_plane_backend.prompts.store import PromptRecord
+from control_plane_backend.product.prompt_starter_kit import seed_starter_kit
 from control_plane_backend.scheduler.policies.policy_engine import (
     evaluate_policy_for_request,
 )
@@ -427,42 +422,10 @@ async def _seed_starter_kit(team_id: TeamId, deps: TeamServiceDependencies) -> N
     """
 
     try:
-        category_store = deps.get_prompt_category_store()
-        # Each category is independent of its siblings — only the prompt
-        # phase below depends on this one having finished (it needs every
-        # category_id to link prompts to their category).
-        created_categories = await asyncio.gather(
-            *(
-                category_store.create(
-                    PromptCategoryRecord(
-                        category_id=str(uuid4()), team_id=team_id, name=name
-                    )
-                )
-                for name in STARTER_CATEGORY_NAMES
-            )
-        )
-        category_id_by_name = {
-            record.name: record.category_id for record in created_categories
-        }
-
-        prompt_store = deps.get_prompt_store()
-        # Independent of each other too — each prompt only needs its own
-        # (already-resolved) category id, not any sibling prompt.
-        await asyncio.gather(
-            *(
-                prompt_store.create(
-                    PromptRecord(
-                        prompt_id=str(uuid4()),
-                        team_id=team_id,
-                        name=spec.name,
-                        description=spec.description,
-                        category_id=category_id_by_name.get(spec.category_name),
-                        text=spec.text,
-                        created_by=None,
-                    )
-                )
-                for spec in STARTER_PROMPTS
-            )
+        await seed_starter_kit(
+            team_id,
+            prompt_store=deps.get_prompt_store(),
+            category_store=deps.get_prompt_category_store(),
         )
     except Exception:
         logger.warning(

--- a/apps/control-plane-backend/tests/test_personal_prompt_seeding.py
+++ b/apps/control-plane-backend/tests/test_personal_prompt_seeding.py
@@ -1,0 +1,281 @@
+"""Personal spaces get the prompt starter kit too (#2410).
+
+Personal teams are *virtual* (`teams/system.py::build_personal_team`): they are
+synthesized as `personal-<uid>` on the fly, never go through `create_team`, and
+own no `teammetadata` row - so PROMPT-09's creation-time seeding and its
+backfill migration both missed them entirely. The fix seeds them lazily, on the
+first read of any prompt surface, using the same shared `seed_starter_kit`.
+
+These run fully offline against a temporary SQLite file so the stores' real
+`(team_id, name)` unique constraints - the whole basis of the convergent
+create-or-reuse behaviour asserted below - are actually exercised.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from control_plane_backend.models.base import Base as CPBase
+from control_plane_backend.product.dependencies import ProductServiceDependencies
+from control_plane_backend.product.prompt_starter_kit import (
+    STARTER_CATEGORY_NAMES,
+    STARTER_PROMPTS,
+    seed_starter_kit,
+)
+from control_plane_backend.product.service import (
+    _ensure_personal_starter_kit,
+    list_prompt_categories,
+    list_prompts,
+)
+from control_plane_backend.prompts.category_store import (
+    PromptCategoryRecord,
+    PromptCategoryStore,
+)
+from control_plane_backend.prompts.store import PromptRecord, PromptStore
+from fred_core.common import TeamId
+from sqlalchemy.ext.asyncio import create_async_engine
+
+PERSONAL_TEAM = TeamId("personal-alice-uid")
+COLLAB_TEAM = TeamId("swiftpost-team-id")
+
+
+class _Stores:
+    def __init__(self, prompts: PromptStore, categories: PromptCategoryStore) -> None:
+        self.prompts = prompts
+        self.categories = categories
+
+
+@pytest_asyncio.fixture
+async def stores(tmp_path) -> AsyncIterator[_Stores]:
+    db_path = tmp_path / "personal_seeding_test.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(CPBase.metadata.create_all)
+    try:
+        yield _Stores(PromptStore(engine), PromptCategoryStore(engine))
+    finally:
+        await engine.dispose()
+
+
+def _deps(stores: _Stores, *, prompt_store: Any = None) -> ProductServiceDependencies:
+    """A `ProductServiceDependencies` carrying real prompt stores and nothing else.
+
+    Every other collaborator is a `MagicMock`: the seeding path must not touch
+    ReBAC, sessions, KPI, or the scheduler, and a mock would blow up loudly if
+    it ever did.
+    """
+
+    deps = MagicMock(spec=ProductServiceDependencies)
+    deps.get_prompt_store = lambda: prompt_store or stores.prompts
+    deps.get_prompt_category_store = lambda: stores.categories
+    return cast(ProductServiceDependencies, deps)
+
+
+async def _names(stores: _Stores, team_id: TeamId) -> tuple[list[str], list[str]]:
+    prompts = await stores.prompts.list_by_team(team_id)
+    categories = await stores.categories.list_by_team(team_id)
+    return sorted(p.name for p in prompts), sorted(c.name for c in categories)
+
+
+# --------------------------- seed_starter_kit (shared core) -----------------
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_the_full_kit_linked_to_its_categories(
+    stores: _Stores,
+) -> None:
+    await seed_starter_kit(
+        COLLAB_TEAM, prompt_store=stores.prompts, category_store=stores.categories
+    )
+
+    prompts = await stores.prompts.list_by_team(COLLAB_TEAM)
+    categories = await stores.categories.list_by_team(COLLAB_TEAM)
+    assert sorted(c.name for c in categories) == sorted(STARTER_CATEGORY_NAMES)
+    assert sorted(p.name for p in prompts) == sorted(s.name for s in STARTER_PROMPTS)
+
+    category_name_by_id = {c.category_id: c.name for c in categories}
+    expected_category_by_prompt = {s.name: s.category_name for s in STARTER_PROMPTS}
+    for prompt in prompts:
+        assert prompt.category_id is not None
+        assert (
+            category_name_by_id[prompt.category_id]
+            == expected_category_by_prompt[prompt.name]
+        )
+        # Seeded content is authored by the platform, not by a user, and is
+        # never auto-published to the marketplace (PROMPT-06).
+        assert prompt.created_by is None
+        assert prompt.published is False
+
+
+@pytest.mark.asyncio
+async def test_seeding_twice_converges_instead_of_duplicating(stores: _Stores) -> None:
+    """Convergence matters because the personal-space caller is a *read* path:
+    two concurrent first visits would otherwise race into duplicate rows (or a
+    500 from the unique constraint)."""
+
+    await seed_starter_kit(
+        PERSONAL_TEAM, prompt_store=stores.prompts, category_store=stores.categories
+    )
+    await seed_starter_kit(
+        PERSONAL_TEAM, prompt_store=stores.prompts, category_store=stores.categories
+    )
+
+    prompt_names, category_names = await _names(stores, PERSONAL_TEAM)
+    assert len(category_names) == len(STARTER_CATEGORY_NAMES)
+    assert len(prompt_names) == len(STARTER_PROMPTS)
+
+
+@pytest.mark.asyncio
+async def test_seed_reuses_a_pre_existing_category_of_the_same_name(
+    stores: _Stores,
+) -> None:
+    """A name collision must reuse the existing row, not orphan the prompt that
+    belongs in it: the "Communication" starter prompt still has to resolve to
+    the category id that was already there."""
+
+    existing = await stores.categories.create(
+        PromptCategoryRecord(
+            category_id="pre-existing", team_id=PERSONAL_TEAM, name="Communication"
+        )
+    )
+
+    await seed_starter_kit(
+        PERSONAL_TEAM, prompt_store=stores.prompts, category_store=stores.categories
+    )
+
+    categories = await stores.categories.list_by_team(PERSONAL_TEAM)
+    assert sorted(c.name for c in categories) == sorted(STARTER_CATEGORY_NAMES)
+    assert len([c for c in categories if c.name == "Communication"]) == 1
+
+    spec = next(s for s in STARTER_PROMPTS if s.category_name == "Communication")
+    prompts = await stores.prompts.list_by_team(PERSONAL_TEAM)
+    seeded = next(p for p in prompts if p.name == spec.name)
+    assert seeded.category_id == existing.category_id
+
+
+# --------------------------- _ensure_personal_starter_kit -------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_seeds_a_pristine_personal_space(stores: _Stores) -> None:
+    await _ensure_personal_starter_kit(PERSONAL_TEAM, _deps(stores))
+
+    prompt_names, category_names = await _names(stores, PERSONAL_TEAM)
+    assert len(category_names) == len(STARTER_CATEGORY_NAMES)
+    assert len(prompt_names) == len(STARTER_PROMPTS)
+
+
+@pytest.mark.asyncio
+async def test_ensure_is_a_no_op_for_a_collaborative_team(stores: _Stores) -> None:
+    """Collaborative teams are already seeded at creation time; re-seeding them
+    on read would resurrect content their editors deliberately deleted."""
+
+    await _ensure_personal_starter_kit(COLLAB_TEAM, _deps(stores))
+
+    assert await _names(stores, COLLAB_TEAM) == ([], [])
+
+
+@pytest.mark.asyncio
+async def test_ensure_leaves_a_personal_space_that_has_prompts_alone(
+    stores: _Stores,
+) -> None:
+    await stores.prompts.create(
+        PromptRecord(
+            prompt_id="p1",
+            team_id=PERSONAL_TEAM,
+            name="my own prompt",
+            description=None,
+            text="hello",
+            created_by="alice-uid",
+        )
+    )
+
+    await _ensure_personal_starter_kit(PERSONAL_TEAM, _deps(stores))
+
+    prompt_names, category_names = await _names(stores, PERSONAL_TEAM)
+    assert prompt_names == ["my own prompt"]
+    assert category_names == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_leaves_a_personal_space_that_has_only_categories_alone(
+    stores: _Stores,
+) -> None:
+    """Categories without prompts is a real state (the user emptied their
+    library but kept their taxonomy) - pristine means *both* are empty."""
+
+    await stores.categories.create(
+        PromptCategoryRecord(
+            category_id="c1", team_id=PERSONAL_TEAM, name="Mes catégories"
+        )
+    )
+
+    await _ensure_personal_starter_kit(PERSONAL_TEAM, _deps(stores))
+
+    prompt_names, category_names = await _names(stores, PERSONAL_TEAM)
+    assert prompt_names == []
+    assert category_names == ["Mes catégories"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_swallows_store_failures(stores: _Stores) -> None:
+    """Best-effort: seeding is a side effect of a listing call, so a store
+    failure must degrade to an empty library, never a 500 on the listing."""
+
+    failing = MagicMock()
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("db unavailable")
+
+    failing.list_by_team = _boom
+
+    await _ensure_personal_starter_kit(
+        PERSONAL_TEAM, _deps(stores, prompt_store=failing)
+    )
+
+    assert await _names(stores, PERSONAL_TEAM) == ([], [])
+
+
+# --------------------------- service read surfaces --------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_seeds_the_personal_space_on_first_read(
+    stores: _Stores,
+) -> None:
+    summaries = await list_prompts(PERSONAL_TEAM, _deps(stores))
+    assert sorted(s.name for s in summaries) == sorted(s.name for s in STARTER_PROMPTS)
+
+    categories = await list_prompt_categories(PERSONAL_TEAM, _deps(stores))
+    assert sorted(c.name for c in categories) == sorted(STARTER_CATEGORY_NAMES)
+    # Second read returns the same kit, not a duplicated one.
+    assert len(await list_prompts(PERSONAL_TEAM, _deps(stores))) == len(STARTER_PROMPTS)
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_does_not_seed_a_collaborative_team(
+    stores: _Stores,
+) -> None:
+    assert await list_prompts(COLLAB_TEAM, _deps(stores)) == []
+    assert await list_prompt_categories(COLLAB_TEAM, _deps(stores)) == []
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_survives_a_seeding_failure(stores: _Stores) -> None:
+    class _FailOnSeedOnly:
+        """Reports an empty library, then fails the seeding write."""
+
+        async def list_by_team(self, *_a, **_k):
+            return []
+
+        async def create(self, *_a, **_k):
+            raise RuntimeError("db unavailable")
+
+    assert (
+        await list_prompts(PERSONAL_TEAM, _deps(stores, prompt_store=_FailOnSeedOnly()))
+        == []
+    )

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -1991,8 +1991,26 @@ synthèse", "Stratégie et idéation", "Communication") and one prompt per
 category. From that point on the starter kit is normal team content — any
 `team_editor` can rename, edit, or delete every part of it, including the
 categories themselves. Seeding is **best-effort**: unlike the ReBAC relation
-writes, a seeding failure logs a warning and does not fail team creation. The
-personal prompt space is **not** seeded.
+writes, a seeding failure logs a warning and does not fail team creation.
+
+**Personal spaces are seeded lazily, on first read (2026-08-25, #2410).**
+Personal teams are virtual - `teams/system.py::build_personal_team` synthesizes
+`personal-<uid>` on the fly, so they never go through `create_team` and own no
+`teammetadata` row; the creation hook above and the backfill migration below
+both missed them, and a new user's personal library started empty. The three
+personal-reachable read surfaces (`GET /teams/{team_id}/prompts`, the chat
+context picker, `GET /teams/{team_id}/prompt-categories`) now call
+`_ensure_personal_starter_kit` first. It seeds only a **pristine** personal
+library (zero prompts *and* zero categories), so a curated space is never
+given content back; it is **convergent** (create-or-reuse by `(team_id,
+name)`), so concurrent first reads cannot duplicate rows; and it is
+**best-effort**, so a store failure degrades to an empty library rather than
+failing the listing. There is deliberately **no migration**: personal teams
+cannot be enumerated, so seed-on-first-read *is* the backfill. A virtual team
+has no marker row, so "library is empty" is the only available proxy for
+"never seeded" - which means a user who deletes every prompt *and* every
+category is re-seeded on the next visit, and a run that fails halfway is not
+retried (the space is no longer pristine).
 
 **Migration (`8ca7cafc292f`)** backfills the same starter kit into every
 *existing* team that had zero prompt rows at migration time (teams that

--- a/docs/swift/design/PROMPTS.md
+++ b/docs/swift/design/PROMPTS.md
@@ -94,7 +94,10 @@ The main API surface is:
 real row in the `prompt` table, owned and fully editable by its team. New teams
 are seeded with a 4-category / 4-prompt starter kit at creation time
 (`_seed_starter_kit`, best-effort — a seeding failure never fails team
-creation); from that point on the starter kit is ordinary team content.
+creation); personal spaces, being virtual, are seeded lazily on first access
+instead (`_ensure_personal_starter_kit`, #2410 — only a library with zero
+prompts *and* zero categories). From that point on the starter kit is ordinary
+team content.
 
 ### 3.1 Prompt categories
 


### PR DESCRIPTION
## Problem

A new user's personal space starts with an **empty prompt library**. The starter kit shipped by PROMPT-09 (#2174) - 4 categories and 4 prompts - only ever reached collaborative team spaces.

## Mechanism

Personal teams are **virtual**. `teams/system.py::build_personal_team` synthesizes `personal-<uid>` on the fly from the caller's identity: there is no `create_team` call and no `teammetadata` row behind them.

PROMPT-09 seeded the kit from exactly two places, and both are blind to that:

- `teams/service.py::_seed_starter_kit`, called only from `create_team` - personal teams never go through it;
- the backfill migration `8ca7cafc292f`, which iterated the `teammetadata` table - personal teams have no row there.

So the gap was structural, not a missed case. `CONTROL-PLANE-PRODUCT-CONTRACT.md` even documented it as intended behaviour ("The personal prompt space is **not** seeded") - this PR reverses that decision.

## Fix

- **Shared convergent core.** The seeding body moves out of `teams/service.py` into `product/prompt_starter_kit.py::seed_starter_kit`, next to the content it writes. It is now create-or-reuse by `(team_id, name)`: a duplicate hitting either store's unique constraint is swallowed for that item alone, and a category name that was already taken is re-read so its prompt still links to a real id. Calling it twice, or concurrently from two requests, converges on one kit.
- **`teams/service.py::_seed_starter_kit` shrinks to a thin wrapper** - same name, same signature, same best-effort semantics, ~45 lines lighter. `create_team` is untouched.
- **Lazy seeding for personal spaces.** `product/service.py::_ensure_personal_starter_kit` runs first in the three personal-reachable read surfaces: `list_prompts` (`GET /teams/{team_id}/prompts`), `list_context_prompts` (chat picker), and `list_prompt_categories`. It is a no-op for any non-personal id, and it seeds only a **pristine** library (zero prompts *and* zero categories), so a curated personal space is never handed content back. Failures are logged and swallowed - seeding is a side effect of a listing call and must never break it.
- **No migration, by design.** There is no reliable way to enumerate the personal teams that already exist, so seed-on-first-read *is* the backfill: every pristine personal space heals itself on the owner's next visit.
- **No frontend, route, or model change** -> no client regeneration, no OpenAPI change, no authz matrix change.

Verified compatible with the marketplace (#2317 / #2320): seeded rows default to `published=False`, and personal prompts cannot be published anyway.

## Tests

New `apps/control-plane-backend/tests/test_personal_prompt_seeding.py` - 11 tests, fully offline against a temporary SQLite file so the stores' real `(team_id, name)` unique constraints (the whole basis of the convergent behaviour) are actually exercised:

- the kit lands complete, each prompt linked to its own category, `created_by=None`, `published=False`;
- seeding twice converges instead of duplicating;
- a pre-existing "Communication" category is reused, and the matching starter prompt resolves to that existing id;
- `_ensure_personal_starter_kit` seeds a pristine personal space, and is a no-op for a collaborative id / when prompts exist / when only categories exist;
- `list_prompts` and `list_prompt_categories` return the seeded kit on a pristine personal space and stay empty for a collaborative one;
- a store failure inside the seeding path does not propagate out of `list_prompts`.

`make code-quality`: clean (ruff, format, bandit, detect-secrets, basedpyright 0 errors).
`make test`: **859 passed**. The existing `test_seed_starter_kit_*` tests in `test_team_registry_governance.py`, plus `test_prompts_marketplace.py` and `test_import_export_teardown.py`, pass unchanged.

## Docs updated

- `docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md` §32 - replaced "The personal prompt space is **not** seeded" with the lazy-seed rule (dated `2026-08-25, #2410`), including why there is no migration.
- `docs/swift/design/PROMPTS.md` §3 - notes that personal spaces are seeded lazily on first access.

Untouched on purpose: migration `8ca7cafc292f` and its frozen embedded copies of the starter content, and `STARTER_PROMPTS` itself.

## Not done here - editorial review of the starter prompts (issue part 2, needs your call)

Part 2 of #2410 is editorial, so **no prompt content was changed**. Suggestions for you to decide on:

- **Keep as-is**: "Vulgarisation Technique", "Brainstorming Inversé", "Approche Diplomate" - short, parameterised with `[placeholders]`, and they read well in the picker.
- **"Agent : synthèse de document"** - the weakest fit for the chat picker: it is a full system-prompt with emoji section headers (🎯 / 🔑 / 🚀 / ⚠️) and reads as agent configuration rather than something you fire off in a conversation. Either trim the emoji headers, or leave it unchanged if that is deliberate for the "Création agent" category.
- **Optional additions**: "Compte rendu de réunion" and "Relecture / amélioration d'un texte" - two of the most common everyday asks, and neither is covered today.

Note that any content change only affects **future** seedings: already-seeded teams own editable copies and are never rewritten.

## Also needs sign-off

Because a virtual team has no marker row, "library is empty" is the only available proxy for "never seeded". Two consequences, both knowingly accepted rather than overlooked - flagging them explicitly:

1. A user who deliberately wipes their **entire** personal library (all prompts **and** all categories) gets the starter kit back on their next visit. There is no opt-out. If that is not acceptable, the fix is a durable marker (a `seeded_at` row keyed by personal team id) rather than the emptiness check - say the word and I will add it.
2. A seeding run that fails halfway leaves the space non-pristine, so it is not retried; the user keeps whatever landed and can edit from there.

Both are documented in the contract doc and in the helper's docstring so the next reader does not mistake them for bugs.

Closes #2410
