### PR TITLE
fix(#2364): tabular parquet reads on GCS bypass signBlob via server-side ADC downloads

### DIFF
--- a/apps/knowledge-flow-backend/config/schema/configuration.schema.json
+++ b/apps/knowledge-flow-backend/config/schema/configuration.schema.json
@@ -416,7 +416,7 @@
             }
           ],
           "default": null,
-          "description": "Service account email used to sign V4 signed URLs for backend-internal tabular Parquet reads, via IAM signBlob under Workload Identity (no JSON key). Required for content_storage.type=gcs; startup fails clearly when omitted. The Workload Identity service account must hold iam.serviceAccounts.signBlob on this account, which must have storage.objects.get on the objects bucket.",
+          "description": "Optional service account email used to sign V4 signed URLs via IAM signBlob under Workload Identity (no JSON key). Tabular Parquet reads no longer need it: they download artifacts server-side with the ADC client, which only requires storage.objects.get on the objects bucket (#2364). Set it only to re-enable internal V4 signed URLs for code paths that explicitly call get_presigned_url_internal.",
           "title": "Signing Service Account Email"
         }
       },
@@ -2370,13 +2370,13 @@
         "access_mode": {
           "const": "presigned_url",
           "default": "presigned_url",
-          "description": "Primary object-access method for remote tabular artifacts.",
+          "description": "Primary object-access method for remote tabular artifacts on S3-compatible stores. GCS ignores it: artifacts are downloaded server-side to a job-local file instead (#2364).",
           "title": "Access Mode",
           "type": "string"
         },
         "internal_presigned_ttl_seconds": {
           "default": 3600,
-          "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads.",
+          "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads on S3-compatible stores. Unused on GCS (no URLs are minted).",
           "minimum": 1,
           "title": "Internal Presigned Ttl Seconds",
           "type": "integer"
@@ -2435,6 +2435,13 @@
           "description": "Maximum datasets one request may mount or scan. Backstop for searches and for queries whose referenced-relation set is still too large.",
           "minimum": 1,
           "title": "Max Selected Datasets",
+          "type": "integer"
+        },
+        "max_local_artifact_bytes": {
+          "default": 536870912,
+          "description": "Per-job disk budget, in bytes, for tabular artifacts materialized onto the pod's local storage (GCS access path, #2364). A query needing more fails as a caller error (400) instead of filling the pod's ephemeral storage; the declared artifact size is checked before downloading. This is also the effective per-artifact ceiling on GCS - raise it on deployments that ingest very large tabular files. Instantaneous worst case per pod: max_concurrent_queries times this value.",
+          "minimum": 1,
+          "title": "Max Local Artifact Bytes",
           "type": "integer"
         }
       },

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/application_context.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/application_context.py
@@ -558,18 +558,12 @@ class ApplicationContext:
                 public_secure=config.public_secure,
             )
         elif isinstance(config, GcsStorageConfig):
-            # Fail fast at startup: GCS tabular Parquet reads need a signing SA to
-            # mint V4 signed URLs via IAM signBlob. There is no per-feature flag to
-            # detect tabular usage, so a missing email must stop the boot with a
-            # clear message rather than surfacing later as an opaque runtime error.
-            if not config.signing_service_account_email:
-                raise ValueError(
-                    "content_storage.type=gcs requires 'signing_service_account_email' "
-                    "to sign V4 signed URLs for tabular Parquet reads (IAM signBlob under "
-                    "Workload Identity, no JSON key). Set it to the signing service account "
-                    "that holds storage.objects.get on the objects bucket and on which the "
-                    "Workload Identity service account has iam.serviceAccounts.signBlob."
-                )
+            # signing_service_account_email is optional: tabular Parquet reads
+            # download artifacts through the ADC/Workload-Identity client instead
+            # of minting V4 signed URLs (#2364 — signBlob is not grantable on
+            # every deployment), and browser-facing presigned URLs are
+            # unsupported on GCS by design. The email is consumed only if a code
+            # path explicitly calls get_presigned_url_internal.
             self._content_store_instance = GcsContentStore(
                 document_bucket=f"{config.bucket_name}-documents",
                 object_bucket=f"{config.bucket_name}-objects",

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py
@@ -196,12 +196,12 @@ class GcsStorageConfig(BaseModel):
     signing_service_account_email: Optional[str] = Field(
         default=None,
         description=(
-            "Service account email used to sign V4 signed URLs for backend-internal "
-            "tabular Parquet reads, via IAM signBlob under Workload Identity (no JSON "
-            "key). Required for content_storage.type=gcs; startup fails clearly when "
-            "omitted. The Workload Identity service account must hold "
-            "iam.serviceAccounts.signBlob on this account, which must have "
-            "storage.objects.get on the objects bucket."
+            "Optional service account email used to sign V4 signed URLs via IAM "
+            "signBlob under Workload Identity (no JSON key). Tabular Parquet reads "
+            "no longer need it: they download artifacts server-side with the ADC "
+            "client, which only requires storage.objects.get on the objects bucket "
+            "(#2364). Set it only to re-enable internal V4 signed URLs for code "
+            "paths that explicitly call get_presigned_url_internal."
         ),
     )
 
@@ -861,12 +861,12 @@ class TabularQueryConfig(BaseModel):
     )
     access_mode: Literal["presigned_url"] = Field(
         default="presigned_url",
-        description="Primary object-access method for remote tabular artifacts.",
+        description="Primary object-access method for remote tabular artifacts on S3-compatible stores. GCS ignores it: artifacts are downloaded server-side to a job-local file instead (#2364).",
     )
     internal_presigned_ttl_seconds: int = Field(
         default=3600,
         ge=1,
-        description="TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads.",
+        description="TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads on S3-compatible stores. Unused on GCS (no URLs are minted).",
     )
     default_max_rows: int = Field(
         default=200,
@@ -907,6 +907,19 @@ class TabularQueryConfig(BaseModel):
         default=50,
         ge=1,
         description="Maximum datasets one request may mount or scan. Backstop for searches and for queries whose referenced-relation set is still too large.",
+    )
+    max_local_artifact_bytes: int = Field(
+        default=512 * 1024 * 1024,
+        ge=1,
+        description=(
+            "Per-job disk budget, in bytes, for tabular artifacts materialized onto the "
+            "pod's local storage (GCS access path, #2364). A query needing more fails as "
+            "a caller error (400) instead of filling the pod's ephemeral storage; the "
+            "declared artifact size is checked before downloading. This is also the "
+            "effective per-artifact ceiling on GCS - raise it on deployments that ingest "
+            "very large tabular files. Instantaneous worst case per pod: "
+            "max_concurrent_queries times this value."
+        ),
     )
 
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/gcs_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/gcs_content_store.py
@@ -62,9 +62,11 @@ class GcsContentStore(BaseContentStore):
     - :meth:`get_presigned_url` (browser-facing) stays intentionally unsupported.
       The VFS share flow uses application-level HMAC tokens, which are
       backend-agnostic and work over GCS as-is.
-    - :meth:`get_presigned_url_internal` (backend-internal tabular Parquet reads)
-      mints short-lived V4 signed URLs via IAM ``signBlob`` under Workload
-      Identity — keyless, no SA JSON key. Requires ``signing_service_account_email``.
+    - :meth:`get_presigned_url_internal` mints short-lived V4 signed URLs via IAM
+      ``signBlob`` under Workload Identity — keyless, no SA JSON key. Requires
+      ``signing_service_account_email``. No knowledge-flow feature consumes it
+      anymore: tabular Parquet reads use :meth:`download_object_to_path` instead
+      (#2364), because ``signBlob`` is not grantable on every deployment.
     """
 
     def __init__(
@@ -76,10 +78,11 @@ class GcsContentStore(BaseContentStore):
     ):
         self.document_bucket_name = document_bucket
         self.object_bucket_name = object_bucket
-        # Service account used to sign V4 signed URLs for backend-internal tabular
-        # reads via IAM signBlob (Workload Identity, no JSON key). Optional here;
-        # the application factory enforces its presence for GCS deployments so
-        # construction stays testable. Consumed in get_presigned_url_internal.
+        # Service account used to sign V4 signed URLs via IAM signBlob (Workload
+        # Identity, no JSON key). Optional everywhere since #2364: no
+        # knowledge-flow feature calls get_presigned_url_internal anymore, and
+        # that method refuses clearly when invoked without this email — there is
+        # no startup validation for it.
         self.signing_service_account_email = signing_service_account_email
         # Lazily-acquired ADC credentials, cached and refreshed on demand to mint
         # the access token for IAM signBlob. None until the first signing call.
@@ -319,6 +322,51 @@ class GcsContentStore(BaseContentStore):
         except NotFound as e:
             raise FileNotFoundError(f"Object not found: {key}") from e
 
+    def download_object_to_path(self, key: str, destination: Path, *, timeout_seconds: int = 60) -> None:
+        """
+        Download one object from the objects bucket into a local file, streaming.
+
+        Why this exists:
+        - Tabular DuckDB reads used to require a V4 signed URL so `httpfs` could
+          fetch the Parquet artifact over HTTPS, and minting one needs
+          `iam.serviceAccounts.signBlob` — a grant sovereign deployments
+          (tp-s3ns, #2364) do not hold. This method uses the same
+          ADC/Workload-Identity client as every other download in this store,
+          so plain `storage.objects.get` on the objects bucket is enough.
+        - `blob.download_to_filename` streams to disk in chunks, unlike
+          `get_object_stream` which buffers the whole object in memory.
+
+        How to use:
+        - Call from server-side code that wants a local reader (DuckDB) to
+          consume the artifact from disk; the caller owns the destination's
+          lifecycle and should scope it to the reading job.
+        - `timeout_seconds` bounds per-request socket inactivity (connect/read),
+          not total transfer time, so a stalled connection releases the calling
+          worker instead of pinning its execution slot indefinitely.
+
+        Example:
+        - `store.download_object_to_path("tabular/datasets/d/r/data.parquet", job_dir / "data.parquet")`
+        """
+        object_name = self._normalize_key(key)
+        blob = self.object_bucket.blob(object_name)
+        started = time.monotonic()
+        try:
+            blob.download_to_filename(str(destination), timeout=timeout_seconds)
+        except NotFound as e:
+            destination.unlink(missing_ok=True)
+            raise FileNotFoundError(f"Object not found: {key}") from e
+        except Exception:
+            # Never leave a truncated file behind: a partial Parquet would fail
+            # later with a confusing DuckDB error instead of a clear one here.
+            destination.unlink(missing_ok=True)
+            raise
+        logger.info(
+            "[CONTENT][GCS] downloaded object key=%s size_bytes=%s in %dms",
+            key,
+            destination.stat().st_size,
+            int((time.monotonic() - started) * 1000),
+        )
+
     def get_presigned_url(self, key: str, expires: timedelta = timedelta(hours=1)) -> str:
         """
         Not supported on the pure Workload Identity path.
@@ -357,25 +405,29 @@ class GcsContentStore(BaseContentStore):
         Mint a short-lived V4 signed URL for backend-internal object reads.
 
         Why this exists:
-        - Tabular DuckDB reads need a DuckDB-readable HTTPS location for Parquet
-          artifacts. Under Workload Identity there is no SA private key, so the
-          URL is signed via the IAM signBlob API using the configured signing
-          service account (keyless).
+        - Under Workload Identity there is no SA private key, so the URL is
+          signed via the IAM signBlob API using the configured signing service
+          account (keyless). No knowledge-flow feature calls this anymore —
+          tabular DuckDB reads use `download_object_to_path` instead (#2364) —
+          but the capability stays available for callers that explicitly opt
+          into internal signed URLs.
 
         How to use:
-        - Call from server-side code paths such as tabular DuckDB reads. The
-          returned URL is a secret: never log it, return it in API/MCP payloads,
-          or persist it.
+        - Call only from server-side code. The returned URL is a secret: never
+          log it, return it in API/MCP payloads, or persist it.
 
         Example:
         - `store.get_presigned_url_internal("tabular/datasets/d/r/data.parquet", expires=timedelta(minutes=5))`
         """
         object_name = self._normalize_key(key)
         if not self.signing_service_account_email:
-            # Defensive guard: the application factory already fails fast at
-            # startup, but a store built outside it must still refuse clearly
-            # rather than emit an unusable URL.
-            raise RuntimeError(f"[CONTENT][GCS] Cannot sign internal URL for '{key}': no signing_service_account_email configured for the GCS content store.")
+            # This is the only guard: nothing validates the email at startup
+            # anymore (#2364 removed the factory fail-fast). NotImplementedError
+            # keeps the base-class contract — "this backend does not support
+            # presigned URLs (as configured)" — so a caller probing capabilities
+            # degrades to its explicit unsupported-operation path instead of an
+            # opaque 500.
+            raise NotImplementedError(f"[CONTENT][GCS] Cannot sign internal URL for '{key}': no signing_service_account_email configured for the GCS content store.")
 
         signed_url = self.object_bucket.blob(object_name).generate_signed_url(
             version="v4",

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/tabular/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/tabular/service.py
@@ -18,10 +18,13 @@ import asyncio
 import hashlib
 import logging
 import re
+import tempfile
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
+from pathlib import Path
+from typing import Callable, Iterator
 
 import duckdb
 import pandas as pd
@@ -31,6 +34,7 @@ from fred_core.documents.document_structures import DocumentMetadata
 
 from knowledge_flow_backend.application_context import ApplicationContext
 from knowledge_flow_backend.core.stores.content.filesystem_content_store import FileSystemContentStore
+from knowledge_flow_backend.core.stores.content.gcs_content_store import GcsContentStore
 from knowledge_flow_backend.features.tabular.artifacts import (
     TabularArtifactV1,
     TabularTableArtifactV1,
@@ -87,9 +91,10 @@ class TabularDatasetAccessUnsupportedError(RuntimeError):
     Raised when a tabular artifact cannot be exposed to DuckDB.
 
     Why this exists:
-    - Tabular reads need either a backend-internal signed URL or a local file
-      path. Some content stores, notably GCS before internal V4 signing lands,
-      support object streams but not DuckDB-readable locations.
+    - Tabular reads need a backend-internal signed URL, a direct local file
+      path, or a store-side download to a job-local file (GCS, #2364). A store
+      that provides none of these can stream objects without ever yielding a
+      DuckDB-readable location.
 
     How to use:
     - Let controllers map this to an explicit unsupported-operation response.
@@ -211,6 +216,48 @@ def _redacting_query_execution_errors():
 # Below this length a keyword is too generic to locate anything useful; the
 # value-locator rejects it rather than matching a large fraction of every table.
 _MIN_KEYWORD_LENGTH = 2
+
+
+@dataclass
+class _JobDiskBudget:
+    """
+    Cumulative disk budget for one job's locally materialized artifacts.
+
+    Why this exists:
+    - The GCS access path downloads Parquet artifacts onto the pod's ephemeral
+      storage, and without a bound one query mounting many large datasets could
+      evict the pod — DuckDB spilling is disabled for exactly that reason
+      (execution.py).
+    - `precheck(...)` refuses an artifact whose declared ingestion size alone
+      busts the budget *before* a single byte is written, so one oversized
+      artifact cannot fill the disk mid-download. `charge(...)` then accounts
+      the actual on-disk bytes, which stays correct for legacy artifacts that
+      declared no size (they skip the precheck and are charged after the
+      fact — overshoot bounded by that one artifact, deleted with the scope).
+
+    How to use:
+    - One instance per `_dataset_location_scope()`; call `precheck(...)` before
+      and `charge(...)` after every download.
+    """
+
+    limit_bytes: int
+    used_bytes: int = 0
+
+    def precheck(self, declared_size_bytes: int) -> None:
+        if declared_size_bytes > 0 and self.used_bytes + declared_size_bytes > self.limit_bytes:
+            raise TabularQueryError(self._over_budget_message())
+
+    def charge(self, size_bytes: int) -> None:
+        self.used_bytes += size_bytes
+        if self.used_bytes > self.limit_bytes:
+            raise TabularQueryError(self._over_budget_message())
+
+    def _over_budget_message(self) -> str:
+        return (
+            f"Materializing the referenced datasets exceeds the per-query local storage budget ({self.limit_bytes} bytes). "
+            "Query fewer or smaller datasets; reading a single dataset above the budget requires raising "
+            "storage.tabular_store.query.max_local_artifact_bytes."
+        )
 
 
 class TabularService:
@@ -562,26 +609,30 @@ class TabularService:
         )
 
         def _job(handle: DuckDBAbortHandle) -> tuple[str, list[dict], list[ResolvedDataset]]:
-            connection = open_duckdb_connection(handle, config=query_config)
-            try:
-                handle.raise_if_aborted()
-                # Validation parses the SQL and already knows which authorized
-                # aliases it touches, so it runs here — inside the worker, since
-                # it opens its own DuckDB connection — and its result decides
-                # what gets mounted.
-                validated = validate_read_query(request.sql_text, allowed_relations=allowed_aliases)
-                mounted_datasets = self._datasets_to_mount(
-                    selected_datasets=selected_datasets,
-                    referenced_relations=validated.referenced_relations,
-                )
-                self._mount_datasets(connection=connection, datasets=mounted_datasets, handle=handle)
-                handle.raise_if_aborted()
-                limited_query = f"SELECT * FROM ({validated.sql}) AS fred_result LIMIT {effective_max_rows}"
-                with _redacting_query_execution_errors():
-                    rows_df = connection.execute(limited_query).df()
-                return validated.sql, rows_df.to_dict(orient="records"), mounted_datasets
-            finally:
-                close_duckdb_connection(handle, connection)
+            # The location scope wraps the whole connection lifetime: DuckDB
+            # opens Parquet lazily at execution time, and GCS-materialized temp
+            # files must only be unlinked after the connection released them.
+            with self._dataset_location_scope() as resolve_location:
+                connection = open_duckdb_connection(handle, config=query_config)
+                try:
+                    handle.raise_if_aborted()
+                    # Validation parses the SQL and already knows which authorized
+                    # aliases it touches, so it runs here — inside the worker, since
+                    # it opens its own DuckDB connection — and its result decides
+                    # what gets mounted.
+                    validated = validate_read_query(request.sql_text, allowed_relations=allowed_aliases)
+                    mounted_datasets = self._datasets_to_mount(
+                        selected_datasets=selected_datasets,
+                        referenced_relations=validated.referenced_relations,
+                    )
+                    self._mount_datasets(connection=connection, datasets=mounted_datasets, handle=handle, resolve_location=resolve_location)
+                    handle.raise_if_aborted()
+                    limited_query = f"SELECT * FROM ({validated.sql}) AS fred_result LIMIT {effective_max_rows}"
+                    with _redacting_query_execution_errors():
+                        rows_df = connection.execute(limited_query).df()
+                    return validated.sql, rows_df.to_dict(orient="records"), mounted_datasets
+                finally:
+                    close_duckdb_connection(handle, connection)
 
         started_at = time.perf_counter()
         sql_query, rows, mounted_datasets = await run_duckdb_job(_job, config=query_config, operation="query")
@@ -671,22 +722,21 @@ class TabularService:
             )
 
         def _job(handle: DuckDBAbortHandle) -> tuple[str, list[TabularTableMatch], bool]:
-            connection = open_duckdb_connection(handle, config=query_config)
-            try:
-                handle.raise_if_aborted()
-                # Normalize the keyword through the exact same DuckDB expression the
-                # column values pass through, so both operands are strictly comparable.
-                keyword_probe_sql = f"SELECT {self._normalize_expr(quote_string_literal(raw_keyword))}"
-                probe_row = connection.execute(keyword_probe_sql).fetchone()
-                probe_keyword = probe_row[0] if probe_row else None
-                if not probe_keyword:
-                    raise ValueError("Keyword is empty after normalization; provide a more specific value")
+            # Scope outside the connection lifetime — see query_read._job.
+            with self._dataset_location_scope() as resolve_location:
+                connection = open_duckdb_connection(handle, config=query_config)
+                try:
+                    handle.raise_if_aborted()
+                    # Normalize the keyword through the exact same DuckDB expression the
+                    # column values pass through, so both operands are strictly comparable.
+                    keyword_probe_sql = f"SELECT {self._normalize_expr(quote_string_literal(raw_keyword))}"
+                    probe_row = connection.execute(keyword_probe_sql).fetchone()
+                    probe_keyword = probe_row[0] if probe_row else None
+                    if not probe_keyword:
+                        raise ValueError("Keyword is empty after normalization; provide a more specific value")
 
-                self._mount_datasets(connection=connection, datasets=scanned_datasets, handle=handle)
-
-                matches: list[TabularTableMatch] = []
-                tables_truncated = selection_truncated
-                with _redacting_dataset_read_errors():
+                    matches: list[TabularTableMatch] = []
+                    tables_truncated = selection_truncated
                     for dataset in scanned_datasets:
                         if len(matches) >= request.max_matching_tables:
                             # The cap is reached and at least one more table remains
@@ -694,17 +744,23 @@ class TabularService:
                             tables_truncated = True
                             break
                         handle.raise_if_aborted()
-                        match = self._search_one_table(
-                            connection=connection,
-                            dataset=dataset,
-                            normalized_keyword=probe_keyword,
-                            max_rows_per_table=request.max_rows_per_table,
-                        )
+                        # Mounted lazily, one dataset at a time: the early break
+                        # above must also skip the artifact fetch — on GCS an
+                        # eager mount would download (and charge against the
+                        # per-job disk budget) datasets the scan never opens.
+                        self._mount_datasets(connection=connection, datasets=[dataset], handle=handle, resolve_location=resolve_location)
+                        with _redacting_dataset_read_errors():
+                            match = self._search_one_table(
+                                connection=connection,
+                                dataset=dataset,
+                                normalized_keyword=probe_keyword,
+                                max_rows_per_table=request.max_rows_per_table,
+                            )
                         if match is not None:
                             matches.append(match)
-                return probe_keyword, matches, tables_truncated
-            finally:
-                close_duckdb_connection(handle, connection)
+                    return probe_keyword, matches, tables_truncated
+                finally:
+                    close_duckdb_connection(handle, connection)
 
         started_at = time.perf_counter()
         normalized_keyword, matches, tables_truncated = await run_duckdb_job(_job, config=query_config, operation="search")
@@ -1085,6 +1141,7 @@ class TabularService:
         connection: duckdb.DuckDBPyConnection,
         datasets: list[ResolvedDataset],
         handle: DuckDBAbortHandle,
+        resolve_location: Callable[[TabularArtifactV1], str],
     ) -> None:
         """
         Mount authorized Parquet datasets as temporary DuckDB views.
@@ -1096,17 +1153,20 @@ class TabularService:
         How to use:
         - Call on a fresh in-memory connection, inside the worker thread, before
           executing one SQL query.
+        - `resolve_location` comes from `_dataset_location_scope()`, so remote
+          materialization (GCS downloads) stays scoped to the calling job.
         - The abort handle is checked before each dataset because this loop is
           the one part of a job `connection.interrupt()` cannot stop: resolving a
-          location and opening a remote Parquet are blocking calls outside
-          DuckDB's own interruptible execution. Checking between datasets bounds
-          how much of an abandoned mount still runs.
+          location (a full artifact download on GCS) and opening a remote Parquet
+          are blocking calls outside DuckDB's own interruptible execution.
+          Checking between datasets bounds how much of an abandoned mount still
+          runs.
         """
 
         dataset_locations: list[tuple[ResolvedDataset, str]] = []
         for dataset in datasets:
             handle.raise_if_aborted()
-            location = self._resolve_dataset_location(dataset.artifact.object_key)
+            location = resolve_location(dataset.artifact)
             dataset_locations.append((dataset, location))
 
         if any(self._requires_httpfs(location) for _, location in dataset_locations):
@@ -1117,16 +1177,98 @@ class TabularService:
                 handle.raise_if_aborted()
                 connection.from_parquet(location).create_view(dataset.query_alias)
 
+    @contextmanager
+    def _dataset_location_scope(self) -> Iterator[Callable[[TabularArtifactV1], str]]:
+        """
+        Yield a per-job resolver turning artifacts into DuckDB-readable locations.
+
+        Why this exists:
+        - On GCS, tabular reads bypass signed URLs entirely (#2364): minting a
+          V4 URL needs `iam.serviceAccounts.signBlob`, which sovereign
+          deployments (tp-s3ns) do not grant, while the store's ADC client
+          already downloads objects with plain `storage.objects.get`. Artifacts
+          are materialized into one temp directory per job and DuckDB reads
+          them as local files — no `httpfs` involved, and GCS client errors are
+          stripped of store internals before they surface.
+        - The temp directory must live exactly as long as the job: DuckDB opens
+          Parquet lazily at execution time, not at view creation, so cleanup
+          cannot happen right after mounting.
+        - Each replica downloads into its own pod-local temp directory, so this
+          stays correct with several knowledge-flow pods — the content store
+          remains the single store of record.
+        - The branch is keyed on the concrete class on purpose: this is a
+          *strategy* choice, not a capability probe. GCS implements internal
+          presigned URLs but must not use them, so "supports download" cannot
+          be the discriminator — any store could implement a download.
+
+        How to use:
+        - Open the scope before creating the DuckDB connection and close it
+          after the connection is closed, so materialized files are never
+          unlinked while DuckDB still holds them open.
+        - Pass the yielded callable to `_mount_datasets(...)` or call it
+          directly with a dataset's artifact.
+        """
+
+        if isinstance(self.content_store, GcsContentStore):
+            gcs_store = self.content_store
+            budget = _JobDiskBudget(limit_bytes=self.tabular_config.query.max_local_artifact_bytes)
+            with tempfile.TemporaryDirectory(prefix="tabular-datasets-") as temp_dir:
+                temp_root = Path(temp_dir)
+                yield lambda artifact: self._materialize_gcs_dataset(store=gcs_store, artifact=artifact, temp_dir=temp_root, budget=budget)
+            return
+
+        yield lambda artifact: self._resolve_dataset_location(artifact.object_key)
+
+    @staticmethod
+    def _materialize_gcs_dataset(*, store: GcsContentStore, artifact: TabularArtifactV1, temp_dir: Path, budget: _JobDiskBudget) -> str:
+        """
+        Download one GCS Parquet artifact into the job's temp directory.
+
+        Why this exists:
+        - See `_dataset_location_scope`: GCS reads use the ADC-authenticated
+          client instead of signed URLs, so DuckDB consumes a local file.
+        - The file name is a digest of the object key: traversal-safe,
+          collision-free within the job, and stable so an artifact referenced
+          twice by one job is downloaded once.
+        - The job's disk budget is prechecked with the artifact's declared
+          ingestion size before downloading and charged with the actual bytes
+          after, so one query cannot fill the pod's ephemeral storage — not
+          even with a single oversized artifact.
+        - Download errors are re-raised with store internals stripped: the
+          tabular controllers surface `str(e)` to API/MCP callers, and neither
+          the object key (404 path) nor the raw GCS REST URL embedded in google
+          client errors (500 path) is theirs to see. This mirrors what
+          `_redacting_dataset_read_errors` does for the `httpfs` path.
+
+        How to use:
+        - Only call with the temp directory and budget owned by the current job
+          scope.
+        """
+
+        destination = temp_dir / f"{hashlib.sha256(artifact.object_key.encode('utf-8')).hexdigest()}.parquet"
+        if not destination.exists():
+            budget.precheck(artifact.file_size_bytes)
+            try:
+                store.download_object_to_path(artifact.object_key, destination)
+            except FileNotFoundError as exc:
+                raise FileNotFoundError("Tabular dataset artifact was not found in content storage") from exc
+            except Exception as exc:  # noqa: BLE001 — google client errors embed the raw object URL
+                raise TabularDatasetReadError(_redact_signed_urls(str(exc))) from exc
+            budget.charge(destination.stat().st_size)
+        return str(destination)
+
     def _resolve_dataset_location(self, object_key: str) -> str:
         """
         Resolve one content-store object to a DuckDB-readable location.
 
         Why this exists:
-        - Remote object stores use backend-internal presigned URLs through
-          DuckDB `httpfs`.
+        - Remote S3-compatible object stores use backend-internal presigned
+          URLs through DuckDB `httpfs`.
         - The local filesystem content store used in local development and
           offline tests should expose a direct file path instead of emulating a
           remote download flow.
+        - GCS never reaches this helper: `_dataset_location_scope` materializes
+          its artifacts to job-local files instead (#2364).
 
         How to use:
         - Call while mounting the per-query DuckDB session.
@@ -1263,21 +1405,23 @@ class TabularService:
         query_config = self.tabular_config.query
 
         def _job(handle: DuckDBAbortHandle) -> pd.DataFrame:
-            connection = open_duckdb_connection(handle, config=query_config)
-            try:
-                handle.raise_if_aborted()
-                location = self._resolve_dataset_location(dataset.artifact.object_key)
-                if self._requires_httpfs(location):
-                    self._ensure_httpfs_ready(connection)
+            # Scope outside the connection lifetime — see query_read._job.
+            with self._dataset_location_scope() as resolve_location:
+                connection = open_duckdb_connection(handle, config=query_config)
+                try:
+                    handle.raise_if_aborted()
+                    location = resolve_location(dataset.artifact)
+                    if self._requires_httpfs(location):
+                        self._ensure_httpfs_ready(connection)
 
-                handle.raise_if_aborted()
-                with _redacting_dataset_read_errors():
-                    relation = connection.from_parquet(location)
-                    if max_rows is not None:
-                        relation = relation.limit(max_rows)
-                    return relation.df()
-            finally:
-                close_duckdb_connection(handle, connection)
+                    handle.raise_if_aborted()
+                    with _redacting_dataset_read_errors():
+                        relation = connection.from_parquet(location)
+                        if max_rows is not None:
+                            relation = relation.limit(max_rows)
+                        return relation.df()
+                finally:
+                    close_duckdb_connection(handle, connection)
 
         started_at = time.perf_counter()
         frame = await run_duckdb_job(_job, config=query_config, operation="preview")

--- a/apps/knowledge-flow-backend/tests/core/test_content_store_factory_gcs.py
+++ b/apps/knowledge-flow-backend/tests/core/test_content_store_factory_gcs.py
@@ -12,27 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Factory-level tests for the GCS content store fail-fast guard (FILES-06)."""
+"""Factory-level tests for the GCS content store construction (FILES-06, #2364)."""
 
-import pytest
+from types import SimpleNamespace
 
 from knowledge_flow_backend.application_context import ApplicationContext
 from knowledge_flow_backend.common.structures import GcsStorageConfig
 
 
-def test_gcs_content_store_factory_fails_fast_without_signing_email(app_context: ApplicationContext):
-    """A GCS content store without a signing SA email must refuse to build.
+def test_gcs_content_store_factory_builds_without_signing_email(app_context: ApplicationContext, monkeypatch):
+    """A GCS content store must boot without a signing SA email (#2364).
 
     Why this exists:
-    - tabular_store is always configured, so there is no per-feature flag to
-      detect tabular usage; a missing signing email is a deployment error that
-      must surface clearly at startup rather than as an opaque later failure.
+    - Tabular Parquet reads download artifacts through the ADC client instead
+      of minting V4 signed URLs, so deployments that cannot grant
+      iam.serviceAccounts.signBlob (tp-s3ns) must start normally with the
+      email unset. The old fail-fast guard would have blocked exactly them.
     """
+    from knowledge_flow_backend.core.stores.content import gcs_content_store
+
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: SimpleNamespace(bucket=lambda name: None))
     config = app_context.get_config()
     config.content_storage = GcsStorageConfig(type="gcs", bucket_name="fred")
 
-    with pytest.raises(ValueError, match="signing_service_account_email"):
-        app_context.get_content_store()
+    store = app_context.get_content_store()
+
+    assert store.signing_service_account_email is None
 
 
 def test_get_content_store_builds_once_and_reuses_the_instance(app_context: ApplicationContext):

--- a/apps/knowledge-flow-backend/tests/services/test_tabular_service.py
+++ b/apps/knowledge-flow-backend/tests/services/test_tabular_service.py
@@ -28,7 +28,7 @@ from knowledge_flow_backend.features.tabular.artifacts import (
     document_artifact_prefix,
     read_tabular_artifact,
 )
-from knowledge_flow_backend.features.tabular.service import TabularDatasetAccessUnsupportedError, TabularService
+from knowledge_flow_backend.features.tabular.service import TabularDatasetAccessUnsupportedError, TabularQueryError, TabularService
 from knowledge_flow_backend.features.tabular.structures import TabularQueryRequest
 from knowledge_flow_backend.features.tag.structure import MissingTeamIdError
 
@@ -258,8 +258,10 @@ class _UnsupportedRemoteContentStore:
     Remote-style content store wrapper with no DuckDB-readable location support.
 
     Why this exists:
-    - GCS can stream objects through the Python client while still lacking
-      backend-internal signed URLs for DuckDB Parquet reads.
+    - A hypothetical store can stream objects through its client while offering
+      neither backend-internal signed URLs, nor a local path, nor the GCS
+      job-local download path (#2364) — tabular reads must then fail as an
+      explicit capability error.
 
     How to use:
     - Wrap the local test content store to exercise the unsupported remote
@@ -275,6 +277,90 @@ class _UnsupportedRemoteContentStore:
 
     def __getattr__(self, name):
         return getattr(self._delegate, name)
+
+
+class _FakeGcsBlob:
+    """In-memory stand-in for the two google blob calls the tabular path uses."""
+
+    def __init__(self, objects: dict, name: str):
+        self._objects = objects
+        self.name = name
+
+    def upload_from_filename(self, path, content_type=None):
+        del content_type
+        with open(path, "rb") as handle:
+            self._objects[self.name] = handle.read()
+
+    def download_to_filename(self, path, timeout=None):
+        from google.cloud.exceptions import NotFound
+
+        del timeout
+        if self.name not in self._objects:
+            # Mirror the real client: the destination is created (then truncated)
+            # before the request fails, so the store must clean up the leftover.
+            open(path, "wb").close()
+            raise NotFound(self.name)
+        with open(path, "wb") as handle:
+            handle.write(self._objects[self.name])
+
+
+def _fake_gcs_content_store(monkeypatch):
+    """Build a real GcsContentStore backed by an in-memory fake client.
+
+    Why this exists:
+    - The service selects the GCS materialization path with an isinstance
+      check (a deliberate strategy choice, see _dataset_location_scope), so
+      tests need an actual GcsContentStore instance — a delegate wrapper like
+      the ones above would not be recognized.
+    """
+    from knowledge_flow_backend.core.stores.content import gcs_content_store
+
+    objects: dict[str, bytes] = {}
+    bucket = SimpleNamespace(blob=lambda name: _FakeGcsBlob(objects, name))
+    monkeypatch.setattr(gcs_content_store, "build_gcs_client", lambda project_id=None: SimpleNamespace(bucket=lambda name: bucket))
+    store = gcs_content_store.GcsContentStore(document_bucket="kf-documents", object_bucket="kf-objects")
+    store._fake_objects = objects  # test-only handle to mutate the bucket
+    return store
+
+
+async def _gcs_tabular_setup(*, tmp_path, metadata_store, monkeypatch, documents):
+    """Ingest CSVs, move their Parquet artifacts into a fake GCS bucket, and
+    return `(service, gcs_store, downloaded_paths)` with downloads tracked.
+
+    Why this exists:
+    - Every GCS tabular test needs the same arrangement: local ingestion, the
+      artifact re-homed into the fake GCS objects bucket (so reads can only
+      succeed through the download path), the service's store swapped, and a
+      tracking wrapper around `download_object_to_path`.
+    """
+    content_store = ApplicationContext.get_instance().get_content_store()
+    content_store.clear()
+
+    gcs_store = _fake_gcs_content_store(monkeypatch)
+    for document_uid, file_name, content in documents:
+        metadata = await _ingest_csv(
+            tmp_path=tmp_path,
+            metadata_store=metadata_store,
+            document_uid=document_uid,
+            file_name=file_name,
+            content=content,
+        )
+        artifact = read_tabular_artifact(metadata)
+        assert artifact is not None
+        gcs_store.object_bucket.blob(artifact.object_key).upload_from_filename(str(content_store.object_root / artifact.object_key))
+
+    service = TabularService()
+    service.content_store = gcs_store
+
+    downloaded_paths: list[Path] = []
+    original_download = gcs_store.download_object_to_path
+
+    def _tracked_download(key, destination, **kwargs):
+        downloaded_paths.append(destination)
+        return original_download(key, destination, **kwargs)
+
+    monkeypatch.setattr(gcs_store, "download_object_to_path", _tracked_download)
+    return service, gcs_store, downloaded_paths
 
 
 @pytest.mark.asyncio
@@ -753,9 +839,9 @@ async def test_tabular_service_fails_cleanly_without_signed_url_or_local_path(tm
     Verify unsupported content stores fail as an explicit tabular capability error.
 
     Why this exists:
-    - GCS Workload Identity deployments can write Parquet artifacts before GCS
-      V4 signed URLs are implemented, but DuckDB cannot read those artifacts
-      through `get_object_stream(...)`.
+    - A store can write Parquet artifacts and stream objects while offering no
+      DuckDB-readable location: no signed URLs, no local path, and not the GCS
+      job-local download path (#2364).
 
     How to use:
     - The API layer maps this service exception to an unsupported-operation
@@ -778,6 +864,186 @@ async def test_tabular_service_fails_cleanly_without_signed_url_or_local_path(tm
 
     with pytest.raises(TabularDatasetAccessUnsupportedError, match="Unsupported operation"):
         await service.read_dataset_frame(_user(), "doc-sales")
+
+
+@pytest.mark.asyncio
+async def test_tabular_service_reads_gcs_datasets_via_job_local_download(tmp_path, metadata_store, monkeypatch):
+    """
+    GCS tabular reads materialize the Parquet artifact server-side (#2364).
+
+    Why this exists:
+    - Deployments without iam.serviceAccounts.signBlob (tp-s3ns) cannot mint
+      the V4 signed URLs the httpfs path needs. On GCS the service must
+      download artifacts through the ADC client into a job-scoped temp
+      directory, query them as local files, never mint a URL, and delete the
+      temp files with the job.
+    """
+
+    service, gcs_store, downloaded_paths = await _gcs_tabular_setup(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        monkeypatch=monkeypatch,
+        documents=[("doc-sales", "sales.csv", "city,amount\nParis,10\nLyon,20\n")],
+    )
+    monkeypatch.setattr(gcs_store, "get_presigned_url_internal", lambda *args, **kwargs: pytest.fail("GCS tabular reads must not mint signed URLs"))
+
+    alias = (await service.list_datasets(_user()))[0].query_alias
+    response = await service.query_read(
+        _user(),
+        request=TabularQueryRequest(sql=f"SELECT city, amount FROM {alias} ORDER BY amount DESC"),
+    )
+
+    assert [row["city"] for row in response.rows] == ["Lyon", "Paris"]
+    assert downloaded_paths, "expected the artifact to be downloaded from GCS"
+
+    frame = await service.read_dataset_preview_frame(_user(), "doc-sales", max_rows=1)
+    assert len(frame) == 1
+
+    # Job-scoped cleanup: every materialized file and its temp directory are
+    # gone once their job returned.
+    assert all(not path.exists() for path in downloaded_paths)
+    assert all(not path.parent.exists() for path in downloaded_paths)
+
+
+@pytest.mark.asyncio
+async def test_tabular_service_gcs_disk_budget_refuses_before_downloading(tmp_path, metadata_store, monkeypatch):
+    """
+    One query may not fill the pod's ephemeral storage (#2364).
+
+    Why this exists:
+    - GCS materialization writes to pod-local disk, where DuckDB spilling is
+      already deliberately disabled to protect ephemeral storage. An artifact
+      whose declared ingestion size busts the budget must be refused as a
+      caller error (400) BEFORE any byte is written — otherwise one oversized
+      artifact could fill the disk mid-download.
+    """
+
+    service, _gcs_store, downloaded_paths = await _gcs_tabular_setup(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        monkeypatch=monkeypatch,
+        documents=[("doc-sales", "sales.csv", "city,amount\nParis,10\nLyon,20\n")],
+    )
+    monkeypatch.setattr(service.tabular_config.query, "max_local_artifact_bytes", 1)
+
+    alias = (await service.list_datasets(_user()))[0].query_alias
+    with pytest.raises(TabularQueryError, match="local storage budget"):
+        await service.query_read(
+            _user(),
+            request=TabularQueryRequest(sql=f"SELECT city FROM {alias}"),
+        )
+
+    assert not downloaded_paths, "the declared-size precheck must refuse the artifact before downloading it"
+
+
+def test_job_disk_budget_charges_actual_bytes_when_no_size_declared():
+    """Legacy artifacts (declared size 0) skip the precheck but are still charged."""
+    from knowledge_flow_backend.features.tabular.service import _JobDiskBudget
+
+    budget = _JobDiskBudget(limit_bytes=10)
+    budget.precheck(0)
+    budget.charge(8)
+    with pytest.raises(TabularQueryError, match="local storage budget"):
+        budget.charge(8)
+
+
+@pytest.mark.asyncio
+async def test_tabular_service_gcs_missing_artifact_does_not_leak_object_key(tmp_path, metadata_store, monkeypatch):
+    """
+    A missing GCS artifact surfaces without the internal object key (#2364).
+
+    Why this exists:
+    - Tabular controllers put `str(e)` in the 404 detail, and
+      `_dataset_to_response` deliberately never exposes the content-store key;
+      the download path must not leak it either.
+    """
+
+    service, gcs_store, _downloaded_paths = await _gcs_tabular_setup(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        monkeypatch=monkeypatch,
+        documents=[("doc-sales", "sales.csv", "city,amount\nParis,10\n")],
+    )
+    gcs_store._fake_objects.clear()
+
+    alias = (await service.list_datasets(_user()))[0].query_alias
+    with pytest.raises(FileNotFoundError, match="was not found in content storage") as exc_info:
+        await service.query_read(
+            _user(),
+            request=TabularQueryRequest(sql=f"SELECT city FROM {alias}"),
+        )
+
+    assert "tabular/datasets" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_tabular_service_gcs_download_errors_are_redacted(tmp_path, metadata_store, monkeypatch):
+    """
+    Google client errors must not leak the raw GCS REST URL to callers (#2364).
+
+    Why this exists:
+    - `str()` of google exceptions embeds the full object URL (bucket + key);
+      the controller's catch-all returns `str(e)` as the 500 detail, so the
+      materializer must re-raise them redacted, exactly as the httpfs path
+      redacts signed URLs.
+    """
+    from google.api_core.exceptions import Forbidden
+
+    from knowledge_flow_backend.features.tabular.service import TabularDatasetReadError
+
+    service, gcs_store, _downloaded_paths = await _gcs_tabular_setup(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        monkeypatch=monkeypatch,
+        documents=[("doc-sales", "sales.csv", "city,amount\nParis,10\n")],
+    )
+
+    def _forbidden(key, destination, **kwargs):
+        raise Forbidden("403 GET https://storage.googleapis.com/download/storage/v1/b/kf-objects/o/tabular%2Fdatasets%2Fdoc%2Frev%2Fdata.parquet?alt=media: denied")
+
+    monkeypatch.setattr(gcs_store, "download_object_to_path", _forbidden)
+
+    alias = (await service.list_datasets(_user()))[0].query_alias
+    with pytest.raises(TabularDatasetReadError) as exc_info:
+        await service.query_read(
+            _user(),
+            request=TabularQueryRequest(sql=f"SELECT city FROM {alias}"),
+        )
+
+    assert "<redacted-signed-url>" in str(exc_info.value)
+    assert "storage.googleapis.com" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_tabular_service_gcs_search_downloads_lazily_until_match_cap(tmp_path, metadata_store, monkeypatch):
+    """
+    `search_values` must not download datasets its early break never scans (#2364).
+
+    Why this exists:
+    - The scan loop stops at `max_matching_tables`; with eager mounting every
+      selected dataset would be fully downloaded (and charged against the disk
+      budget) even when never opened.
+    """
+    from knowledge_flow_backend.features.tabular.structures import TabularSearchRequest
+
+    service, _gcs_store, downloaded_paths = await _gcs_tabular_setup(
+        tmp_path=tmp_path,
+        metadata_store=metadata_store,
+        monkeypatch=monkeypatch,
+        documents=[
+            ("doc-a", "a.csv", "city,amount\nParis,10\n"),
+            ("doc-b", "b.csv", "city,amount\nParis,20\n"),
+        ],
+    )
+
+    response = await service.search_values(
+        _user(),
+        request=TabularSearchRequest(keyword="Paris", max_matching_tables=1),
+    )
+
+    assert len(response.matches) == 1
+    assert response.tables_truncated is True
+    assert len(downloaded_paths) == 1, "the second dataset must not be downloaded once the match cap is reached"
 
 
 @pytest.mark.asyncio
@@ -1235,9 +1501,9 @@ async def test_query_mounts_only_the_datasets_the_sql_references(tmp_path):
     mounted: list[list[str]] = []
     original_mount = service._mount_datasets
 
-    def _record(*, connection, datasets, handle):
+    def _record(*, connection, datasets, handle, resolve_location):
         mounted.append([dataset.query_alias for dataset in datasets])
-        return original_mount(connection=connection, datasets=datasets, handle=handle)
+        return original_mount(connection=connection, datasets=datasets, handle=handle, resolve_location=resolve_location)
 
     service._mount_datasets = _record
 

--- a/apps/knowledge-flow-backend/tests/stores/content/test_gcs_content_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/content/test_gcs_content_store.py
@@ -68,7 +68,15 @@ class _FakeBlob:
             return data
         return data[start : (end + 1) if end is not None else None]
 
-    def download_to_filename(self, path):
+    def download_to_filename(self, path, timeout=None):
+        from google.cloud.exceptions import NotFound
+
+        del timeout
+        if self.name not in self._bucket:
+            # Mirror the real client: the file is created (then truncated) before
+            # the request fails, so the store must clean up the empty leftover.
+            open(path, "wb").close()
+            raise NotFound(self.name)
         with open(path, "wb") as f:
             f.write(self._bucket[self.name][0])
 
@@ -192,6 +200,26 @@ def test_missing_object_raises(gcs_store):
         gcs_store.delete_object("nope")
 
 
+def test_download_object_to_path_roundtrip(gcs_store, tmp_path):
+    """Tabular reads download artifacts via ADC instead of signed URLs (#2364)."""
+    gcs_store.put_object("tabular/datasets/d/r/data.parquet", BytesIO(b"PARQUET"), content_type="application/vnd.apache.parquet")
+
+    destination = tmp_path / "data.parquet"
+    gcs_store.download_object_to_path("tabular/datasets/d/r/data.parquet", destination)
+
+    assert destination.read_bytes() == b"PARQUET"
+
+
+def test_download_object_to_path_missing_raises_and_leaves_no_file(gcs_store, tmp_path):
+    """A missing object maps to FileNotFoundError without a truncated leftover file."""
+    destination = tmp_path / "data.parquet"
+
+    with pytest.raises(FileNotFoundError, match="nope"):
+        gcs_store.download_object_to_path("nope", destination)
+
+    assert not destination.exists()
+
+
 def test_clear_empties_both_buckets(gcs_store, tmp_path):
     gcs_store.save_input("doc1", _make_doc(tmp_path) / "input")
     gcs_store.put_object("k", BytesIO(b"x"), content_type="text/plain")
@@ -292,11 +320,17 @@ def test_get_presigned_url_internal_mints_v4_signed_url(monkeypatch):
 
 
 def test_get_presigned_url_internal_requires_signing_email(monkeypatch):
-    """Signing without a configured SA email fails clearly (defensive guard)."""
+    """Signing without a configured SA email fails as an unsupported capability.
+
+    NotImplementedError (not RuntimeError) on purpose: since #2364 nothing
+    validates the email at startup, and the base-class contract treats
+    NotImplementedError as "presigned URLs unsupported", letting callers degrade
+    to their explicit unsupported-operation path instead of an opaque 500.
+    """
     captured: dict = {}
     store = _signing_store(monkeypatch, captured, email=None)
 
-    with pytest.raises(RuntimeError, match="signing_service_account_email"):
+    with pytest.raises(NotImplementedError, match="signing_service_account_email"):
         store.get_presigned_url_internal("tabular/datasets/doc/rev/data.parquet")
 
 

--- a/deploy/charts/fred/values-gcp.yaml
+++ b/deploy/charts/fred/values-gcp.yaml
@@ -67,9 +67,9 @@ applications:
 
   knowledge-flow-backend:
     # --- Workload Identity: bind the KSA to a Google service account (GSA) ---
-    # The GSA needs roles/storage.objectAdmin on the content + fs buckets, and
-    # iam.serviceAccounts.signBlob on the signing service account below
-    # (typically roles/iam.serviceAccountTokenCreator) for tabular signed URLs.
+    # The GSA needs roles/storage.objectAdmin on the content + fs buckets.
+    # No signBlob grant is needed: tabular Parquet reads download artifacts
+    # through the ADC client instead of minting signed URLs (#2364).
     serviceAccount:
       annotations:
         iam.gke.io/gcp-service-account: "<GSA_NAME>@<GCP_PROJECT_ID>.iam.gserviceaccount.com"
@@ -81,11 +81,11 @@ applications:
         type: gcs
         bucket_name: "<CONTENT_BUCKET_PREFIX>" # e.g. <GCP_PROJECT_ID>-content
         project_id: "" # optional; inferred from ADC when empty
-        # Required: service account used to sign V4 signed URLs for tabular
-        # Parquet reads via IAM signBlob (keyless). Startup fails clearly if unset.
-        # It needs storage.objects.get on the -objects bucket; the GSA above needs
-        # iam.serviceAccounts.signBlob on it. May be the GSA itself (self-signing).
-        signing_service_account_email: "<GSA_NAME>@<GCP_PROJECT_ID>.iam.gserviceaccount.com"
+        # Optional: only needed to re-enable internal V4 signed URLs via IAM
+        # signBlob (no knowledge-flow feature consumes them anymore - tabular
+        # reads use ADC downloads, #2364). Leave unset on deployments without
+        # the iam.serviceAccounts.signBlob grant (e.g. tp-s3ns).
+        # signing_service_account_email: "<GSA_NAME>@<GCP_PROJECT_ID>.iam.gserviceaccount.com"
 
       # --- Virtual filesystem: native GCS ---
       filesystem:
@@ -116,11 +116,11 @@ applications:
           pointer_chunks_enabled: false
           query:
             engine: "duckdb"
-            # Tabular SQL preview reads Parquet through backend-internal V4 signed
-            # URLs. On GCS these are minted via iam.serviceAccounts.signBlob using
-            # content_storage.signing_service_account_email (see above).
+            # On GCS, tabular SQL reads download the Parquet artifact server-side
+            # (ADC client, storage.objects.get) into a job-local temp file - no
+            # signed URLs, no signBlob (#2364). access_mode and the TTL below only
+            # apply to S3-compatible stores (MinIO), which keep presigned URLs.
             access_mode: "presigned_url"
-            # TTL for the internal signed URL; keep short — only DuckDB uses it.
             internal_presigned_ttl_seconds: 3600
             default_max_rows: 200
             max_rows: 1000

--- a/deploy/charts/fred/values.schema.json
+++ b/deploy/charts/fred/values.schema.json
@@ -4385,7 +4385,7 @@
                             }
                           ],
                           "default": null,
-                          "description": "Service account email used to sign V4 signed URLs for backend-internal tabular Parquet reads, via IAM signBlob under Workload Identity (no JSON key). Required for content_storage.type=gcs; startup fails clearly when omitted. The Workload Identity service account must hold iam.serviceAccounts.signBlob on this account, which must have storage.objects.get on the objects bucket.",
+                          "description": "Optional service account email used to sign V4 signed URLs via IAM signBlob under Workload Identity (no JSON key). Tabular Parquet reads no longer need it: they download artifacts server-side with the ADC client, which only requires storage.objects.get on the objects bucket (#2364). Set it only to re-enable internal V4 signed URLs for code paths that explicitly call get_presigned_url_internal.",
                           "title": "Signing Service Account Email"
                         }
                       },
@@ -6546,13 +6546,13 @@
                             "access_mode": {
                               "const": "presigned_url",
                               "default": "presigned_url",
-                              "description": "Primary object-access method for remote tabular artifacts.",
+                              "description": "Primary object-access method for remote tabular artifacts on S3-compatible stores. GCS ignores it: artifacts are downloaded server-side to a job-local file instead (#2364).",
                               "title": "Access Mode",
                               "type": "string"
                             },
                             "internal_presigned_ttl_seconds": {
                               "default": 3600,
-                              "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads.",
+                              "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads on S3-compatible stores. Unused on GCS (no URLs are minted).",
                               "minimum": 1,
                               "title": "Internal Presigned Ttl Seconds",
                               "type": "integer"
@@ -6611,6 +6611,13 @@
                               "description": "Maximum datasets one request may mount or scan. Backstop for searches and for queries whose referenced-relation set is still too large.",
                               "minimum": 1,
                               "title": "Max Selected Datasets",
+                              "type": "integer"
+                            },
+                            "max_local_artifact_bytes": {
+                              "default": 536870912,
+                              "description": "Per-job disk budget, in bytes, for tabular artifacts materialized onto the pod's local storage (GCS access path, #2364). A query needing more fails as a caller error (400) instead of filling the pod's ephemeral storage; the declared artifact size is checked before downloading. This is also the effective per-artifact ceiling on GCS - raise it on deployments that ingest very large tabular files. Instantaneous worst case per pod: max_concurrent_queries times this value.",
+                              "minimum": 1,
+                              "title": "Max Local Artifact Bytes",
                               "type": "integer"
                             }
                           },
@@ -8958,7 +8965,7 @@
                             }
                           ],
                           "default": null,
-                          "description": "Service account email used to sign V4 signed URLs for backend-internal tabular Parquet reads, via IAM signBlob under Workload Identity (no JSON key). Required for content_storage.type=gcs; startup fails clearly when omitted. The Workload Identity service account must hold iam.serviceAccounts.signBlob on this account, which must have storage.objects.get on the objects bucket.",
+                          "description": "Optional service account email used to sign V4 signed URLs via IAM signBlob under Workload Identity (no JSON key). Tabular Parquet reads no longer need it: they download artifacts server-side with the ADC client, which only requires storage.objects.get on the objects bucket (#2364). Set it only to re-enable internal V4 signed URLs for code paths that explicitly call get_presigned_url_internal.",
                           "title": "Signing Service Account Email"
                         }
                       },
@@ -11119,13 +11126,13 @@
                             "access_mode": {
                               "const": "presigned_url",
                               "default": "presigned_url",
-                              "description": "Primary object-access method for remote tabular artifacts.",
+                              "description": "Primary object-access method for remote tabular artifacts on S3-compatible stores. GCS ignores it: artifacts are downloaded server-side to a job-local file instead (#2364).",
                               "title": "Access Mode",
                               "type": "string"
                             },
                             "internal_presigned_ttl_seconds": {
                               "default": 3600,
-                              "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads.",
+                              "description": "TTL in seconds for backend-internal object-storage URLs used by tabular DuckDB reads on S3-compatible stores. Unused on GCS (no URLs are minted).",
                               "minimum": 1,
                               "title": "Internal Presigned Ttl Seconds",
                               "type": "integer"
@@ -11184,6 +11191,13 @@
                               "description": "Maximum datasets one request may mount or scan. Backstop for searches and for queries whose referenced-relation set is still too large.",
                               "minimum": 1,
                               "title": "Max Selected Datasets",
+                              "type": "integer"
+                            },
+                            "max_local_artifact_bytes": {
+                              "default": 536870912,
+                              "description": "Per-job disk budget, in bytes, for tabular artifacts materialized onto the pod's local storage (GCS access path, #2364). A query needing more fails as a caller error (400) instead of filling the pod's ephemeral storage; the declared artifact size is checked before downloading. This is also the effective per-artifact ceiling on GCS - raise it on deployments that ingest very large tabular files. Instantaneous worst case per pod: max_concurrent_queries times this value.",
+                              "minimum": 1,
+                              "title": "Max Local Artifact Bytes",
                               "type": "integer"
                             }
                           },

--- a/docs/swift/design/DESIGN.md
+++ b/docs/swift/design/DESIGN.md
@@ -267,10 +267,11 @@ advertised (`output.md` or a dataset listing):
 3. **Mount** — a fresh in-memory DuckDB connection **per query** mounts only
    the caller's readable datasets as read-only views over Parquet. No
    cross-query state, no writable tables.
-4. **Locate** — remote object stores resolve Parquet through a short-lived
-   backend-internal presigned URL (§3), read via DuckDB `httpfs`; local
-   filesystem storage uses a direct path. A store offering neither fails as
-   an explicit unsupported operation.
+4. **Locate** — S3-compatible stores resolve Parquet through a short-lived
+   backend-internal presigned URL, read via DuckDB `httpfs`; GCS downloads
+   the artifact server-side into a job-scoped temp file (§3); local
+   filesystem storage uses a direct path. A store offering none of these
+   fails as an explicit unsupported operation.
 5. **Redact** — signed URLs are stripped from any caught `duckdb`/`httpfs`
    error before it is logged or surfaced.
 
@@ -346,34 +347,71 @@ cannot unblock a stalled read; the bound is `httpfs`'s own retry defaults
 (~2 min worst case against a 30s `query_timeout_seconds`), not a deployment
 setting, since the remote path can't be exercised offline to tighten it.
 
-## 3. Tabular Reads on GCS — Signed URLs
+## 3. Tabular Reads on GCS — Server-Side Downloads (#2364)
 
 Backend-internal tabular reads (DuckDB mounting Parquet, §2) need a
-DuckDB-readable location. On GCS this is a short-lived **V4 signed URL**
-minted via IAM `signBlob` under Workload Identity — never a service-account
-JSON key:
+DuckDB-readable location. On GCS this is a **job-scoped local file**: the
+artifact is downloaded server-side through the same ADC / Workload Identity
+`storage.Client` the store uses for every other read — no signed URLs, no
+`httpfs`, no service-account JSON key.
 
-- `GcsContentStore.get_presigned_url_internal(...)` implements it, gated by
-  config `content_storage.signing_service_account_email` (required when
-  `content_storage.type: gcs`; startup fails clearly if missing rather than
-  guessing).
-- IAM: the signing service account needs `storage.objects.get` on the
-  tabular-artifacts bucket; the Workload Identity service account needs
-  `iam.serviceAccounts.signBlob` on the signing account
-  (`roles/iam.serviceAccountTokenCreator`).
-- TTL bounded by `storage.tabular_store.query.internal_presigned_ttl_seconds`.
-  Signed URLs are never returned in API responses, MCP payloads, or logs —
-  including on error: object URLs are redacted from caught `duckdb`/`httpfs`
-  exceptions before logging (a failed Parquet read otherwise echoes the full
-  signed URL in the exception string).
+This replaced the earlier V4-signed-URL design (`get_presigned_url_internal`
+via IAM `signBlob`): tabular reads are 100% backend-internal, so nothing ever
+needed a URL except `httpfs`, and the `iam.serviceAccounts.signBlob` grant the
+signing required is not obtainable on every deployment (tp-s3ns, the incident
+behind #2364). Plain `storage.objects.get` on the objects bucket is enough.
+
+- `TabularService._dataset_location_scope()` selects the path per store type
+  and owns the lifecycle: one temp directory per DuckDB job, downloads via
+  `GcsContentStore.download_object_to_path(...)` (streaming, chunked), cleanup
+  when the job returns. The scope wraps the whole connection lifetime, since
+  DuckDB opens Parquet lazily at execution time, not at view creation.
+  Download errors are stripped of store internals before they surface: a
+  missing artifact maps to a generic not-found (never the internal object
+  key), and google client errors — whose text embeds the raw GCS REST URL —
+  are re-raised redacted, mirroring the `httpfs` signed-URL redaction.
+- Replica-safe by construction: each pod downloads into its own local temp
+  directory; the bucket stays the single store of record.
+- Disk cost is bounded twice. The per-job directory is deleted in every
+  outcome — the scope wraps the whole job body (opened before the DuckDB
+  connection, closed after it), and the worker thread always finishes the job
+  function even after a caller-side 504, so cleanup runs on success, error,
+  abort, and timeout alike. And
+  `storage.tabular_store.query.max_local_artifact_bytes` (default 512 MiB)
+  caps what one job may materialize, failing over-budget queries as `400`:
+  the artifact's declared ingestion size is checked *before* downloading, so
+  a single oversized artifact cannot fill the disk mid-transfer (legacy
+  artifacts that declared no size are charged after the fact — overshoot
+  bounded by that one artifact). The budget is thereby also the per-artifact
+  ceiling on GCS; deployments ingesting very large tabular files raise it.
+  Instantaneous worst case per pod: `max_concurrent_queries × budget`.
+  DuckDB spilling stays disabled (§2) so queries cannot add to it.
+- Trade-off: the whole artifact is fetched instead of `httpfs` range reads —
+  acceptable at CSV/Excel sizes; a pod-local cache keyed by object key + etag
+  is the natural follow-up if latency ever warrants it. Downloads are
+  sequential within a job (deliberate: the abort handle is checked between
+  datasets, and job slots already bound per-pod concurrency), so a
+  many-dataset join pays its downloads serially inside the job's wall-clock
+  budget; `search_values` mounts lazily, one table at a time, so its early
+  break also skips the fetches. Each download call carries an explicit
+  socket-inactivity timeout, which bounds fully stalled connections — a
+  slow-but-active transfer still holds its execution slot for the transfer's
+  duration (the abort handle cannot interrupt mid-download; the disk budget's
+  pre-download size check is the ceiling on how long that can be). This is
+  the same class of limit the `httpfs` path already documents in §2.
+- `content_storage.signing_service_account_email` is now optional and unused
+  by knowledge-flow features; `GcsContentStore.get_presigned_url_internal`
+  remains implemented for callers that explicitly opt into signed URLs.
 - Cross-backend invariant: MinIO/S3-compatible stores keep serving tabular
-  reads through their existing backend-internal presigned-URL path; local
-  storage keeps the direct filesystem fallback. The GCS path is additive and
-  does not change either.
+  reads through their existing backend-internal presigned-URL path (TTL
+  bounded by `storage.tabular_store.query.internal_presigned_ttl_seconds`);
+  local storage keeps the direct filesystem fallback. Signed URLs remain
+  redacted from caught `duckdb`/`httpfs` errors on those paths.
 - Browser-facing document/VFS sharing is unrelated and unchanged — it uses
   application-level HMAC download tokens, not provider signed URLs;
   `GcsContentStore.get_presigned_url` (the browser-facing method) still
-  raises `NotImplementedError` for knowledge-flow documents.
+  raises `NotImplementedError` for knowledge-flow documents (proxy-URL
+  design tracked in #2318).
 - **Amendment — control-plane team assets (banner/logo):** the
   control-plane's `TeamService` serves these straight to the browser with no
   HMAC-token fallback of its own, so `fred_core.store.GcsContentStore`'s

--- a/docs/swift/rfc/TABULAR-SQL-SANDBOX-PRESENTATION.html
+++ b/docs/swift/rfc/TABULAR-SQL-SANDBOX-PRESENTATION.html
@@ -1,0 +1,537 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tabular SQL sandbox — team presentation</title>
+<style>
+  :root {
+    --bg: #0b0f17;
+    --slide-bg: #0f1522;
+    --text: #e6edf5;
+    --muted: #8b96a8;
+    --faint: #55617a;
+    --accent: #2dd4bf;
+    --accent-dim: rgba(45, 212, 191, .12);
+    --amber: #fbbf24;
+    --red: #f87171;
+    --green: #4ade80;
+    --blue: #60a5fa;
+    --violet: #c084fc;
+    --line: #232c3f;
+    --code-bg: #0a0e16;
+    --chip-bg: #161e30;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; overflow: hidden; background: var(--bg); }
+  body {
+    font-family: "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+    color: var(--text);
+    -webkit-font-smoothing: antialiased;
+  }
+  code, pre, .mono {
+    font-family: ui-monospace, "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+  }
+
+  /* ---------- deck mechanics ---------- */
+  .slide {
+    position: absolute; top: 50%; left: 50%;
+    width: 1280px; height: 720px;
+    transform: translate(-50%, -50%);
+    background:
+      radial-gradient(1000px 600px at 85% -10%, rgba(45,212,191,.05), transparent 60%),
+      var(--slide-bg);
+    border-radius: 14px;
+    padding: 54px 72px 60px;
+    opacity: 0; visibility: hidden;
+    transition: opacity .22s ease;
+    display: flex; flex-direction: column;
+  }
+  .slide.active { opacity: 1; visibility: visible; }
+
+  #progress {
+    position: fixed; top: 0; left: 0; height: 3px;
+    background: var(--accent); width: 0; z-index: 10;
+    transition: width .25s ease;
+  }
+  #counter { position: fixed; bottom: 14px; right: 20px; z-index: 10; color: var(--faint); font-size: 13px; user-select: none; }
+  #navhint { position: fixed; bottom: 14px; left: 20px; z-index: 10; color: var(--faint); font-size: 13px; user-select: none; }
+  .navbtn { position: fixed; top: 0; bottom: 0; width: 12%; z-index: 5; background: transparent; border: 0; cursor: pointer; }
+  #prevzone { left: 0; } #nextzone { right: 0; }
+
+  /* ---------- typography ---------- */
+  .kicker { font-size: 15px; letter-spacing: .22em; text-transform: uppercase; color: var(--accent); margin-bottom: 14px; font-weight: 600; }
+  h1 { font-size: 58px; line-height: 1.1; font-weight: 700; }
+  h2 { font-size: 38px; line-height: 1.15; font-weight: 700; margin-bottom: 24px; }
+  .sub { color: var(--muted); font-size: 23px; line-height: 1.5; }
+  .body, li { font-size: 22px; line-height: 1.5; }
+  ul { list-style: none; }
+  ul li { padding-left: 30px; position: relative; margin-bottom: 13px; }
+  ul li::before { content: "—"; position: absolute; left: 0; color: var(--accent); }
+  ul.tight li { margin-bottom: 8px; font-size: 20px; }
+  strong { color: #fff; }
+  em { color: var(--amber); font-style: normal; }
+  .muted { color: var(--muted); }
+  .punch { margin-top: auto; padding-top: 16px; border-top: 1px solid var(--line); font-size: 23px; color: var(--amber); font-weight: 600; }
+  .cols { display: flex; gap: 46px; flex: 1; min-height: 0; }
+  .col { flex: 1; min-width: 0; }
+  h4.colhead { font-size: 15px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); margin-bottom: 14px; font-weight: 600; }
+
+  /* ---------- code ---------- */
+  pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 10px; padding: 18px 22px; font-size: 17px; line-height: 1.5; overflow: hidden; }
+  pre.small { font-size: 15.5px; }
+  .k { color: #f472b6; } .t { color: #7dd3fc; } .s { color: #bef264; } .c { color: #5b6b84; } .f { color: #fbbf24; }
+
+  /* ---------- tables ---------- */
+  table { border-collapse: collapse; width: 100%; font-size: 19px; }
+  th, td { text-align: left; padding: 10px 15px; border-bottom: 1px solid var(--line); }
+  th { color: var(--muted); font-weight: 600; font-size: 15px; text-transform: uppercase; letter-spacing: .06em; }
+  td { line-height: 1.38; vertical-align: top; }
+  td code { font-size: 16px; color: var(--blue); }
+  table.dense { font-size: 16.5px; }
+  table.dense th, table.dense td { padding: 7px 13px; }
+  table.dense td code { font-size: 14.5px; }
+
+  /* ---------- pills / chips ---------- */
+  .pill { display: inline-block; padding: 3px 14px; border-radius: 999px; font-size: 15px; font-weight: 600; vertical-align: middle; margin-left: 12px; }
+  .pill.shipped { background: rgba(74,222,128,.14); color: var(--green); }
+  .pill.rfc     { background: rgba(96,165,250,.14); color: var(--blue); }
+  .pill.future  { background: rgba(251,191,36,.14); color: var(--amber); }
+  .pill.horizon { background: rgba(192,132,252,.14); color: var(--violet); }
+
+  .tag { display:inline-block; padding: 2px 10px; border-radius: 6px; font-size: 14px; font-weight: 700; }
+  .tag.broken  { background: rgba(248,113,113,.16); color: var(--red); }
+  .tag.viable  { background: rgba(74,222,128,.16); color: var(--green); }
+  .tag.rejected{ background: rgba(139,150,168,.16); color: var(--muted); }
+  .tag.died    { background: rgba(251,191,36,.16); color: var(--amber); }
+
+  /* before / after + generic panels */
+  .ba { display: flex; gap: 32px; flex: 1; align-items: stretch; }
+  .ba-panel { flex: 1; border-radius: 12px; padding: 22px 26px; border: 1px solid var(--line); background: var(--chip-bg); display: flex; flex-direction: column; }
+  .ba-panel h3 { font-size: 22px; margin-bottom: 4px; }
+  .ba-panel .cap { font-size: 16.5px; color: var(--muted); margin-bottom: 16px; }
+  .ba-panel.a { border-color: rgba(45,212,191,.45); }
+  .ba-panel.b { border-color: rgba(96,165,250,.45); }
+  .ba-panel ul li { font-size: 18.5px; margin-bottom: 10px; padding-left: 26px; line-height: 1.4; }
+
+  /* flow steps */
+  .flow { display: flex; align-items: stretch; gap: 0; margin: 6px 0 18px; }
+  .flow-step { background: var(--chip-bg); border: 1px solid var(--line); border-radius: 10px; padding: 13px 16px; flex: 1; text-align: center; }
+  .flow-step b { display: block; font-size: 16px; margin-bottom: 4px; color: var(--accent); }
+  .flow-step span { color: var(--muted); font-size: 13.5px; line-height: 1.35; display: block; }
+  .flow-arrow { font-size: 22px; color: var(--faint); padding: 0 9px; align-self: center; flex: 0 0 auto; }
+
+  /* pod schema */
+  .podmap { display: flex; align-items: stretch; gap: 0; margin: 4px 0 2px; }
+  .pod { border: 1px solid var(--line); background: var(--chip-bg); border-radius: 11px; padding: 15px 16px; flex: 1; display: flex; flex-direction: column; }
+  .pod b { display: block; font-size: 17px; margin-bottom: 7px; }
+  .pod span { display: block; color: var(--muted); font-size: 13.5px; line-height: 1.4; }
+  .pod .egress { margin-top: auto; padding-top: 9px; font-size: 12.5px; line-height: 1.45; }
+  .pod .ok { color: var(--green); } .pod .no { color: var(--red); }
+  .pod.kf { border-color: rgba(96,165,250,.4); } .pod.kf b { color: var(--blue); }
+  .pod.exec { border-color: rgba(45,212,191,.5); } .pod.exec b { color: var(--accent); }
+  .pod.store { border-color: rgba(192,132,252,.4); } .pod.store b { color: var(--violet); }
+  .pod-arrow { flex: 0 0 auto; align-self: center; padding: 0 12px; text-align: center; color: var(--muted); font-size: 12px; width: 110px; }
+  .pod-arrow b { display: block; color: var(--accent); font-size: 20px; line-height: 1; margin-bottom: 3px; }
+  .pod-arrow.small { width: 70px; }
+
+  /* architecture diagram — a "canvas", visually distinct from step rows */
+  .diagram {
+    flex: 1; margin: 8px 0 4px;
+    display: flex; align-items: center; justify-content: center; gap: 0;
+    border: 1px solid var(--line); border-radius: 16px;
+    padding: 20px 34px;
+    background:
+      linear-gradient(rgba(255,255,255,.022) 1px, transparent 1px) 0 0 / 24px 24px,
+      linear-gradient(90deg, rgba(255,255,255,.022) 1px, transparent 1px) 0 0 / 24px 24px,
+      radial-gradient(700px 380px at 50% 0%, rgba(45,212,191,.05), transparent 65%),
+      #070b12;
+    box-shadow: inset 0 2px 34px rgba(0,0,0,.45);
+  }
+  .node { display: flex; flex-direction: column; align-items: center; text-align: center; width: 214px; }
+  .node .glyph {
+    font-size: 62px; line-height: 1; margin-bottom: 12px;
+    filter: drop-shadow(0 6px 14px rgba(0,0,0,.5));
+  }
+  .node .plate {
+    border-radius: 16px; padding: 16px 14px 14px; width: 100%;
+    border: 1px solid var(--line); background: rgba(255,255,255,.015);
+  }
+  .node.kf .plate   { border-color: rgba(96,165,250,.5);  box-shadow: 0 0 0 1px rgba(96,165,250,.08), 0 10px 30px rgba(0,0,0,.35); }
+  .node.exec .plate { border-color: rgba(45,212,191,.6);  box-shadow: 0 0 0 1px rgba(45,212,191,.1), 0 10px 30px rgba(0,0,0,.35); }
+  .node.store .plate{ border-color: rgba(192,132,252,.5); box-shadow: 0 0 0 1px rgba(192,132,252,.08), 0 10px 30px rgba(0,0,0,.35); }
+  .node b { font-size: 18px; display: block; }
+  .node .role { font-size: 12.5px; color: var(--muted); margin-top: 4px; line-height: 1.35; }
+  .node .egress-tag { margin-top: 10px; font-size: 12px; line-height: 1.5; }
+  .node .egress-tag .ok { color: var(--green); display: block; }
+  .node .egress-tag .no { color: var(--red); display: block; }
+  .node .egress-tag .warn { color: var(--amber); display: block; }
+  .wire { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; padding: 0 10px; margin-bottom: 40px; }
+  .wire .arw { font-size: 34px; line-height: 1; color: var(--accent); }
+  .wire span { font-size: 11.5px; color: var(--muted); margin-top: 5px; max-width: 100px; line-height: 1.3; }
+
+  /* holes / status cards */
+  .cards { display: flex; gap: 22px; flex: 1; }
+  .card { flex: 1; border-radius: 12px; padding: 20px 22px; border: 1px solid var(--line); background: var(--chip-bg); }
+  .card.bad { border-color: rgba(248,113,113,.4); background: rgba(248,113,113,.06); }
+  .card.good { border-color: rgba(74,222,128,.35); background: rgba(74,222,128,.05); }
+  .card h3 { font-size: 20px; margin-bottom: 10px; }
+  .card.bad h3 { color: var(--red); } .card.good h3 { color: var(--green); }
+  .card p { font-size: 16.5px; color: var(--muted); line-height: 1.45; }
+  .card .mono { color: var(--text); font-size: 15px; }
+
+  /* gap rows */
+  .risk-low { color: var(--green); font-weight: 600; }
+  .risk-med { color: var(--amber); font-weight: 600; }
+  .hot td:first-child { color: var(--accent); }
+
+  /* divider slide */
+  .divider { justify-content: center; align-items: flex-start; }
+
+  @media print {
+    html, body { overflow: visible; background: #fff; }
+    .slide { position: relative; top: 0; left: 0; transform: none !important; opacity: 1; visibility: visible; page-break-after: always; margin: 0 auto; }
+    #progress, #counter, #navhint, .navbtn { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div id="progress"></div>
+<div id="counter"></div>
+<div id="navhint">← → to navigate</div>
+<button id="prevzone" class="navbtn" aria-label="previous slide"></button>
+<button id="nextzone" class="navbtn" aria-label="next slide"></button>
+
+<!-- ============ 1 · TITLE ============ -->
+<section class="slide">
+  <div style="margin: auto 0;">
+    <div class="kicker">Fred · Knowledge Flow · RFC TABULAR-SANDBOX</div>
+    <h1>Executing agent SQL over<br>tabular data, safely</h1>
+    <p class="sub" style="margin-top:22px; max-width: 940px;">
+      The agent writes arbitrary SQL. It runs in <strong>DuckDB</strong>, in our pod, over
+      Parquet the user is allowed to read. <strong>Where does the security boundary sit?</strong>
+    </p>
+    <p class="muted" style="margin-top:56px; font-size:19px;">
+      Florian Muller · August 2026<br>
+      Full design: <code class="mono" style="color:var(--accent); font-size:17px;">docs/swift/rfc/TABULAR-SQL-SANDBOX-RFC.md</code>
+      · trigger: <code class="mono" style="color:var(--blue); font-size:17px;">#2364</code> (GCS signBlob outage)
+    </p>
+  </div>
+</section>
+
+<!-- ============ 2 · THE PROBLEM ============ -->
+<section class="slide">
+  <div class="kicker">The problem</div>
+  <h2>Arbitrary SQL, authored by an LLM, run in our pod</h2>
+  <div class="cols">
+    <div class="col">
+      <ul>
+        <li>The tabular feature lets an agent answer questions over CSV/Excel by writing <strong>read-only SQL</strong>, executed by DuckDB against the ingested Parquet.</li>
+        <li>The SQL text is <strong>attacker-controlled</strong> in the worst case (prompt injection through an ingested document).</li>
+        <li>ReBAC already decides <em>which datasets</em> the user may read. The question is enforcing that — and nothing more — at execution.</li>
+      </ul>
+    </div>
+    <div class="col">
+      <h4 class="colhead">Four requirements</h4>
+      <ul class="tight">
+        <li><strong>R1</strong> — never read a dataset the user can't see</li>
+        <li><strong>R2</strong> — never read anything <em>else</em> in the pod: local files, other buckets, internal HTTP, the metadata server</li>
+        <li><strong style="color:var(--accent);">R3</strong> — the boundary must <strong>not</strong> be a hand-written SQL parser: a parser gap must not be a breach</li>
+        <li><strong>R4</strong> <span class="muted">(goal)</span> — read big Parquet without downloading the whole file</li>
+      </ul>
+    </div>
+  </div>
+  <p class="punch">Today R1/R2 rest on an AST-walking SQL validator. R3 says: that's exactly what we don't want to depend on.</p>
+</section>
+
+<!-- ============ 3 · THREAT MODEL ============ -->
+<section class="slide">
+  <div class="kicker">Why R3 matters</div>
+  <h2>What one gap in the SQL parser costs</h2>
+  <p class="sub" style="margin-bottom:22px;">DuckDB is powerful by design. If a crafted query slips past the validator, plain SQL functions reach far beyond the dataset:</p>
+  <div class="cols">
+    <div class="col">
+      <pre class="small"><span class="c">-- read any file the pod can read</span>
+<span class="k">SELECT</span> * <span class="k">FROM</span> <span class="f">read_text</span>(<span class="s">'/app/.env'</span>);
+
+<span class="c">-- SSRF → the cloud metadata server →</span>
+<span class="c">-- the pod's service-account token</span>
+<span class="k">SELECT</span> * <span class="k">FROM</span> <span class="f">read_csv</span>(
+  <span class="s">'http://169.254.169.254/computeMetadata/...'</span>);
+
+<span class="c">-- reach another team's bucket with</span>
+<span class="c">-- the pod's own store credentials</span>
+<span class="k">SELECT</span> * <span class="k">FROM</span> <span class="f">read_parquet</span>(
+  <span class="s">'s3://fred-data/other-team/secret.parquet'</span>);</pre>
+    </div>
+    <div class="col">
+      <ul class="tight">
+        <li>The validator is a <strong>recursive AST walk</strong> (joins, CTEs, subqueries, table functions). It works today — but it is a hand-written allowlist.</li>
+        <li>One missed node shape = full reach of the pod's <strong>filesystem, network, and credentials</strong>.</li>
+        <li>A boundary that fails <strong>closed</strong> — and lives outside the SQL stream — is worth more than a cleverer parser.</li>
+      </ul>
+      <p class="muted" style="margin-top:18px; font-size:17px;">This is the lens for judging every option that follows.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 4 · EVERY SOLUTION CONSIDERED ============ -->
+<section class="slide">
+  <div class="kicker">The homework</div>
+  <h2>Ten approaches considered</h2>
+  <table class="dense">
+    <tr><th style="width:30px;">#</th><th>Approach</th><th style="width:120px;">Verdict</th><th>Why</th></tr>
+    <tr><td>1</td><td>DuckDB + pre-registered views + <strong>SQL parsing guard</strong></td><td><span class="tag rejected">rejected</span></td><td>Security depends on the parser (fails R3). Ships today as UX only.</td></tr>
+    <tr><td>2</td><td>DuckDB + httpfs reading <code>s3://</code> with normal store creds</td><td><span class="tag broken">broken</span></td><td>Credential grants the whole bucket; a gap reads any team's data.</td></tr>
+    <tr><td>3</td><td>Download authorized files locally + <code>enable_external_access=false</code></td><td><span class="tag viable">viable → A</span></td><td>Security by physical absence. Cost: full-file download.</td></tr>
+    <tr><td>4</td><td>Postgres RLS + <code>SET app.current_team</code></td><td><span class="tag broken">broken</span></td><td>Agent controls the stream → <code>SET</code>/<code>RESET</code> clears the context.</td></tr>
+    <tr><td>5</td><td>Postgres schema-per-team + <code>SET ROLE</code></td><td><span class="tag broken">broken</span></td><td>Runner is member of every role → <code>SET ROLE</code> escalates.</td></tr>
+    <tr><td>6</td><td>Postgres per-team LOGIN role, no memberships</td><td><span class="tag rejected">rejected</span></td><td>Genuinely secure, but roles are cluster-global — doesn't scale.</td></tr>
+    <tr><td>7</td><td>SQLite file per team <span class="muted">(+ setuid / pod-per-query variants)</span></td><td><span class="tag broken">broken</span></td><td>No engine-level ACL; <code>ATTACH</code> can't be disabled. Variants too heavy.</td></tr>
+    <tr><td>8</td><td>Object-store <strong>STS</strong> scoped creds + DuckDB httpfs</td><td><span class="tag viable">viable → B</span></td><td>Boundary = the credential, at the store's IAM layer.</td></tr>
+    <tr><td>9</td><td>Presigned URL per object + httpfs <span class="muted">(what shipped)</span></td><td><span class="tag died">died on GCS</span></td><td>Needs <code>signBlob</code> — not granted on tp-s3ns (#2364).</td></tr>
+    <tr><td>10</td><td>GCS server-side ADC download <span class="muted">(current branch, PR #2444)</span></td><td><span class="tag viable">= A, partial</span></td><td>The GCS-shaped instance of 3 — without the sandbox flags yet.</td></tr>
+  </table>
+  <p class="punch" style="font-size:21px;">Two survive the R1–R3 filter: <strong style="color:var(--accent);">A</strong> (download + sandbox) and <strong style="color:var(--blue);">B</strong> (STS + httpfs).</p>
+</section>
+
+<!-- ============ 5 · A vs B OVERVIEW ============ -->
+<section class="slide">
+  <div class="kicker">The two survivors</div>
+  <h2>Same job, opposite strategy</h2>
+  <div class="ba">
+    <div class="ba-panel a">
+      <h3 style="color:var(--accent);">A · Local materialization + sandbox</h3>
+      <p class="cap">Bring the data to a locked-down DuckDB.</p>
+      <ul>
+        <li>Backend downloads <strong>only the authorized files</strong> into a per-job directory</li>
+        <li>DuckDB runs with external access off, pinned to that directory, config locked</li>
+        <li><strong>Boundary = physical absence</strong> — there is nothing else to reach</li>
+        <li>No credential in DuckDB's hands, no network</li>
+      </ul>
+      <p class="muted" style="margin-top:auto; font-size:16px;">Cost: full-file download (weak on R4). Verified workable on DuckDB 1.5.4.</p>
+    </div>
+    <div class="ba-panel b">
+      <h3 style="color:var(--blue);">B · STS-scoped credential + httpfs</h3>
+      <p class="cap">Give DuckDB a key that only opens the right doors.</p>
+      <ul>
+        <li>Backend mints a <strong>short-lived credential scoped to exactly those object keys</strong></li>
+        <li>DuckDB reads <code>s3://</code>/<code>https://</code> directly, with range reads</li>
+        <li><strong>Boundary = the credential</strong>, enforced at the object store's IAM layer</li>
+        <li>A foreign key → 403 from the store, outside the SQL stream</li>
+      </ul>
+      <p class="muted" style="margin-top:auto; font-size:16px;">Meets R4. But httpfs stays on → needs a network layer (next).</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 6 · SOLUTION A DEPTH ============ -->
+<section class="slide">
+  <div class="kicker">Solution A · in depth</div>
+  <h2>Download, sandbox, delete</h2>
+  <div class="flow">
+    <div class="flow-step"><b>ReBAC</b><span>resolve the authorized datasets</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><b>Materialize</b><span>download only those into a per-job dir</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><b>Sandbox</b><span>external access off · pinned to dir · locked</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><b>Run &amp; delete</b><span>query, then drop the whole dir</span></div>
+  </div>
+  <div class="cols">
+    <div class="col">
+      <h4 class="colhead">The lock (verified on 1.5.4)</h4>
+<pre class="small"><span class="k">SET</span> allowed_directories = [<span class="s">'&lt;job dir&gt;'</span>];
+<span class="k">SET</span> enable_external_access = <span class="t">false</span>;
+<span class="k">SET</span> lock_configuration   = <span class="t">true</span>;
+<span class="c">-- httpfs never loaded · no s3 · no http</span>
+<span class="c">-- agent SQL cannot leave the dir or re-SET</span></pre>
+      <p class="muted" style="margin-top:12px; font-size:16.5px;">The job dir contains <strong>only</strong> authorized artifacts, so "which files are present" is the boundary — not the parser.</p>
+    </div>
+    <div class="col">
+      <h4 class="colhead">Efficiency — a pnpm-style cache</h4>
+      <ul class="tight">
+        <li>Shared pod-local cache; each job dir gets <strong>hardlinks</strong> to what it may read (symlinks are correctly refused by the sandbox)</li>
+        <li>Invalidation = the store's own <strong>etag / generation</strong> (one HEAD per mount) — catches re-ingestion and out-of-band writes</li>
+        <li>Eviction is safe: a running job's hardlink keeps the file alive</li>
+        <li><strong>Local mode</strong>: copy instead, no cache — the local file <em>is</em> the store of record</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============ 7 · SOLUTION B DEPTH ============ -->
+<section class="slide">
+  <div class="kicker">Solution B · in depth</div>
+  <h2>Mint a scoped key — in a pod that can only reach the store</h2>
+  <p class="sub" style="font-size:19px; margin-bottom:2px;">Per query: ReBAC picks the datasets, KF mints a token scoped to <em>those keys only</em>, and hands it to a locked-down executor.</p>
+  <div class="diagram">
+    <div class="node kf">
+      <div class="glyph">📦</div>
+      <div class="plate">
+        <b>Knowledge Flow</b>
+        <div class="role">ReBAC · mints the scoped token</div>
+        <div class="egress-tag"><span class="warn">↳ needs the metadata server</span></div>
+      </div>
+    </div>
+    <div class="wire"><span class="arw">→</span><span>SQL + scoped token</span></div>
+    <div class="node exec">
+      <div class="glyph">🔒</div>
+      <div class="plate">
+        <b>tabular-executor</b>
+        <div class="role">DuckDB + httpfs · no-privilege pod</div>
+        <div class="egress-tag"><span class="no">✗ metadata · ✗ internal</span></div>
+      </div>
+    </div>
+    <div class="wire"><span class="arw">↔</span><span>range reads</span></div>
+    <div class="node store">
+      <div class="glyph">🪣</div>
+      <div class="plate">
+        <b>GCS / MinIO</b>
+        <div class="role">403 on a foreign key, at the IAM layer</div>
+        <div class="egress-tag"><span class="ok">✓ scoped token only</span></div>
+      </div>
+    </div>
+  </div>
+  <p class="punch" style="font-size:20px;">The catch: httpfs can't be locked down like A — external access must stay on, so SSRF is closed at the <strong>pod's network edge</strong>, not in DuckDB. That edge can't live on KF (it needs the metadata server) → a <strong>separate minimal pod</strong>.</p>
+</section>
+
+<!-- ============ 8 · THE PARSER, DEMOTED ============ -->
+<section class="slide">
+  <div class="kicker">Both solutions · a fair question</div>
+  <h2>"So do we delete the parser?" — No, we demote it</h2>
+  <div class="ba">
+    <div class="ba-panel">
+      <h3 style="color:var(--red);">Today — the parser is the wall</h3>
+      <p class="cap">A row cap forces the SQL into one wrapped SELECT; the AST allowlist is what keeps it safe.</p>
+<pre class="small"><span class="c"># the query is wrapped to force a cap</span>
+<span class="k">SELECT</span> * <span class="k">FROM</span> (
+    &lt;agent sql&gt;          <span class="c"># must be ONE SELECT</span>
+) <span class="k">AS</span> fred_result
+<span class="k">LIMIT</span> 200;</pre>
+      <ul class="tight" style="margin-top:14px;">
+        <li>Security = the recursive AST allowlist</li>
+        <li>Wrapper is injectable if a gap admits a 2nd statement</li>
+        <li>No multi-statement, no temp-table staging</li>
+      </ul>
+    </div>
+    <div class="ba-panel a">
+      <h3 style="color:var(--accent);">With the sandbox — the parser steps back</h3>
+      <p class="cap">The sandbox (A) or the scoped credential (B) is the wall. The cap becomes a Python fetch.</p>
+<pre class="small"><span class="c"># no wrapper — cap is a streaming fetch</span>
+cur = con.<span class="f">execute</span>(agent_sql)   <span class="c"># any script</span>
+rows = cur.<span class="f">fetchmany</span>(max_rows + 1)</pre>
+      <ul class="tight" style="margin-top:14px;">
+        <li>Security = sandbox / credential — <strong>not</strong> the parser</li>
+        <li>Parser kept only for <strong>clean 400s</strong> + <strong>mount-narrowing</strong></li>
+        <li>Multi-statement + <code>CREATE TEMP TABLE</code> now allowed</li>
+      </ul>
+    </div>
+  </div>
+  <p class="punch">The agent gets <strong>more</strong> SQL power, not less — the sandbox is what makes that safe.</p>
+</section>
+
+<!-- ============ 9 · WHERE WE ARE TODAY ============ -->
+<section class="slide">
+  <div class="kicker">Current state · PR #2444</div>
+  <h2>The GCS outage is fixed — the boundary isn't moved yet</h2>
+  <p class="sub" style="margin-bottom:20px;">
+    #2364 removed the presigned URL: GCS reads now download server-side via ADC (plain <code class="mono" style="font-size:19px; color:var(--blue);">storage.objects.get</code>, no <code class="mono" style="font-size:19px; color:var(--blue);">signBlob</code>). Good. But the DuckDB sandbox flags aren't on, so <strong>even with the download in place</strong>, the agent's SQL can still:
+  </p>
+  <div class="cards">
+    <div class="card bad">
+      <h3>Reach any URL</h3>
+      <p>httpfs is still loadable → <span class="mono">read_csv('http://169.254.169.254/…')</span> — SSRF to the SA token.</p>
+    </div>
+    <div class="card bad">
+      <h3>Read any file in the pod</h3>
+      <p>External access is on → <span class="mono">read_text('/app/.env')</span>, any path the process can reach.</p>
+    </div>
+    <div class="card bad">
+      <h3>Change its own config</h3>
+      <p>No <span class="mono">lock_configuration</span> → a query can <span class="mono">SET</span> its way around limits.</p>
+    </div>
+  </div>
+  <p class="punch">The parser is still the only wall. Solution A is half-built: the expensive half.</p>
+</section>
+
+<!-- ============ 10 · HOW FAR FROM A ============ -->
+<section class="slide">
+  <div class="kicker">The gap to full Solution A</div>
+  <h2>One small change moves the boundary off the parser</h2>
+  <table>
+    <tr><th style="width:52px;">Gap</th><th>What's needed</th><th style="width:150px;">Size</th></tr>
+    <tr class="hot"><td><strong>G1</strong></td><td><strong>Sandbox flags</strong> on the local-file path: <code>allowed_directories</code> + <code>enable_external_access=false</code> + <code>lock_configuration</code>. The strategy is already known at connection-open.</td><td class="risk-low">small — the one that matters</td></tr>
+    <tr><td>G2</td><td>Non-GCS remote stores (MinIO/SeaweedFS) still use presigned URL + httpfs → decide: extend download model, or hold for B</td><td class="risk-med">decision + medium</td></tr>
+    <tr><td>G3</td><td>Local filesystem store hands direct paths into <code>object_root</code> (all docs) → copy authorized artifacts into the job dir</td><td class="risk-low">small</td></tr>
+    <tr><td>G4</td><td>Pod-local artifact cache (hardlinks, etag invalidation) — kills per-request re-downloads</td><td class="risk-med">medium · optimization</td></tr>
+    <tr><td>G5</td><td>Unrestricted-SQL execution model — streaming row cap, multi-statement, temp tables (adds capability)</td><td class="risk-med">medium · contract change</td></tr>
+  </table>
+  <p class="punch">With <strong style="color:var(--accent);">G1 alone</strong>, the GCS path — the one in production trouble — stops depending on the parser.</p>
+</section>
+
+<!-- ============ 11 · THE DECISION ============ -->
+<section class="slide">
+  <div style="margin:auto 0;">
+    <div class="kicker">The decision for this room</div>
+    <h2 style="margin-bottom:20px;">Do we go A, or B?</h2>
+    <div class="ba" style="flex:0 0 auto; margin-bottom:26px;">
+      <div class="ba-panel a" style="padding:18px 24px;">
+        <h3 style="color:var(--accent); font-size:20px;">A wins if…</h3>
+        <p style="font-size:17px; color:var(--muted); line-height:1.5;">artifacts stay within a disk budget · we want no new infrastructure · we want the boundary that fails closed with zero credential and zero network. <strong style="color:var(--text);">Meets R1–R3 today via G1.</strong></p>
+      </div>
+      <div class="ba-panel b" style="padding:18px 24px;">
+        <h3 style="color:var(--blue); font-size:20px;">B wins if…</h3>
+        <p style="font-size:17px; color:var(--muted); line-height:1.5;">big-Parquet analysis (R4) becomes real · we accept running a <span class="mono" style="font-size:15px;">tabular-executor</span> service + egress policy · and S3NS actually exposes STS.</p>
+      </div>
+    </div>
+    <ul class="tight" style="font-size:19px;">
+      <li><strong>Open question, gating B:</strong> does S3NS (sovereign GCP) expose STS / Credential Access Boundaries at all? <span class="muted">Same class of gap as the <code class="mono" style="font-size:16px;">signBlob</code> denial that started this.</span></li>
+      <li><strong>Not exclusive:</strong> A now (uniform, small), B later behind the executor when R4 arrives — the parser is demoted either way.</li>
+    </ul>
+    <p class="muted" style="margin-top:30px; font-size:18px;">
+      Detail + test results: <code class="mono" style="color:var(--accent); font-size:16px;">docs/swift/rfc/TABULAR-SQL-SANDBOX-RFC.md</code>
+    </p>
+  </div>
+</section>
+
+<script>
+(function () {
+  const slides = Array.from(document.querySelectorAll('.slide'));
+  const progress = document.getElementById('progress');
+  const counter = document.getElementById('counter');
+  let idx = 0;
+
+  const fromHash = parseInt(location.hash.slice(1), 10);
+  if (!isNaN(fromHash) && fromHash >= 1 && fromHash <= slides.length) idx = fromHash - 1;
+
+  function show(i) {
+    idx = Math.max(0, Math.min(slides.length - 1, i));
+    slides.forEach((s, j) => s.classList.toggle('active', j === idx));
+    progress.style.width = ((idx + 1) / slides.length * 100) + '%';
+    counter.textContent = (idx + 1) + ' / ' + slides.length;
+    history.replaceState(null, '', '#' + (idx + 1));
+  }
+
+  function fit() {
+    const scale = Math.min(window.innerWidth / 1320, window.innerHeight / 760);
+    slides.forEach(s => { s.style.transform = 'translate(-50%, -50%) scale(' + scale + ')'; });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown') { e.preventDefault(); show(idx + 1); }
+    else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); show(idx - 1); }
+    else if (e.key === 'Home') { e.preventDefault(); show(0); }
+    else if (e.key === 'End') { e.preventDefault(); show(slides.length - 1); }
+  });
+  document.getElementById('prevzone').addEventListener('click', () => show(idx - 1));
+  document.getElementById('nextzone').addEventListener('click', () => show(idx + 1));
+  window.addEventListener('resize', fit);
+
+  fit();
+  show(idx);
+})();
+</script>
+</body>
+</html>

--- a/docs/swift/rfc/TABULAR-SQL-SANDBOX-PRESENTATION.html
+++ b/docs/swift/rfc/TABULAR-SQL-SANDBOX-PRESENTATION.html
@@ -166,9 +166,15 @@
   .node .egress-tag .ok { color: var(--green); display: block; }
   .node .egress-tag .no { color: var(--red); display: block; }
   .node .egress-tag .warn { color: var(--amber); display: block; }
-  .wire { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; padding: 0 10px; margin-bottom: 40px; }
+  .wire { flex: 0 0 auto; width: 110px; display: flex; flex-direction: column; align-items: center; padding: 0 6px; margin-bottom: 40px; }
   .wire .arw { font-size: 34px; line-height: 1; color: var(--accent); }
   .wire span { font-size: 11.5px; color: var(--muted); margin-top: 5px; max-width: 100px; line-height: 1.3; }
+  .diagram-inner { position: relative; width: 862px; }
+  .diagram-row { display: flex; align-items: center; justify-content: center; }
+  .mint-arc { display: block; width: 862px; height: 78px; margin-top: -26px; overflow: visible; }
+  .mint-arc path { fill: none; stroke: var(--amber); stroke-width: 2; stroke-dasharray: 7 6; }
+  .mint-arc text { fill: var(--amber); font-size: 13.5px; font-weight: 600; }
+  .mint-arc .halo { stroke: #070b12; stroke-width: 9; fill: none; }
 
   /* holes / status cards */
   .cards { display: flex; gap: 22px; flex: 1; }
@@ -365,33 +371,56 @@
 <section class="slide">
   <div class="kicker">Solution B · in depth</div>
   <h2>Mint a scoped key — in a pod that can only reach the store</h2>
-  <p class="sub" style="font-size:19px; margin-bottom:2px;">Per query: ReBAC picks the datasets, KF mints a token scoped to <em>those keys only</em>, and hands it to a locked-down executor.</p>
+  <div class="flow">
+    <div class="flow-step"><b>ReBAC</b><span>resolve the authorized datasets</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><b>Mint token</b><span>scoped to those exact object keys</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><b>Executor runs</b><span>DuckDB httpfs, with the scoped token</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><b>Range-read</b><span>only needed bytes → rows back to KF</span></div>
+  </div>
   <div class="diagram">
-    <div class="node kf">
-      <div class="glyph">📦</div>
-      <div class="plate">
-        <b>Knowledge Flow</b>
-        <div class="role">ReBAC · mints the scoped token</div>
-        <div class="egress-tag"><span class="warn">↳ needs the metadata server</span></div>
+    <div class="diagram-inner">
+      <div class="diagram-row">
+        <div class="node kf">
+          <div class="glyph">📦</div>
+          <div class="plate">
+            <b>Knowledge Flow</b>
+            <div class="role">ReBAC · mints the scoped token</div>
+            <div class="egress-tag"><span class="warn">↳ needs the metadata server</span></div>
+          </div>
+        </div>
+        <div class="wire"><span class="arw">→</span><span>SQL + scoped token</span></div>
+        <div class="node exec">
+          <div class="glyph">🔒</div>
+          <div class="plate">
+            <b>tabular-executor</b>
+            <div class="role">DuckDB + httpfs · no-privilege pod</div>
+            <div class="egress-tag"><span class="no">✗ metadata · ✗ internal</span></div>
+          </div>
+        </div>
+        <div class="wire"><span class="arw">↔</span><span>range reads</span></div>
+        <div class="node store">
+          <div class="glyph">🪣</div>
+          <div class="plate">
+            <b>GCS / MinIO</b>
+            <div class="role">403 on a foreign key, at the IAM layer</div>
+            <div class="egress-tag"><span class="ok">✓ scoped token only</span></div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="wire"><span class="arw">→</span><span>SQL + scoped token</span></div>
-    <div class="node exec">
-      <div class="glyph">🔒</div>
-      <div class="plate">
-        <b>tabular-executor</b>
-        <div class="role">DuckDB + httpfs · no-privilege pod</div>
-        <div class="egress-tag"><span class="no">✗ metadata · ✗ internal</span></div>
-      </div>
-    </div>
-    <div class="wire"><span class="arw">↔</span><span>range reads</span></div>
-    <div class="node store">
-      <div class="glyph">🪣</div>
-      <div class="plate">
-        <b>GCS / MinIO</b>
-        <div class="role">403 on a foreign key, at the IAM layer</div>
-        <div class="egress-tag"><span class="ok">✓ scoped token only</span></div>
-      </div>
+      <svg class="mint-arc" viewBox="0 0 862 78" aria-label="Knowledge Flow mints the scoped token against the store's STS API">
+        <defs>
+          <marker id="arcArrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#fbbf24" stroke="none"/>
+          </marker>
+        </defs>
+        <path class="halo" d="M 107 6 C 250 74, 612 74, 755 6"/>
+        <path d="M 107 6 C 250 74, 612 74, 755 6" marker-start="url(#arcArrow)" marker-end="url(#arcArrow)"/>
+        <rect x="330" y="46" width="202" height="24" rx="6" fill="#070b12"/>
+        <text x="431" y="63" text-anchor="middle">mint scoped token · STS API</text>
+      </svg>
     </div>
   </div>
   <p class="punch" style="font-size:20px;">The catch: httpfs can't be locked down like A — external access must stay on, so SSRF is closed at the <strong>pod's network edge</strong>, not in DuckDB. That edge can't live on KF (it needs the metadata server) → a <strong>separate minimal pod</strong>.</p>

--- a/docs/swift/rfc/TABULAR-SQL-SANDBOX-RFC.md
+++ b/docs/swift/rfc/TABULAR-SQL-SANDBOX-RFC.md
@@ -1,0 +1,270 @@
+# RFC TABULAR-SANDBOX — Security boundary for agent-authored SQL over tabular datasets
+
+**Status:** draft pending sign-off (2026-08-26)
+**Scope:** where the security boundary sits when executing agent/LLM-authored SQL
+(DuckDB) over ingested Parquet artifacts — replacing the SQL parser
+(`validate_read_query`) as the *sole* boundary. Related: #2364 (GCS signBlob
+outage, fixed by PR #2444), #2318 (browser-facing signed URLs, out of scope).
+**Decides:** which of two viable enforcement models each content-store family
+uses, and what infrastructure each requires.
+
+---
+
+## 1. Problem
+
+The tabular feature (`knowledge-flow-backend/features/tabular/`) executes
+arbitrary read-only SQL written by an agent against Parquet artifacts the
+*user* is authorized to read (ReBAC). Requirements:
+
+- R1 — the agent must never read a dataset the user cannot see;
+- R2 — the agent must never read anything else reachable from the pod
+  (local files such as `.env`, other buckets, internal HTTP endpoints,
+  the cloud metadata server / service-account tokens);
+- R3 — the enforcement mechanism should not be a hand-written SQL analyzer:
+  a parser gap must not become a data breach;
+- R4 — (goal, not yet met) large Parquet files should be readable without
+  materializing the whole object (HTTP range reads: footer + needed row
+  groups/columns only).
+
+Today R1/R2 rest on `validate_read_query` — a DuckDB-AST walk that allowlists
+relation names and rejects table functions. It works, but it is exactly the
+kind of boundary R3 rules out: one gap exposes everything the pod's
+credentials and filesystem can reach, including SSRF to the metadata server
+(on AWS-style IMDSv1, a plain `read_csv('http://169.254.169.254/...')`
+reaches credential material; on GCP the token endpoint additionally requires
+a `Metadata-Flavor` header, but DuckDB `CREATE SECRET (TYPE http,
+EXTRA_HTTP_HEADERS …)` exists, so the header is not a safety net).
+
+## 2. Solutions considered (consolidated history)
+
+Options 1–8 were explored during the original design; the verdicts below are
+updated with the 2026-08-26 empirical results of §3.
+
+| # | Design | Verdict |
+|---|--------|---------|
+| 1 | DuckDB `:memory:` + pre-registered views + SQL parsing guard (first token, then AST walk) | **Rejected as sole boundary** (R3): security depends on the parser. This is what ships today; the parser stays as a UX/perf layer only (§6). |
+| 2 | DuckDB + `httpfs` reading `s3://` with the backend's normal store credentials | **Broken:** the credential grants the whole bucket; any parser gap (`read_csv_auto('s3://…/other-team/…')`) reads foreign data. |
+| 3 | DuckDB + server-side download of exactly the authorized files into a per-job directory + `enable_external_access=false` | **Viable → Solution A (§4).** Security by physical absence. Confirmed workable on DuckDB 1.5.4 with `allowed_directories` + `lock_configuration`. Cost: full-file downloads (fails R4 for big Parquet). |
+| 4 | Postgres RLS, one `csv_data` table, `SET app.current_team_id` | **Broken:** agent controls the SQL stream → `SET`/`RESET` clears the context. RLS is only safe when a typed API compiles the SQL (PostgREST-style). |
+| 5 | Postgres schema-per-team + `SET ROLE team_N_agent` | **Broken:** runner is a member of every team role → `SET ROLE team_other` escalates. |
+| 6 | Postgres per-team LOGIN role, no memberships, `GRANT SELECT` on own schema only | **Secure but rejected:** roles are cluster-global (`pg_authid`); dynamic per-team provisioning + view maintenance doesn't scale. |
+| 7 | SQLite, one DB file per team | **Rejected:** no engine-level access control; `ATTACH DATABASE` cannot be disabled → arbitrary file reach. |
+| 7b | SQLite + OS isolation (setuid per team) | **Rejected:** process-wide/irreversible, breaks async FastAPI; K8s containers run one UID. |
+| 7c | SQLite/DuckDB in an ephemeral pod per query | **Rejected as-is:** real isolation but heavy, cold-start slow. Resurfaces in softened form as the persistent minimal executor of Solution B (§5). |
+| 8 | Object-store STS (MinIO `AssumeRole` + inline policy; GCS Credential Access Boundaries) + DuckDB `httpfs`, "layered with `enable_external_access=false`" | **Viable but corrected → Solution B (§5).** The credential-as-boundary half is right. The layering half is impossible: §3 shows `enable_external_access=false` blocks `httpfs` itself (`s3://` included). With external access ON, arbitrary-host HTTP (SSRF) stays open and **no DuckDB setting can close it** — the missing layer is a network egress allowlist, not a DuckDB flag. |
+| 9 | Presigned URL per object + `httpfs` (what shipped pre-#2364) | A capability-URL variant of 8: per-object short-TTL scoping without STS. Fine on MinIO/S3; **died on GCS** where minting V4 URLs needs `iam.serviceAccounts.signBlob` (not granted on tp-s3ns). Also leaks bearer URLs into DuckDB error text (redaction machinery required), and leaves the same SSRF/local-read exposure as 8 since `httpfs` is on. |
+| 10 | GCS server-side ADC download to per-job temp dir (PR #2444, current branch) | The GCS-shaped instance of 3, **without the DuckDB sandbox flags yet** — parser still the boundary. Gap analysis in §7. |
+
+## 3. Empirical results — DuckDB 1.5.4 (prod version), 2026-08-26
+
+Method: local tests, including two local HTTP servers ("allowed" and
+"attacker") that log every connection, so "config-blocked" is distinguishable
+from "network failed".
+
+| Knob | Measured behavior |
+|------|-------------------|
+| `enable_external_access=false` | Blocks local files outside the allowlist, `http(s)://` **and `s3://`** — checked *before* any network/credential use. Therefore **mutually exclusive with `httpfs` reads**: options 3 and 8 cannot be layered. |
+| `allowed_directories` / `allowed_paths` | **Local-filesystem allowlist only.** With `allowed_paths=['http://allowed-host/']` set and locked, a request to a *different* host still connected (attacker server logged the hit). Does **not** gate URL hosts → useless against SSRF. Also directory-granular: *any* file inside an allowed dir is readable (`read_text` on a planted secret succeeded), so the job dir must contain only authorized artifacts. |
+| `disabled_filesystems` | All-or-nothing per filesystem (`'LocalFileSystem'`, `'HTTPFileSystem'`). Cannot pin `httpfs` to one host. |
+| `lock_configuration=true` | Effective: subsequent `SET` of any security option fails. Must be set *after* the allowlist/flags, and any needed extension (`httpfs`) must be loaded *before* external access is disabled. |
+| `ATTACH` | Still permitted *inside* an allowed directory under `enable_external_access=false`. Harmless for reads (blocked outside the dir) but note it can write a `.db` file into the job dir; the single-`SELECT` statement check (§6) blocks it anyway. |
+| Host pinning for `httpfs` | **No in-DuckDB mechanism exists.** Egress control must come from the network layer. |
+
+## 4. Solution A — local materialization + directory sandbox ("physical absence")
+
+For each job: ReBAC resolves the authorized datasets → the backend downloads
+exactly those artifacts into a per-job temp dir (digest-named files, disk
+budget) → DuckDB opens with:
+
+```sql
+SET allowed_directories = ['<job temp dir>'];
+SET enable_external_access = false;
+SET lock_configuration = true;
+-- httpfs never loaded; temp_directory already '' (spilling disabled)
+```
+
+Properties (all measured, §3): agent SQL cannot leave the job dir, cannot
+reach http/s3, cannot re-`SET`. The security boundary is *which files the
+trusted code put in the directory* — no parser, no credential in DuckDB's
+hands, no network. Works identically for GCS (ADC download), S3/MinIO/
+SeaweedFS (`get_local_copy`-style download), and the local filesystem store
+(copy into the job dir — pointing `allowed_directories` at the store's
+`object_root` would expose *every* document and is forbidden).
+
+Limits: full-file download (fails R4 for large Parquet); per-job disk budget
+(`max_local_artifact_bytes`) is the ceiling. The re-download cost is
+addressed by the artifact cache below.
+
+### 4.1 Pod-local artifact cache (pnpm-style, hardlinks)
+
+Downloads persist in a shared pod-local cache; each job dir receives
+**hardlinks** to the cached artifacts it is authorized to mount. Verified on
+1.5.4 (2026-08-26):
+
+- the shared cache holds *every* team's artifacts, so it must never be the
+  `allowed_directories` target (same reasoning as G3's `object_root`) — the
+  per-job dir of links *is* the sandbox boundary;
+- **hardlinks work** under the sandbox (the link is the file; direct cache
+  paths stay blocked). **Symlinks do not**: DuckDB canonicalizes the path and
+  checks the *target*, refusing a symlink out of the job dir — which both
+  rules out the symlink variant and confirms there is no symlink-escape hole;
+- write-protection: cache files `chmod 444`, job dir `chmod 500` after
+  linking — both `COPY … TO` into the dir and overwrite of an artifact fail
+  at the OS (retires §6 reason 3 without metering);
+- **eviction is safe by construction**: evicting an entry unlinks only the
+  cache's name; a running job's hardlink keeps the inode alive until its job
+  dir is deleted. No coordination between eviction and queries;
+- invalidation: **one mechanism — the store's own version marker.** Object
+  stores version every object (GCS *generation*, S3/MinIO *ETag*); the cache
+  key is `(object_key, generation/etag)`. Per mount, one `HEAD` returns the
+  current marker without content (~ms, parallelizable across a query's
+  datasets → ~one store round trip per query — noise next to the full
+  download the no-cache design pays today). This covers every change path:
+  re-ingestion *and* objects overwritten directly in the bucket behind
+  Fred's back (admin `gsutil`/`mc` write, bucket restore). Not by hashing
+  the remote (that is a full download), and not by ingestion metadata
+  (`generated_at`) — a metadata-based key would be a second mechanism with
+  a blind spot for out-of-band writes, for no gain. On a miss, record the
+  generation/etag returned *by the download response itself* (not the
+  HEAD's), closing the HEAD-then-download race. Accepted trade-off: a cache
+  hit requires the store to answer the HEAD, so a store outage fails even
+  cached queries — misses need the store anyway, and serving possibly-stale
+  data during an outage is not a property this feature wants;
+- mechanics: cache and job dirs on the **same filesystem** (one emptyDir —
+  hardlinks do not cross devices); download to a temp name + atomic rename
+  for concurrent jobs; two budgets — pod-level cache size (physical, LRU by
+  atime) and the per-job *logical* budget (sum of linked artifact sizes,
+  enforced cache hit or miss);
+- **local mode (`FileSystemContentStore`): no cache layer.** Artifacts are
+  already local, so there is nothing to avoid re-downloading — and therefore
+  nothing to invalidate. Each job **copies** (not hardlinks) its authorized
+  artifacts into the job dir: a hardlink would share the inode with the
+  store's own file, and here the local file *is* the store of record — a
+  write through the link would corrupt it, whereas the GCS/S3 cache file is
+  a disposable copy. Copy keeps the store physically unreachable from the
+  sandbox; local mode is dev/test, so the copy cost is irrelevant
+  (`cp --reflink=auto` where the filesystem supports CoW). Both modes end on
+  the same contract: job dir contains only authorized artifacts, sandboxed
+  per §4.
+
+## 5. Solution B — STS-scoped credentials + `httpfs` + network egress allowlist
+
+For each job: ReBAC resolves the authorized datasets → the backend mints a
+short-TTL credential scoped to exactly those object keys (MinIO
+`AssumeRole` + inline policy; GCS Credential Access Boundary via
+`sts.googleapis.com` — one rule per bucket, multiple `startsWith` prefixes
+OR-ed in one CEL condition, ≤10 rules/token) → DuckDB reads `s3://`/`https://`
+directly with range requests. A foreign object key gets 403 **from the object
+store's IAM layer**, entirely outside the SQL stream. Meets R4.
+
+The mandatory second half: because `httpfs` requires external access ON,
+DuckDB can `GET` *any* host (§3) — SSRF is open unless the **network layer**
+closes it. That means a K8s egress `NetworkPolicy` allowing only the object
+store endpoint (+ DNS), denying everything else including `169.254.169.254`.
+
+### 5.1 Why the egress allowlist cannot be applied to knowledge-flow itself
+
+`NetworkPolicy` is pod-granular; DuckDB runs in-process, so KF's policy is
+DuckDB's policy. KF legitimately needs egress to Postgres/OpenSearch,
+Keycloak, OpenFGA, the object store, LLM/embedding APIs, and — fatally — on
+GCS with Workload Identity the pod **must** reach the metadata server to
+obtain its own tokens. An allowlist tight enough to stop SSRF breaks KF; one
+loose enough for KF lets DuckDB reach every internal service KF can (worst on
+unauthenticated/link-local endpoints). Sidecar containers share the pod's
+network namespace, so they don't help either.
+
+**Consequence: Solution B requires a separate minimal executor service** — a
+small deployment (`tabular-executor`) that:
+
+- accepts `(SQL, scoped credential, object locations, limits)` from KF and
+  returns rows — KF keeps ReBAC, dataset resolution, and STS minting;
+- runs under a **no-privilege service account**, no secrets/env of its own
+  (credentials arrive per-request, already downscoped);
+- carries the tight egress `NetworkPolicy`: object-store endpoint + DNS only,
+  explicit deny for the metadata endpoint;
+- is the softened form of option 7c: pod-boundary isolation, but persistent
+  (no cold start per query). Also shrinks the blast radius of any residual
+  gap: the executor pod has nothing else to read.
+
+## 6. What remains of the SQL parser
+
+Under either solution, **every semantic restriction on the SQL is dropped** —
+no `SELECT`-only rule, no single-statement rule. Each of the three reasons the
+restriction used to serve is engineered away (all verified on 1.5.4,
+2026-08-26):
+
+1. *Row cap:* today the cap is a SQL wrapper (`SELECT * FROM (<sql>) AS
+   fred_result LIMIT n`), which is both injectable (a statement that closes
+   the parenthesis runs outside the cap) and the reason the input had to be
+   one SELECT expression. Replaced by a **Python-side streaming fetch**:
+   DuckDB's client streams results (`fetchmany(11)` on a 2·10⁹-row query
+   returns in ~1 ms), so the executor fetches `max_rows + 1` rows and stops —
+   no wrapper, no injection surface, no restriction.
+2. *Result shape:* multi-statement scripts are split with DuckDB's own
+   `duckdb.extract_statements` (typed statements, not a hand-rolled parser),
+   executed sequentially, and the response returns **one result set per
+   `SELECT`** (contract change: `rows` becomes a list of result sets; MCP
+   schema + client update). Staging workflows — `CREATE TEMP TABLE … AS …;
+   SELECT …` — verified working under the full A sandbox; temp tables are
+   in-memory, bounded by `memory_limit` with spilling disabled.
+3. *Writes under A:* nothing persists across queries anyway — the job dir is
+   created per job and deleted with it. Within one job, `chmod 500` on the
+   dir after materializing closes `COPY … TO`/`ATTACH` writes (verified:
+   write fails with a permission error, reads unaffected).
+
+Also verified: `lock_configuration` blocks the `PRAGMA` and `RESET` spellings
+of `SET`, so a script cannot lift its own limits; under B, set
+`autoinstall_known_extensions=false` / `autoload_known_extensions=false`
+before locking so `INSTALL` cannot fetch extensions (the egress policy blocks
+it anyway).
+
+What remains of `validate_read_query` is mechanical, not a boundary:
+statement splitting (`extract_statements`) and the AST relation walk kept
+*as UX and performance* — clean 400s the LLM can self-correct from, and
+`referenced_relations` narrowing which datasets are downloaded (A) or
+included in the STS scope (B); mounting everything per query is the
+round-trip/download explosion the narrowing was added to fix. A gap in it
+under A reads only the job dir; under B, only what the scoped credential and
+the egress policy allow.
+
+## 7. Gap: current branch (PR #2444) vs Solution A
+
+The branch already implements the expensive parts of A for GCS: per-job temp
+dir wrapping the whole connection lifetime, ADC streaming download, disk
+budget with declared-size precheck, digest filenames, lazy per-table mounting
+in search, error redaction, spilling disabled. What's missing:
+
+| Gap | Size |
+|-----|------|
+| G1 — sandbox flags: when a job's location strategy is "local files", open the connection with `allowed_directories=[job dir]`, `enable_external_access=false`, `lock_configuration=true` (ordering per §3). Strategy is known before `open_duckdb_connection` (store class → `_dataset_location_scope`), so this is a parameter to connection open + tests. | small (few lines + tests) |
+| G2 — non-GCS remote stores (MinIO/SeaweedFS) still use presigned URL + `httpfs` → external access ON → unsandboxed, parser still the boundary there. Decide: extend the download model (A everywhere, uniform, loses range reads) or hold for Solution B on S3-compatible stores. | decision + medium |
+| G3 — `FileSystemContentStore` hands DuckDB direct paths into `object_root` (all documents). For A, copy authorized artifacts into the job dir (copy, not hardlink — §4.1 local-mode note; no cache layer needed). | small |
+| G4 — artifact cache per §4.1: shared pod-local cache + per-job hardlink dirs, metadata-keyed invalidation, LRU eviction, chmod write-protection. Optimization (kills per-request re-downloads for queries *and* previews), not security. | medium |
+| G5 — unrestricted-SQL execution model (§6): replace the `LIMIT` wrapper with a streaming `fetchmany(max_rows+1)` cap, split scripts with `extract_statements` and return one result set per `SELECT` (response/MCP contract change), chmod the job dir read-only after materializing. Separable from G1 and lower priority: it *adds* agent capability, while G1 removes the parser dependency. | medium (contract change) |
+
+With G1 alone, the GCS path (the one in production trouble) stops depending
+on the parser. G2/G3 decide how uniform the model is.
+
+## 8. Open questions
+
+1. Does S3NS (sovereign GCP universe, `s3nsapis.fr`) expose the STS
+   endpoint / Credential Access Boundaries at all? (Same class of gap as the
+   `signBlob` denial that caused #2364 — verify before committing to B on
+   that environment; fmuller to check.)
+2. CEL/expression size limits on a Credential Access Boundary rule vs
+   `max_selected_datasets` (how many object prefixes fit one token).
+3. Live confirmation that `storage.objects.get` works on the tp-s3ns
+   `-objects` bucket (open verification from #2364; SeaweedFS is the
+   documented fallback).
+4. B's executor service: worth the operational cost now, or adopt A
+   uniformly (G2) and revisit B when large-Parquet demand (R4) is real?
+
+## 9. Recommendation
+
+- **Now:** land PR #2444, then close G1 (sandbox flags on the local-file
+  strategy) as a small follow-up — GCS tabular reads stop relying on the
+  parser with a few lines.
+- **Next:** decide G2/G3 (uniform Solution A) — simplest coherent model,
+  no new infrastructure, acceptable while artifacts stay ≤ the disk budget.
+- **When R4 matters (big Parquet):** implement Solution B behind the
+  `tabular-executor` service, gated on open questions 1–2.


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**Issue:** Closes #2364

**Problem in one sentence:** On tp-s3ns (S3NS sovereign cloud), `read_query` and `search_tabular_values` fail with `Permission 'iam.serviceAccounts.signBlob' denied` because tabular Parquet reads mint a V4 signed URL just so DuckDB's `httpfs` extension has an HTTPS location — a signing grant that deployment does not hold.

**Backlog ref:** n/a — GitHub issue is the tracking unit (milestone `swift-v2.2`, Priority: Critical).

---

## 2. Before you wrote a single line of code

**RFC written?** Not required — this is a fix that *removes* a dependency rather than adding a design. The change is scoped to swapping one access strategy for another already-working one inside `TabularService`; the durable what/why went straight into the compact doc (`docs/swift/design/DESIGN.md §3`) per the "settled decision → compact doc, not RFC" rule.

**Plan presented to the team before implementation?** Yes — the root-cause analysis and the proposed fix were written up in #2364 itself (issue body: "Why this path doesn't need a signed URL at all" / "Fix (implemented)") before the code landed, including the explicitly ruled-out alternative (the suspected `universe_domain` bug, which turned out to be a non-issue on `google-cloud-storage==3.1.0`).

**Confirmation received?** Issue is assigned and prioritized Critical against the prod incident; live verification on tp-s3ns is coordinated with Sébastien/Arthur once deployed.

---

## 3. What you built

Tabular reads on GCS no longer go through signed URLs or `httpfs` at all. `TabularService` gained `_dataset_location_scope()`, a per-job context manager that yields a resolver turning a `TabularArtifactV1` into a DuckDB-readable location: for `GcsContentStore` it downloads the Parquet artifact server-side into a job-scoped temp directory via the new `GcsContentStore.download_object_to_path()` (the same ADC / Workload-Identity `storage.Client` already used by `get_content`/`get_media`, needing only `storage.objects.get`), and DuckDB reads a local file; every other store keeps its existing behaviour (S3-compatible → internal presigned URL + `httpfs`, filesystem → direct path). The scope wraps the entire DuckDB connection lifetime in all three job sites (`query_read`, `search_values`, `_load_dataset_frame`) because DuckDB opens Parquet lazily at execution time, so temp files must outlive view creation and are cleaned up when the job returns — on success, error, abort and timeout alike.

Three supporting changes came with it:

- **Disk budget.** New `storage.tabular_store.query.max_local_artifact_bytes` (default 512 MiB) with a `_JobDiskBudget` helper: the artifact's *declared* ingestion size is prechecked before a byte is written (so one oversized artifact cannot fill the pod's ephemeral storage mid-download), and actual on-disk bytes are charged after (correct for legacy artifacts with no declared size). Over-budget queries fail as a caller error rather than evicting the pod. `search_values` now mounts lazily one table at a time so its early break on `max_matching_tables` also skips the fetches it would never open.
- **Error redaction.** A missing artifact maps to a generic not-found (never the internal object key); google client errors — whose text embeds the raw GCS REST URL — are re-raised redacted, mirroring the existing `httpfs` signed-URL redaction.
- **Config relaxation.** `content_storage.signing_service_account_email` is now optional: the startup fail-fast in `application_context.py` is deleted, and `get_presigned_url_internal` (still implemented, now unused by any knowledge-flow feature) raises `NotImplementedError` instead of `RuntimeError` when unconfigured, so a capability-probing caller degrades to its unsupported-operation path instead of a 500.

Out of scope, unchanged: browser-facing presigned URLs for avatars/media — that's #2318's proxy-URL design.

---

## 4. Proof of quality

**Tests added or updated:**

| Test | File | What it covers |
| ---- | ---- | -------------- |
| `test_download_object_to_path_roundtrip` | `tests/stores/content/test_gcs_content_store.py` | New store method streams an object to a local file |
| `test_download_object_to_path_missing_raises_and_leaves_no_file` | `tests/stores/content/test_gcs_content_store.py` | 404 raises `FileNotFoundError` and leaves no truncated file behind |
| `test_gcs_content_store_factory_builds_without_signing_email` | `tests/core/test_content_store_factory_gcs.py` | Startup no longer fails when `signing_service_account_email` is unset (replaces the old fail-fast test) |
| `test_tabular_service_reads_gcs_datasets_via_job_local_download` | `tests/services/test_tabular_service.py` | GCS path downloads to a job-local file and never calls `get_presigned_url_internal` |
| `test_tabular_service_gcs_disk_budget_refuses_before_downloading` | `tests/services/test_tabular_service.py` | Declared-size precheck rejects an over-budget artifact with zero bytes downloaded |
| `test_job_disk_budget_charges_actual_bytes_when_no_size_declared` | `tests/services/test_tabular_service.py` | Legacy artifacts with no declared size are charged post-download |
| `test_tabular_service_gcs_missing_artifact_does_not_leak_object_key` | `tests/services/test_tabular_service.py` | Not-found message contains no internal object key |
| `test_tabular_service_gcs_download_errors_are_redacted` | `tests/services/test_tabular_service.py` | GCS client errors surface without the raw REST URL |
| `test_tabular_service_gcs_search_downloads_lazily_until_match_cap` | `tests/services/test_tabular_service.py` | `search_values` stops downloading once the match cap is hit |

**`make code-quality` output:**

```
************ All code quality checks completed ************
```

**Raw `basedpyright` output:**

```
0 errors, 0 warnings, 0 notes
```

**`make test` output (touched suites):**

```
55 passed, 3 warnings in 5.49s
```

(`tests/services/test_tabular_service.py tests/stores/content/test_gcs_content_store.py tests/core/test_content_store_factory_gcs.py`)

---

## 5. Docs updated

| What changed | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done | n/a — backlog files are frozen; GitHub issue #2364 is the tracking unit |
| New behaviour, API field, or contract change | `docs/swift/design/DESIGN.md` §2 (Locate step) and §3, rewritten as "Tabular Reads on GCS — Server-Side Downloads (#2364)" |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — no runtime/control-plane contract surface touched |
| UX component implemented or visual status changed | n/a — backend only |
| Phase progress row exists for this area | n/a |
| WORKPLAN sprint item finished | n/a — frozen |
| Code and a design doc now diverge | Fixed in the same change (DESIGN.md §3 rewritten); config descriptions updated in `common/structures.py`, regenerated `config/schema/configuration.schema.json` + `deploy/charts/fred/values.schema.json`, and `deploy/charts/fred/values-gcp.yaml` comments/IAM guidance |

---

## 6. Close-out statement

```
## Task close-out
- Code: GCS tabular Parquet reads download artifacts server-side via the ADC storage.Client into a job-scoped temp file (new GcsContentStore.download_object_to_path + TabularService._dataset_location_scope) instead of minting V4 signed URLs for httpfs; signing_service_account_email becomes optional and a per-job disk budget (max_local_artifact_bytes, 512 MiB) bounds local materialization.
- Tests: 55 passed across the three touched suites; 9 tests added/replaced covering the download path, the disk budget (pre- and post-check), error redaction, lazy search mounting, and the relaxed factory.
- Docs updated: docs/swift/design/DESIGN.md, apps/knowledge-flow-backend/knowledge_flow_backend/common/structures.py, apps/knowledge-flow-backend/config/schema/configuration.schema.json, deploy/charts/fred/values.schema.json, deploy/charts/fred/values-gcp.yaml
- Tracking: closes #2364
- Skipped steps: Step 1 (RFC) — settled fix that removes an IAM dependency, not an open design question; the what/why went into DESIGN.md per the RFC-vs-doc rule.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** The blast radius is the GCS content-store path only — MinIO/S3 and filesystem deployments take the unchanged branches. Two residual risks: (1) if the deployment lacks `storage.objects.get` on the `-objects` bucket the reads still fail (the pod's readiness already proves `storage.objects.list` works there, so this is unlikely; documented fallback per #2364 is deploying SeaweedFS for that environment); (2) whole-artifact downloads replace `httpfs` range reads, so a very large Parquet costs more latency and pod-local disk than before — bounded by `max_local_artifact_bytes`, and a pod-local cache keyed by object key + etag is the natural follow-up if latency warrants it. Live verification against tp-s3ns has not happened yet — this is code review plus unit tests from this side.

**How do we roll back?** Revert the single commit. Redeploying then also requires re-setting `content_storage.signing_service_account_email` in values (the old code fails fast at startup without it) — that's the only config coupling.
