### PR TITLE
feat(#2453): restore the mailto invitation request on public invite-only teams

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2209,7 +2209,7 @@
       "inviteOnly": "Invite only",
       "invitationMail": {
         "subject": "[{{site}}] Request to join the {{team}} team",
-        "body": "Hello,\n\nI would like to join the {{team}} team on {{site}}.\n\nUser details: {{user}}\n\nManage the {{team}} team members: {{teamUrl}}"
+        "body": "Hello,\n\nI would like to join the {{team}} team on {{site}}.\n\nUser details: {{user}}\n\nGo to the {{team}} team page: {{agentsUrl}}\nManage the {{team}} team members: {{membersUrl}}"
       },
       "memberCount": "{{count}} members"
     },

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2209,7 +2209,7 @@
       "inviteOnly": "Invite only",
       "invitationMail": {
         "subject": "[{{site}}] Request to join the {{team}} team",
-        "body": "Hello,\n\nI would like to join the {{team}} team on {{site}}.\n\nUser details: {{user}}\n\nGo to the {{team}} team page: {{teamUrl}}"
+        "body": "Hello,\n\nI would like to join the {{team}} team on {{site}}.\n\nUser details: {{user}}\n\nManage the {{team}} team members: {{teamUrl}}"
       },
       "memberCount": "{{count}} members"
     },

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2207,6 +2207,10 @@
     "teamCard": {
       "join": "Join",
       "inviteOnly": "Invite only",
+      "invitationMail": {
+        "subject": "[{{site}}] Request to join the {{team}} team",
+        "body": "Hello,\n\nI would like to join the {{team}} team on {{site}}.\n\nUser details: {{user}}\n\nGo to the {{team}} team page: {{teamUrl}}"
+      },
       "memberCount": "{{count}} members"
     },
     "teamRoles": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2209,7 +2209,7 @@
       "inviteOnly": "Sur invitation",
       "invitationMail": {
         "subject": "[{{site}}] Demande pour rejoindre l'équipe {{team}}",
-        "body": "Bonjour,\n\nJe souhaite rejoindre l'équipe {{team}} sur {{site}}.\n\nInformations utilisateur : {{user}}\n\nAller à la page de l'équipe {{team}} : {{teamUrl}}"
+        "body": "Bonjour,\n\nJe souhaite rejoindre l'équipe {{team}} sur {{site}}.\n\nInformations utilisateur : {{user}}\n\nGérer les membres de l'équipe {{team}} : {{teamUrl}}"
       },
       "memberCount": "{{count}} membres"
     },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2207,6 +2207,10 @@
     "teamCard": {
       "join": "Rejoindre",
       "inviteOnly": "Sur invitation",
+      "invitationMail": {
+        "subject": "[{{site}}] Demande pour rejoindre l'équipe {{team}}",
+        "body": "Bonjour,\n\nJe souhaite rejoindre l'équipe {{team}} sur {{site}}.\n\nInformations utilisateur : {{user}}\n\nAller à la page de l'équipe {{team}} : {{teamUrl}}"
+      },
       "memberCount": "{{count}} membres"
     },
     "teamRoles": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2209,7 +2209,7 @@
       "inviteOnly": "Sur invitation",
       "invitationMail": {
         "subject": "[{{site}}] Demande pour rejoindre l'équipe {{team}}",
-        "body": "Bonjour,\n\nJe souhaite rejoindre l'équipe {{team}} sur {{site}}.\n\nInformations utilisateur : {{user}}\n\nGérer les membres de l'équipe {{team}} : {{teamUrl}}"
+        "body": "Bonjour,\n\nJe souhaite rejoindre l'équipe {{team}} sur {{site}}.\n\nInformations utilisateur : {{user}}\n\nAller à la page de l'équipe {{team}} : {{agentsUrl}}\nGérer les membres de l'équipe {{team}} : {{membersUrl}}"
       },
       "memberCount": "{{count}} membres"
     },

--- a/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.module.scss
@@ -5,10 +5,8 @@
   gap: var(--spacing-2xs);
 
   > * {
-    /* An avatar is a fixed-size circle: as a flex item it would shrink when
-     * the row runs out of width and render as an ellipse with the initials
-     * squeezed out of it. The "+N" badge sits at the row's main-start, so it
-     * took that first. Let the row overflow (and its container clip) instead. */
+    /* A fixed-size circle: shrinking it as a flex item renders an ellipse
+     * with the initials squeezed out. Let the row overflow and clip instead. */
     flex-shrink: 0;
     border: 2px solid var(--surface-container);
     border-radius: 50%;
@@ -16,8 +14,7 @@
 }
 
 /* Names behind the "+N" badge. A `content` tooltip drops the plain hint's
- * padding (Tooltip.module.scss: the content owns its own spacing), so restate
- * it here, and keep each name on its own unwrapped line. */
+ * padding (its content owns that), so restate it here. */
 .hiddenAvatarNames {
   margin: 0;
   padding: var(--spacing-2xs) var(--spacing-s);

--- a/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.module.scss
@@ -5,7 +5,22 @@
   gap: var(--spacing-2xs);
 
   > * {
+    /* An avatar is a fixed-size circle: as a flex item it would shrink when
+     * the row runs out of width and render as an ellipse with the initials
+     * squeezed out of it. The "+N" badge sits at the row's main-start, so it
+     * took that first. Let the row overflow (and its container clip) instead. */
+    flex-shrink: 0;
     border: 2px solid var(--surface-container);
     border-radius: 50%;
   }
+}
+
+/* Names behind the "+N" badge. A `content` tooltip drops the plain hint's
+ * padding (Tooltip.module.scss: the content owns its own spacing), so restate
+ * it here, and keep each name on its own unwrapped line. */
+.hiddenAvatarNames {
+  margin: 0;
+  padding: var(--spacing-2xs) var(--spacing-s);
+  list-style: none;
+  white-space: nowrap;
 }

--- a/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.tsx
@@ -29,13 +29,10 @@ export default function AvatarGroup({ avatars, max = 4 }: AvatarGroupProps) {
   return (
     <div className={styles.userAvatarContainer}>
       {hidden.length > 0 && (
-        // Wrapped in a Tooltip like every other avatar rather than rendered
-        // bare: `.userAvatarContainer > *` puts the 2px ring on the direct
-        // child, and under the global `box-sizing: border-box` a bare avatar
-        // pays for that ring out of its own 2rem while a Tooltip-wrapped one
-        // grows by it - the badge came out 4px smaller than its neighbours.
-        // The tooltip then also names the people "+N" stands for, one per line
-        // (a comma-joined run stops being readable past two or three).
+        // Wrapped like every other avatar, not bare: the container puts its
+        // 2px ring on the direct child, and under the global border-box a
+        // bare badge pays for that ring out of its own 2rem - it rendered 4px
+        // smaller. The wrapper also earns it the list of hidden names.
         <Tooltip
           content={
             <ul className={styles.hiddenAvatarNames}>

--- a/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.tsx
@@ -18,13 +18,37 @@ import { Tooltip } from "@shared/atoms/Tooltip/Tooltip.tsx";
 
 interface AvatarGroupProps {
   avatars: Omit<UserAvatarProps, "size">[];
+  /** How many avatars render before the rest collapse into a "+N" badge.
+   *  Lower it where the row shares a narrow line with something else - a
+   *  TeamCard footer holding a join button has ~118px for the whole row. */
+  max?: number;
 }
 
-export default function AvatarGroup({ avatars }: AvatarGroupProps) {
+export default function AvatarGroup({ avatars, max = 4 }: AvatarGroupProps) {
+  const hidden = avatars.slice(max);
   return (
     <div className={styles.userAvatarContainer}>
-      {avatars.length > 4 && <UserAvatar name={`+ ${(avatars.length - 4).toString()}`} size={"small"} />}
-      {avatars.slice(0, 4).map((avatar, index) => (
+      {hidden.length > 0 && (
+        // Wrapped in a Tooltip like every other avatar rather than rendered
+        // bare: `.userAvatarContainer > *` puts the 2px ring on the direct
+        // child, and under the global `box-sizing: border-box` a bare avatar
+        // pays for that ring out of its own 2rem while a Tooltip-wrapped one
+        // grows by it - the badge came out 4px smaller than its neighbours.
+        // The tooltip then also names the people "+N" stands for, one per line
+        // (a comma-joined run stops being readable past two or three).
+        <Tooltip
+          content={
+            <ul className={styles.hiddenAvatarNames}>
+              {hidden.map((avatar, index) => (
+                <li key={index}>{avatar.name}</li>
+              ))}
+            </ul>
+          }
+        >
+          <UserAvatar name={`+ ${hidden.length.toString()}`} size={"small"} />
+        </Tooltip>
+      )}
+      {avatars.slice(0, max).map((avatar, index) => (
         <Tooltip key={index} text={avatar.name}>
           <UserAvatar size={"small"} {...avatar} />
         </Tooltip>

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -83,10 +83,29 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  /* Without a gap the two halves touch as soon as the row is full - the card
+   * is a fixed 290px, so that happens on any team with a few admins. */
+  gap: var(--spacing-s);
   margin-top: auto;
 }
 
+/* The admin avatars are the elastic half of the footer: a team with several
+ * admins used to push the join button past the card's right edge (#2453).
+ * The button keeps its whole label and the avatar row clips instead -
+ * AvatarGroup's `max` already collapses the tail into "+N", so this only
+ * bites on an unusually long translation. Clipping the row does not hide the
+ * badge: the avatars run right-to-left, so the overflow falls off the left. */
+.teamCardAdmins {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.teamCardJoinAction {
+  flex-shrink: 0;
+}
+
 .teamJoiningLabel {
+  flex-shrink: 0;
   /* Escape-hatch margin (see design system guidance): this offset applies
    * only to the label-only (invite-only) state — the sibling join button in
    * the same footer slot must stay flush with the card's padding edge, so

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -83,18 +83,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  /* Without a gap the two halves touch as soon as the row is full - the card
-   * is a fixed 290px, so that happens on any team with a few admins. */
+  /* The card is a fixed 290px: without a gap the two halves touch as soon as
+   * a team has a few admins. */
   gap: var(--spacing-s);
   margin-top: auto;
 }
 
-/* The admin avatars are the elastic half of the footer: a team with several
- * admins used to push the join button past the card's right edge (#2453).
- * The button keeps its whole label and the avatar row clips instead -
- * AvatarGroup's `max` already collapses the tail into "+N", so this only
- * bites on an unusually long translation. Clipping the row does not hide the
- * badge: the avatars run right-to-left, so the overflow falls off the left. */
+/* The avatars are the elastic half of the footer: the button keeps its whole
+ * label, the row clips instead (#2453). AvatarGroup's `max` collapses the tail
+ * first, so this only bites on an unusually long translation - and the row runs
+ * right-to-left, so what falls off the left is never the "+N" badge. */
 .teamCardAdmins {
   min-width: 0;
   overflow: hidden;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -90,7 +90,7 @@
 }
 
 /* The avatars are the elastic half of the footer: the button keeps its whole
- * label, the row clips instead (#2453). AvatarGroup's `max` collapses the tail
+ * label, the row clips instead. AvatarGroup's `max` collapses the tail
  * first, so this only bites on an unusually long translation - and the row runs
  * right-to-left, so what falls off the left is never the "+N" badge. */
 .teamCardAdmins {

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
@@ -44,7 +44,7 @@ const k = vi.hoisted(() => ({
 
 vi.mock("react-i18next", () => ({
   // Interpolation values are appended to the key so the mailto assertions can
-  // check what the card actually fed into the subject/body templates.
+  // see what the card fed into the subject/body templates.
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key}:${Object.values(opts).join("|")}` : key),
   }),
@@ -71,18 +71,17 @@ vi.mock("../../../../../security/KeycloakService.ts", () => ({
   KeyCloakService: { GetUserFullName: () => k.fullName, GetUserName: () => k.username },
 }));
 
-// A subpath deployment is the interesting case: the mailed link must carry the
-// basename, which a router-less string concat does not get for free.
+// A subpath deployment: the mailed link must carry the basename.
 vi.mock("src/common/config", () => ({
   getConfig: () => ({ frontend_basename: "/fred/" }),
 }));
 
 import TeamCard from "./TeamCard.tsx";
 
-// The mailto is triggered by assigning window.location.href; happy-dom would
-// try to navigate on that, so intercept the assignment and record it instead.
-// Restored in afterAll: the stub carries only what this file needs, so leaving
-// it in place would silently break anything else that reads window.location.
+// Record the mailto instead of letting happy-dom act on it. The href setter
+// doubles as the assertion that this tab is never navigated away. location is
+// restored in afterAll - the stub only carries what this file needs.
+const openSpy = vi.fn();
 const hrefSetter = vi.fn();
 const realLocation = Object.getOwnPropertyDescriptor(window, "location");
 Object.defineProperty(window, "location", {
@@ -102,7 +101,7 @@ afterAll(() => {
 const admin = { id: "u-1", first_name: "Ay", last_name: "One", email: "ay@example.com" };
 
 function lastMailto(): string {
-  const calls = hrefSetter.mock.calls;
+  const calls = openSpy.mock.calls;
   return calls[calls.length - 1]?.[0] ?? "";
 }
 
@@ -110,6 +109,7 @@ let container: HTMLDivElement;
 let root: Root;
 
 function render(ui: React.ReactElement) {
+  vi.stubGlobal("open", openSpy);
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -125,6 +125,8 @@ afterEach(() => {
   container.remove();
   h.joinTeam.mockClear();
   hrefSetter.mockClear();
+  openSpy.mockClear();
+  vi.unstubAllGlobals();
   h.isJoining = false;
   k.fullName = "Test User";
   k.username = "test.user";
@@ -158,8 +160,7 @@ describe("TeamCard joining_mode rendering", () => {
   });
 
   it("INVITE_ONLY with no visibility on the payload: fails closed to the label", () => {
-    // A version-skew backend can omit `visibility` (#2433) - the card must not
-    // hand out the admin addresses on a payload it cannot read as public.
+    // A version-skew backend can omit `visibility` (#2433).
     render(<TeamCard team={baseTeam({ joining_mode: "invite_only", admins: [admin] })} withDescription={false} />);
 
     expect(container.querySelector("button")).toBeNull();
@@ -219,17 +220,19 @@ describe("TeamCard invitation request (#2453)", () => {
       button?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     });
 
+    // A new tab, and this one left alone.
+    expect(openSpy).toHaveBeenCalledWith(expect.any(String), "_blank", "noopener,noreferrer");
+    expect(hrefSetter).not.toHaveBeenCalled();
+
     // Recipients are comma-separated per RFC 6068 and percent-encoded.
     const raw = lastMailto();
     expect(raw.startsWith("mailto:ay%40example.com,bee%40example.com?")).toBe(true);
-    // Spaces must survive as %20, never as the "+" URLSearchParams emits: mail
-    // clients render that literally in the subject line.
+    // Spaces survive as %20, never the "+" URLSearchParams emits.
     expect(raw).not.toContain("+");
 
     const href = decodeURIComponent(raw);
     expect(href).toContain("rework.teamCard.invitationMail.subject:Fred Platform|Team One");
-    // The link lands on the members page (the admins add the sender by hand)
-    // and carries the configured basename ("/fred/").
+    // The members page, under the configured basename.
     expect(href).toContain(
       "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|http://localhost:3000/fred/team/team-1/settings/members",
     );

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
@@ -228,9 +228,10 @@ describe("TeamCard invitation request (#2453)", () => {
 
     const href = decodeURIComponent(raw);
     expect(href).toContain("rework.teamCard.invitationMail.subject:Fred Platform|Team One");
-    // The mailed team link carries the configured basename ("/fred/").
+    // The link lands on the members page (the admins add the sender by hand)
+    // and carries the configured basename ("/fred/").
     expect(href).toContain(
-      "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|http://localhost:3000/fred/team/team-1/agents",
+      "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|http://localhost:3000/fred/team/team-1/settings/members",
     );
   });
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
@@ -18,7 +18,7 @@
 // button for OPEN, an "invite only" label otherwise, plus the self-service
 // join mutation actually firing for OPEN.
 //
-// #2453 adds one branch on top: a public INVITE_ONLY team whose admins have a
+// One branch on top: a public INVITE_ONLY team whose admins have a
 // reachable address gets a prefilled mailto button instead of that label.
 
 import { act } from "react";
@@ -199,7 +199,7 @@ describe("TeamCard joining_mode rendering", () => {
   });
 });
 
-describe("TeamCard invitation request (#2453)", () => {
+describe("TeamCard invitation request", () => {
   it("PUBLIC + INVITE_ONLY: opens a prefilled mailto addressed to every admin", () => {
     render(
       <TeamCard

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
@@ -17,10 +17,13 @@
 // affordance is driven entirely by `joining_mode` (+ `is_member`) — the join
 // button for OPEN, an "invite only" label otherwise, plus the self-service
 // join mutation actually firing for OPEN.
+//
+// #2453 adds one branch on top: a public INVITE_ONLY team whose admins have a
+// reachable address gets a prefilled mailto button instead of that label.
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import type { Team } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 
 declare global {
@@ -34,8 +37,17 @@ const h = vi.hoisted(() => ({
   isJoining: false,
 }));
 
+const k = vi.hoisted(() => ({
+  fullName: "Test User" as string | null,
+  username: "test.user" as string | null,
+}));
+
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string, opts?: { count?: number }) => (opts ? `${key}:${opts.count}` : key) }),
+  // Interpolation values are appended to the key so the mailto assertions can
+  // check what the card actually fed into the subject/body templates.
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key}:${Object.values(opts).join("|")}` : key),
+  }),
 }));
 
 vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
@@ -50,14 +62,49 @@ vi.mock("src/hooks/useFrontendProperties", () => ({
   useFrontendProperties: () => ({
     defaultTeamAvatarFile: undefined,
     defaultPersonalAvatarFile: undefined,
+    siteTitle: "Fred",
+    siteSubtitle: "Platform",
   }),
 }));
 
 vi.mock("../../../../../security/KeycloakService.ts", () => ({
-  KeyCloakService: { GetUserFullName: () => "Test User", GetUserName: () => "test.user" },
+  KeyCloakService: { GetUserFullName: () => k.fullName, GetUserName: () => k.username },
+}));
+
+// A subpath deployment is the interesting case: the mailed link must carry the
+// basename, which a router-less string concat does not get for free.
+vi.mock("src/common/config", () => ({
+  getConfig: () => ({ frontend_basename: "/fred/" }),
 }));
 
 import TeamCard from "./TeamCard.tsx";
+
+// The mailto is triggered by assigning window.location.href; happy-dom would
+// try to navigate on that, so intercept the assignment and record it instead.
+// Restored in afterAll: the stub carries only what this file needs, so leaving
+// it in place would silently break anything else that reads window.location.
+const hrefSetter = vi.fn();
+const realLocation = Object.getOwnPropertyDescriptor(window, "location");
+Object.defineProperty(window, "location", {
+  configurable: true,
+  value: {
+    origin: "http://localhost:3000",
+    set href(value: string) {
+      hrefSetter(value);
+    },
+  },
+});
+
+afterAll(() => {
+  if (realLocation) Object.defineProperty(window, "location", realLocation);
+});
+
+const admin = { id: "u-1", first_name: "Ay", last_name: "One", email: "ay@example.com" };
+
+function lastMailto(): string {
+  const calls = hrefSetter.mock.calls;
+  return calls[calls.length - 1]?.[0] ?? "";
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -77,7 +124,10 @@ afterEach(() => {
   });
   container.remove();
   h.joinTeam.mockClear();
+  hrefSetter.mockClear();
   h.isJoining = false;
+  k.fullName = "Test User";
+  k.username = "test.user";
 });
 
 function baseTeam(overrides: Partial<Team>): Team {
@@ -107,8 +157,34 @@ describe("TeamCard joining_mode rendering", () => {
     expect(h.joinTeam).toHaveBeenCalledWith({ teamId: "team-1" });
   });
 
-  it("INVITE_ONLY + not a member: no button, shows the invite-only label", () => {
-    render(<TeamCard team={baseTeam({ joining_mode: "invite_only" })} withDescription={false} />);
+  it("INVITE_ONLY with no visibility on the payload: fails closed to the label", () => {
+    // A version-skew backend can omit `visibility` (#2433) - the card must not
+    // hand out the admin addresses on a payload it cannot read as public.
+    render(<TeamCard team={baseTeam({ joining_mode: "invite_only", admins: [admin] })} withDescription={false} />);
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toContain("rework.teamCard.inviteOnly");
+  });
+
+  it("INVITE_ONLY + private: no button, shows the invite-only label", () => {
+    render(
+      <TeamCard
+        team={baseTeam({ joining_mode: "invite_only", visibility: "private", admins: [admin] })}
+        withDescription={false}
+      />,
+    );
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toContain("rework.teamCard.inviteOnly");
+  });
+
+  it("INVITE_ONLY + public without a reachable admin address: falls back to the label", () => {
+    render(
+      <TeamCard
+        team={baseTeam({ joining_mode: "invite_only", visibility: "public", admins: [{ ...admin, email: null }] })}
+        withDescription={false}
+      />,
+    );
 
     expect(container.querySelector("button")).toBeNull();
     expect(container.textContent).toContain("rework.teamCard.inviteOnly");
@@ -119,5 +195,70 @@ describe("TeamCard joining_mode rendering", () => {
 
     expect(container.querySelector("button")).toBeNull();
     expect(container.textContent).not.toContain("rework.teamCard.join");
+  });
+});
+
+describe("TeamCard invitation request (#2453)", () => {
+  it("PUBLIC + INVITE_ONLY: opens a prefilled mailto addressed to every admin", () => {
+    render(
+      <TeamCard
+        team={baseTeam({
+          joining_mode: "invite_only",
+          visibility: "public",
+          admins: [admin, { id: "u-2", first_name: "Bee", last_name: "Two", email: "bee@example.com" }],
+        })}
+        withDescription={false}
+      />,
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toContain("rework.teamCard.join");
+    expect(container.textContent).not.toContain("rework.teamCard.inviteOnly");
+
+    act(() => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    // Recipients are comma-separated per RFC 6068 and percent-encoded.
+    const raw = lastMailto();
+    expect(raw.startsWith("mailto:ay%40example.com,bee%40example.com?")).toBe(true);
+    // Spaces must survive as %20, never as the "+" URLSearchParams emits: mail
+    // clients render that literally in the subject line.
+    expect(raw).not.toContain("+");
+
+    const href = decodeURIComponent(raw);
+    expect(href).toContain("rework.teamCard.invitationMail.subject:Fred Platform|Team One");
+    // The mailed team link carries the configured basename ("/fred/").
+    expect(href).toContain(
+      "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|http://localhost:3000/fred/team/team-1/agents",
+    );
+  });
+
+  it("falls back to whichever identity claim Keycloak returned", () => {
+    k.fullName = null;
+    render(
+      <TeamCard
+        team={baseTeam({ joining_mode: "invite_only", visibility: "public", admins: [admin] })}
+        withDescription={false}
+      />,
+    );
+
+    act(() => {
+      container.querySelector("button")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    // "(test.user)" alone, never a stray "  ()" the admin cannot act on.
+    expect(decodeURIComponent(lastMailto())).toContain("|(test.user)|");
+  });
+
+  it("PUBLIC + INVITE_ONLY but already a member: no mail button", () => {
+    render(
+      <TeamCard
+        team={baseTeam({ joining_mode: "invite_only", visibility: "public", is_member: true, admins: [admin] })}
+        withDescription={false}
+      />,
+    );
+
+    expect(container.querySelector("button")).toBeNull();
   });
 });

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
@@ -232,9 +232,10 @@ describe("TeamCard invitation request", () => {
 
     const href = decodeURIComponent(raw);
     expect(href).toContain("rework.teamCard.invitationMail.subject:Fred Platform|Team One");
-    // The members page, under the configured basename.
+    // The team page and the members page, both under the configured basename.
     expect(href).toContain(
-      "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|http://localhost:3000/fred/team/team-1/settings/members",
+      "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|" +
+        "http://localhost:3000/fred/team/team-1/agents|http://localhost:3000/fred/team/team-1/settings/members",
     );
   });
 

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -80,16 +80,22 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
     const site = [siteTitle, siteSubtitle].filter(Boolean).join(" ");
     // Keycloak omits `name` / `preferred_username` on some accounts.
     const user = [userFullName, username && `(${username})`].filter(Boolean).join(" ");
-    // The members page, not the agents: the recipients are the admins who add
-    // the sender by hand. A mailed link inherits no router basename.
-    const base = normalizeBasename(getConfig().frontend_basename);
-    const teamUrl = `${window.location.origin}${base}/team/${team.id}/settings/members`;
+    // Two links: the team page for context, and the members page where the
+    // recipients - its admins - actually add the sender. A mailed link
+    // inherits no router basename.
+    const teamPath = `${window.location.origin}${normalizeBasename(getConfig().frontend_basename)}/team/${team.id}`;
     // Comma-separated and encoded per RFC 6068 - the addresses come from a
     // directory sync, so nothing guarantees they are URL-safe.
     const recipients = adminEmails.map(encodeURIComponent).join(",");
     const params = new URLSearchParams({
       subject: t("rework.teamCard.invitationMail.subject", { site, team: team.name }),
-      body: t("rework.teamCard.invitationMail.body", { site, team: team.name, user, teamUrl }),
+      body: t("rework.teamCard.invitationMail.body", {
+        site,
+        team: team.name,
+        user,
+        agentsUrl: `${teamPath}/agents`,
+        membersUrl: `${teamPath}/settings/members`,
+      }),
     });
     // `+` back to %20 or mail clients render it literally in the subject.
     const href = `mailto:${recipients}?${params.toString().replace(/\+/g, "%20")}`;

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -25,6 +25,8 @@ import { useFrontendBootstrap } from "src/hooks/useFrontendBootstrap";
 import Button from "@shared/atoms/Button/Button.tsx";
 import React from "react";
 import { KeyCloakService } from "../../../../../security/KeycloakService.ts";
+import { getConfig } from "src/common/config";
+import { normalizeBasename } from "../../../../utils/documentViewerUtils";
 
 export interface TeamCardProps {
   team: Team;
@@ -36,11 +38,12 @@ export interface TeamCardProps {
 }
 
 export default function TeamCard({ team, withDescription, onJoined }: TeamCardProps) {
-  const { defaultTeamAvatarFile, defaultPersonalAvatarFile } = useFrontendProperties();
+  const { defaultTeamAvatarFile, defaultPersonalAvatarFile, siteTitle, siteSubtitle } = useFrontendProperties();
   const { activeTeam } = useFrontendBootstrap();
   const { t } = useTranslation();
   const [joinTeam, { isLoading: isJoining }] = useJoinTeamMutation();
   const userFullName = KeyCloakService.GetUserFullName();
+  const username = KeyCloakService.GetUserName();
 
   // A configured default avatar replaces initials; without one, the card keeps
   // the name-derived coloured initials. The personal space renders round, teams
@@ -59,6 +62,40 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
     } catch (error) {
       console.error("Join team error:", error);
     }
+  };
+
+  // #2453: a public invite-only team is discoverable but not joinable, which
+  // left the visitor on a dead-end label. Restore the pre-TEAM-09 escape hatch
+  // (still live on main): a prefilled mail to the team admins. Only public
+  // teams get the button - the UI must not hand a non-member a private team's
+  // admin addresses - and only when at least one address actually resolved,
+  // otherwise there is nobody to write to and the passive label stays.
+  const isInviteOnlyOutsider = !team.is_member && team.joining_mode === "invite_only";
+  const adminEmails = (team.admins ?? [])
+    .map((admin) => admin.email)
+    .filter((email): email is string => Boolean(email));
+  const canRequestInvitation = isInviteOnlyOutsider && team.visibility === "public" && adminEmails.length > 0;
+
+  const handleRequestInvitation = (e: React.MouseEvent<HTMLButtonElement>): void => {
+    e.preventDefault();
+    const site = [siteTitle, siteSubtitle].filter(Boolean).join(" ");
+    // Keycloak omits `name` / `preferred_username` on some accounts; render
+    // whichever resolved rather than the empty "  ()" the admin cannot act on.
+    const user = [userFullName, username && `(${username})`].filter(Boolean).join(" ");
+    // A mailed link does not inherit the router basename, so prepend it - the
+    // same reason buildDocumentViewerPath does (subpath deployments).
+    const base = normalizeBasename(getConfig().frontend_basename);
+    const teamUrl = `${window.location.origin}${base}/team/${team.id}/agents`;
+    // URLSearchParams encodes spaces as "+", which mail clients render
+    // literally in a mailto subject/body - swap them back to %20. The
+    // recipients are comma-separated (RFC 6068) and percent-encoded: they come
+    // from a directory sync, so nothing guarantees they are URL-safe.
+    const recipients = adminEmails.map(encodeURIComponent).join(",");
+    const params = new URLSearchParams({
+      subject: t("rework.teamCard.invitationMail.subject", { site, team: team.name }),
+      body: t("rework.teamCard.invitationMail.body", { site, team: team.name, user, teamUrl }),
+    });
+    window.location.href = `mailto:${recipients}?${params.toString().replace(/\+/g, "%20")}`;
   };
 
   return (
@@ -115,7 +152,18 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
               {t("rework.teamCard.join")}
             </Button>
           )}
-          {!team.is_member && team.joining_mode === "invite_only" && (
+          {canRequestInvitation && (
+            <Button
+              color={"primary"}
+              variant={"outlined"}
+              size={"medium"}
+              icon={{ category: "outlined", type: "mail" }}
+              onClick={handleRequestInvitation}
+            >
+              {t("rework.teamCard.join")}
+            </Button>
+          )}
+          {isInviteOnlyOutsider && !canRequestInvitation && (
             <span className={styles.teamJoiningLabel}>{t("rework.teamCard.inviteOnly")}</span>
           )}
         </div>

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -64,12 +64,10 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
     }
   };
 
-  // #2453: a public invite-only team is discoverable but not joinable, which
-  // left the visitor on a dead-end label. Restore the pre-TEAM-09 escape hatch
-  // (still live on main): a prefilled mail to the team admins. Only public
-  // teams get the button - the UI must not hand a non-member a private team's
-  // admin addresses - and only when at least one address actually resolved,
-  // otherwise there is nobody to write to and the passive label stays.
+  // #2453: a public invite-only team gets a prefilled mail to its admins
+  // instead of a dead-end label. Public only (never hand a non-member a
+  // private team's addresses), and only when one resolved - nobody to write
+  // to otherwise. Full rationale: COMPONENT-UX.md `TeamCard`.
   const canJoinDirectly = !team.is_member && team.joining_mode === "open";
   const isInviteOnlyOutsider = !team.is_member && team.joining_mode === "invite_only";
   const adminEmails = (team.admins ?? [])
@@ -80,25 +78,24 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
   const handleRequestInvitation = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.preventDefault();
     const site = [siteTitle, siteSubtitle].filter(Boolean).join(" ");
-    // Keycloak omits `name` / `preferred_username` on some accounts; render
-    // whichever resolved rather than the empty "  ()" the admin cannot act on.
+    // Keycloak omits `name` / `preferred_username` on some accounts.
     const user = [userFullName, username && `(${username})`].filter(Boolean).join(" ");
-    // Deep-link the team's members page, not its agents: the recipients are the
-    // admins, and adding the sender by hand is the whole point of the mail.
-    // A mailed link does not inherit the router basename, so prepend it - the
-    // same reason buildDocumentViewerPath does (subpath deployments).
+    // The members page, not the agents: the recipients are the admins who add
+    // the sender by hand. A mailed link inherits no router basename.
     const base = normalizeBasename(getConfig().frontend_basename);
     const teamUrl = `${window.location.origin}${base}/team/${team.id}/settings/members`;
-    // URLSearchParams encodes spaces as "+", which mail clients render
-    // literally in a mailto subject/body - swap them back to %20. The
-    // recipients are comma-separated (RFC 6068) and percent-encoded: they come
-    // from a directory sync, so nothing guarantees they are URL-safe.
+    // Comma-separated and encoded per RFC 6068 - the addresses come from a
+    // directory sync, so nothing guarantees they are URL-safe.
     const recipients = adminEmails.map(encodeURIComponent).join(",");
     const params = new URLSearchParams({
       subject: t("rework.teamCard.invitationMail.subject", { site, team: team.name }),
       body: t("rework.teamCard.invitationMail.body", { site, team: team.name, user, teamUrl }),
     });
-    window.location.href = `mailto:${recipients}?${params.toString().replace(/\+/g, "%20")}`;
+    // `+` back to %20 or mail clients render it literally in the subject.
+    const href = `mailto:${recipients}?${params.toString().replace(/\+/g, "%20")}`;
+    // A new tab: a webmail registered for mailto: would otherwise replace the
+    // app. `noopener` makes window.open return null, so no fallback to test.
+    window.open(href, "_blank", "noopener,noreferrer");
   };
 
   return (

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -64,7 +64,7 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
     }
   };
 
-  // #2453: a public invite-only team gets a prefilled mail to its admins
+  // A public invite-only team gets a prefilled mail to its admins
   // instead of a dead-end label. Public only (never hand a non-member a
   // private team's addresses), and only when one resolved - nobody to write
   // to otherwise. Full rationale: COMPONENT-UX.md `TeamCard`.

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -83,10 +83,12 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
     // Keycloak omits `name` / `preferred_username` on some accounts; render
     // whichever resolved rather than the empty "  ()" the admin cannot act on.
     const user = [userFullName, username && `(${username})`].filter(Boolean).join(" ");
+    // Deep-link the team's members page, not its agents: the recipients are the
+    // admins, and adding the sender by hand is the whole point of the mail.
     // A mailed link does not inherit the router basename, so prepend it - the
     // same reason buildDocumentViewerPath does (subpath deployments).
     const base = normalizeBasename(getConfig().frontend_basename);
-    const teamUrl = `${window.location.origin}${base}/team/${team.id}/agents`;
+    const teamUrl = `${window.location.origin}${base}/team/${team.id}/settings/members`;
     // URLSearchParams encodes spaces as "+", which mail clients render
     // literally in a mailto subject/body - swap them back to %20. The
     // recipients are comma-separated (RFC 6068) and percent-encoded: they come

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -70,6 +70,7 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
   // teams get the button - the UI must not hand a non-member a private team's
   // admin addresses - and only when at least one address actually resolved,
   // otherwise there is nobody to write to and the passive label stays.
+  const canJoinDirectly = !team.is_member && team.joining_mode === "open";
   const isInviteOnlyOutsider = !team.is_member && team.joining_mode === "invite_only";
   const adminEmails = (team.admins ?? [])
     .map((admin) => admin.email)
@@ -139,9 +140,15 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
         </div>
         {withDescription && <div className={styles.teamCardDescription}>{team.description}</div>}
         <div className={styles.teamCardFooter}>
-          <AvatarGroup avatars={(team.admins ?? []).map((o) => ({ name: o.first_name + " " + o.last_name }))} />
-          {!team.is_member && team.joining_mode === "open" && (
+          <div className={styles.teamCardAdmins}>
+            <AvatarGroup
+              avatars={(team.admins ?? []).map((o) => ({ name: o.first_name + " " + o.last_name }))}
+              max={canJoinDirectly || canRequestInvitation ? 2 : 4}
+            />
+          </div>
+          {canJoinDirectly && (
             <Button
+              className={styles.teamCardJoinAction}
               color={"primary"}
               variant={"outlined"}
               size={"medium"}
@@ -154,6 +161,7 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
           )}
           {canRequestInvitation && (
             <Button
+              className={styles.teamCardJoinAction}
               color={"primary"}
               variant={"outlined"}
               size={"medium"}

--- a/apps/frontend/src/rework/utils/documentViewerUtils.ts
+++ b/apps/frontend/src/rework/utils/documentViewerUtils.ts
@@ -107,7 +107,19 @@ export function isTabularFile(fileName: string | null | undefined): boolean {
   return lower.endsWith(".csv") || lower.endsWith(".tsv");
 }
 
-function normalizeBasename(basename: string): string {
+/**
+ * Strip the React Router basename down to a prefix that concatenates cleanly.
+ *
+ * Why this function exists:
+ * - links built outside the router (a plain anchor, a URL mailed to someone)
+ *   do not inherit the basename, so they must prepend it by hand
+ * - "/" and a trailing slash both have to collapse to "" / no trailing slash,
+ *   otherwise the concatenated path doubles the separator
+ *
+ * How to use it:
+ * - `${normalizeBasename(getConfig().frontend_basename)}/team/${id}/agents`
+ */
+export function normalizeBasename(basename: string): string {
   if (basename === "/") return "";
   return basename.endsWith("/") ? basename.slice(0, -1) : basename;
 }

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1329,7 +1329,8 @@ the team's `joining_mode`, gated on `!team.is_member`:
 | `joining_mode` | Footer content |
 | --- | --- |
 | `open` | "Join" button (`person_add` icon) — calls `useJoinTeamMutation` directly (instant self-service, no confirmation step); on success calls the `onJoined` prop so the page can refresh anything outside this card's own cache (bootstrap's team navbar) |
-| `invite_only` | No button; muted label (`on-surface-retreat`) |
+| `invite_only`, team is `public`, at least one admin has an email | "Join" button (`mail` icon) - opens the user's mail client on a `mailto:` prefilled for the team admins (#2453, see below) |
+| `invite_only`, any other case | No button; muted label (`on-surface-retreat`) |
 | already a member | Nothing renders in the footer's join slot |
 
 The former lock icon next to the team name (driven by the retired
@@ -1341,6 +1342,44 @@ so keeping both would duplicate the signal.
 system to route requests to team admins was never built) and `closed` (a
 second muted label, indistinguishable in practice from `invite_only`) were
 dropped from the enum entirely; see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §29.
+
+**Ask for an invitation (#2453, 2026-08-27).** A public invite-only team is
+discoverable but not joinable, and the muted label alone left the visitor with
+no next step. The card restores the pre-TEAM-09 escape hatch: a `mailto:`
+addressed to every team admin whose `UserSummary.email` resolved, prefilled
+with the subject, the caller's identity, and a link to the team page
+(`rework.teamCard.invitationMail.*`; the FR strings are the pre-TEAM-09 wording
+verbatim, now translated rather than hardcoded French as it was then). The
+button reuses the `join` label - it is the same intent, and a second, longer
+label wrapped the card's footer onto two lines; the `mail` icon and the draft
+that opens are what distinguish it from the instant `open` join.
+
+Two guards decide whether the button replaces the label:
+
+- **public only.** A private team keeps the label: the UI does not offer a
+  non-member a private team's admin addresses. This is a product rule about
+  what the card *proposes*, not a disclosure guarantee - `GET /teams` puts
+  `admins` (email included) in the payload for every team it returns, and
+  `MarketplaceTeams` records that private teams reach the client at all when
+  authorization is disabled. Withholding them from the wire is a server-side
+  question, still open. `TeamCard` checks `visibility` itself rather than
+  trusting `MarketplaceTeams`' filter: it is a shared component, and the check
+  is `=== "public"` so a payload with no `visibility` fails closed (#2433).
+- **a reachable address.** `admins` falls back to a bare `UserSummary(id=...)`
+  when the Keycloak lookup returns nothing, so an admin list can render with no
+  email at all. With no recipient there is nothing to open, so the label stays
+  rather than producing an empty `mailto:`.
+
+Mechanics worth keeping: recipients are comma-separated (RFC 6068) and
+percent-encoded, since the addresses come from a directory sync and nothing
+guarantees they are URL-safe; `URLSearchParams`' `+` is rewritten to `%20` or
+mail clients render it literally in the subject; the team link prepends the
+router basename (`normalizeBasename`, shared with `buildDocumentViewerPath`)
+because a mailed URL inherits nothing from the router; and the identity line
+degrades to whichever of `name` / `preferred_username` Keycloak returned.
+
+No server-side request flow is involved: this is a client-side mail draft, the
+same as before TEAM-09. Nothing routes an invitation request through the API.
 
 ---
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1374,7 +1374,13 @@ Two guards decide whether the button replaces the label:
   email at all. With no recipient there is nothing to open, so the label stays
   rather than producing an empty `mailto:`.
 
-Mechanics worth keeping: recipients are comma-separated (RFC 6068) and
+Mechanics worth keeping: the draft opens with `window.open(..., "_blank",
+"noopener,noreferrer")` rather than a `location.href` assignment, so a webmail
+registered as the `mailto:` handler opens beside the app instead of replacing
+it (a native client takes over the throwaway tab and the browser drops it);
+`noopener` makes `window.open` return `null` by spec, so there is nothing to
+test for a fallback - the click is the user gesture popup blockers key off.
+Recipients are comma-separated (RFC 6068) and
 percent-encoded, since the addresses come from a directory sync and nothing
 guarantees they are URL-safe; `URLSearchParams`' `+` is rewritten to `%20` or
 mail clients render it literally in the subject; the team link prepends the

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1347,12 +1347,11 @@ dropped from the enum entirely; see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §29.
 discoverable but not joinable, and the muted label alone left the visitor with
 no next step. The card restores the pre-TEAM-09 escape hatch: a `mailto:`
 addressed to every team admin whose `UserSummary.email` resolved, prefilled
-with the subject, the caller's identity, and a deep link to the team's members
-page - the recipients are the admins and adding the sender by hand is the whole
-point of the mail, so the link lands where they do that, not on the team's
-agents. The wording is the pre-TEAM-09 one (`rework.teamCard.invitationMail.*`)
-apart from that closing line, and now lives in the locale files instead of
-hardcoded French as it did then.
+with the subject, the caller's identity, and two links: the team's agents page
+for context (what `main` sent) plus a deep link to its members page, where the
+recipients - the admins - actually add the sender by hand. The wording is the
+pre-TEAM-09 one (`rework.teamCard.invitationMail.*`) plus that second line, and
+now lives in the locale files instead of hardcoded French as it did then.
 
 The button reuses the `join` label - it is the same intent, and a second,
 longer label wrapped the card's footer onto two lines; the `mail` icon and the

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1347,12 +1347,16 @@ dropped from the enum entirely; see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §29.
 discoverable but not joinable, and the muted label alone left the visitor with
 no next step. The card restores the pre-TEAM-09 escape hatch: a `mailto:`
 addressed to every team admin whose `UserSummary.email` resolved, prefilled
-with the subject, the caller's identity, and a link to the team page
-(`rework.teamCard.invitationMail.*`; the FR strings are the pre-TEAM-09 wording
-verbatim, now translated rather than hardcoded French as it was then). The
-button reuses the `join` label - it is the same intent, and a second, longer
-label wrapped the card's footer onto two lines; the `mail` icon and the draft
-that opens are what distinguish it from the instant `open` join.
+with the subject, the caller's identity, and a deep link to the team's members
+page - the recipients are the admins and adding the sender by hand is the whole
+point of the mail, so the link lands where they do that, not on the team's
+agents. The wording is the pre-TEAM-09 one (`rework.teamCard.invitationMail.*`)
+apart from that closing line, and now lives in the locale files instead of
+hardcoded French as it did then.
+
+The button reuses the `join` label - it is the same intent, and a second,
+longer label wrapped the card's footer onto two lines; the `mail` icon and the
+draft that opens are what distinguish it from the instant `open` join.
 
 Two guards decide whether the button replaces the label:
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1381,6 +1381,36 @@ degrades to whichever of `name` / `preferred_username` Keycloak returned.
 No server-side request flow is involved: this is a client-side mail draft, the
 same as before TEAM-09. Nothing routes an invitation request through the API.
 
+**Footer layout.** The card is a fixed 290px, so the admin avatars and the join
+button compete for one line: a team with five admins pushed the button past the
+card's right edge and squashed the avatars into ellipses on the way. Three
+changes, none of them resizing an avatar: the button never shrinks (it must
+keep its whole label), `AvatarGroup` gained a `max` prop (default 4, so its
+other consumer is unchanged) and the card drops to `max={2}` whenever a button
+shares the footer, and an avatar is now `flex-shrink: 0` - a fixed-size circle
+should clip, never deform. `.teamCardAdmins` does that clipping as a last
+resort for an unusually long translation; the row runs right-to-left, so the
+overflow falls off the left and the "+N" badge stays visible.
+
+Two `AvatarGroup` fixes came out of the same pass, and apply everywhere it is
+used. The "+N" badge now goes through the same `Tooltip` wrapper as the other
+avatars: `.userAvatarContainer > *` puts the 2px ring on the direct child, so
+under the global `box-sizing: border-box` a bare badge paid for that ring out
+of its own 2rem while a wrapped avatar grew by it - the badge rendered 4px
+smaller than its neighbours. That wrapper also gives the badge a tooltip
+listing the hidden names, one per line (a `content` tooltip, so it owns its own
+padding).
+
+**Footer layout.** The card is a fixed 290px, so the admin avatars and the join
+button compete for one line: a team with five admins pushed the button past the
+card's right edge. The button never shrinks (it must keep its whole label) and
+the avatar row is the half that gives up width - `AvatarGroup` gained a `max`
+prop (default 4, so its other consumer is unchanged) and the card drops to
+`max={2}` whenever a button shares the footer, collapsing the rest into "+N".
+`.teamCardAdmins` clips as a last resort for an unusually long translation; the
+avatars run right-to-left, so the overflow falls off the left and the badge
+stays visible.
+
 ---
 
 ### `MarketplaceTeams` — what the discover section may list (#2398)


### PR DESCRIPTION
Closes #2453.

## What

A public invite-only team is discoverable in the marketplace but not joinable,
and the card only offered a muted "Invite only" label - a dead end. This
restores the pre-TEAM-09 behaviour that `main` still has: a mail action that
opens the user's mail client with the invitation request prefilled.

| State | Before | After |
| --- | --- | --- |
| `open`, not a member | Join button (`person_add`), instant join | unchanged |
| `invite_only` + `public` + an admin address | muted "Invite only" | **Join button (`mail`) opening a prefilled `mailto:`** |
| `invite_only`, anything else | muted "Invite only" | unchanged |
| already a member | nothing | unchanged |

The button reuses the existing `join` label: a longer "Request an invitation"
wrapped the footer onto two lines. The `mail` icon and the draft that opens are
what distinguish it from the instant join.

## Prefilled mail

Recipients are the team admins' addresses; subject and body carry the branding,
the team name, the caller's identity, and a link to the team page. The FR
wording is `main`'s verbatim - it just moved from hardcoded French in the
component to the `fr`/`en` translation files (`rework.teamCard.invitationMail.*`).

## Guards (why the label can still win)

- **public only.** A private team never gets the button. `TeamCard` checks
  `visibility` itself rather than trusting `MarketplaceTeams`' filter - it is a
  shared component - and uses `=== "public"` so a payload missing the field
  fails closed (#2433).
- **a reachable address.** `admins` falls back to a bare `UserSummary(id=...)`
  when the Keycloak lookup returns nothing, so the list can render with no email
  at all. No recipient, no button.

## Hardened past what main did

- recipients comma-separated (RFC 6068, `main` used `;`) and percent-encoded -
  the addresses come from a directory sync, nothing guarantees they are URL-safe
- the team link prepends the router basename, so it resolves on a subpath
  deployment (`normalizeBasename` is now exported from `documentViewerUtils`
  instead of being duplicated)
- the identity line degrades to whichever of `name` / `preferred_username`
  Keycloak returned, instead of mailing "Informations utilisateur :  ()"

## Scope

Frontend only. `Team.admins` already carries `email`, `visibility` and
`joining_mode` are already on the DTO - no backend change, no client
regeneration. No server-side request flow: this is a client-side mail draft,
same as before TEAM-09.

## Tests

`TeamCard.test.tsx`: 8 tests (was 3). New coverage for the mailto (recipients,
encoding, basename, prefilled subject/body), the fail-closed `visibility`
absent case, the no-admin-email fallback, the private case, and the identity
fallback. Full frontend suite 1474 passed, root `make code-quality` clean.

## Not done here

`GET /teams` ships `admins` with emails for every team it returns, so a
non-member's browser can hold a private team's admin addresses on an
authz-disabled deployment. This PR only stops the UI from *offering* them;
withholding them from the wire is a server-side question left open.

## Footer layout (second commit)

The 290px card gives the admin avatars and the join button one shared line. A
team with five admins pushed the button past the card's right edge and squashed
the avatars into ellipses on the way - the "+N" badge worst of all, since it
sits at the row's main-start.

- footer gets a gap; the join affordance never shrinks; the avatars are the half
  that gives up width
- `AvatarGroup` gains `max` (default 4, `AdminTeamsPage` unchanged); the card
  uses `max={2}` whenever a button shares the footer
- an avatar is now `flex-shrink: 0` - a fixed-size circle should clip, never
  deform
- the "+N" badge goes through the same `Tooltip` wrapper as the other avatars:
  `.userAvatarContainer > *` puts the 2px ring on the direct child, so under the
  global `box-sizing: border-box` the bare badge paid for that ring out of its
  own 2rem while a wrapped avatar grew by it - it rendered 4px smaller than its
  neighbours. The wrapper also earns it a tooltip listing the hidden names, one
  per line.
