### PR TITLE
feat(frontend): split chat reasoning chip menu into Models + Effort sections

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -407,7 +407,7 @@
       "reasoningRowLabel": "Reasoning",
       "reasoningModelsSection": "Models",
       "reasoningEffortSection": "Effort",
-      "reasoningOff": "Normal",
+      "reasoningOff": "Low",
       "reasoningOn": "High",
       "reasoningOnMenu": "High (Reasoning)",
       "reasoningHint": "Turns on reasoning for in-depth questions (increases response time and token usage).",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -405,8 +405,11 @@
       "searchPolicyRowLabel": "Search",
       "searchPolicyTitle": "Search policy",
       "reasoningRowLabel": "Reasoning",
-      "reasoningOff": "Fast",
-      "reasoningOn": "Boost",
+      "reasoningModelsSection": "Models",
+      "reasoningEffortSection": "Effort",
+      "reasoningOff": "Normal",
+      "reasoningOn": "High",
+      "reasoningOnMenu": "High (Reasoning)",
       "reasoningHint": "Turns on reasoning for in-depth questions (increases response time and token usage).",
       "selectLibraryFirst": "Select a library first.",
       "modelNotEnabledForTeam": "This model is not enabled for this team — the message will fail. Ask a platform administrator to enable it."

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -405,8 +405,11 @@
       "searchPolicyRowLabel": "Recherche",
       "searchPolicyTitle": "Politique de recherche",
       "reasoningRowLabel": "Raisonnement",
-      "reasoningOff": "Rapide",
-      "reasoningOn": "Boost",
+      "reasoningModelsSection": "Modèles",
+      "reasoningEffortSection": "Effort",
+      "reasoningOff": "Normal",
+      "reasoningOn": "Élevé",
+      "reasoningOnMenu": "Élevé (Raisonnement)",
       "reasoningHint": "Active le raisonnement pour les questions approfondies (augmente le temps de réponse et la consommation de tokens).",
       "selectLibraryFirst": "Sélectionnez d'abord une bibliothèque.",
       "modelNotEnabledForTeam": "Ce modèle n'est pas activé pour cette équipe — le message échouera. Demandez à un administrateur de la plateforme de l'activer."

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -407,7 +407,7 @@
       "reasoningRowLabel": "Raisonnement",
       "reasoningModelsSection": "Modèles",
       "reasoningEffortSection": "Effort",
-      "reasoningOff": "Normal",
+      "reasoningOff": "Faible",
       "reasoningOn": "Élevé",
       "reasoningOnMenu": "Élevé (Raisonnement)",
       "reasoningHint": "Active le raisonnement pour les questions approfondies (augmente le temps de réponse et la consommation de tokens).",

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.menu.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.menu.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The open reasoning menu is split into two sections (#2446-adjacent UI rework):
+// a read-only "Models" section (per-turn model selection has no backend yet, so
+// the resolved model is shown checked but not selectable) and an "Effort"
+// section (Normal / "Élevé (Raisonnement)"). The parenthetical reasoning wording
+// lives in the menu only — the closed chip keeps just "Élevé" (reasoningOn).
+// These need a live DOM to open the menu, so they sit apart from the SSR tests
+// in ReasoningChip.test.tsx.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReasoningChip } from "./ReasoningChip";
+import type { ChatControlDescriptor, EffectiveChatModel } from "../../../slices/controlPlane/controlPlaneOpenApi";
+import type { ChatTurnControlComposerState } from "./types";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@shared/atoms/Icon/Icon.tsx", () => ({
+  default: ({ type }: { type: string }) => <i data-icon={type} />,
+}));
+
+function reasoningControl(): ChatControlDescriptor {
+  return { capability_id: "platform", widget: "reasoning_toggle", params: { default: false } };
+}
+function composerState(over: Partial<ChatTurnControlComposerState> = {}): ChatTurnControlComposerState {
+  return {
+    teamId: "fredlab",
+    onAttach: () => undefined,
+    selectedLibraryIds: [],
+    onSelectedLibraryIdsChange: () => undefined,
+    selectedDocumentUids: [],
+    onSelectedDocumentUidsChange: () => undefined,
+    searchPolicy: "hybrid",
+    onSearchPolicyChange: () => undefined,
+    ragScope: "hybrid",
+    onRagScopeChange: () => undefined,
+    reasoning: false,
+    onReasoningChange: () => undefined,
+    ...over,
+  } as ChatTurnControlComposerState;
+}
+const model: EffectiveChatModel = {
+  enabled_for_team: true,
+  reasoning_enabled: true,
+  capability_id: "model__openai__mistral-small-latest",
+} as EffectiveChatModel;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(composer: ChatTurnControlComposerState) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(<ReasoningChip chatControls={[reasoningControl()]} composer={composer} effectiveModel={model} />);
+  });
+}
+function openMenu() {
+  const trigger = container.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement;
+  act(() => trigger.click());
+}
+function menuButtons() {
+  return [...container.querySelectorAll('[role="option"]')] as HTMLElement[];
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("ReasoningChip — split menu (Models + Effort)", () => {
+  it("closed chip shows just 'Élevé' (reasoningOn), never the menu-only parenthetical", () => {
+    mount(composerState({ reasoning: true }));
+    const html = container.innerHTML;
+    expect(html).toContain("chatbot.composerSettings.reasoningOn");
+    // The "(Raisonnement)" wording (reasoningOnMenu) must not leak into the
+    // closed chip.
+    expect(html).not.toContain("chatbot.composerSettings.reasoningOnMenu");
+  });
+
+  it("opens a menu with a Models section and an Effort section", () => {
+    mount(composerState());
+    openMenu();
+    const html = container.innerHTML;
+    expect(html).toContain("chatbot.composerSettings.reasoningModelsSection");
+    expect(html).toContain("chatbot.composerSettings.reasoningEffortSection");
+    // Effort rows: Normal (off) and the fuller "Élevé (Raisonnement)" (menu-only).
+    expect(html).toContain("chatbot.composerSettings.reasoningOff");
+    expect(html).toContain("chatbot.composerSettings.reasoningOnMenu");
+  });
+
+  it("shows the resolved model as a read-only, checked row (no onClick to change it)", () => {
+    mount(composerState());
+    openMenu();
+    const modelRow = menuButtons().find((b) => b.textContent?.includes("Mistral Small Latest"));
+    expect(modelRow).toBeTruthy();
+    // It is the active model: rendered checked. Clicking it does nothing (no
+    // per-turn model selection yet) — asserted by the effort spy staying clean.
+    expect(container.innerHTML).toContain('data-icon="check_circle"');
+  });
+
+  it("picking 'Élevé (Raisonnement)' turns reasoning on; 'Normal' turns it off", () => {
+    const onReasoningChange = vi.fn();
+    mount(composerState({ reasoning: false, onReasoningChange }));
+    openMenu();
+    const high = menuButtons().find((b) => b.textContent?.includes("reasoningOnMenu")) as HTMLElement;
+    act(() => high.click());
+    expect(onReasoningChange).toHaveBeenCalledWith(true);
+
+    onReasoningChange.mockClear();
+    openMenu();
+    const normal = menuButtons().find(
+      (b) => b.textContent?.includes("reasoningOff") && !b.textContent?.includes("reasoningOnMenu"),
+    ) as HTMLElement;
+    act(() => normal.click());
+    expect(onReasoningChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.module.css
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.module.css
@@ -82,43 +82,12 @@
      rather than widening the row's `gap`, which would push the chevron out
      too and re-open the space the mockup keeps tight. */
   margin-left: var(--spacing-2xs);
-  /* One step fainter than retreat in both themes — the colour contrast alone
-     separates the model name from the reasoning state. */
-  color: var(--on-surface-muted);
+  /* Uniform muted styling for the effort word in BOTH modes (Faible/Élevé):
+     no gradient, no per-mode accent — the word alone carries the state, one
+     step fainter than the model name so the colour contrast still separates
+     the two. */
+  color: var(--on-surface-retreat);
   line-height: 1;
-}
-
-/* Boost is a live mode, not a resting state: it steps forward instead of
-   retreating, wearing the same spectrum as the agent surfaces' rotating border
-   so the one "this is the AI doing more" signal reads the same everywhere.
-
-   Two deliberate departures from the border version, both carried by the
-   `-core` stop list in styles/gradients.css. It is a LINEAR gradient, not
-   conic: a conic sweep across ~40px of text reads as an arbitrary smear rather
-   than a sweep. And the white/peach stops are gone — white is a hole in text
-   rather than a travelling highlight.
-
-   The WORD still carries the state on its own, so this is reinforcement and
-   never the only signal — a colour-blind reader reads "Boost" vs "Rapide". */
-.state[data-on] {
-  background: linear-gradient(90deg, var(--gradient-spectrum-stops-core));
-  background-clip: text;
-  -webkit-background-clip: text;
-  /* Fallback first: any engine that ignores background-clip: text keeps a
-     solid, readable colour instead of transparent (invisible) text. */
-  color: var(--primary);
-  font-weight: 500;
-  -webkit-text-fill-color: transparent;
-}
-
-/* Forced-colours users get the system palette, not our spectrum — a gradient
-   clipped to text is exactly what that mode exists to override. */
-@media (forced-colors: active) {
-  .state[data-on] {
-    background: none;
-    -webkit-text-fill-color: currentcolor;
-    color: highlight;
-  }
 }
 
 .chevron {

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.module.css
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.module.css
@@ -139,6 +139,15 @@
   font: var(--font-body-small);
 }
 
+/* Section heading inside the menu ("Modèles", "Effort") — a quiet label that
+   groups the rows below it, one step above the muted body so it reads as a
+   heading without competing with the selectable rows. */
+.sectionTitle {
+  padding: var(--spacing-xs) var(--spacing-s) var(--spacing-3xs);
+  color: var(--on-surface-muted);
+  font: var(--font-label-small);
+}
+
 .menu {
   position: absolute;
   right: 0;

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.test.tsx
@@ -265,16 +265,18 @@ describe("ReasoningChip (REASON-01 level 4, mockup text button)", () => {
   // #2387 — the state reads as two modes, not on/off. "Désactivé" beside a model
   // name read as though the MODEL were off; nothing tied the word to reasoning.
 
-  it("marks the active mode so colour reinforces the word", () => {
+  it("shows the effort word for both modes, uniformly styled with no per-mode marker", () => {
+    // The gradient "boost" accent was dropped: the effort word is plain
+    // on-surface-retreat text in both modes, so neither carries a data-on hook.
     const on = render([reasoningControl({ default: false })], true, false, effectiveModel({ name: "gpt-4.1" }));
-    expect(on).toContain("data-on");
     expect(on).toContain("chatbot.composerSettings.reasoningOn");
+    expect(on).not.toContain("data-on");
+    // The menu-only parenthetical never leaks into the closed chip.
+    expect(on).not.toContain("chatbot.composerSettings.reasoningOnMenu");
 
     const off = render([reasoningControl({ default: false })], false, false, effectiveModel({ name: "gpt-4.1" }));
-    // The resting mode carries no marker — and still says which mode it is,
-    // so the accent is reinforcement and never the only signal.
-    expect(off).not.toContain("data-on");
     expect(off).toContain("chatbot.composerSettings.reasoningOff");
+    expect(off).not.toContain("data-on");
   });
 
   it("ties the state to reasoning in the accessible name", () => {

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.tsx
@@ -171,6 +171,11 @@ export function ReasoningChip({ chatControls, composer, disabled = false, effect
   // back at the user implied a per-question choice that never existed (#2387).
   const onLabel = t("chatbot.composerSettings.reasoningOn");
   const offLabel = t("chatbot.composerSettings.reasoningOff");
+  // The "Élevé (Raisonnement)" wording is shown ONLY in the menu, where the
+  // parenthetical says which effort level maps to reasoning; the closed chip
+  // keeps just "Élevé" (onLabel) after the model name — the reasoning meaning
+  // is already carried by the menu the user picked it from.
+  const onMenuLabel = t("chatbot.composerSettings.reasoningOnMenu");
   // Model identity first, Claude-style ("Mistral Small Élevé"): model in the
   // regular button text, reasoning state one step fainter
   // (--on-surface-muted) — the color contrast is the separator.
@@ -269,9 +274,37 @@ export function ReasoningChip({ chatControls, composer, disabled = false, effect
         <div className={styles.menu}>
           <MenuPopover
             aria-label={title}
-            header={<div className={styles.description}>{t("chatbot.composerSettings.reasoningHint")}</div>}
             groups={[
+              // Section 1 — Models. Per-turn model selection does not exist yet
+              // (no runtime override field, routing is server-resolved), so the
+              // resolved model shows as a single read-only, already-checked row.
+              // The section is here so real multi-model selection can later drop
+              // sibling rows with an onClick beside this one. Omitted when no
+              // model label resolved (older backend / unreachable pod).
+              ...(displayLabel
+                ? [
+                    [
+                      <div key="models-title" className={styles.sectionTitle}>
+                        {t("chatbot.composerSettings.reasoningModelsSection")}
+                      </div>,
+                      <MenuPopoverItem
+                        key="model"
+                        role="option"
+                        label={displayLabel}
+                        selected
+                        accentSelected
+                        trailingIcon="check_circle"
+                      />,
+                    ],
+                  ]
+                : []),
+              // Section 2 — Effort. "Normal" = reasoning off, "Élevé
+              // (Raisonnement)" = reasoning on (the parenthetical lives here, not
+              // in the closed chip). The effort/latency explainer trails the two.
               [
+                <div key="effort-title" className={styles.sectionTitle}>
+                  {t("chatbot.composerSettings.reasoningEffortSection")}
+                </div>,
                 <MenuPopoverItem
                   key="off"
                   role="option"
@@ -284,12 +317,15 @@ export function ReasoningChip({ chatControls, composer, disabled = false, effect
                 <MenuPopoverItem
                   key="on"
                   role="option"
-                  label={onLabel}
+                  label={onMenuLabel}
                   selected={on}
                   accentSelected
                   trailingIcon={on ? "check_circle" : undefined}
                   onClick={() => pick(true)}
                 />,
+                <div key="effort-hint" className={styles.description}>
+                  {t("chatbot.composerSettings.reasoningHint")}
+                </div>,
               ],
             ]}
           />

--- a/apps/frontend/src/rework/features/capabilities/ReasoningChip.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ReasoningChip.tsx
@@ -258,9 +258,7 @@ export function ReasoningChip({ chatControls, composer, disabled = false, effect
                 <Icon category="outlined" type="error_outline" />
               </span>
             )}
-            <span className={styles.state} data-on={on || undefined}>
-              {stateLabel}
-            </span>
+            <span className={styles.state}>{stateLabel}</span>
           </>
         ) : (
           <span className={styles.value}>{on ? onLabel : title}</span>


### PR DESCRIPTION
## What

Rework of the in-composer reasoning selector (`ReasoningChip`) in the chat field. Its menu now opens into **two labelled sections** instead of a single off/on group.

### Models section
The server-resolved model shown as a **read-only, checked row**. Per-turn model selection has no backend support yet (no runtime override field on the execute request, model is governed by the team routing policy / platform binding), so it stays read-only — the section shape is ready to grow sibling *selectable* rows when that feature lands. Matches the "single model → read-only item" case.

### Effort section
- **Normal** = reasoning off
- **Élevé (Raisonnement)** = reasoning on

The parenthetical *(Raisonnement)* wording appears **only in the menu**. The closed chip keeps just **"Élevé"** right after the model name, wearing the existing "Boost" gradient styling (`.state[data-on]`, unchanged). Off shows "Normal".

The wire is untouched — still the tri-state reasoning boolean (`composer.reasoning`).

## i18n

Relabels the composer reasoning keys (`reasoningOff` → "Normal", `reasoningOn` → "Élevé"/"High"), adds `reasoningOnMenu` (the menu-only fuller label) and the two section titles (`reasoningModelsSection`, `reasoningEffortSection`), FR + EN. These keys are used only by `ReasoningChip`.

## Tests

New interactive menu test (`ReasoningChip.menu.test.tsx`, happy-dom): opens the menu, asserts both sections render, the model shows as a checked read-only row, the menu shows the fuller `reasoningOnMenu` label while the closed chip shows only `reasoningOn`, and picking each effort row toggles reasoning on/off. The existing SSR tests (closed-chip behaviour) are unchanged and still pass — 31/31.

`make code-quality` clean.

## Scope note

This is the frontend-only slice explicitly agreed with the requester. Real **per-turn multi-model selection** (usable-models list + a runtime model-override field + how it fits the team routing-policy governance) is out of scope here and would need its own RFC + backend work.