### PR TITLE
fix(#2431): correct agent KPI chart unit label and series assembly

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/kpi/presets/top_agents_by_conversations.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/presets/top_agents_by_conversations.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from datetime import datetime
 from typing import Any
 
@@ -113,13 +114,24 @@ async def query_top_agents_by_conversations(
             interval=interval,
         )
 
-    # agent_instance_id → display label (agent_instance_name if stored, else the id).
-    id_to_label: dict[str, str] = {}
+    # agent_instance_id → name (agent_instance_name if stored, else the id).
+    id_to_name: dict[str, str] = {}
     for bucket in top_buckets:
         instance_id = str(bucket["key"])
         hits = bucket.get("latest_name", {}).get("hits", {}).get("hits", [])
         dims = hits[0]["_source"].get("dims", {}) if hits else {}
-        id_to_label[instance_id] = dims.get("agent_instance_name") or instance_id
+        id_to_name[instance_id] = dims.get("agent_instance_name") or instance_id
+
+    # Instance names are not unique — two live instances may share one. Keying
+    # the series by name would merge them into a single line whose counts are
+    # the sum of both, so the id stays the accumulation key throughout and the
+    # name is only ever a display label. Colliding names get a short id suffix
+    # so the chart still shows two distinguishable lines.
+    name_counts = Counter(id_to_name.values())
+    id_to_label: dict[str, str] = {
+        instance_id: f"{name} ({instance_id[:8]})" if name_counts[name] > 1 else name
+        for instance_id, name in id_to_name.items()
+    }
 
     # Phase 2: time-series breakdown per instance.
     series_body: dict[str, Any] = {
@@ -137,8 +149,17 @@ async def query_top_agents_by_conversations(
                     },
                 },
                 "aggs": {
+                    # `include` pins this sub-agg to the instances phase 1
+                    # picked. Without it each date bucket independently returns
+                    # *its own* top N, so a globally-top agent that lost a
+                    # single bucket to N busier ones silently drops that
+                    # bucket's turns from its running total.
                     "by_agent": {
-                        "terms": {"field": "dims.agent_instance_id", "size": TOP_N}
+                        "terms": {
+                            "field": "dims.agent_instance_id",
+                            "size": TOP_N,
+                            "include": list(id_to_label),
+                        }
                     }
                 },
             }
@@ -153,18 +174,26 @@ async def query_top_agents_by_conversations(
     series_labels = list(id_to_label.values())
 
     # Accumulate per-bucket counts into running totals so each point represents
-    # the total number of conversations for that agent up to that point in time.
-    running: dict[str, float] = {label: 0.0 for label in series_labels}
+    # the total number of turns for that agent up to that point in time.
+    running: dict[str, float] = {instance_id: 0.0 for instance_id in id_to_label}
     rows: list[MultiSeriesPoint] = []
     for bucket in time_buckets:
         date_label = datetime.fromisoformat(
             bucket["key_as_string"].replace("Z", "+00:00")
         ).strftime(date_fmt)
         for agent_bucket in bucket.get("by_agent", {}).get("buckets", []):
-            label = id_to_label.get(str(agent_bucket["key"]))
-            if label is not None:
-                running[label] += float(agent_bucket["doc_count"])
-        rows.append(MultiSeriesPoint(date=date_label, values=dict(running)))
+            instance_id = str(agent_bucket["key"])
+            if instance_id in running:
+                running[instance_id] += float(agent_bucket["doc_count"])
+        rows.append(
+            MultiSeriesPoint(
+                date=date_label,
+                values={
+                    id_to_label[instance_id]: total
+                    for instance_id, total in running.items()
+                },
+            )
+        )
 
     return MultiSeriesTimeSeriesResponse(
         rows=rows,

--- a/apps/control-plane-backend/tests/test_kpi_top_agents_by_conversations.py
+++ b/apps/control-plane-backend/tests/test_kpi_top_agents_by_conversations.py
@@ -1,0 +1,212 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+`top_agents_by_conversations` series-assembly regressions.
+
+Both bugs covered here made the drawn lines disagree with the phase-1 ranking
+that chose them:
+
+1. Phase 2's per-bucket `by_agent` terms agg had no `include`, so every date
+   bucket independently returned *its own* top N. A globally-top agent that
+   lost one bucket to N busier ones silently dropped that bucket's turns.
+2. Series were keyed by `agent_instance_name`, so two distinct instances
+   sharing a name were merged into one line whose counts were the sum of both.
+
+Only the series assembly is under test — the OpenSearch client is faked, since
+the aggregation itself is the store's contract, not this preset's.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from control_plane_backend.kpi.presets.top_agents_by_conversations import (
+    TOP_N,
+    query_top_agents_by_conversations,
+)
+
+SINCE = datetime(2026, 8, 1, tzinfo=timezone.utc)
+UNTIL = SINCE + timedelta(days=3)
+
+
+class _FakeClient:
+    """Returns the phase-1 then the phase-2 response, recording both bodies."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.bodies: list[dict[str, Any]] = []
+
+    def search(self, *, index: str, body: dict[str, Any]) -> dict[str, Any]:
+        del index
+        self.bodies.append(body)
+        return self._responses.pop(0)
+
+
+class _FakeStore:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.client = _FakeClient(responses)
+        self.index = "kpi-test"
+
+
+def _top_response(agents: list[tuple[str, str, int]]) -> dict[str, Any]:
+    """Phase-1 shape: (instance_id, instance_name, doc_count) per bucket."""
+    return {
+        "aggregations": {
+            "by_agent": {
+                "buckets": [
+                    {
+                        "key": instance_id,
+                        "doc_count": count,
+                        "latest_name": {
+                            "hits": {
+                                "hits": [
+                                    {"_source": {"dims": {"agent_instance_name": name}}}
+                                ]
+                            }
+                        },
+                    }
+                    for instance_id, name, count in agents
+                ]
+            }
+        }
+    }
+
+
+def _series_response(buckets: list[tuple[str, dict[str, int]]]) -> dict[str, Any]:
+    """Phase-2 shape: (bucket timestamp, {instance_id: doc_count}) per bucket."""
+    return {
+        "aggregations": {
+            "by_time": {
+                "buckets": [
+                    {
+                        "key_as_string": key_as_string,
+                        "by_agent": {
+                            "buckets": [
+                                {"key": instance_id, "doc_count": count}
+                                for instance_id, count in per_agent.items()
+                            ]
+                        },
+                    }
+                    for key_as_string, per_agent in buckets
+                ]
+            }
+        }
+    }
+
+
+async def _run(store: _FakeStore) -> Any:
+    return await query_top_agents_by_conversations(
+        store,  # pyright: ignore[reportArgumentType]
+        user=None,  # pyright: ignore[reportArgumentType]
+        since=SINCE,
+        until=UNTIL,
+        request=None,  # pyright: ignore[reportArgumentType]
+    )
+
+
+@pytest.mark.asyncio
+async def test_series_query_is_pinned_to_the_phase_one_winners() -> None:
+    """Without `include`, each date bucket returns its own top N and a
+    globally-top agent can be crowded out of a bucket it had turns in."""
+    store = _FakeStore(
+        [
+            _top_response([("id-a", "Alpha", 5), ("id-b", "Beta", 3)]),
+            _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 5, "id-b": 3})]),
+        ]
+    )
+
+    await _run(store)
+
+    series_body = store.client.bodies[1]
+    terms = series_body["aggs"]["by_time"]["aggs"]["by_agent"]["terms"]
+    assert terms["include"] == ["id-a", "id-b"]
+    assert terms["size"] == TOP_N
+
+
+@pytest.mark.asyncio
+async def test_instances_sharing_a_name_stay_separate_series() -> None:
+    """Keying by name merged two instances into one line summing both counts.
+    Keying by id keeps them apart; the colliding names get an id suffix so the
+    two lines remain distinguishable in the chart."""
+    store = _FakeStore(
+        [
+            _top_response(
+                [("id-aaaa1111", "Support", 7), ("id-bbbb2222", "Support", 4)]
+            ),
+            _series_response(
+                [("2026-08-01T00:00:00.000Z", {"id-aaaa1111": 7, "id-bbbb2222": 4})]
+            ),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == ["Support (id-aaaa1)", "Support (id-bbbb2)"]
+    assert result.rows[-1].values == {
+        "Support (id-aaaa1)": 7.0,
+        "Support (id-bbbb2)": 4.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unique_names_are_not_suffixed() -> None:
+    """The id suffix is a collision escape hatch, not the normal display."""
+    store = _FakeStore(
+        [
+            _top_response([("id-a", "Alpha", 2), ("id-b", "Beta", 1)]),
+            _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 2, "id-b": 1})]),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == ["Alpha", "Beta"]
+
+
+@pytest.mark.asyncio
+async def test_running_totals_accumulate_across_buckets() -> None:
+    """Each point is the cumulative turn count up to that bucket, and a bucket
+    an agent is absent from carries its previous total forward unchanged."""
+    store = _FakeStore(
+        [
+            _top_response([("id-a", "Alpha", 5), ("id-b", "Beta", 2)]),
+            _series_response(
+                [
+                    ("2026-08-01T00:00:00.000Z", {"id-a": 3, "id-b": 2}),
+                    ("2026-08-02T00:00:00.000Z", {"id-a": 2}),
+                ]
+            ),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert [row.values for row in result.rows] == [
+        {"Alpha": 3.0, "Beta": 2.0},
+        {"Alpha": 5.0, "Beta": 2.0},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_turns_returns_empty_without_a_second_query() -> None:
+    store = _FakeStore([_top_response([])])
+
+    result = await _run(store)
+
+    assert result.rows == []
+    assert result.series == []
+    assert len(store.client.bodies) == 1

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1244,7 +1244,7 @@
         },
         "topByConversations": {
           "title": "Most talked-to agents",
-          "valueLabel": "Conversations"
+          "valueLabel": "Messages"
         },
         "total": "Total agents number"
       },
@@ -1367,7 +1367,7 @@
         },
         "mostActiveAgents": {
           "title": "Most active agents",
-          "valueLabel": "Conversations"
+          "valueLabel": "Messages"
         }
       }
     },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1244,7 +1244,7 @@
         },
         "topByConversations": {
           "title": "Agents les plus sollicités",
-          "valueLabel": "Conversations"
+          "valueLabel": "Messages"
         },
         "total": "Nombre d'agents total"
       },
@@ -1367,7 +1367,7 @@
         },
         "mostActiveAgents": {
           "title": "Agents les plus actifs",
-          "valueLabel": "Conversations"
+          "valueLabel": "Messages"
         }
       }
     },


### PR DESCRIPTION
Closes #2431.

The admin analytics dashboard showed an agent at **161 "conversations"** next to
its own team at **139 "conversations"** in *Teams with most conversations* — a
total that is supposed to include that agent plus every other one in the team.
Three defects, one visible and two found while reading the preset.

### 1. The charts label turns and sessions with the same word

`top_agents_by_conversations` aggregates `agent.turn_completed`, emitted once
per **turn** (one user message → one agent answer). `top_teams_by_sessions`
aggregates `session.created_total`, emitted once per **session**. Both charts
labelled their axis `"Conversations"`, so a message count and a conversation
count were presented as the same unit — the agent's 161 was 161 messages.

Renamed the axis to "Messages" on the two charts fed by this preset: the admin
dashboard's *Most talked-to agents* and `TeamUsagePage`'s *Most active agents*,
which carried the identical mislabel. Titles are unchanged. The team charts keep
"Conversations" — they genuinely count sessions.

### 2. Phase 2's per-bucket agg was not pinned to phase 1's winners

The per-bucket `by_agent` terms agg had no `include`, so every date bucket
independently returned *its own* top N. On a platform with more agents than
`TOP_N`, a globally-top agent that lost a single bucket to N busier ones
contributed `0` for that bucket — those turns vanished from its running total
even though phase 1 counted them, so the drawn line disagreed with the ranking
that selected it. Now pinned to phase 1's ids.

### 3. Same-named instances merged into one line

Series were keyed by `agent_instance_name`, so two distinct instances sharing a
name collapsed into a single series summing both counts. `agent_instance_id` is
now the accumulation key end to end and the name is purely a display label;
colliding names get a short id suffix so the chart still draws two
distinguishable lines. The response shape is unchanged, so **no OpenAPI
regeneration is needed**.

### What this does not fix

The relabel makes the two charts honest about their units; it does not make them
comparable. The agent chart still counts turns over the window while the team
chart counts sessions *created* in it, and still ignores `scope_type`. A genuine
conversations-per-agent metric is separate work — `session.created_total`
already carries `dims.agent_instance_id`, so the data exists (see #2426). The
full analysis of those asymmetries is recorded in #2431.

### Tests

New `tests/test_kpi_top_agents_by_conversations.py` — 5 cases faking the
OpenSearch client, covering both series-assembly regressions plus the cumulative
running-total behaviour. `make code-quality` green on `control-plane-backend`
and `frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
