### PR TITLE
fix(frontend): stop the agent-form prompt library from auto-reopening on an emptied field

### DIFF
--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/AgentFormBody.tsx
@@ -166,6 +166,11 @@ export function AgentFormBody({
   // per-capability list. UI-only, reset to Simple on each mount (#2220).
   const [capabilityView, setCapabilityView] = useState<"simple" | "advanced">("simple");
 
+  // Prompt-picker mode per field key, kept here (this body stays mounted across
+  // section switches) so a field the user emptied doesn't auto-reopen the
+  // library when they leave and return to the Prompts section (#bug).
+  const [promptPickerExplicit, setPromptPickerExplicit] = useState<Record<string, boolean | null>>({});
+
   // Resolve audit uids (created_by / updated_by) to display names (#1952).
   const auditUids = Array.from(
     new Set([editInstance?.created_by, editInstance?.updated_by].filter((uid): uid is string => Boolean(uid))),
@@ -247,6 +252,8 @@ export function AgentFormBody({
         disabled={isSubmitting}
         teamId={teamId}
         allValues={effectiveTuningValues}
+        pickerExplicit={promptPickerExplicit[field.key] ?? null}
+        onPickerExplicitChange={(v) => setPromptPickerExplicit((prev) => ({ ...prev, [field.key]: v }))}
         error={
           submitAttempted && field.required && !tuningFieldValues[field.key] ? `${field.title} is required` : undefined
         }

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.test.tsx
@@ -115,4 +115,55 @@ describe("TuningFieldRenderer — prompt library auto-open", () => {
     expect(pickerShown()).toBe(false);
     expect(textareaShown()).toBe(true);
   });
+
+  it("keeps the library closed across an unmount/remount once emptied (controlled state)", () => {
+    // The form owns pickerExplicit so the decision survives a section switch
+    // (which unmounts this field). Emptying it reports write mode upward.
+    const changes: (boolean | null)[] = [];
+    const onPickerExplicitChange = (v: boolean | null) => changes.push(v);
+
+    act(() => {
+      root.render(
+        <TuningFieldRenderer
+          field={PROMPT_FIELD}
+          value="Existing prompt"
+          onChange={vi.fn()}
+          disabled={false}
+          teamId="t1"
+          pickerExplicit={null}
+          onPickerExplicitChange={onPickerExplicitChange}
+        />,
+      );
+    });
+    expect(textareaShown()).toBe(true);
+
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+    act(() => {
+      nativeSetter?.call(textarea, "");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(changes).toContain(false); // reported write mode to the form
+
+    // Simulate leaving and returning to the Prompts section: unmount, then
+    // remount fresh with the persisted pickerExplicit=false and empty value.
+    act(() => root.unmount());
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <TuningFieldRenderer
+          field={PROMPT_FIELD}
+          value=""
+          onChange={vi.fn()}
+          disabled={false}
+          teamId="t1"
+          pickerExplicit={false}
+          onPickerExplicitChange={onPickerExplicitChange}
+        />,
+      );
+    });
+
+    expect(pickerShown()).toBe(false);
+    expect(textareaShown()).toBe(true);
+  });
 });

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression: the prompt-field library auto-opens ONLY on the initial empty
+// state. Clearing the field while editing (e.g. wiping the system prompt) must
+// NOT reopen the library — the user is writing from scratch and can reopen it
+// from the "pick from library" button.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedAgentFieldSpec } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
+import { TuningFieldRenderer } from "./TuningFieldRenderer";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+
+// One context prompt → the library exists (hasLibrary), so auto-open logic applies.
+vi.mock("../../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
+  useGetContextPromptsEarlyControlPlaneV1TeamsTeamIdPromptsContextGetQuery: () => ({
+    data: [{ id: "p1", name: "Prompt 1", scope: "team" }],
+  }),
+  useGetTeamPromptCategoriesControlPlaneV1TeamsTeamIdPromptCategoriesGetQuery: () => ({ data: [] }),
+  useLazyGetTeamPromptControlPlaneV1TeamsTeamIdPromptsPromptIdGetQuery: () => [vi.fn(), { isLoading: false }],
+  usePostRecordPromptUseControlPlaneV1TeamsTeamIdPromptsPromptIdUsePostMutation: () => [vi.fn()],
+}));
+
+// Keep the picker a simple marker so its presence is trivial to assert.
+vi.mock("@shared/molecules/PromptPicker/PromptPicker", () => ({
+  PromptPicker: () => <div data-testid="prompt-picker" />,
+}));
+
+const PROMPT_FIELD = {
+  key: "system_prompt",
+  type: "prompt",
+  title: "System prompt",
+  required: false,
+} as unknown as ManagedAgentFieldSpec;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderWithValue(value: string, onChange = vi.fn()) {
+  act(() => {
+    root.render(
+      <TuningFieldRenderer field={PROMPT_FIELD} value={value} onChange={onChange} disabled={false} teamId="t1" />,
+    );
+  });
+}
+
+const pickerShown = () => !!container.querySelector('[data-testid="prompt-picker"]');
+const textareaShown = () => !!container.querySelector("textarea");
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("TuningFieldRenderer — prompt library auto-open", () => {
+  it("auto-opens the library on the initial EMPTY state", () => {
+    renderWithValue("");
+    expect(pickerShown()).toBe(true);
+    expect(textareaShown()).toBe(false);
+  });
+
+  it("shows the textarea (not the library) when the field has a value", () => {
+    renderWithValue("Existing prompt");
+    expect(textareaShown()).toBe(true);
+    expect(pickerShown()).toBe(false);
+  });
+
+  it("does NOT reopen the library when the field is cleared by editing", () => {
+    // Start with content → textarea (write mode).
+    renderWithValue("Existing prompt");
+    expect(textareaShown()).toBe(true);
+
+    // User wipes the field in the textarea. Use the native value setter so
+    // React's controlled-input value tracker registers the change and fires
+    // onChange (a plain `.value = ""` is swallowed by the tracker).
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+    act(() => {
+      nativeSetter?.call(textarea, "");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    // The form re-renders with the now-empty value (as the parent would).
+    renderWithValue("");
+
+    // The library must stay closed — the write-mode textarea is still shown.
+    expect(pickerShown()).toBe(false);
+    expect(textareaShown()).toBe(true);
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx
@@ -41,6 +41,12 @@ type TuningFieldRendererProps = {
   /** Effective values (current input or declared default) of every sibling field
    * in the same form — drives the `ui.visible_when` conditional display. */
   allValues?: Record<string, unknown>;
+  /** Controlled prompt-picker mode, lifted so it survives this field being
+   * unmounted/remounted when the form switches sections (otherwise a cleared
+   * field would auto-reopen the library on return). null = auto, true = picker
+   * forced open, false = write-from-scratch. Omit to fall back to local state. */
+  pickerExplicit?: boolean | null;
+  onPickerExplicitChange?: (value: boolean | null) => void;
 };
 
 export function TuningFieldRenderer({
@@ -51,6 +57,8 @@ export function TuningFieldRenderer({
   error,
   teamId,
   allValues,
+  pickerExplicit: pickerExplicitProp,
+  onPickerExplicitChange,
 }: TuningFieldRendererProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language.split("-")[0];
@@ -62,7 +70,11 @@ export function TuningFieldRenderer({
   // null = auto: picker shown when field is empty, textarea shown when field has value.
   // true = user explicitly opened picker from editing mode.
   // false = user explicitly chose to write from scratch (override auto-picker for empty fields).
-  const [pickerExplicit, setPickerExplicit] = useState<boolean | null>(null);
+  // Controlled by the form when it wants this decision to persist across section
+  // switches (the field unmounts then); otherwise kept in local state.
+  const [localPickerExplicit, setLocalPickerExplicit] = useState<boolean | null>(null);
+  const pickerExplicit = pickerExplicitProp !== undefined ? pickerExplicitProp : localPickerExplicit;
+  const setPickerExplicit = onPickerExplicitChange ?? setLocalPickerExplicit;
 
   const { data: contextPrompts = [] } = useGetContextPromptsEarlyControlPlaneV1TeamsTeamIdPromptsContextGetQuery(
     { teamId: teamId ?? "" },

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/AgentFormModal/TuningFieldRenderer.tsx
@@ -188,7 +188,15 @@ export function TuningFieldRenderer({
           value={String(fieldValue)}
           rows={field.ui?.max_lines ?? 4}
           placeholder={field.ui?.placeholder ?? undefined}
-          onChange={(e) => onChange(field.key, e.target.value)}
+          onChange={(e) => {
+            onChange(field.key, e.target.value);
+            // Clearing the field WHILE EDITING must not re-trigger the
+            // auto-picker: the auto-open (pickerExplicit === null && empty) is
+            // only meant for the initial empty state. Once the user has emptied
+            // it themselves, lock into write mode — they can still reopen the
+            // library from the "pick from library" button above.
+            if (e.target.value.trim() === "") setPickerExplicit(false);
+          }}
           disabled={disabled || isLoadingDetail}
           error={error}
         />


### PR DESCRIPTION
## Bug

In the agent form's **Prompts** section, the prompt field auto-opens the prompt library while the field is empty. That auto-open is meant only for the *initial* empty state, but it also fired whenever the field became empty:

1. Clearing the system prompt while editing reopened the library.
2. After clearing + blurring + switching to another section and back, the library reopened again.

## Fix

The picker mode (`auto` / `write-from-scratch` / `picker-open`) is now:

- Set to **write mode** when the user empties the field by editing, so it no longer falls back to auto-open.
- **Lifted into `AgentFormBody`** (which stays mounted across section switches) and passed to `TuningFieldRenderer` as a controlled prop, so the decision survives the field unmounting/remounting when the user leaves and returns to the Prompts section. Local-state fallback is preserved for any standalone use.

The initial auto-open on a brand-new empty field is unchanged.

## Testing

New `TuningFieldRenderer.test.tsx` (4 tests): initial auto-open, textarea when the field has a value, no reopen on clear-while-editing, and no reopen across an unmount/remount once emptied. Verified the tests fail without the fix. `make code-quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
