### PR TITLE
fix(#2456): run the control-plane and knowledge-flow migration jobs by default

### DIFF
--- a/deploy/charts/fred/values.yaml
+++ b/deploy/charts/fred/values.yaml
@@ -1096,9 +1096,12 @@ applications:
     job:
       enabled: false
     migration:
-      enabled: false    # Enable when knowledge-flow-backend gets Alembic migrations
-      scaleDown: true
-      backoffLimit: 3
+      # ON: knowledge-flow owns an Alembic tree (alembic_version_knowledge_flow)
+      # and creates no table at startup - it refuses to boot on an unmigrated
+      # database. The pre-install/pre-upgrade hook Job runs before the new pods.
+      enabled: true
+      scaleDown: true         # Scale deployment to 0 before migrating (downtime acceptable)
+      backoffLimit: 3         # Retry count on migration failure
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
@@ -1468,9 +1471,12 @@ applications:
     job:
       enabled: false
     migration:
-      enabled: false    # Enable when control-plane-backend gets Alembic migrations
-      scaleDown: true
-      backoffLimit: 3
+      # ON: control-plane owns an Alembic tree (alembic_version_control_plane).
+      # It also migrates the users/teammetadata tables knowledge-flow reads, so
+      # this job must succeed for knowledge-flow to boot at all.
+      enabled: true
+      scaleDown: true         # Scale deployment to 0 before migrating (downtime acceptable)
+      backoffLimit: 3         # Retry count on migration failure
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0


### PR DESCRIPTION
**Rolled back - this change is not the one we want.** The chart's migration
defaults stay `false` on purpose: a platform overlay either turns the Job on in
its own values or runs the upgrade imperatively. Only the stale comments needed
fixing, which is now the whole scope of #2456.

Original description below, kept for the record.

---

Since #2314 knowledge-flow creates no table at startup - both entrypoints call
`require_tables(REQUIRED_TABLES)` and refuse to boot on an unmigrated database.
The chart's `knowledge-flow-backend` and `control-plane-backend` values still
carried `migration.enabled: false` commented "Enable when <backend> gets Alembic
migrations", which has been false for months.

This PR flipped both defaults to `true`. That part is reverted; the comment fix
lands separately.
