### PR TITLE
fix(#2408): Prevent agent capability-activation if default tool capabilities are not activated for the targeted team

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/capabilities/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/schemas.py
@@ -96,6 +96,17 @@ class CapabilityEnablementItem(BaseModel):
             " (provider, name) pair (OBSERV-02 v3, RFC §8.7)."
         ),
     )
+    default_capability_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            'For a `kind="agent"` row: the template\'s default tool/MCP '
+            "capability ids (RFC §8.6 `depends_on` gate, GitHub #2004 item 5). "
+            "Enabling the agent for a team 409s unless each of these is "
+            "already usable by that team - exposed so the admin UI can "
+            "disable the grant up front and explain why (GitHub #2408). "
+            'Always empty for `kind="tool"`/`"model"`.'
+        ),
+    )
     suspended_instances: int = Field(
         default=0,
         description=(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -247,10 +247,6 @@ async def _build_enablement_item(
         personal_scope=personal_scope,
         team_settings_fields=list(entry.team_settings_fields),
         kind=entry.kind,
-        # #2408: the `depends_on` gate the enable/personal-scope writes enforce
-        # (RFC §8.6) was invisible to the admin UI, which offered "Enable" for
-        # an agent whose tools the team lacks and then took a bare 409. Carried
-        # verbatim; empty for every kind but "agent" by construction.
         default_capability_ids=list(entry.default_capability_ids),
         suspended_instances=entry_impact.suspended_instances if entry_impact else 0,
         health_unknown_instances=(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -247,6 +247,11 @@ async def _build_enablement_item(
         personal_scope=personal_scope,
         team_settings_fields=list(entry.team_settings_fields),
         kind=entry.kind,
+        # #2408: the `depends_on` gate the enable/personal-scope writes enforce
+        # (RFC §8.6) was invisible to the admin UI, which offered "Enable" for
+        # an agent whose tools the team lacks and then took a bare 409. Carried
+        # verbatim; empty for every kind but "agent" by construction.
+        default_capability_ids=list(entry.default_capability_ids),
         suspended_instances=entry_impact.suspended_instances if entry_impact else 0,
         health_unknown_instances=(
             entry_impact.skipped_unreachable if entry_impact else 0

--- a/apps/control-plane-backend/tests/test_capability_enablement_1980.py
+++ b/apps/control-plane-backend/tests/test_capability_enablement_1980.py
@@ -2705,3 +2705,62 @@ async def test_aggregate_list_derives_personal_scope(
         deps=deps,  # type: ignore[arg-type]
     )
     assert result.items[0].personal_scope == expected
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_surfaces_agent_default_capability_ids(
+    monkeypatch,
+) -> None:
+    """#2408: the `depends_on` gate must be visible to the admin UI.
+
+    `PUT /admin/capabilities/{id}/teams/{team_id}` 409s for a `kind="agent"`
+    entry whose `default_capability_ids` aren't all usable by the team (RFC
+    §8.6). The list contract used to hide those ids, so the dashboard offered
+    "Enable" and took the 409 blind. Projected verbatim here, and empty for a
+    tool row — the per-kind emptiness IS the contract (`CapabilityCatalogEntry`
+    is a tagged union in practice).
+    """
+
+    from types import SimpleNamespace
+
+    from control_plane_backend.capabilities import service as capability_service
+
+    rebac = _FakeRebac()
+
+    async def _fake_catalog(_deps):
+        return {
+            "sentinel": _entry(
+                "sentinel",
+                kind="agent",
+                default_capability_ids=("mcp-knowledge-flow-mcp-tabular",),
+            ),
+            "mcp-knowledge-flow-mcp-tabular": _entry("mcp-knowledge-flow-mcp-tabular"),
+        }
+
+    async def _fake_count(_team_deps):
+        return 3
+
+    monkeypatch.setattr(
+        capability_service, "aggregate_capability_catalog", _fake_catalog
+    )
+    monkeypatch.setattr(
+        capability_service, "count_all_collaborative_teams", _fake_count
+    )
+    monkeypatch.setattr(capability_service, "count_all_personal_spaces", _fake_count)
+
+    deps = SimpleNamespace(
+        team_dependencies=SimpleNamespace(rebac=rebac),
+        get_agent_instance_store=lambda: _FakeAgentInstanceStore([]),
+        get_model_reasoning_store=_NoReasoningEnabledStore,
+    )
+    result = await capability_service.list_capability_enablement(
+        user=SimpleNamespace(uid="admin"),  # type: ignore[arg-type]
+        deps=deps,  # type: ignore[arg-type]
+    )
+
+    by_id = {item.id: item for item in result.items}
+    assert by_id["sentinel"].default_capability_ids == [
+        "mcp-knowledge-flow-mcp-tabular"
+    ]
+    # A tool has no defaults by construction — the UI must not gate on it.
+    assert by_id["mcp-knowledge-flow-mcp-tabular"].default_capability_ids == []

--- a/apps/fred-agents/fred_agents/deep_assistant.py
+++ b/apps/fred-agents/fred_agents/deep_assistant.py
@@ -45,10 +45,8 @@ Example:
 """
 
 from fred_sdk import (
-    MCP_SERVER_KNOWLEDGE_FLOW_CORPUS,
-    MCP_SERVER_KNOWLEDGE_FLOW_OPENSEARCH_OPS,
-    MCP_SERVER_KNOWLEDGE_FLOW_PROMETHEUS_OPS,
     MCP_SERVER_KNOWLEDGE_FLOW_TABULAR,
+    MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
     FieldSpec,
     MCPServerRef,
     UIHints,
@@ -121,15 +119,14 @@ class DeepAssistantDefinition(DeepAgentDefinition):
     tags: tuple[str, ...] = ("general", "deep")
     system_prompt_template: str = _SYSTEM_PROMPT_EN
 
-    # Same read/query-oriented defaults as GENERAL_ASSISTANT_AGENT, minus
-    # MCP_SERVER_KNOWLEDGE_FLOW_FS — see module docstring.
+    # Same slim end-user defaults as GENERAL_ASSISTANT_AGENT (#2429): document
+    # search + tabular analysis - see that template's comment for the full
+    # rationale (admin/ops servers out, #2408 dependency gate, text-search
+    # server over the `document_access` pilot). Filesystem stays excluded -
+    # see module docstring.
     default_mcp_servers: tuple[MCPServerRef, ...] = (
-        MCPServerRef(id="document_access"),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_CORPUS),
+        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TABULAR),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_OPENSEARCH_OPS),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_PROMETHEUS_OPS),
-        MCPServerRef(id="mcp-web-github-readonly"),
     )
 
     fields: tuple[FieldSpec, ...] = (

--- a/apps/fred-agents/fred_agents/deep_assistant.py
+++ b/apps/fred-agents/fred_agents/deep_assistant.py
@@ -125,6 +125,12 @@ class DeepAssistantDefinition(DeepAgentDefinition):
     default_mcp_servers: tuple[MCPServerRef, ...] = (
         MCPServerRef(id="document_access"),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TABULAR),
+        # Removed from the prod defaults (#2429) - uncomment to restore (and
+        # re-import the constants from fred_sdk):
+        # MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_CORPUS),
+        # MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_OPENSEARCH_OPS),
+        # MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_PROMETHEUS_OPS),
+        # MCPServerRef(id="mcp-web-github-readonly"),
     )
 
     fields: tuple[FieldSpec, ...] = (

--- a/apps/fred-agents/fred_agents/deep_assistant.py
+++ b/apps/fred-agents/fred_agents/deep_assistant.py
@@ -46,7 +46,6 @@ Example:
 
 from fred_sdk import (
     MCP_SERVER_KNOWLEDGE_FLOW_TABULAR,
-    MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
     FieldSpec,
     MCPServerRef,
     UIHints,
@@ -120,12 +119,11 @@ class DeepAssistantDefinition(DeepAgentDefinition):
     system_prompt_template: str = _SYSTEM_PROMPT_EN
 
     # Same slim end-user defaults as GENERAL_ASSISTANT_AGENT (#2429): document
-    # search + tabular analysis - see that template's comment for the full
-    # rationale (admin/ops servers out, #2408 dependency gate, text-search
-    # server over the `document_access` pilot). Filesystem stays excluded -
-    # see module docstring.
+    # search (the `document_access` #1906 pilot) + tabular analysis - see that
+    # template's comment for the full rationale (admin/ops servers out, #2408
+    # dependency gate). Filesystem stays excluded - see module docstring.
     default_mcp_servers: tuple[MCPServerRef, ...] = (
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
+        MCPServerRef(id="document_access"),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TABULAR),
     )
 

--- a/apps/fred-agents/fred_agents/general_assistant.py
+++ b/apps/fred-agents/fred_agents/general_assistant.py
@@ -43,7 +43,6 @@ Example:
 
 from fred_sdk import (
     MCP_SERVER_KNOWLEDGE_FLOW_TABULAR,
-    MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
     FieldSpec,
     MCPServerRef,
     UIHints,
@@ -137,17 +136,18 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
     # every listed server to be usable by that team. Operators who need one of
     # the removed servers add it per instance via the control-plane agent form.
     #
-    # Document search: the proven `mcp-knowledge-flow-mcp-text` server rather
-    # than the `document_access` native pilot (#1906) - a production default
-    # must not ride an A/B arm; the pilot stays selectable per instance. Never
-    # select both on one instance (duplicate vector-search tool, see
+    # Document search: `document_access` (native, #1906 pilot) rather than the
+    # legacy inprocess `mcp-knowledge-flow-mcp-text` - the forward path under
+    # live A/B evaluation against `react_rag_mcp`, which stays on the legacy
+    # capability on purpose as the comparison baseline. Do not select both on
+    # one instance (duplicate vector-search tool, see
     # `document_access/capability.py`'s module docstring).
     #
     # Filesystem (`mcp-knowledge-flow-fs`) is deliberately excluded: the /fs
     # boundary is not agent/team-scoped yet (AGENT-FILESYSTEM-HARDENING-RFC F1,
     # #2334) - same stance as `deep_assistant`. Do not re-add until that lands.
     default_mcp_servers: tuple[MCPServerRef, ...] = (
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
+        MCPServerRef(id="document_access"),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TABULAR),
     )
 

--- a/apps/fred-agents/fred_agents/general_assistant.py
+++ b/apps/fred-agents/fred_agents/general_assistant.py
@@ -149,6 +149,12 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
     default_mcp_servers: tuple[MCPServerRef, ...] = (
         MCPServerRef(id="document_access"),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TABULAR),
+        # Removed from the prod defaults (#2429) - uncomment to restore (and
+        # re-import the constants from fred_sdk):
+        # MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_CORPUS),
+        # MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_OPENSEARCH_OPS),
+        # MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_PROMETHEUS_OPS),
+        # MCPServerRef(id="mcp-web-github-readonly"),
     )
 
     fields: tuple[FieldSpec, ...] = (

--- a/apps/fred-agents/fred_agents/general_assistant.py
+++ b/apps/fred-agents/fred_agents/general_assistant.py
@@ -22,10 +22,10 @@ Why this module exists:
   `general_assistant` (all KF MCP servers by default), which was confusing
 
 Key design:
-- declares its core capabilities in `default_mcp_servers` (MCP-backed and
-  native alike, RFC §2) so the Tools tab in the enrollment form shows every
-  available one
-- all of them are active by default (selected_capability_ids = null → the
+- declares a slim, end-user default set in `default_mcp_servers` (document
+  search + tabular analysis, #2429); admin/ops servers are added per instance
+  via the control-plane agent form, never by default
+- all defaults are active by default (selected_capability_ids = null → the
   template's default capabilities, #1978, #1988); each is a capability the
   operator unchecks in the Tools tab when not needed
 - one `prompts.system` field lets operators specialise the role without creating
@@ -42,10 +42,8 @@ Example:
 """
 
 from fred_sdk import (
-    MCP_SERVER_KNOWLEDGE_FLOW_CORPUS,
-    MCP_SERVER_KNOWLEDGE_FLOW_OPENSEARCH_OPS,
-    MCP_SERVER_KNOWLEDGE_FLOW_PROMETHEUS_OPS,
     MCP_SERVER_KNOWLEDGE_FLOW_TABULAR,
+    MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
     FieldSpec,
     MCPServerRef,
     UIHints,
@@ -90,10 +88,10 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
 
     Why this class exists:
     - single entry point for operators who want to build a custom agent from
-      scratch: they see every available capability, pick what they need, and
-      write their own system prompt
-    - exposes its core capabilities so the Tools tab is fully populated at
-      enrollment time without requiring any code change
+      scratch: they pick the capabilities they need and write their own
+      system prompt
+    - ships end-user defaults only (document search + tabular, #2429); the
+      Tools tab lets operators add or remove capabilities per instance
 
     Key design choices:
     - `default_mcp_servers` lists this template's default capabilities, MCP-backed
@@ -131,30 +129,26 @@ class GeneralAssistantDefinition(ReActAgentDefinition):
     tags: tuple[str, ...] = ("general", "react")
     system_prompt_template: str = _SYSTEM_PROMPT
 
-    # Core capabilities that are part of the standard platform deployment —
-    # MCP-backed and native alike (RFC §2, no distinction at this level).
-    # Demo servers are omitted here because they are not guaranteed to be
-    # running — an unreachable declared server crashes the agent turn.
-    # Operators who have those services running should create a custom
-    # instance and add them via the control-plane agent form.
+    # End-user capabilities only (#2429): document search and tabular analysis.
+    # Admin/ops servers (corpus administration, OpenSearch and Prometheus
+    # monitoring, GitHub read-only) are too technical for the production
+    # deployments this blank-slate template lands on, and each default also
+    # feeds the #2408 dependency gate - enabling this agent for a team requires
+    # every listed server to be usable by that team. Operators who need one of
+    # the removed servers add it per instance via the control-plane agent form.
     #
-    # Document search: `document_access` (native, #1906 pilot) rather than the
-    # legacy inprocess `mcp-knowledge-flow-mcp-text` — this is the forward path
-    # under live A/B evaluation against `react_rag_mcp`, which stays on the
-    # legacy capability on purpose as the comparison baseline. Do not select
-    # both on one instance (duplicate vector-search tool, see
+    # Document search: the proven `mcp-knowledge-flow-mcp-text` server rather
+    # than the `document_access` native pilot (#1906) - a production default
+    # must not ride an A/B arm; the pilot stays selectable per instance. Never
+    # select both on one instance (duplicate vector-search tool, see
     # `document_access/capability.py`'s module docstring).
     #
     # Filesystem (`mcp-knowledge-flow-fs`) is deliberately excluded: the /fs
     # boundary is not agent/team-scoped yet (AGENT-FILESYSTEM-HARDENING-RFC F1,
-    # #2334) — same stance as `deep_assistant`. Do not re-add until that lands.
+    # #2334) - same stance as `deep_assistant`. Do not re-add until that lands.
     default_mcp_servers: tuple[MCPServerRef, ...] = (
-        MCPServerRef(id="document_access"),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_CORPUS),
+        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TABULAR),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_OPENSEARCH_OPS),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_PROMETHEUS_OPS),
-        MCPServerRef(id="mcp-web-github-readonly"),
     )
 
     fields: tuple[FieldSpec, ...] = (

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1098,6 +1098,8 @@
           "defaultSuspendedToast": "{{team}} now follows the platform default — {{count}} instance(s) suspended.",
           "defaultError": "Could not reset the feature to the platform default.",
           "rowControlAria": "Access for {{team}}",
+          "dependencyHint": "Requires {{deps}} to be enabled for this team first.",
+          "dependencyConflict": "This agent needs {{deps}} enabled for this team first.",
           "personal": {
             "label": "All personal spaces",
             "hint": "Applies to every user's personal space at once — past, future, and users who never log in.",
@@ -1108,9 +1110,13 @@
             "disableError": "Could not disable the feature for personal spaces.",
             "defaultToast": "Personal spaces now follow the platform default.",
             "defaultSuspendedToast": "Personal spaces now follow the platform default — {{count}} instance(s) suspended.",
-            "defaultError": "Could not reset the personal-space default."
+            "defaultError": "Could not reset the personal-space default.",
+            "dependencyHint": "Requires {{deps}} to be enabled for all personal spaces (or on by default) first.",
+            "dependencyConflict": "This agent needs {{deps}} enabled for all personal spaces (or on by default) first."
           }
         },
+        "defaultOnRequiresSettingsHint": "This feature has required team settings, so it cannot be on by default - enable it team by team instead.",
+        "defaultOnConflict": "This feature has required team settings, so it cannot be on by default. Enable it team by team instead.",
         "defaultOffReasoningToast": "Reasoning was switched off with the model. Re-enable the model, then reasoning, to bring it back.",
         "reasoningHint": "Whether this model runs with reasoning enabled, for every team. Separate from access: enabling a model does not enable its reasoning — but disabling the model switches its reasoning off.",
         "reasoningOffToast": "Reasoning disabled for this model.",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1098,6 +1098,8 @@
           "defaultSuspendedToast": "{{team}} suit désormais le défaut de la plateforme — {{count}} instance(s) suspendue(s).",
           "defaultError": "Impossible de remettre la fonctionnalité au défaut de la plateforme.",
           "rowControlAria": "Accès pour {{team}}",
+          "dependencyHint": "Nécessite d'abord l'activation de {{deps}} pour cette équipe.",
+          "dependencyConflict": "Cet agent nécessite d'abord l'activation de {{deps}} pour cette équipe.",
           "personal": {
             "label": "Tous les espaces personnels",
             "hint": "S'applique d'un coup à l'espace personnel de chaque utilisateur — passés, futurs, et ceux qui ne se connectent jamais.",
@@ -1108,9 +1110,13 @@
             "disableError": "Impossible de désactiver la fonctionnalité pour les espaces personnels.",
             "defaultToast": "Les espaces personnels suivent désormais le défaut de la plateforme.",
             "defaultSuspendedToast": "Les espaces personnels suivent désormais le défaut de la plateforme — {{count}} instance(s) suspendue(s).",
-            "defaultError": "Impossible de remettre le défaut des espaces personnels."
+            "defaultError": "Impossible de remettre le défaut des espaces personnels.",
+            "dependencyHint": "Nécessite d'abord l'activation de {{deps}} pour tous les espaces personnels (ou par défaut).",
+            "dependencyConflict": "Cet agent nécessite d'abord l'activation de {{deps}} pour tous les espaces personnels (ou par défaut)."
           }
         },
+        "defaultOnRequiresSettingsHint": "Cette fonctionnalité a des réglages d'équipe obligatoires : elle ne peut pas être activée par défaut. Activez-la équipe par équipe.",
+        "defaultOnConflict": "Cette fonctionnalité a des réglages d'équipe obligatoires : elle ne peut pas être activée par défaut. Activez-la équipe par équipe.",
         "defaultOffReasoningToast": "Le raisonnement a été désactivé avec le modèle. Réactivez le modèle, puis le raisonnement, pour le rétablir.",
         "reasoningHint": "Indique si ce modèle s'exécute avec le raisonnement activé, pour toutes les équipes. Indépendant de l'accès : activer un modèle n'active pas son raisonnement — mais désactiver le modèle éteint son raisonnement.",
         "reasoningOffToast": "Raisonnement désactivé pour ce modèle.",

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.test.tsx
@@ -27,6 +27,11 @@ const h = vi.hoisted(() => ({
     isError: boolean;
   },
   allTeams: { data: [] as Team[], isLoading: false, isError: false },
+  // Every key `t` was asked for during the last render. Needed for hints that
+  // live in a `Tooltip`: its panel is portaled and only mounts once hovered, so
+  // `renderToStaticMarkup` (no effects, no DOM) never contains the hint text —
+  // the key request is the only observable signal that the hint was wired up.
+  tKeys: [] as string[],
 }));
 
 // `t` echoes its key, but appends an interpolated `count` (or the composed
@@ -36,6 +41,7 @@ const h = vi.hoisted(() => ({
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: { defaultValue?: string; count?: number; content?: string }) => {
+      h.tKeys.push(key);
       const interpolated = opts?.count ?? opts?.content;
       return opts?.defaultValue ?? (interpolated === undefined ? key : `${key}:${interpolated}`);
     },
@@ -93,6 +99,7 @@ function cap(over: Partial<CapabilityEnablementItem> & Pick<CapabilityEnablement
 }
 
 function render(): string {
+  h.tKeys = [];
   return renderToStaticMarkup(<CapabilitiesPage />);
 }
 
@@ -140,6 +147,16 @@ describe("CapabilitiesPage team registry wiring", () => {
     h.allTeams = { data: registryTeams, isLoading: false, isError: false };
     render();
     expect(drawerProps.current).toMatchObject({ teams: registryTeams });
+  });
+
+  it("passes the FULL catalog to the drawer, not the kind-filtered view", () => {
+    // #2408: an agent's `default_capability_ids` name TOOL rows, which the
+    // Agents tab has filtered out — the drawer cannot evaluate the dependency
+    // gate unless it receives the unfiltered list.
+    const items = [cap({ id: "sentinel", kind: "agent" }), cap({ id: "web_search", kind: "tool" })];
+    h.list = { data: { items }, isLoading: false, isError: false };
+    render();
+    expect(drawerProps.current).toMatchObject({ allCapabilities: items });
   });
 
   it("forwards the registry's loading and error flags to the drawer", () => {
@@ -327,6 +344,67 @@ describe("CapabilitiesPage catalog rows", () => {
       isError: false,
     };
     expect(render()).toContain("checked");
+  });
+});
+
+// Regression coverage for #2408: the default-on switch was offered for a
+// capability with a required team setting, which the backend always refuses
+// (`DefaultOnNotAllowed`, HTTP 409) — nobody has filled the settings for the
+// teams that would inherit it (RFC §8.2).
+describe("CapabilitiesPage default-on gate for required team settings (#2408)", () => {
+  const REQUIRED_FIELD = { key: "endpoint", type: "url" as const, title: "Endpoint", required: true };
+
+  /** The default-on column is the first cell, so its Switch is the first input. */
+  function defaultOnInput(html: string): string {
+    return html.split("<input").slice(1)[0] ?? "";
+  }
+
+  it("disables the switch and offers the hint when a required setting blocks default-on", () => {
+    h.list = {
+      data: { items: [cap({ id: "corp_drive", default_on: false, team_settings_fields: [REQUIRED_FIELD] })] },
+      isLoading: false,
+      isError: false,
+    };
+    const html = render();
+
+    expect(defaultOnInput(html)).toContain("disabled");
+    // The hint lives in a portaled Tooltip panel that only mounts on hover, so
+    // the requested key — not rendered text — is what proves it was wired up.
+    expect(h.tKeys).toContain("rework.admin.capabilities.defaultOnRequiresSettingsHint");
+  });
+
+  it("leaves the switch usable for an already-default-on capability, so it can be turned back OFF", () => {
+    // Settings can be made required after the fact; trapping such a row in
+    // default-on would be a worse bug than the 409 this gate prevents.
+    h.list = {
+      data: { items: [cap({ id: "corp_drive", default_on: true, team_settings_fields: [REQUIRED_FIELD] })] },
+      isLoading: false,
+      isError: false,
+    };
+    const html = render();
+
+    expect(defaultOnInput(html)).not.toContain("disabled");
+    expect(h.tKeys).not.toContain("rework.admin.capabilities.defaultOnRequiresSettingsHint");
+  });
+
+  it("leaves the switch usable when every team setting is optional", () => {
+    h.list = {
+      data: {
+        items: [
+          cap({
+            id: "corp_drive",
+            default_on: false,
+            team_settings_fields: [{ key: "note", type: "string", title: "Note" }],
+          }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    };
+    const html = render();
+
+    expect(defaultOnInput(html)).not.toContain("disabled");
+    expect(h.tKeys).not.toContain("rework.admin.capabilities.defaultOnRequiresSettingsHint");
   });
 });
 

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilitiesPage.tsx
@@ -43,11 +43,13 @@ import styles from "./CapabilitiesPage.module.css";
 import { CapabilityTeamMatrixDrawer } from "./CapabilityTeamMatrixDrawer.tsx";
 import { PlatformModelBindingsPanel } from "./PlatformModelBindingsPanel/PlatformModelBindingsPanel.tsx";
 import { SuspendedInstancesDrawer } from "./SuspendedInstancesDrawer.tsx";
+import { normalizeApiError } from "../../../../core/errors/normalizeApiError";
 import {
   enabledTeamCount,
   hasReasoningControl,
   isCapabilityUnused as isUnused,
   personalSpaceCount,
+  requiresTeamSettings,
 } from "./capabilityEnablement";
 
 // "tool" (MCP servers, etc.) vs "agent" (a control-plane-side projection of
@@ -154,8 +156,17 @@ export default function CapabilitiesPage() {
       if (result.reasoning_disabled) {
         showWarn({ summary: t("rework.admin.capabilities.defaultOffReasoningToast") });
       }
-    } catch {
-      showError({ summary: t("rework.admin.capabilities.defaultToggleError") });
+    } catch (error) {
+      // The one reachable 409 here is DefaultOnNotAllowed: a capability with a
+      // required team setting can never be on by default (#2408). The switch is
+      // already disabled for that case, so reaching this branch means a stale
+      // client — explain it rather than showing "could not change" (the
+      // backend's own sentence is the fallback for anything else).
+      const normalized = normalizeApiError(error);
+      showError({
+        summary: t("rework.admin.capabilities.defaultToggleError"),
+        detail: normalized.kind === "conflict" ? t("rework.admin.capabilities.defaultOnConflict") : normalized.detail,
+      });
     } finally {
       inFlightDefaultOnIdRef.current = null;
       setTogglingCapabilityId(null);
@@ -178,8 +189,11 @@ export default function CapabilitiesPage() {
           nextValue ? "rework.admin.capabilities.reasoningOnToast" : "rework.admin.capabilities.reasoningOffToast",
         ),
       });
-    } catch {
-      showError({ summary: t("rework.admin.capabilities.reasoningToggleError") });
+    } catch (error) {
+      showError({
+        summary: t("rework.admin.capabilities.reasoningToggleError"),
+        detail: normalizeApiError(error).detail,
+      });
     } finally {
       inFlightReasoningIdRef.current = null;
       setTogglingReasoningId(null);
@@ -261,16 +275,40 @@ export default function CapabilitiesPage() {
     {
       label: t("rework.admin.capabilities.col.defaultOn"),
       size: "1fr",
-      cellRenderer: (cap) => (
-        <div className={styles.centered}>
+      cellRenderer: (cap) => {
+        // §8.2: a capability with a REQUIRED team setting can never be on by
+        // default — nobody has filled the settings for the teams that would
+        // inherit it, so the write 409s (`DefaultOnNotAllowed`). Turning it
+        // OFF stays possible, hence the `!cap.default_on` guard: a row that is
+        // already default-on (settings added after the fact) must not be
+        // trapped in that state.
+        //
+        // This flips only when `default_on` itself does, i.e. on the
+        // turn-OFF path — which runs through the confirmation dialog, so the
+        // Switch does not hold focus when the cell re-renders (the dialog
+        // restores focus to nothing on close). That is why the swap between
+        // the wrapped and bare control cannot reintroduce the Chromium
+        // focus-yank bug documented above; it is not because `blockedOn` is
+        // constant, which it isn't.
+        const blockedOn = !cap.default_on && requiresTeamSettings(cap);
+        const control = (
           <Switch
             checked={cap.default_on}
-            disabled={isTogglingDefault && togglingCapabilityId !== cap.id}
+            disabled={blockedOn || (isTogglingDefault && togglingCapabilityId !== cap.id)}
             onChange={() => onToggleDefault(cap)}
             aria-label={t("rework.admin.capabilities.col.defaultOn")}
           />
-        </div>
-      ),
+        );
+        return (
+          <div className={styles.centered}>
+            {blockedOn ? (
+              <Tooltip text={t("rework.admin.capabilities.defaultOnRequiresSettingsHint")}>{control}</Tooltip>
+            ) : (
+              control
+            )}
+          </div>
+        );
+      },
     },
     {
       label: t("rework.admin.capabilities.col.capability"),
@@ -488,6 +526,9 @@ export default function CapabilitiesPage() {
 
       <CapabilityTeamMatrixDrawer
         capability={matrixCapability}
+        // The FULL catalog, not the kind-filtered `capabilities`: an agent's
+        // dependencies are tool rows the Agents tab has filtered out (#2408).
+        allCapabilities={allCapabilities}
         teams={teams}
         teamsLoading={isTeamsLoading}
         teamsError={isTeamsError}

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.module.css
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.module.css
@@ -58,9 +58,18 @@
 
 .teamMain {
   display: flex;
-  align-items: center;
-  gap: var(--spacing-s);
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
+}
+
+/* Why a control on this row is unavailable (#2408) — the agent's default tool
+ * capabilities aren't usable by this team / by personal spaces yet, so the
+ * backend would 409 the grant. Warning-toned rather than retreat-grey: it is
+ * an actionable blocker, not ambient help text like `.personalSub`. */
+.blockedSub {
+  color: var(--warning);
+  font: var(--font-body-small);
 }
 
 /* The synthetic "All personal spaces" row (RFC §8.4): a class control, not a

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.test.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.test.tsx
@@ -30,9 +30,14 @@ import { CapabilityTeamMatrixDrawer } from "./CapabilityTeamMatrixDrawer";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: { defaultValue?: string; team?: string; count?: number }) =>
-      opts?.defaultValue ??
-      (opts?.team ? `${key}:${opts.team}` : opts?.count === undefined ? key : `${key}:${opts.count}`),
+    t: (key: string, opts?: { defaultValue?: string; team?: string; count?: number; deps?: string }) => {
+      if (opts?.defaultValue !== undefined) return opts.defaultValue;
+      // `deps` (the #2408 dependency hints) is echoed like `team`/`count`: the
+      // resolved dependency NAMES are what the assertions are about, and a
+      // bare key echo would hide whether they ever reached the label.
+      const interpolated = opts?.team ?? opts?.deps ?? opts?.count;
+      return interpolated === undefined ? key : `${key}:${interpolated}`;
+    },
     i18n: { language: "en" },
   }),
 }));
@@ -69,6 +74,7 @@ function render(props: Partial<ComponentProps<typeof CapabilityTeamMatrixDrawer>
   return renderToStaticMarkup(
     <CapabilityTeamMatrixDrawer
       capability={capability()}
+      allCapabilities={[]}
       teams={[]}
       teamsLoading={false}
       teamsError={false}
@@ -153,5 +159,96 @@ describe("CapabilityTeamMatrixDrawer tri-state controls", () => {
     expect(html).toContain("rework.admin.capabilities.matrix.disable");
     expect(html).toContain("rework.admin.capabilities.matrix.default");
     expect(html).toContain("rework.admin.capabilities.matrix.enable");
+  });
+});
+
+// Regression coverage for #2408: activating an agent whose default tool
+// capabilities the target team (or every personal space) cannot use yet was
+// offered freely and answered with a bare HTTP 409. The grant is now blocked
+// up front, and the row says which dependency is in the way.
+describe("CapabilityTeamMatrixDrawer agent dependency gate (#2408, RFC §8.6 depends_on)", () => {
+  const agent = capability({ id: "sentinel", name: "cap.sentinel", kind: "agent", default_capability_ids: ["dep"] });
+  const dep = (over: Partial<CapabilityEnablementItem> = {}) => capability({ id: "dep", name: "Tabular MCP", ...over });
+  const nb = [team("nb", "Nightly Build")];
+
+  const rows = (html: string) => html.split("<li ").slice(1);
+  const teamRow = (html: string) => rows(html).find((row) => !row.includes("_personalRow_")) ?? "";
+  const personalRow = (html: string) => rows(html).find((row) => row.includes("_personalRow_")) ?? "";
+  /** The row's three tri-state buttons, in CHOICES (disable/default/enable) order. */
+  const enableSegment = (rowHtml: string) => rowHtml.split("<button").slice(1, 4)[2] ?? "";
+
+  it("blocks Enable and names the dependency when the team cannot use it", () => {
+    const html = render({ capability: agent, allCapabilities: [agent, dep()], teams: nb });
+    const row = teamRow(html);
+    expect(row).toContain("rework.admin.capabilities.matrix.dependencyHint:Tabular MCP");
+    expect(enableSegment(row)).toContain("disabled");
+  });
+
+  it("offers Enable normally once the dependency is enabled for that team", () => {
+    const html = render({
+      capability: agent,
+      allCapabilities: [agent, dep({ enabled_team_ids: ["nb"] })],
+      teams: nb,
+    });
+    const row = teamRow(html);
+    expect(row).not.toContain("rework.admin.capabilities.matrix.dependencyHint");
+    expect(enableSegment(row)).not.toContain("disabled");
+  });
+
+  it("fails open when the dependency is not in the catalog list at all", () => {
+    // The backend stays the authority; blocking on a row we cannot evaluate
+    // would forbid a grant the server may well accept.
+    const html = render({ capability: agent, allCapabilities: [agent], teams: nb });
+    const row = teamRow(html);
+    expect(row).not.toContain("rework.admin.capabilities.matrix.dependencyHint");
+    expect(enableSegment(row)).not.toContain("disabled");
+  });
+
+  it("leaves an ordinary tool row untouched", () => {
+    const tool = capability({ id: "web_search" });
+    const html = render({ capability: tool, allCapabilities: [tool, dep()], teams: nb });
+    const row = teamRow(html);
+    expect(row).not.toContain("rework.admin.capabilities.matrix.dependencyHint");
+    expect(enableSegment(row)).not.toContain("disabled");
+  });
+
+  it("never disables the segment a team is already on, even with the dependency revoked", () => {
+    // A dependency CAN be revoked after the agent was granted. `ButtonGroup`
+    // gives only the selected item `tabIndex={0}`, so disabling it would strand
+    // the whole row for keyboard users — the admin could not even undo the
+    // now-broken grant. The stale "enable X first" hint is dropped with it.
+    const html = render({
+      capability: capability({ ...agent, enabled_team_ids: ["nb"] }),
+      allCapabilities: [agent, dep()],
+      teams: nb,
+    });
+    const row = teamRow(html);
+    expect(enableSegment(row)).not.toContain("disabled");
+    expect(row).not.toContain("rework.admin.capabilities.matrix.dependencyHint");
+  });
+
+  it("never disables the personal segment when the class is already enabled", () => {
+    const html = render({
+      capability: capability({ ...agent, personal_scope: "enabled" }),
+      allCapabilities: [agent, dep()],
+      teams: nb,
+    });
+    const row = personalRow(html);
+    expect(enableSegment(row)).not.toContain("disabled");
+    expect(row).not.toContain("rework.admin.capabilities.matrix.personal.dependencyHint");
+  });
+
+  it("blocks the personal-space class row when the dependency has no personal access", () => {
+    const html = render({ capability: agent, allCapabilities: [agent, dep()], teams: nb });
+    const row = personalRow(html);
+    expect(row).toContain("rework.admin.capabilities.matrix.personal.dependencyHint:Tabular MCP");
+    expect(enableSegment(row)).toContain("disabled");
+  });
+
+  it("offers the personal-space class row once the dependency is on by default", () => {
+    const html = render({ capability: agent, allCapabilities: [agent, dep({ default_on: true })], teams: nb });
+    const row = personalRow(html);
+    expect(row).not.toContain("rework.admin.capabilities.matrix.personal.dependencyHint");
+    expect(enableSegment(row)).not.toContain("disabled");
   });
 });

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.tsx
@@ -295,7 +295,9 @@ export function CapabilityTeamMatrixDrawer({
       // dependencies are missing when we can name them locally, otherwise pass
       // the backend's own sentence through instead of swallowing it (#2408).
       const normalized = normalizeApiError(err);
-      const missing = capability ? missingAgentDependenciesForTeam(capability, allCapabilities, teamId) : [];
+      // `capability` is non-null here: guarded at the top of `submitEnable`,
+      // and this closure's binding cannot change mid-invocation.
+      const missing = missingAgentDependenciesForTeam(capability, allCapabilities, teamId);
       const detail =
         normalized.kind === "conflict" && missing.length > 0
           ? t("rework.admin.capabilities.matrix.dependencyConflict", { deps: dependencyLabels(missing) })

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/CapabilityTeamMatrixDrawer.tsx
@@ -37,6 +37,7 @@ import {
   useEnableTeamCapabilityMutation,
   useSetCapabilityPersonalScopeMutation,
 } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
+import { normalizeApiError } from "../../../../core/errors/normalizeApiError";
 import { TuningFieldRenderer } from "../../TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx";
 import styles from "./CapabilityTeamMatrixDrawer.module.css";
 import {
@@ -45,6 +46,9 @@ import {
   excludePersonalTeams,
   filterTeamsByName,
   isCapabilityOnForTeam,
+  missingAgentDependenciesForPersonalSpaces,
+  missingAgentDependenciesForTeam,
+  requiresTeamSettings,
   seedSettingsFromFields,
   sortTeamsForMatrix,
   teamCapabilityChoice,
@@ -54,6 +58,11 @@ import {
 
 interface CapabilityTeamMatrixDrawerProps {
   capability: CapabilityEnablementItem | null;
+  /** The FULL unfiltered catalog, not the kind-filtered view: an agent's
+   * `default_capability_ids` name tool capabilities, which the Agents tab has
+   * already filtered out. Needed to tell whether each dependency is usable by
+   * the row's team before offering "Enable" (#2408). */
+  allCapabilities: CapabilityEnablementItem[];
   teams: Team[];
   /** `useListAllTeamsQuery` in flight — the roster isn't `teams.length === 0`, it's unknown yet. */
   teamsLoading: boolean;
@@ -107,6 +116,7 @@ const PERSONAL_TOAST_KEYS = {
 
 export function CapabilityTeamMatrixDrawer({
   capability,
+  allCapabilities,
   teams,
   teamsLoading,
   teamsError,
@@ -201,7 +211,23 @@ export function CapabilityTeamMatrixDrawer({
   const hasSettings = fields.length > 0;
   // A capability with a REQUIRED team setting cannot be class-enabled for all
   // personal spaces (nobody filled the settings) — same §8.2 rule as default-on.
-  const requiresSettings = fields.some((field) => field.required);
+  const requiresSettings = capability ? requiresTeamSettings(capability) : false;
+
+  // Dependency ids are opaque; the hint has to name what the admin actually
+  // sees in the catalog. Falls back to the raw id for a dependency the list
+  // doesn't carry — the same fail-open direction the predicates take.
+  const dependencyLabels = (ids: string[]) =>
+    ids
+      .map((depId) => {
+        const dep = allCapabilities.find((candidate) => candidate.id === depId);
+        return dep ? t(dep.name, { defaultValue: dep.name }) : depId;
+      })
+      .join(", ");
+
+  // The personal-class `depends_on` gate (RFC §8.6): class-enabling an agent
+  // 409s unless each default tool capability already has org-level personal
+  // access. Computed once — it has no per-row axis, unlike the team variant.
+  const missingPersonalDeps = capability ? missingAgentDependenciesForPersonalSpaces(capability, allCapabilities) : [];
 
   const hasQuery = teamQuery.trim() !== "";
   const visibleTeams = filterTeamsByName(orderedTeams, teamQuery);
@@ -238,6 +264,19 @@ export function CapabilityTeamMatrixDrawer({
 
   const submitEnable = async (teamId: string, settings: Record<string, unknown>) => {
     if (!capability) return;
+    // The single choke point for the #2408 gate: both the tri-state click and
+    // the enable-with-settings form's submit land here, and the catalog can
+    // refetch (revoking a dependency) while that form sits open. Refused with
+    // the same sentence the residual 409 would have carried, rather than
+    // silently doing nothing to a Save the admin just clicked.
+    const blocking = missingAgentDependenciesForTeam(capability, allCapabilities, teamId);
+    if (blocking.length > 0) {
+      showError({
+        summary: t("rework.admin.capabilities.matrix.enableError"),
+        detail: t("rework.admin.capabilities.matrix.dependencyConflict", { deps: dependencyLabels(blocking) }),
+      });
+      return;
+    }
     markPending(teamId, "enabled");
     try {
       await enableCapability({
@@ -249,9 +288,19 @@ export function CapabilityTeamMatrixDrawer({
         summary: t("rework.admin.capabilities.matrix.enabledToast", { team: teamLabel(teamId) }),
       });
       setEditingTeamId(null);
-    } catch {
+    } catch (err) {
       unmarkPending(teamId);
-      showError({ summary: t("rework.admin.capabilities.matrix.enableError") });
+      // A 409 here is a real, explainable refusal (the `depends_on` gate, or a
+      // stale client racing another admin) — not a transport failure. Say which
+      // dependencies are missing when we can name them locally, otherwise pass
+      // the backend's own sentence through instead of swallowing it (#2408).
+      const normalized = normalizeApiError(err);
+      const missing = capability ? missingAgentDependenciesForTeam(capability, allCapabilities, teamId) : [];
+      const detail =
+        normalized.kind === "conflict" && missing.length > 0
+          ? t("rework.admin.capabilities.matrix.dependencyConflict", { deps: dependencyLabels(missing) })
+          : normalized.detail;
+      showError({ summary: t("rework.admin.capabilities.matrix.enableError"), detail });
     }
   };
 
@@ -268,9 +317,9 @@ export function CapabilityTeamMatrixDrawer({
       } else {
         showSuccess({ summary: t(keys.done, { team: teamLabel(teamId) }) });
       }
-    } catch {
+    } catch (err) {
       unmarkPending(teamId);
-      showError({ summary: t(keys.error) });
+      showError({ summary: t(keys.error), detail: normalizeApiError(err).detail });
     }
   };
 
@@ -295,21 +344,31 @@ export function CapabilityTeamMatrixDrawer({
       } else {
         showSuccess({ summary: t(keys.done, { team: personalLabel }) });
       }
-    } catch {
+    } catch (err) {
       unmarkPending(PERSONAL_SCOPE_ROW_ID);
-      showError({ summary: t(keys.error) });
+      const normalized = normalizeApiError(err);
+      const detail =
+        normalized.kind === "conflict" && missingPersonalDeps.length > 0
+          ? t("rework.admin.capabilities.matrix.personal.dependencyConflict", {
+              deps: dependencyLabels(missingPersonalDeps),
+            })
+          : normalized.detail;
+      showError({ summary: t(keys.error), detail });
     }
   };
 
   const selectPersonalChoice = (current: TeamCapabilityChoice, next: TeamCapabilityChoice) => {
     if (busy || next === current) return;
-    if (next === "enabled" && requiresSettings) return;
+    if (next === "enabled" && (requiresSettings || missingPersonalDeps.length > 0)) return;
     void submitPersonalScope(next);
   };
 
   const selectChoice = (teamId: string, current: TeamCapabilityChoice, next: TeamCapabilityChoice) => {
     if (busy || next === current) return;
     if (next === "enabled") {
+      // Defensive twin of the disabled segment: a grant the backend would 409
+      // (#2408) must not reach the wire from a keyboard path either.
+      if (!capability || missingAgentDependenciesForTeam(capability, allCapabilities, teamId).length > 0) return;
       startEnable(teamId);
       return;
     }
@@ -368,6 +427,13 @@ export function CapabilityTeamMatrixDrawer({
                       const pendingChoice = pendingByTeam[PERSONAL_SCOPE_ROW_ID];
                       const isPending = pendingChoice !== undefined;
                       const displayChoice = pendingChoice ?? personalChoice;
+                      // Same rule as the team rows: never block the segment
+                      // that is already selected, or a class grant whose
+                      // dependency was revoked afterwards would strand this
+                      // row's control for keyboard users (`ButtonGroup` only
+                      // gives the selected item `tabIndex={0}`).
+                      const enableBlocked =
+                        displayChoice !== "enabled" && (requiresSettings || missingPersonalDeps.length > 0);
                       return (
                         <li
                           key={PERSONAL_SCOPE_ROW_ID}
@@ -379,6 +445,13 @@ export function CapabilityTeamMatrixDrawer({
                             <span className={styles.personalSub}>
                               {t("rework.admin.capabilities.matrix.personal.hint")}
                             </span>
+                            {missingPersonalDeps.length > 0 && displayChoice !== "enabled" && (
+                              <span className={styles.blockedSub}>
+                                {t("rework.admin.capabilities.matrix.personal.dependencyHint", {
+                                  deps: dependencyLabels(missingPersonalDeps),
+                                })}
+                              </span>
+                            )}
                           </div>
                           <div className={styles.teamActions}>
                             {isPending && <span className={styles.spinner} aria-hidden="true" />}
@@ -393,7 +466,7 @@ export function CapabilityTeamMatrixDrawer({
                               onSelectedIndexChange={(index) => selectPersonalChoice(displayChoice, CHOICES[index])}
                               items={CHOICES.map((target) => ({
                                 label: t(CHOICE_LABEL_KEY[target]),
-                                disabled: busy || (target === "enabled" && requiresSettings),
+                                disabled: busy || (target === "enabled" && enableBlocked),
                               }))}
                             />
                           </div>
@@ -410,6 +483,20 @@ export function CapabilityTeamMatrixDrawer({
                       const pendingChoice = pendingByTeam[team.id];
                       const isPending = pendingChoice !== undefined;
                       const displayChoice = pendingChoice ?? choice;
+                      // #2408: the same `depends_on` gate the enable write
+                      // enforces (RFC §8.6). Blocking here is what turns a bare
+                      // 409 into an explanation the admin can act on.
+                      //
+                      // Never applied to the segment that is already selected.
+                      // A dependency CAN be revoked after the agent was granted
+                      // (`product/service.py` documents that exact sequence),
+                      // and `ButtonGroup` gives only the selected item
+                      // `tabIndex={0}` — disabling it would make the whole row
+                      // keyboard-unreachable, so the admin could no longer even
+                      // revoke the now-broken grant. Nothing is lost: an
+                      // already-enabled row has no enable action to prevent.
+                      const missingDeps = missingAgentDependenciesForTeam(capability, allCapabilities, team.id);
+                      const dependencyBlocked = missingDeps.length > 0 && displayChoice !== "enabled";
                       return (
                         <li
                           key={team.id}
@@ -420,6 +507,13 @@ export function CapabilityTeamMatrixDrawer({
                             <span className={styles.teamName} title={team.name}>
                               {team.name}
                             </span>
+                            {dependencyBlocked && (
+                              <span className={styles.blockedSub}>
+                                {t("rework.admin.capabilities.matrix.dependencyHint", {
+                                  deps: dependencyLabels(missingDeps),
+                                })}
+                              </span>
+                            )}
                           </div>
                           <div className={styles.teamActions}>
                             {isPending && <span className={styles.spinner} aria-hidden="true" />}
@@ -432,7 +526,7 @@ export function CapabilityTeamMatrixDrawer({
                               onSelectedIndexChange={(index) => selectChoice(team.id, displayChoice, CHOICES[index])}
                               items={CHOICES.map((target) => ({
                                 label: t(CHOICE_LABEL_KEY[target]),
-                                disabled: busy || (target === "enabled" && isEditing),
+                                disabled: busy || (target === "enabled" && (isEditing || dependencyBlocked)),
                               }))}
                             />
                           </div>

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/capabilityEnablement.test.ts
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/capabilityEnablement.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, it } from "vitest";
-import type { FieldSpec } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import type { CapabilityEnablementItem, FieldSpec } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 import {
   PERSONAL_SCOPE_ROW_ID,
   capabilityPersonalScopeChoice,
@@ -24,7 +24,10 @@ import {
   isCapabilityOnForTeam,
   isCapabilityUnused,
   isPersonalTeamId,
+  missingAgentDependenciesForPersonalSpaces,
+  missingAgentDependenciesForTeam,
   personalSpaceCount,
+  requiresTeamSettings,
   seedSettingsFromFields,
   sortTeamsForMatrix,
   teamCapabilityChoice,
@@ -393,5 +396,128 @@ describe("hasReasoningControl (REASON-01, MODEL-REASONING-ENABLEMENT-RFC.md §5.
 
   it("shows no control when the field is absent (pre-REASON-01 pod, or a tool row)", () => {
     expect(hasReasoningControl({})).toBe(false);
+  });
+});
+
+// --- #2408: the client-side mirrors of the backend's 409 gates ---------------
+
+function item(
+  over: Partial<CapabilityEnablementItem> & Pick<CapabilityEnablementItem, "id">,
+): CapabilityEnablementItem {
+  return {
+    name: `cap.${over.id}`,
+    version: "1.0.0",
+    icon: "extension",
+    team_scope: "admin_gated",
+    default_on: false,
+    enabled_team_ids: [],
+    team_settings_fields: [],
+    kind: "tool",
+    ...over,
+  };
+}
+
+const AGENT = { kind: "agent" as const, default_capability_ids: ["dep"] };
+
+describe("requiresTeamSettings (#2408, mirrors enablement.py team_settings_has_required_fields)", () => {
+  it("is true when at least one team setting is required", () => {
+    expect(
+      requiresTeamSettings({
+        team_settings_fields: [
+          { key: "note", type: "string", title: "Note" },
+          { key: "url", type: "url", title: "URL", required: true },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when every field is optional — those can still be default-on", () => {
+    expect(requiresTeamSettings({ team_settings_fields: [{ key: "note", type: "string", title: "Note" }] })).toBe(
+      false,
+    );
+  });
+
+  it("is false for a capability with no settings form at all", () => {
+    expect(requiresTeamSettings({})).toBe(false);
+  });
+});
+
+describe("missingAgentDependenciesForTeam (#2408, mirrors agent_capability_missing_dependencies)", () => {
+  it("reports a dependency the team cannot use — the exact 409 condition", () => {
+    expect(missingAgentDependenciesForTeam(AGENT, [item({ id: "dep" })], "nb")).toEqual(["dep"]);
+  });
+
+  it("accepts a dependency explicitly enabled for that team", () => {
+    expect(missingAgentDependenciesForTeam(AGENT, [item({ id: "dep", enabled_team_ids: ["nb"] })], "nb")).toEqual([]);
+  });
+
+  it("accepts a dependency the team inherits through default_on", () => {
+    expect(missingAgentDependenciesForTeam(AGENT, [item({ id: "dep", default_on: true })], "nb")).toEqual([]);
+  });
+
+  it("treats an explicit opt-out as missing even when the dependency is default_on", () => {
+    // Opt-out beats inheritance in the FGA schema, so the grant would 409.
+    const deps = [item({ id: "dep", default_on: true, disabled_team_ids: ["nb"] })];
+    expect(missingAgentDependenciesForTeam(AGENT, deps, "nb")).toEqual(["dep"]);
+  });
+
+  it("fails OPEN for a dependency absent from the catalog list", () => {
+    // It cannot be evaluated here and the backend stays the authority —
+    // blocking would forbid a grant the server may well accept.
+    expect(missingAgentDependenciesForTeam(AGENT, [], "nb")).toEqual([]);
+  });
+
+  it("is empty for a non-agent row, whatever ids it carries", () => {
+    const cap = { kind: "tool" as const, default_capability_ids: ["dep"] };
+    expect(missingAgentDependenciesForTeam(cap, [item({ id: "dep" })], "nb")).toEqual([]);
+  });
+
+  it("is empty for an agent that declares no dependency", () => {
+    expect(missingAgentDependenciesForTeam({ kind: "agent" }, [], "nb")).toEqual([]);
+  });
+
+  it("names every blocking dependency, not just the first", () => {
+    const cap = { kind: "agent" as const, default_capability_ids: ["a", "b", "c"] };
+    const deps = [item({ id: "a" }), item({ id: "b", default_on: true }), item({ id: "c" })];
+    expect(missingAgentDependenciesForTeam(cap, deps, "nb")).toEqual(["a", "c"]);
+  });
+});
+
+describe("missingAgentDependenciesForPersonalSpaces (#2408, mirrors the personal-scope gate)", () => {
+  it("accepts a dependency class-enabled for personal spaces", () => {
+    expect(missingAgentDependenciesForPersonalSpaces(AGENT, [item({ id: "dep", personal_scope: "enabled" })])).toEqual(
+      [],
+    );
+  });
+
+  it("accepts a default_on dependency personal spaces inherit", () => {
+    expect(missingAgentDependenciesForPersonalSpaces(AGENT, [item({ id: "dep", default_on: true })])).toEqual([]);
+  });
+
+  it("reports a dependency that is neither personal_on nor default_on", () => {
+    expect(missingAgentDependenciesForPersonalSpaces(AGENT, [item({ id: "dep", personal_scope: "default" })])).toEqual([
+      "dep",
+    ]);
+  });
+
+  it("treats personal_disabled as missing even when the dependency is default_on", () => {
+    // `(personal_on OR default_on) AND NOT personal_disabled` — the block wins.
+    const deps = [item({ id: "dep", default_on: true, personal_scope: "disabled" })];
+    expect(missingAgentDependenciesForPersonalSpaces(AGENT, deps)).toEqual(["dep"]);
+  });
+
+  it("ignores per-team grants — the class position is what the backend reads", () => {
+    expect(missingAgentDependenciesForPersonalSpaces(AGENT, [item({ id: "dep", enabled_team_ids: ["nb"] })])).toEqual([
+      "dep",
+    ]);
+  });
+
+  it("fails OPEN for a dependency absent from the catalog list", () => {
+    expect(missingAgentDependenciesForPersonalSpaces(AGENT, [])).toEqual([]);
+  });
+
+  it("is empty for a non-agent row", () => {
+    const cap = { kind: "model" as const, default_capability_ids: ["dep"] };
+    expect(missingAgentDependenciesForPersonalSpaces(cap, [item({ id: "dep" })])).toEqual([]);
   });
 });

--- a/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/capabilityEnablement.ts
+++ b/apps/frontend/src/rework/components/pages/admin/CapabilitiesPage/capabilityEnablement.ts
@@ -50,6 +50,87 @@ export function isCapabilityOnForTeam(capability: EnablementFacts, teamId: strin
 }
 
 /**
+ * Whether this capability carries a REQUIRED team setting (#2408).
+ *
+ * Mirrors the backend's `team_settings_has_required_fields` (`enablement.py`):
+ * such a capability can be neither default-on nor class-enabled for all
+ * personal spaces, because nobody has filled the settings for the teams that
+ * would inherit it (RFC §8.2/§8.4) — both writes 409. Surfaced here so the
+ * admin controls can be disabled with an explanation instead of failing.
+ */
+export function requiresTeamSettings(capability: Pick<CapabilityEnablementItem, "team_settings_fields">): boolean {
+  return (capability.team_settings_fields ?? []).some((field) => field.required);
+}
+
+/**
+ * The `default_capability_ids` of a `kind="agent"` capability that the team
+ * cannot use yet — the client-side mirror of `enablement.py`'s
+ * `agent_capability_missing_dependencies` (RFC §8.6 `depends_on` gate, #2004
+ * item 5). A non-empty answer is exactly what makes the enable write 409
+ * (#2408), so the drawer can disable the grant and name the blockers up front.
+ *
+ * **Fails open on an unknown dependency**: an id with no row in
+ * `allCapabilities` is skipped rather than counted as missing. A dependency
+ * can be absent (a pod stopped advertising it, a stale client), and the
+ * backend remains the sole authority — blocking on a row we cannot evaluate
+ * would forbid a grant the server would happily accept.
+ *
+ * Known asymmetry, accepted: the backend counts an id with no ReBAC grant at
+ * all as missing, so a template declaring a default capability no pod
+ * advertises 409s for every team while this returns `[]` and the row stays
+ * enabled-looking. The click is still explained — with no locally-known
+ * blockers the toast falls through to the backend's own sentence, which names
+ * the offending ids. Guessing "missing" from an absent row would instead
+ * block every legitimate grant the moment the list is incomplete.
+ */
+export function missingAgentDependenciesForTeam(
+  capability: Pick<CapabilityEnablementItem, "kind" | "default_capability_ids">,
+  allCapabilities: CapabilityEnablementItem[],
+  teamId: string,
+): string[] {
+  if (capability.kind !== "agent") {
+    return [];
+  }
+  const missing: string[] = [];
+  for (const depId of capability.default_capability_ids ?? []) {
+    const dep = allCapabilities.find((candidate) => candidate.id === depId);
+    if (!dep) continue;
+    if (teamCapabilityState(dep, teamId) === "off") {
+      missing.push(depId);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Personal-class counterpart of `missingAgentDependenciesForTeam`, mirroring
+ * `_require_agent_capability_dependencies_usable_by_all_personal_spaces`
+ * (`enablement.py`): there is no single team to evaluate, so a dependency
+ * counts as usable only when it has ORG-level personal access — `personal_on`
+ * or `default_on`, and not `personal_disabled`. Same fail-open rule for an
+ * unknown dependency id.
+ */
+export function missingAgentDependenciesForPersonalSpaces(
+  capability: Pick<CapabilityEnablementItem, "kind" | "default_capability_ids">,
+  allCapabilities: CapabilityEnablementItem[],
+): string[] {
+  if (capability.kind !== "agent") {
+    return [];
+  }
+  const missing: string[] = [];
+  for (const depId of capability.default_capability_ids ?? []) {
+    const dep = allCapabilities.find((candidate) => candidate.id === depId);
+    if (!dep) continue;
+    const scope = capabilityPersonalScopeChoice(dep);
+    const usable = (scope === "enabled" || dep.default_on) && scope !== "disabled";
+    if (!usable) {
+      missing.push(depId);
+    }
+  }
+  return missing;
+}
+
+/**
  * The team's *explicit* tri-state position — what the admin actually chose,
  * as opposed to `teamCapabilityState` which is the *effective* access after
  * inheritance. `default` means "no explicit tuple: the platform default

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -2630,6 +2630,8 @@ export type CapabilityEnablementItem = {
   team_settings_fields?: FieldSpec[];
   /** "tool": a pod-advertised capability. "agent": a control-plane-side projection of an agent template into this same catalog (CAPAB-01, RFC §8.6) — every team's access to every agent is an explicit admin grant, exactly like a tool. "model": a pod-advertised projection of one models_catalog.yaml (provider, name) pair (OBSERV-02 v3, RFC §8.7). */
   kind?: "tool" | "agent" | "model";
+  /** For a `kind="agent"` row: the template's default tool/MCP capability ids (RFC §8.6 `depends_on` gate, GitHub #2004 item 5). Enabling the agent for a team 409s unless each of these is already usable by that team - exposed so the admin UI can disable the grant up front and explain why (GitHub #2408). Always empty for `kind="tool"`/`"model"`. */
+  default_capability_ids?: string[];
   /** Agent instances this capability breaks AT REST, across every team (#1975 health). DERIVED per request — `suspension_reason` records why an instance is suspended, never which capability did it, so an instance broken by capa1 while also selecting capa2 must not count against capa2. An instance is counted when it selects this capability AND its team lacks `can_use` on it OR its pod no longer advertises it. */
   suspended_instances?: number;
   /** Instances selecting this capability whose runtime pod was unreachable, so their health is UNKNOWN rather than broken. Kept separate from `suspended_instances`: the reconciliation sweep skips an unreachable pod rather than suspending on a transient outage (#1975, RFC §3.9), and this count reports the same way. */

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -1277,7 +1277,7 @@ another of the caller's teams no longer appears (and can no longer be saved,
 
 | Method + path | Request | Response | Effect |
 | --- | --- | --- | --- |
-| `GET /admin/capabilities` | — | `CapabilityEnablementList` | Aggregated pod catalog with, per capability: `id`, `name` (i18n key), `version`, `icon`, `team_scope` (`default_on` \| `admin_gated`), `default_on`, `enabled_team_ids`, `team_settings_fields` (the enable-with-settings form specs). |
+| `GET /admin/capabilities` | — | `CapabilityEnablementList` | Aggregated pod catalog with, per capability: `id`, `name` (i18n key), `version`, `icon`, `team_scope` (`default_on` \| `admin_gated`), `default_on`, `enabled_team_ids`, `team_settings_fields` (the enable-with-settings form specs), `default_capability_ids` (2026-08-25, see below). |
 | `PUT /admin/capabilities/{capability_id}/teams/{team_id}` | `EnableTeamCapabilityRequest` (`settings`) | `TeamCapabilityEnablementResult` | Enable-with-settings: validates `settings` against `team_settings_fields`, writes the settings row then the `enabled` tuple. |
 | `DELETE /admin/capabilities/{capability_id}/teams/{team_id}` | — | `TeamCapabilityEnablementResult` (`suspended_instances`) | Revoke: deletes the `enabled` tuple (writes a `disabled` opt-out for a default-on cap), reconciles dependent instances → suspension. |
 | `PUT /admin/capabilities/{capability_id}/default-on` | `SetCapabilityDefaultOnRequest` (`default_on`) | `CapabilityDefaultOnResult` (`suspended_instances`) | Toggle the platform-wide `default_on` marker; turning it off revokes inherited access team-by-team and may suspend instances. |
@@ -1426,6 +1426,46 @@ ReBAC is already active for a team, the platform_admin must toggle
 default-on for the desired model(s) in the same deploy window ReBAC
 enforcement reaches that team, or that team's chat fails closed until the
 toggle is flipped — a deploy-runbook step, not a code gap.
+
+**2026-08-25 — the enablement 409s become visible before the click (GitHub
+#2408).** Activating some capabilities from the admin dashboard failed with a
+bare HTTP 409: the gates were enforced server-side but invisible to the UI,
+which offered the action anyway and then showed a generic "could not enable"
+toast. One field added, no route, exception, or error-shape change.
+
+`GET /admin/capabilities` items gain **`default_capability_ids: list[str]`** —
+a verbatim projection of `CapabilityCatalogEntry.default_capability_ids`
+(itself added by the 2026-07-19 `depends_on` entry above), empty for
+`kind="tool"`/`kind="model"` by construction, following the tagged-union rule
+stated for the other per-kind fields. This is the missing half of the
+2026-07-19 gate: the write path already 409'd
+(`AgentCapabilityDependencyNotSatisfied`) when an agent's default tool
+capabilities were not usable by the target team, but the list contract carried
+no way for the dashboard to know it.
+
+Client-side consequences (`CapabilitiesPage.tsx`,
+`CapabilityTeamMatrixDrawer.tsx`, predicates in `capabilityEnablement.ts`):
+the drawer disables "Enable" and names the blocking dependencies for a team
+that cannot use them; the personal-space class row does the same against the
+org-level personal-access rule (`(personal_on OR default_on) AND NOT
+personal_disabled`); the default-on Switch is disabled for a capability with a
+required team setting (`DefaultOnNotAllowed`), while turning it OFF stays
+possible. The predicates **fail open** on a dependency id absent from the list
+— the backend remains the sole authority, and the client gate is a
+better-error affordance, never an enforcement point. Residual 409s (stale
+client, concurrent admin) are mapped through `normalizeApiError` to an
+explanatory toast detail instead of being swallowed.
+
+**Error contract unchanged.** These routes still answer a plain-string
+`detail` and no `error_code`; the per-endpoint 409 semantics are unambiguous
+on their own, so the frontend disambiguates by which mutation failed plus its
+own locally-computed reason.
+
+**Known caveat (accepted).** With ReBAC disabled, `usable_capability_ids`
+returns `None` and the backend applies no dependency scoping at all, but the
+client predicate still reads the (empty) grant lists and can render an agent
+row as blocked. The team matrix is already decorative in that mode, so the
+mismatch is cosmetic and not worth a second code path.
 
 ## 18. Contract Notes — team-scoped candidate-member search (2026-07-20)
 


### PR DESCRIPTION
## Problem

Activating some capabilities on an agent (admin tag -> capabilities section) fails with HTTP 409 Conflict. The drawer offers the action, the click is refused, and the toast says only "Could not enable the feature".

## Root cause

Every admin activation 409 comes from `capabilities/enablement.py`, mapped to HTTP by `_map_error` in `capabilities/api.py`. Three are reachable from the UI:

1. `PUT /admin/capabilities/{id}/teams/{team_id}` - `AgentCapabilityDependencyNotSatisfied`: a `kind="agent"` capability whose `default_capability_ids` are not all usable by the target team (RFC 8.6 `depends_on` gate, 2026-07-19). **The headline bug**: the list contract never exposed `default_capability_ids`, so the drawer could not know and offered "Enable" freely.
2. `PUT /admin/capabilities/{id}/personal-scope` (`scope="enabled"`) - same exception, against org-level personal access for each dependency.
3. `PUT /admin/capabilities/{id}/default-on` - `DefaultOnNotAllowed`: the capability has a required team-settings field, and the default-on Switch was never gated on `team_settings_fields`.

On top of that, every mutation in these two components used a bare `catch {}` with a generic toast, discarding the backend's own explanation.

## Fix

- **Backend (one field, no route/exception/error-shape change)**: `CapabilityEnablementItem.default_capability_ids`, a verbatim projection of `CapabilityCatalogEntry.default_capability_ids`. Empty for `kind="tool"`/`"model"` by construction. Client regenerated with `make update-control-plane-api`.
- **UI gating** mirroring the backend gates, as pure predicates in `capabilityEnablement.ts` (`requiresTeamSettings`, `missingAgentDependenciesForTeam`, `missingAgentDependenciesForPersonalSpaces`): the drawer disables "Enable" and names the blocking dependencies under the row; the personal-space class row does the same; the default-on Switch is disabled (with a tooltip) for a required-settings capability, while turning it OFF stays possible.
- **Never disables the segment a row is already on.** A dependency can be revoked after the agent was granted, and `ButtonGroup` gives only the selected item `tabIndex={0}` - disabling it would make the whole row keyboard-unreachable, so the admin could not even undo the broken grant.
- **409 mapping**: residual conflicts (stale client, concurrent admin) go through the existing `normalizeApiError` and show either the locally-computed dependency sentence or the backend's own `detail`. Same treatment for the reasoning toggle.
- **i18n**: new keys in `en` and `fr`.
- **Docs**: dated 2026-08-25 entry in `CONTROL-PLANE-PRODUCT-CONTRACT.md` section 17, plus the `GET /admin/capabilities` field list.

The client predicates **fail open** on a dependency id absent from the catalog list - the backend remains the sole authority, and blocking on a row the UI cannot evaluate would forbid grants the server would accept.

## Tests

- Backend: `apps/control-plane-backend` - **849 passed** (1 new: the aggregate list surfaces `default_capability_ids` for an agent row, `[]` for a tool row).
- Frontend: **1391 passed / 2 skipped** across 140 files; the CapabilitiesPage folder alone is 116 (23 new): the three predicates across every dependency state, the drawer's disable + hint + fail-open + already-enabled cases, and the page's default-on gate plus the full-catalog forwarding.
- `make code-quality` clean in both projects.

## For the reviewer

- **ReBAC-disabled deployments**: with ReBAC off the backend applies no dependency scoping at all (`usable_capability_ids` returns `None`), but the client predicate still reads the empty grant lists and can render an agent row as blocked. Accepted - the team matrix is already decorative in that mode, and a second code path is not worth it. Documented in the contract note.
- **Known asymmetry (documented in the code)**: the backend treats a `default_capability_ids` entry with no ReBAC grant at all as missing, including one no pod advertises. The client skips those (fail open), so such a row looks enabled-in-principle; the click is still explained, because with no locally-known blockers the toast falls through to the backend's sentence, which names the ids.
- One deviation from the plan: `CapabilitiesPage.test.tsx` asserts the required-settings hint via a recorded `t()` key rather than rendered text. The hint lives in a `Tooltip`, whose panel is portaled and only mounts on hover, so it can never appear in this suite's `renderToStaticMarkup` output.

Closes #2408
