### PR TITLE
fix(#2406): bundle the Whisper model in the knowledge-flow prod image for offline dictation

### DIFF
--- a/apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod
+++ b/apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod
@@ -107,6 +107,16 @@ from sentence_transformers import CrossEncoder; \
 import os; \
 CrossEncoder(model_name_or_path=os.environ['RERANKER_MODEL'], cache_folder=os.environ['RERANKER_MODEL_CACHE'])"
 
+# Whisper dictation/transcription model (issue #2406): bake into the HF hub
+# cache so faster-whisper resolves it offline at runtime (HF_HUB_OFFLINE=1).
+# audio_processor.py reads WHISPER_MODEL_SIZE too, so the baked model and the
+# one requested at runtime cannot drift apart.
+ENV WHISPER_MODEL_SIZE=base
+RUN python -c "\
+from faster_whisper import download_model; \
+import os; \
+print(download_model(os.environ['WHISPER_MODEL_SIZE']))"
+
 # Runtime offline policy for Hugging Face based dependencies.
 ENV HF_HUB_OFFLINE=${HF_OFFLINE_STRICT}
 ENV TRANSFORMERS_OFFLINE=${HF_OFFLINE_STRICT}

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/audio_processor/audio_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/audio_processor/audio_processor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import tempfile
 from pathlib import Path
 from typing import Optional, TypedDict
@@ -70,9 +71,24 @@ class AudioProcessor(BaseMarkdownProcessor):
             from faster_whisper import WhisperModel
 
             audio_cfg = self._get_audio_config()
-            model_size = audio_cfg.get("whisper_model_size", "base")
+            # WHISPER_MODEL_SIZE is set by the prod image, which bakes exactly that
+            # model into the Hugging Face hub cache at build time (#2406). Reading it
+            # here keeps the baked model and the requested one in sync by construction.
+            model_size = audio_cfg.get("whisper_model_size") or os.getenv("WHISPER_MODEL_SIZE") or "base"
             device = audio_cfg.get("device", "cpu")
-            self._model = WhisperModel(model_size, device=device, compute_type="int8")
+            try:
+                # Offline-first (#2406): never touch the network when the model is
+                # already present in the local cache.
+                self._model = WhisperModel(model_size, device=device, compute_type="int8", local_files_only=True)
+            except Exception:
+                # Not necessarily a cache miss (a bad device or a corrupt snapshot lands
+                # here too), so log the real cause instead of asserting one.
+                logger.info(
+                    "Whisper model '%s' could not be loaded from the local cache; retrying with a Hugging Face hub download.",
+                    model_size,
+                    exc_info=True,
+                )
+                self._model = WhisperModel(model_size, device=device, compute_type="int8")
         return self._model
 
     def check_file_validity(self, file_path: Path) -> bool:

--- a/apps/knowledge-flow-backend/tests/processors/input/audio_processor/__init__.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/audio_processor/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/apps/knowledge-flow-backend/tests/processors/input/audio_processor/test_audio_processor_model_loading.py
+++ b/apps/knowledge-flow-backend/tests/processors/input/audio_processor/test_audio_processor_model_loading.py
@@ -1,0 +1,92 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Whisper model loading must stay offline-first (issue #2406).
+
+The knowledge-flow prod image bakes the Whisper model into the Hugging Face hub
+cache and runs with HF_HUB_OFFLINE=1, so `_get_model()` has to resolve the model
+from the local cache first, ask for the very model size the image baked, and only
+reach for a hub download when that local load fails.
+"""
+
+from types import SimpleNamespace
+
+from knowledge_flow_backend.core.processors.input.audio_processor.audio_processor import AudioProcessor
+
+
+def test_get_model_prefers_local_cache(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_whisper_model(model_size_or_path, **kwargs):
+        calls.append({"model_size_or_path": model_size_or_path, **kwargs})
+        return SimpleNamespace(name=model_size_or_path)
+
+    monkeypatch.delenv("WHISPER_MODEL_SIZE", raising=False)
+    monkeypatch.setattr("faster_whisper.WhisperModel", fake_whisper_model)
+
+    model = AudioProcessor()._get_model()
+
+    assert calls == [
+        {
+            "model_size_or_path": "base",
+            "device": "cpu",
+            "compute_type": "int8",
+            "local_files_only": True,
+        }
+    ]
+    assert model.name == "base"
+
+
+def test_get_model_falls_back_to_download_when_not_cached(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_whisper_model(model_size_or_path, **kwargs):
+        calls.append({"model_size_or_path": model_size_or_path, **kwargs})
+        if kwargs.get("local_files_only"):
+            raise RuntimeError("model not found in local cache")
+        return SimpleNamespace(name=model_size_or_path)
+
+    monkeypatch.delenv("WHISPER_MODEL_SIZE", raising=False)
+    monkeypatch.setattr("faster_whisper.WhisperModel", fake_whisper_model)
+
+    processor = AudioProcessor()
+    model = processor._get_model()
+
+    assert len(calls) == 2
+    assert calls[0]["local_files_only"] is True
+    assert "local_files_only" not in calls[1]
+    assert calls[1] == {"model_size_or_path": "base", "device": "cpu", "compute_type": "int8"}
+    assert model.name == "base"
+
+    # The resolved model is cached: a second call must not re-instantiate it.
+    assert processor._get_model() is model
+    assert len(calls) == 2
+
+
+def test_get_model_requests_the_model_size_baked_into_the_image(monkeypatch):
+    """The prod image bakes WHISPER_MODEL_SIZE; the runtime must ask for that same model."""
+    calls: list[dict] = []
+
+    def fake_whisper_model(model_size_or_path, **kwargs):
+        calls.append({"model_size_or_path": model_size_or_path, **kwargs})
+        return SimpleNamespace(name=model_size_or_path)
+
+    monkeypatch.setenv("WHISPER_MODEL_SIZE", "small")
+    monkeypatch.setattr("faster_whisper.WhisperModel", fake_whisper_model)
+
+    model = AudioProcessor()._get_model()
+
+    assert [call["model_size_or_path"] for call in calls] == ["small"]
+    assert model.name == "small"

--- a/docs/FEATURES.html
+++ b/docs/FEATURES.html
@@ -613,7 +613,10 @@
     <p>
       <code>AudioProcessor</code> converts spoken content to timestamped Markdown transcripts.
       Video files have their audio track extracted first; the intermediate WAV is deleted on
-      completion. The Whisper model is loaded lazily on first use.
+      completion. The Whisper model is loaded lazily on first use, local cache first, so an
+      air-gapped runtime never reaches the network: the prod image bakes
+      <code>Systran/faster-whisper-base</code> into its Hugging Face hub cache at build time
+      (<code>WHISPER_MODEL_SIZE=base</code>).
     </p>
     <table>
       <thead>
@@ -622,9 +625,9 @@
       <tbody>
         <tr><td>Engine</td><td><code>faster-whisper</code> ≥ 1.1.0</td></tr>
         <tr><td>Video demux</td><td><code>PyAV</code> ≥ 14.0.0 — resamples to 16 kHz mono WAV</td></tr>
-        <tr><td>Default model</td><td><code>base</code> (configurable via <code>audio_model.whisper_model_size</code>)</td></tr>
-        <tr><td>Device</td><td><code>cpu</code> default; <code>cuda</code> supported (configurable via <code>audio_model.device</code>)</td></tr>
-        <tr><td>Language</td><td>Auto-detected; overridable via <code>audio_model.language</code></td></tr>
+        <tr><td>Model</td><td><code>base</code> — set by <code>WHISPER_MODEL_SIZE</code>, which the prod image also uses to bake the model at build time. The <code>audio_model</code> YAML block is not read by the backend today.</td></tr>
+        <tr><td>Device</td><td><code>cpu</code> — fixed</td></tr>
+        <tr><td>Language</td><td>Auto-detected; overridable per request (dictation passes a language hint)</td></tr>
         <tr><td>Output</td><td>Markdown with <code>[HH:MM:SS]</code> timestamp per segment, detected language, total duration</td></tr>
         <tr><td>Beam size</td><td>5 (Whisper default)</td></tr>
       </tbody>
@@ -1358,7 +1361,7 @@
         <tr><td>Secrets / env</td><td><code>ENV_FILE</code></td><td>Database passwords, API keys, Keycloak secrets</td></tr>
         <tr><td>Deployment config</td><td><code>CONFIG_FILE</code> (YAML)</td><td>Base URL, ingress prefix, runtime catalog sources, processing profiles, log level, metrics config</td></tr>
         <tr><td>Processing profiles</td><td><code>configuration.yaml → processing.profiles</code></td><td>PDF engine, OCR settings, chunk size, input processor registry per suffix</td></tr>
-        <tr><td>Audio config</td><td><code>configuration.yaml → audio_model</code></td><td>Whisper model size, device (cpu/cuda), language override</td></tr>
+        <tr><td>Audio / dictation</td><td><code>WHISPER_MODEL_SIZE</code> (set in <code>dockerfiles/Dockerfile-prod</code>)</td><td>Whisper model, baked into the image at build time and requested at runtime (default <code>base</code>, cpu). No runtime YAML knob.</td></tr>
       </tbody>
     </table>
 

--- a/docs/swift/platform/PROCESSING_GUIDE.md
+++ b/docs/swift/platform/PROCESSING_GUIDE.md
@@ -165,6 +165,17 @@ Additional runtime/model dependencies:
 
 - Keep tiktoken/crossencoder pre-download steps in image build when running without internet
 
+7. Audio transcription and chat dictation need no extra offline setup
+
+- The Whisper model (`Systran/faster-whisper-base`) is pre-baked into the
+  knowledge-flow prod image Hugging Face hub cache at build time
+  (`WHISPER_MODEL_SIZE=base` in `dockerfiles/Dockerfile-prod`)
+- `AudioProcessor` requests the same `WHISPER_MODEL_SIZE` at runtime and loads it
+  with `local_files_only=True` first, so an air-gapped runtime
+  (`HF_HUB_OFFLINE=1`) never reaches the network for a model it already has
+- The hub-download fallback only runs when that local load fails; under
+  `HF_HUB_OFFLINE=1` it fails fast rather than hanging on the network
+
 ---
 
 ## 8) Recommended Configuration Snippets


### PR DESCRIPTION
## Problem

Chat dictation (voice input) does not work offline. The knowledge-flow prod image bakes tiktoken, the CrossEncoder reranker and the docling/PaddleOCR models, but never the Whisper model - and it sets `HF_HUB_OFFLINE=1`. On a stock image, the first dictation request makes faster-whisper try to download `Systran/faster-whisper-base` from the Hugging Face hub, which the offline policy blocks.

## Fix

- **Bake the model at build time.** `dockerfiles/Dockerfile-prod` now calls `faster_whisper.download_model` right after the CrossEncoder warm-up and before `ENV HF_HUB_OFFLINE`. It uses the same `huggingface_hub` snapshot download into `HF_HUB_CACHE` as the runtime, so the runtime cache hit is exact. No new build-arg, so `Build-and-push-docker.yml` is untouched. `Dockerfile-dev` is untouched.
- **Never fetch when the model is present locally.** `AudioProcessor._get_model()` loads with `local_files_only=True` first and only falls back to a hub download when that load fails - same offline-first idiom as the CrossEncoder path in `application_context.py`. The fallback logs the real exception rather than asserting a cache miss, since a bad device or a corrupt snapshot lands there too.
- **One source of truth for the model size.** `WHISPER_MODEL_SIZE=base` drives both the build-time bake and the runtime request, so editing the Dockerfile cannot leave the runtime asking for a model that was never baked.
- **Docs.** `PROCESSING_GUIDE.md` §7 (air-gapped hardening checklist) gains an audio/dictation item. `FEATURES.html` drops the false claim that `audio_model.whisper_model_size` / `.device` / `.language` are configurable - that YAML block is never read (`Configuration` uses pydantic's default `extra=ignore`, so `model_extra` is always `None`), and now points at `WHISPER_MODEL_SIZE` instead.

## Verification

- `make code-quality` in `apps/knowledge-flow-backend`: clean (ruff, format, bandit, detect-secrets, basedpyright 0 errors).
- `make test` in `apps/knowledge-flow-backend`: **946 passed, 27 deselected**. 3 of those are new, in `tests/processors/input/audio_processor/test_audio_processor_model_loading.py`: local-cache-first, download fallback plus instance caching, and the baked-model-size contract.
- The `download_model("base")` one-liner was run locally against the installed faster-whisper 1.2.1 and resolves to `~/.cache/huggingface/hub/models--Systran--faster-whisper-base/...`.

**Pending manual step (not run here - too heavy for CI-less local verification):** build `dockerfiles/Dockerfile-prod` and start a container with `--network none`, then hit `POST /knowledge-flow/v1/audio/transcriptions` and confirm the transcription succeeds. Expected image delta is roughly +145 MB.

Closes #2406
