### PR TITLE
fix(frontend): surface the real prepare-turn error instead of "[object Object]"

### DIFF
--- a/apps/frontend/src/rework/core/hooks/useChatSse.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.test.tsx
@@ -386,6 +386,50 @@ describe("useChatSse — send() ordering barrier and prepare-execution failure h
     expect(onTurnStartedMock).not.toHaveBeenCalled();
   });
 
+  it("surfaces the backend detail (never '[object Object]') when prepare-execution rejects with an RTK Query error", async () => {
+    flushPendingWrites = async () => true;
+    // The real-world failure: `prepareExecution(...).unwrap()` rejects with a
+    // FetchBaseQueryError ({ status, data }), which is NOT an Error and has no
+    // `.message`. The old `String(err)` rendered "[object Object]" and hid the
+    // real cause (#2449).
+    prepareExecutionImpl = async () => {
+      throw { status: 422, data: { detail: "Runtime not connected for this agent." } };
+    };
+    mount();
+
+    await expect(
+      act(async () => {
+        await latest.send("hello", "session-1");
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(onErrorMock).toHaveBeenCalledTimes(1);
+    const message = onErrorMock.mock.calls[0][0] as string;
+    expect(message).toContain("Runtime not connected for this agent.");
+    expect(message).not.toContain("[object Object]");
+    expect(onTurnStartedMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a SerializedError's message when prepare-execution rejects with one (no status field)", async () => {
+    flushPendingWrites = async () => true;
+    // RTK Query also rejects with a bare SerializedError ({ name, message })
+    // when the mutation throws before producing a FetchBaseQueryError — also
+    // not a real Error instance, so it needs the same normalization path.
+    prepareExecutionImpl = async () => {
+      throw { name: "Error", message: "Failed to fetch" };
+    };
+    mount();
+
+    await act(async () => {
+      await latest.send("hello", "session-1");
+    });
+
+    expect(onErrorMock).toHaveBeenCalledTimes(1);
+    const message = onErrorMock.mock.calls[0][0] as string;
+    expect(message).toContain("Failed to fetch");
+    expect(message).not.toContain("[object Object]");
+  });
+
   it("a retry after a prepare-execution failure starts exactly one turn", async () => {
     flushPendingWrites = async () => true;
     prepareExecutionImpl = async () => {

--- a/apps/frontend/src/rework/core/hooks/useChatSse.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatSse.ts
@@ -48,6 +48,7 @@ import {
 } from "../utils/runtimeStream";
 import { countUnicodeCodePoints } from "../utils/chatInput";
 import { personalTeamId } from "../../components/shared/utils/teamId";
+import { normalizeApiError } from "../errors/normalizeApiError";
 
 // The UI may still carry the bare "personal" placeholder (teamId.ts) in the URL
 // before bootstrap resolves the real per-user id. The control-plane resolves
@@ -809,8 +810,19 @@ export function useChatSse(
           console.debug(`[useChatSse][${sendId}] ${stage} settled after cancellation — no toast`);
           return;
         }
-        const msg = (err as Error)?.message ?? String(err);
-        console.error(`[useChatSse][${sendId}] ${stage} failed — ${msg}`);
+        // Extract a readable message. The prepare-execution stage rejects with
+        // an RTK Query error ({ status, data }) or a SerializedError, neither of
+        // which is a real Error nor has a usable `.message` — so the old
+        // `String(err)` rendered "[object Object]" and hid the real failure.
+        // normalizeApiError pulls the backend `detail`/network reason out of
+        // those shapes; fall back to a real Error's message, then the HTTP
+        // status, then a generic string — never "[object Object]".
+        const normalized = normalizeApiError(err);
+        const msg =
+          normalized.detail ??
+          (err instanceof Error ? err.message : undefined) ??
+          (normalized.status !== undefined ? `HTTP ${normalized.status}` : "unexpected error");
+        console.error(`[useChatSse][${sendId}] ${stage} failed — ${msg}`, err);
         onError?.(`Could not prepare this turn: ${msg}`);
       };
 


### PR DESCRIPTION
## What

When a chat turn's preflight failed, the composer showed `Agent error — Could not prepare this turn: [object Object]`, hiding the actual cause.

`failPreflight` in `useChatSse.ts` built its message with `(err as Error)?.message ?? String(err)`. The prepare-execution stage rejects with an RTK Query error (`{ status, data }`) or a `SerializedError` — neither is a real `Error` nor has a usable `.message` — so `String(err)` rendered `[object Object]`.

## Fix

Use the existing `normalizeApiError` helper to extract the backend `detail` / network reason from those error shapes, falling back to a real `Error`'s message, then the HTTP status, then a generic string — **never** `[object Object]`. The raw error object is also logged to the console for debugging.

## Tests

Adds two regression tests (RTK Query `{ status, data }` shape and bare `SerializedError` shape) asserting the surfaced message contains the backend detail and never `[object Object]`. The pre-existing test only threw a real `Error` (which already had a `.message`), which is why the bug slipped through.

`make code-quality` clean; useChatSse suite 35/35.

## Note

This is a diagnosability fix only — it makes preflight failures legible. It does not change turn-preparation behaviour.