### PR TITLE
impr(#2459): capability panel launchers only once the panel has content + fix session leak

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -131,6 +131,21 @@ export default function ManagedChatPage() {
   const isAdmin = isPersonalTeam || canAdministerAdmins;
 
   const chat = useManagedChat({ teamId, agentInstanceId });
+
+  // Opening a push drawer is a statement about ONE conversation, so switching
+  // conversations closes it: the panels (capability, attachments, document
+  // scope) all read the open session, and a drawer carried across would sit
+  // there empty. A capability whose new conversation warrants its panel asks
+  // for it again through the request counter above.
+  const lastDrawerSessionId = useRef(chat.sessionId);
+  useEffect(() => {
+    if (lastDrawerSessionId.current === chat.sessionId) return;
+    // Binding the FIRST conversation of a page load is not a switch - a panel a
+    // probe just asked for must not be closed under it.
+    const wasBound = Boolean(lastDrawerSessionId.current);
+    lastDrawerSessionId.current = chat.sessionId;
+    if (wasBound) setActivePushDrawer(null);
+  }, [chat.sessionId]);
   // The model this agent's next turn will actually route to (#2387) — the
   // composer's label. Its own read rather than part of prepare-execution:
   // prepare runs on every send and is contractually free of pod-catalog

--- a/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.tsx
@@ -67,6 +67,14 @@ interface InlineDrawerProps {
    * Opt-in — default panels stay flush.
    */
   floating?: boolean;
+  /**
+   * Drop the drawer's own title band for content that already has one (a
+   * capability pane naming the artefact it holds). The drawer then contributes no
+   * chrome at all, so the content MUST offer its own close affordance — `title`
+   * still names the panel, as the drawer's accessible name. `headerActions` are
+   * not rendered.
+   */
+  hideHeader?: boolean;
 }
 
 export function InlineDrawer({
@@ -80,6 +88,7 @@ export function InlineDrawer({
   resizable,
   flushBody = false,
   floating = false,
+  hideHeader = false,
   children,
 }: PropsWithChildren<InlineDrawerProps>) {
   const titleId = useId();
@@ -146,7 +155,8 @@ export function InlineDrawer({
         data-floating={floating ? "true" : undefined}
         data-dragging={resizeEnabled && resize.dragging ? "true" : undefined}
         aria-hidden={!open}
-        aria-labelledby={titleId}
+        aria-labelledby={hideHeader ? undefined : titleId}
+        aria-label={hideHeader ? title : undefined}
         style={
           {
             "--drawer-width": drawerWidth,
@@ -164,21 +174,23 @@ export function InlineDrawer({
           />
         )}
         <div className={styles.panel}>
-          <div className={styles.header}>
-            <span id={titleId} className={styles.title}>
-              {title}
-            </span>
-            <div className={styles.headerActions}>
-              {headerActions}
-              <IconButton
-                variant="icon"
-                size="small"
-                icon={{ category: "outlined", type: "close" }}
-                aria-label="Close panel"
-                onClick={handleClose}
-              />
+          {!hideHeader && (
+            <div className={styles.header}>
+              <span id={titleId} className={styles.title}>
+                {title}
+              </span>
+              <div className={styles.headerActions}>
+                {headerActions}
+                <IconButton
+                  variant="icon"
+                  size="small"
+                  icon={{ category: "outlined", type: "close" }}
+                  aria-label="Close panel"
+                  onClick={handleClose}
+                />
+              </div>
             </div>
-          </div>
+          )}
           <div className={`${styles.body}${flushBody ? ` ${styles.bodyFlush}` : ""}`}>{children}</div>
         </div>
       </aside>

--- a/apps/frontend/src/rework/components/shared/utils/Type.ts
+++ b/apps/frontend/src/rework/components/shared/utils/Type.ts
@@ -86,6 +86,7 @@ export const materialIcons = [
   "close",
   "cloud_off",
   "edit_note",
+  "edit_document",
   "tune",
   "forum",
   "build",

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.module.css
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.module.css
@@ -16,13 +16,13 @@
 /* Floating launcher rail — matches the chat page's floating-chrome idiom
  * (position: absolute, zero layout impact). Sits below the top bar on the
  * right edge; each button opens one capability panel.
- * top clears ManagedChatPage's .topBar band (8px padding + 32px small
- * button + 8px padding = 48px, --spacing-3xl) plus a small breathing gap so
- * the rail never overlaps .topBarActions. */
+ * top clears ManagedChatPage's .topBar band, which is two lines tall (8px
+ * padding + a 24px title line + a 20px agent-name line + 8px padding = 60px),
+ * plus a breathing gap — a 48px offset sat on the band. */
 .rail {
   display: flex;
   position: absolute;
-  top: calc(var(--spacing-3xl) + var(--spacing-2xs));
+  top: calc(var(--spacing-4xl) + var(--spacing-s));
   right: var(--spacing-s);
   flex-direction: column;
   gap: var(--spacing-2xs);

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.module.css
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.module.css
@@ -18,7 +18,7 @@
  * right edge; each button opens one capability panel.
  * top clears ManagedChatPage's .topBar band, which is two lines tall (8px
  * padding + a 24px title line + a 20px agent-name line + 8px padding = 60px),
- * plus a breathing gap — a 48px offset sat on the band. */
+ * plus a breathing gap - a 48px offset sat on the band. */
 .rail {
   display: flex;
   position: absolute;

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
@@ -14,7 +14,7 @@
 
 // The launcher rail: what the user sees before opening anything. A session can
 // activate several document-producing capabilities from the start, so a launcher
-// that appears on declaration alone points at an empty panel — the plugin's
+// that appears on declaration alone points at an empty panel - the plugin's
 // `useHasContent` is what turns it on, and its glyph is what tells two of them
 // apart.
 
@@ -97,11 +97,11 @@ describe("CapabilitySidePanelHost launcher rail", () => {
   });
 
   it("gives each panel its own glyph", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "edit_note", () => true)];
+    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "article", () => true)];
     const html = render();
 
     expect(html).toContain('data-icon="slideshow"');
-    expect(html).toContain('data-icon="edit_note"');
+    expect(html).toContain('data-icon="article"');
   });
 
   it("hides a launcher while its own panel is open", () => {
@@ -110,11 +110,12 @@ describe("CapabilitySidePanelHost launcher rail", () => {
   });
 
   it("moves the other launchers into the open drawer's header, off the rail", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "edit_note", () => true)];
+    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "article", () => true)];
     const html = render("writable_document:writable_document_pane");
 
-    // The rail would float over the drawer's own close button.
-    expect(html).not.toContain('class="rail"');
+    // In the drawer header, and ONLY there - the rail would float on the drawer's
+    // own close button. (CSS-module class names are hashed, so count the buttons.)
     expect(html).toContain('<header><button data-icon="slideshow"');
+    expect(html.match(/<button/g)).toHaveLength(1);
   });
 });

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
@@ -38,8 +38,21 @@ vi.mock("@shared/atoms/IconButton/IconButton", () => ({
 }));
 
 vi.mock("@shared/molecules/InlineDrawer/InlineDrawer", () => ({
-  InlineDrawer: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-drawer>{children}</div> : null,
+  InlineDrawer: ({
+    open,
+    headerActions,
+    children,
+  }: {
+    open: boolean;
+    headerActions?: React.ReactNode;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <div data-drawer>
+        <header>{headerActions}</header>
+        {children}
+      </div>
+    ) : null,
 }));
 
 function StubPanel(_props: CapabilitySidePanelProps) {
@@ -94,5 +107,14 @@ describe("CapabilitySidePanelHost launcher rail", () => {
   it("hides a launcher while its own panel is open", () => {
     state.entries = [entry("ppt_filler", "slideshow", () => true)];
     expect(render("ppt_filler:ppt_filler_pane")).not.toContain("<button");
+  });
+
+  it("moves the other launchers into the open drawer's header, off the rail", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "edit_note", () => true)];
+    const html = render("writable_document:writable_document_pane");
+
+    // The rail would float over the drawer's own close button.
+    expect(html).not.toContain('class="rail"');
+    expect(html).toContain('<header><button data-icon="slideshow"');
   });
 });

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
@@ -38,20 +38,38 @@ vi.mock("@shared/atoms/IconButton/IconButton", () => ({
 }));
 
 vi.mock("@shared/molecules/InlineDrawer/InlineDrawer", () => ({
-  InlineDrawer: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-drawer>{children}</div> : null,
+  // Mirrors the real drawer closely enough for what the tests assert: its own
+  // title band, unless the panel says it renders one itself.
+  InlineDrawer: ({
+    open,
+    title,
+    hideHeader,
+    children,
+  }: {
+    open: boolean;
+    title: string;
+    hideHeader?: boolean;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <div data-drawer>
+        {!hideHeader && <div data-drawer-title>{title}</div>}
+        {children}
+      </div>
+    ) : null,
 }));
 
 function StubPanel(_props: CapabilitySidePanelProps) {
   return <div data-panel />;
 }
 
-const entry = (capabilityId: string, icon: string, useHasContent?: () => boolean) => ({
+const entry = (capabilityId: string, icon: string, useHasContent?: () => boolean, ownsHeader = false) => ({
   capabilityId,
   widget: `${capabilityId}_pane`,
   Component: StubPanel,
   icon,
   useHasContent,
+  ownsHeader,
 });
 
 const render = (activeKey: string | null = null) =>
@@ -92,6 +110,20 @@ describe("CapabilitySidePanelHost launcher rail", () => {
 
     expect(html).toContain('data-icon="slideshow"');
     expect(html).toContain('data-icon="edit_document"');
+  });
+
+  it("drops the drawer's own title band for a panel that renders one", () => {
+    // Two stacked title rows - the drawer naming the panel, the pane naming the
+    // artefact - said the same thing twice and ate the top of the column.
+    state.entries = [entry("writable_document", "edit_document", () => true, true)];
+
+    expect(render("writable_document:writable_document_pane")).not.toContain("data-drawer-title");
+  });
+
+  it("keeps the drawer's title band for a panel that has no header of its own", () => {
+    state.entries = [entry("demo_echo", "edit_note", undefined, false)];
+
+    expect(render("demo_echo:demo_echo_pane")).toContain("data-drawer-title");
   });
 
   it("retires the whole rail while a panel is open, other panels included", () => {

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
@@ -1,0 +1,98 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The launcher rail: what the user sees before opening anything. A session can
+// activate several document-producing capabilities from the start, so a launcher
+// that appears on declaration alone points at an empty panel — the plugin's
+// `useHasContent` is what turns it on, and its glyph is what tells two of them
+// apart.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CapabilitySidePanelHost } from "./CapabilitySidePanelHost";
+import type { CapabilitySidePanelProps } from "./types";
+
+const state = vi.hoisted(() => ({ entries: [] as unknown[] }));
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock("./sessionProbeRegistry", () => ({ sessionProbesForCapabilities: () => [] }));
+
+vi.mock("./sidePanelRegistry", () => ({ sidePanelsForCapabilities: () => state.entries }));
+
+vi.mock("@shared/atoms/IconButton/IconButton", () => ({
+  default: ({ icon, ...rest }: { icon: { type: string }; "aria-label": string }) => (
+    <button data-icon={icon.type} aria-label={rest["aria-label"]} />
+  ),
+}));
+
+vi.mock("@shared/molecules/InlineDrawer/InlineDrawer", () => ({
+  InlineDrawer: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-drawer>{children}</div> : null,
+}));
+
+function StubPanel(_props: CapabilitySidePanelProps) {
+  return <div data-panel />;
+}
+
+const entry = (capabilityId: string, icon: string, useHasContent?: () => boolean) => ({
+  capabilityId,
+  widget: `${capabilityId}_pane`,
+  Component: StubPanel,
+  icon,
+  useHasContent,
+});
+
+const render = (activeKey: string | null = null) =>
+  renderToStaticMarkup(
+    <CapabilitySidePanelHost
+      capabilityIds={["ppt_filler"]}
+      activeKey={activeKey}
+      onActiveKeyChange={() => undefined}
+    />,
+  );
+
+describe("CapabilitySidePanelHost launcher rail", () => {
+  beforeEach(() => {
+    state.entries = [];
+  });
+
+  it("offers no launcher while the panel has nothing to show", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => false)];
+    expect(render()).not.toContain("<button");
+  });
+
+  it("offers the launcher once the panel has content", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => true)];
+    expect(render()).toContain('data-icon="slideshow"');
+  });
+
+  it("offers a panel that declares no visibility hook unconditionally", () => {
+    state.entries = [entry("demo_echo", "forum")];
+    expect(render()).toContain('data-icon="forum"');
+  });
+
+  it("gives each panel its own glyph", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "edit_note", () => true)];
+    const html = render();
+
+    expect(html).toContain('data-icon="slideshow"');
+    expect(html).toContain('data-icon="edit_note"');
+  });
+
+  it("hides a launcher while its own panel is open", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => true)];
+    expect(render("ppt_filler:ppt_filler_pane")).not.toContain("<button");
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
@@ -38,21 +38,8 @@ vi.mock("@shared/atoms/IconButton/IconButton", () => ({
 }));
 
 vi.mock("@shared/molecules/InlineDrawer/InlineDrawer", () => ({
-  InlineDrawer: ({
-    open,
-    headerActions,
-    children,
-  }: {
-    open: boolean;
-    headerActions?: React.ReactNode;
-    children: React.ReactNode;
-  }) =>
-    open ? (
-      <div data-drawer>
-        <header>{headerActions}</header>
-        {children}
-      </div>
-    ) : null,
+  InlineDrawer: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-drawer>{children}</div> : null,
 }));
 
 function StubPanel(_props: CapabilitySidePanelProps) {
@@ -97,25 +84,24 @@ describe("CapabilitySidePanelHost launcher rail", () => {
   });
 
   it("gives each panel its own glyph", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "article", () => true)];
+    state.entries = [
+      entry("ppt_filler", "slideshow", () => true),
+      entry("writable_document", "edit_document", () => true),
+    ];
     const html = render();
 
     expect(html).toContain('data-icon="slideshow"');
-    expect(html).toContain('data-icon="article"');
+    expect(html).toContain('data-icon="edit_document"');
   });
 
-  it("hides a launcher while its own panel is open", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => true)];
-    expect(render("ppt_filler:ppt_filler_pane")).not.toContain("<button");
-  });
+  it("retires the whole rail while a panel is open, other panels included", () => {
+    // It floats over the right edge of the slot, drawer included, so it would land
+    // on the drawer's own close button. Closing the open panel brings it back.
+    state.entries = [
+      entry("ppt_filler", "slideshow", () => true),
+      entry("writable_document", "edit_document", () => true),
+    ];
 
-  it("moves the other launchers into the open drawer's header, off the rail", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => true), entry("writable_document", "article", () => true)];
-    const html = render("writable_document:writable_document_pane");
-
-    // In the drawer header, and ONLY there - the rail would float on the drawer's
-    // own close button. (CSS-module class names are hashed, so count the buttons.)
-    expect(html).toContain('<header><button data-icon="slideshow"');
-    expect(html.match(/<button/g)).toHaveLength(1);
+    expect(render("writable_document:writable_document_pane")).not.toContain("<button");
   });
 });

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
@@ -115,6 +115,9 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
             open={active !== null}
             onClose={() => onActiveKeyChange(null)}
             title={active ? titleOf(active) : ""}
+            // A pane with its own header owns the whole column, insets included.
+            hideHeader={active?.ownsHeader ?? false}
+            flushBody={active?.ownsHeader ?? false}
             layout="push"
             // One shared width across every capability panel (writable-document
             // editor, PPT preview, …) — the same behaviour the legacy chat's

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
@@ -57,7 +57,7 @@ const alwaysHasContent = () => true;
 
 /**
  * One panel's launcher. It is its own component so each `useHasContent` runs in a
- * stable hook slot — mapping the hooks inline would reorder them the moment a
+ * stable hook slot - mapping the hooks inline would reorder them the moment a
  * session gains or loses a capability.
  */
 function PanelLauncher({ entry, label, onOpen }: { entry: SidePanelEntry; label: string; onOpen: () => void }) {
@@ -114,7 +114,7 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
           {/* The rail floats over the right edge of the whole slot, drawer
               included, so while a panel is open it would land on that panel's
               own close button. Open, the other launchers move into the drawer's
-              header instead — switching panels stays one click. */}
+              header instead - switching panels stays one click. */}
           {active === null && <div className={styles.rail}>{launchers}</div>}
           <InlineDrawer
             open={active !== null}

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
@@ -26,9 +26,10 @@
 // ppt_filler and writable_document active shows no chrome at all until the agent
 // actually produces a deck or a document.
 //
-// The launchers live in the floating rail only while every panel is closed; with
-// one open they move into that drawer's header, where the rail would otherwise
-// float on top of the drawer's own close button.
+// The rail shows only while every panel is closed. It floats over the right edge
+// of the whole slot, drawer included, so with a panel open it would land on that
+// drawer's own close button - and closing the open panel to reach another one is
+// cheap enough not to be worth a second home for the launchers.
 
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -91,19 +92,6 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
   const titleOf = (entry: SidePanelEntry): string =>
     t(`capability.${entry.capabilityId}.panel.${entry.widget}.title`, { defaultValue: entry.widget });
 
-  // Every panel but the open one; each decides for itself whether it has
-  // anything to launch onto (PanelLauncher).
-  const launchers = entries
-    .filter((entry) => entryKey(entry) !== activeKey)
-    .map((entry) => (
-      <PanelLauncher
-        key={entryKey(entry)}
-        entry={entry}
-        label={titleOf(entry)}
-        onOpen={() => onActiveKeyChange(entryKey(entry))}
-      />
-    ));
-
   return (
     <>
       {probes.map(({ capabilityId, Probe }, index) => (
@@ -111,16 +99,22 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
       ))}
       {entries.length > 0 && (
         <>
-          {/* The rail floats over the right edge of the whole slot, drawer
-              included, so while a panel is open it would land on that panel's
-              own close button. Open, the other launchers move into the drawer's
-              header instead - switching panels stays one click. */}
-          {active === null && <div className={styles.rail}>{launchers}</div>}
+          {active === null && (
+            <div className={styles.rail}>
+              {entries.map((entry) => (
+                <PanelLauncher
+                  key={entryKey(entry)}
+                  entry={entry}
+                  label={titleOf(entry)}
+                  onOpen={() => onActiveKeyChange(entryKey(entry))}
+                />
+              ))}
+            </div>
+          )}
           <InlineDrawer
             open={active !== null}
             onClose={() => onActiveKeyChange(null)}
             title={active ? titleOf(active) : ""}
-            headerActions={active !== null ? launchers : undefined}
             layout="push"
             // One shared width across every capability panel (writable-document
             // editor, PPT preview, …) — the same behaviour the legacy chat's

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
@@ -20,6 +20,11 @@
 // toggles a single `InlineDrawer layout="push"` that reflows the main column.
 // Which panels appear is driven entirely by the session's
 // `selected_capability_ids`, resolved through the one plugin index.
+//
+// A launcher is only offered once its panel has something to show: the plugin's
+// `useHasContent` hook answers for the open conversation, so a fresh chat with
+// ppt_filler and writable_document active shows no chrome at all until the agent
+// actually produces a deck or a document.
 
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -43,6 +48,28 @@ interface CapabilitySidePanelHostProps {
 }
 
 const entryKey = (entry: SidePanelEntry): string => `${entry.capabilityId}:${entry.widget}`;
+
+const alwaysHasContent = () => true;
+
+/**
+ * One panel's launcher. It is its own component so each `useHasContent` runs in a
+ * stable hook slot — mapping the hooks inline would reorder them the moment a
+ * session gains or loses a capability.
+ */
+function PanelLauncher({ entry, label, onOpen }: { entry: SidePanelEntry; label: string; onOpen: () => void }) {
+  const useHasContent = entry.useHasContent ?? alwaysHasContent;
+  if (!useHasContent()) return null;
+
+  return (
+    <IconButton
+      variant="icon"
+      size="small"
+      icon={{ category: "outlined", type: entry.icon }}
+      aria-label={label}
+      onClick={onOpen}
+    />
+  );
+}
 
 export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyChange }: CapabilitySidePanelHostProps) {
   const { t } = useTranslation();
@@ -72,14 +99,7 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
               const key = entryKey(entry);
               if (key === activeKey) return null; // launcher hides while its panel is open
               return (
-                <IconButton
-                  key={key}
-                  variant="icon"
-                  size="small"
-                  icon={{ category: "outlined", type: "edit_note" }}
-                  aria-label={titleOf(entry)}
-                  onClick={() => onActiveKeyChange(key)}
-                />
+                <PanelLauncher key={key} entry={entry} label={titleOf(entry)} onOpen={() => onActiveKeyChange(key)} />
               );
             })}
           </div>

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
@@ -25,6 +25,10 @@
 // `useHasContent` hook answers for the open conversation, so a fresh chat with
 // ppt_filler and writable_document active shows no chrome at all until the agent
 // actually produces a deck or a document.
+//
+// The launchers live in the floating rail only while every panel is closed; with
+// one open they move into that drawer's header, where the rail would otherwise
+// float on top of the drawer's own close button.
 
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -87,6 +91,19 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
   const titleOf = (entry: SidePanelEntry): string =>
     t(`capability.${entry.capabilityId}.panel.${entry.widget}.title`, { defaultValue: entry.widget });
 
+  // Every panel but the open one; each decides for itself whether it has
+  // anything to launch onto (PanelLauncher).
+  const launchers = entries
+    .filter((entry) => entryKey(entry) !== activeKey)
+    .map((entry) => (
+      <PanelLauncher
+        key={entryKey(entry)}
+        entry={entry}
+        label={titleOf(entry)}
+        onOpen={() => onActiveKeyChange(entryKey(entry))}
+      />
+    ));
+
   return (
     <>
       {probes.map(({ capabilityId, Probe }, index) => (
@@ -94,19 +111,16 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
       ))}
       {entries.length > 0 && (
         <>
-          <div className={styles.rail}>
-            {entries.map((entry) => {
-              const key = entryKey(entry);
-              if (key === activeKey) return null; // launcher hides while its panel is open
-              return (
-                <PanelLauncher key={key} entry={entry} label={titleOf(entry)} onOpen={() => onActiveKeyChange(key)} />
-              );
-            })}
-          </div>
+          {/* The rail floats over the right edge of the whole slot, drawer
+              included, so while a panel is open it would land on that panel's
+              own close button. Open, the other launchers move into the drawer's
+              header instead — switching panels stays one click. */}
+          {active === null && <div className={styles.rail}>{launchers}</div>}
           <InlineDrawer
             open={active !== null}
             onClose={() => onActiveKeyChange(null)}
             title={active ? titleOf(active) : ""}
+            headerActions={active !== null ? launchers : undefined}
             layout="push"
             // One shared width across every capability panel (writable-document
             // editor, PPT preview, …) — the same behaviour the legacy chat's

--- a/apps/frontend/src/rework/features/capabilities/demo_echo/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/demo_echo/plugin.ts
@@ -24,5 +24,6 @@ export const demoEchoCapability: CapabilityUiPlugin = {
   id: "demo_echo",
   partRenderers: { demo_card: DemoCardPartRenderer },
   // Side panel keyed by the backend manifest's SidePanelSpec.widget (#1979).
-  sidePanels: { demo_notes: DemoNotesPanel },
+  // No `useHasContent`: the demo panel is always worth offering.
+  sidePanels: { demo_notes: { Component: DemoNotesPanel, icon: "edit_note" } },
 };

--- a/apps/frontend/src/rework/features/capabilities/demo_echo/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/demo_echo/plugin.ts
@@ -23,7 +23,7 @@ import { DemoNotesPanel } from "./DemoNotesPanel";
 export const demoEchoCapability: CapabilityUiPlugin = {
   id: "demo_echo",
   partRenderers: { demo_card: DemoCardPartRenderer },
-  // Side panel keyed by the backend manifest's SidePanelSpec.widget (#1979).
+  // Side panel keyed by the backend manifest's SidePanelSpec.widget.
   // No `useHasContent`: the demo panel is always worth offering.
   sidePanels: { demo_notes: { Component: DemoNotesPanel, icon: "edit_note" } },
 };

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewCardRenderer.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewCardRenderer.tsx
@@ -25,16 +25,21 @@
 // we must NOT auto-open then. So we auto-open a `(preview_id, version)` exactly
 // once, and only if the page has been open for >5s (history replay happens in the
 // first moments after load; a live fill happens well after).
+//
+// Every mount still REGISTERS the deck (`setPreview`), replay included: that is
+// what tells the pane's launcher this conversation produced something, without
+// popping the panel open.
 
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
+import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
 import Button from "@shared/atoms/Button/Button";
 import { requestSidePanelOpen } from "../sidePanelOpenRequestSlice";
 import type { UiPartRendererProps } from "../types";
 import type { PptPreviewPartData } from "./types";
-import { openPreview } from "./pptPreviewSlice";
+import { setPreview } from "./pptPreviewSlice";
 import PptxDownloadButton from "./PptxDownloadButton";
 import styles from "./PptPreviewCardRenderer.module.css";
 
@@ -46,28 +51,31 @@ const AUTO_OPEN_MIN_AGE_MS = 5000;
 export function PptPreviewCardRenderer({ part }: UiPartRendererProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get("session") ?? "";
   const preview = part as unknown as PptPreviewPartData;
 
   const key = `${preview.preview_id}:${preview.version}`;
 
-  // Opening = set the preview data AND signal the page to open the ppt_filler
+  // Opening = register the deck AND signal the page to open the ppt_filler
   // side-panel column (the page owns the single-push-drawer state).
   const openPane = (data: PptPreviewPartData) => {
-    dispatch(openPreview(data));
+    dispatch(setPreview({ sessionId, preview: data }));
     dispatch(requestSidePanelOpen({ capabilityId: "ppt_filler", widget: "ppt_preview_pane" }));
   };
 
   useEffect(() => {
-    if (seenKeys.has(key)) return;
-    const isLiveFill = Date.now() - pageLoadedAt > AUTO_OPEN_MIN_AGE_MS;
+    if (!sessionId) return;
+    const firstSighting = !seenKeys.has(key);
     // Mark seen regardless, so a history-replay mount never auto-opens later and a
     // live fill only pops the panel the first time its part arrives.
     seenKeys.add(key);
-    if (isLiveFill) openPane(preview);
-    // Intentionally keyed on the deck identity only; `preview`/`dispatch` are stable
-    // per that identity for this heuristic.
+    if (firstSighting && Date.now() - pageLoadedAt > AUTO_OPEN_MIN_AGE_MS) openPane(preview);
+    else dispatch(setPreview({ sessionId, preview }));
+    // Intentionally keyed on the deck identity and conversation; `preview`/`dispatch`
+    // are stable per that identity for this heuristic.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+  }, [key, sessionId]);
 
   const title = preview.title || t("capability.ppt_filler.preview.untitled", { defaultValue: "Presentation" });
 

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewCardRenderer.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewCardRenderer.tsx
@@ -28,15 +28,16 @@
 //
 // Every mount still REGISTERS the deck (`setPreview`), replay included: that is
 // what tells the pane's launcher this conversation produced something, without
-// popping the panel open.
+// popping the panel open. It registers under the conversation the card was mounted
+// for (`useMountSessionId`), never the one the user just switched to.
 
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
 import Button from "@shared/atoms/Button/Button";
 import { requestSidePanelOpen } from "../sidePanelOpenRequestSlice";
+import { useMountSessionId } from "../useOpenSessionId";
 import type { UiPartRendererProps } from "../types";
 import type { PptPreviewPartData } from "./types";
 import { setPreview } from "./pptPreviewSlice";
@@ -51,8 +52,7 @@ const AUTO_OPEN_MIN_AGE_MS = 5000;
 export function PptPreviewCardRenderer({ part }: UiPartRendererProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const [searchParams] = useSearchParams();
-  const sessionId = searchParams.get("session") ?? "";
+  const sessionId = useMountSessionId();
   const preview = part as unknown as PptPreviewPartData;
 
   const key = `${preview.preview_id}:${preview.version}`;

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.module.css
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.module.css
@@ -27,9 +27,9 @@
 .header {
   display: flex;
   align-items: center;
-  gap: var(--spacing-s);
+  gap: var(--spacing-xs);
   border-bottom: 1px solid var(--outline-muted);
-  padding: var(--spacing-xs) var(--spacing-m);
+  padding: var(--spacing-2xs) var(--spacing-s);
 }
 
 .titleGroup {

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
@@ -35,6 +35,7 @@ import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
+import IconButton from "@shared/atoms/IconButton/IconButton";
 import type { CapabilitySidePanelProps } from "../types";
 import { useSessionPptPreview } from "./useSessionPptPreview";
 import { usePptPreview } from "./usePptPreview";
@@ -50,7 +51,7 @@ const NO_PREVIEW_KEY = "none";
 // `workerSrc` string) so we can spawn a fresh module Worker per Document mount.
 const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
 
-export function PptPreviewPane(_props: CapabilitySidePanelProps) {
+export function PptPreviewPane({ onClose }: CapabilitySidePanelProps) {
   const { t } = useTranslation();
   const current = useSessionPptPreview();
   const { objectUrl, isLoading, error } = usePptPreview(current);
@@ -161,6 +162,18 @@ export function PptPreviewPane(_props: CapabilitySidePanelProps) {
         {current?.pptx_download_url && (
           <PptxDownloadButton href={current.pptx_download_url} fileName={current.file_name} />
         )}
+        <IconButton
+          variant="icon"
+          size="small"
+          icon={{ category: "outlined", type: "close" }}
+          aria-label="Close panel"
+          // Blur first: closing flips aria-hidden on the drawer, which the browser
+          // blocks while a descendant still holds focus (InlineDrawer does the same).
+          onClick={(e) => {
+            e.currentTarget.blur();
+            onClose();
+          }}
+        />
       </div>
 
       <div className={styles.body} ref={contentRef}>

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
@@ -15,8 +15,8 @@
 // PptPreviewPane
 // --------------
 // The ppt_filler capability's side panel (CapabilitySidePanel) — a read-only pane
-// that renders the filled deck as a PDF. It reads the "current" preview from the
-// slice (set by a card's Open button / auto-open), fetches the bytes with the live
+// that renders the filled deck as a PDF. It reads the deck the OPEN conversation
+// registered (every rendered card registers one), fetches the bytes with the live
 // bearer (usePptPreview), and draws every page vertically with react-pdf.
 //
 // pdf.js worker rule (this exact bug was fought before — see the Kea `pdfWorker.ts`
@@ -33,11 +33,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
 import type { CapabilitySidePanelProps } from "../types";
-import { selectCurrentPreview } from "./pptPreviewSlice";
+import { useSessionPptPreview } from "./useSessionPptPreview";
 import { usePptPreview } from "./usePptPreview";
 import PptxDownloadButton from "./PptxDownloadButton";
 import styles from "./PptPreviewPane.module.css";
@@ -50,7 +49,7 @@ const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.
 
 export function PptPreviewPane(_props: CapabilitySidePanelProps) {
   const { t } = useTranslation();
-  const current = useSelector(selectCurrentPreview);
+  const current = useSessionPptPreview();
   const { objectUrl, isLoading, error } = usePptPreview(current);
 
   const [numPages, setNumPages] = useState<number | null>(null);

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
@@ -43,6 +43,9 @@ import styles from "./PptPreviewPane.module.css";
 
 const PDF_SCALE = 0.95;
 
+/** react-pdf remount key when this conversation has no deck. */
+const NO_PREVIEW_KEY = "none";
+
 // Resolved by Vite to the bundled pdf.js worker asset. Kept as a URL (not a
 // `workerSrc` string) so we can spawn a fresh module Worker per Document mount.
 const pdfWorkerUrl = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url);
@@ -73,13 +76,19 @@ export function PptPreviewPane(_props: CapabilitySidePanelProps) {
 
   // A re-fill (or switching decks) changes this key → react-pdf remounts the
   // <Document> and we provision a fresh worker for it.
-  const remountKey = current ? `${current.preview_id}:${current.version}` : "none";
+  const remountKey = current ? `${current.preview_id}:${current.version}` : NO_PREVIEW_KEY;
 
   // Provision a fresh worker for THIS remount before the child <Document> reads
   // GlobalWorkerOptions (useMemo runs during render, ahead of child effects). The
   // effect below terminates the exact instance this run created.
   const workerRef = useRef<Worker | null>(null);
   useMemo(() => {
+    // No deck for this conversation: the body renders the empty state, no
+    // <Document> reads the port, so a worker here would only wait to be killed.
+    if (remountKey === NO_PREVIEW_KEY) {
+      workerRef.current = null;
+      return;
+    }
     if (typeof Worker === "undefined") {
       pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
       workerRef.current = null;

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptxDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptxDownloadButton.tsx
@@ -60,7 +60,7 @@ export default function PptxDownloadButton({
     <Tooltip text={label}>
       <IconButton
         variant="icon"
-        size="small"
+        size="2xs"
         icon={{ category: "outlined", type: "download" }}
         onClick={handleDownload}
         disabled={isDownloading}

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptxDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptxDownloadButton.tsx
@@ -60,7 +60,7 @@ export default function PptxDownloadButton({
     <Tooltip text={label}>
       <IconButton
         variant="icon"
-        size="2xs"
+        size="small"
         icon={{ category: "outlined", type: "download" }}
         onClick={handleDownload}
         disabled={isDownloading}

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/plugin.ts
@@ -21,6 +21,7 @@ import type { CapabilityUiPlugin } from "../types";
 import { PptFillerConfigForm } from "./PptFillerConfigForm";
 import { PptPreviewCardRenderer } from "./PptPreviewCardRenderer";
 import { PptPreviewPane } from "./PptPreviewPane";
+import { useHasPptPreview } from "./useSessionPptPreview";
 
 export const pptFillerCapability: CapabilityUiPlugin = {
   id: "ppt_filler",
@@ -28,6 +29,9 @@ export const pptFillerCapability: CapabilityUiPlugin = {
   partRenderers: { ppt_preview: PptPreviewCardRenderer },
   // Keyed by the backend FieldSpec's `ui.widget` (RFC §9 item 4).
   configWidgets: { ppt_filler_template: PptFillerConfigForm },
-  // Keyed by the backend manifest's SidePanelSpec.widget (#1979).
-  sidePanels: { ppt_preview_pane: PptPreviewPane },
+  // Keyed by the backend manifest's SidePanelSpec.widget (#1979). `slideshow` is
+  // what fileIconSpec already gives a .pptx, so a deck reads the same everywhere.
+  sidePanels: {
+    ppt_preview_pane: { Component: PptPreviewPane, icon: "slideshow", useHasContent: useHasPptPreview },
+  },
 };

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/plugin.ts
@@ -29,8 +29,8 @@ export const pptFillerCapability: CapabilityUiPlugin = {
   partRenderers: { ppt_preview: PptPreviewCardRenderer },
   // Keyed by the backend FieldSpec's `ui.widget` (RFC §9 item 4).
   configWidgets: { ppt_filler_template: PptFillerConfigForm },
-  // Keyed by the backend manifest's SidePanelSpec.widget (#1979). `slideshow` is
-  // what fileIconSpec already gives a .pptx, so a deck reads the same everywhere.
+  // Keyed by the backend manifest's SidePanelSpec.widget. `slideshow` is what
+  // fileIconSpec gives a .pptx, so a deck reads the same in chat and Resources.
   sidePanels: {
     ppt_preview_pane: { Component: PptPreviewPane, icon: "slideshow", useHasContent: useHasPptPreview },
   },

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/plugin.ts
@@ -32,6 +32,11 @@ export const pptFillerCapability: CapabilityUiPlugin = {
   // Keyed by the backend manifest's SidePanelSpec.widget. `slideshow` is what
   // fileIconSpec gives a .pptx, so a deck reads the same in chat and Resources.
   sidePanels: {
-    ppt_preview_pane: { Component: PptPreviewPane, icon: "slideshow", useHasContent: useHasPptPreview },
+    ppt_preview_pane: {
+      Component: PptPreviewPane,
+      icon: "slideshow",
+      useHasContent: useHasPptPreview,
+      ownsHeader: true,
+    },
   },
 };

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/pptPreviewSlice.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/pptPreviewSlice.ts
@@ -47,8 +47,8 @@ export const pptPreviewSlice = createSlice({
   reducers: {
     /**
      * Register the deck a rendered `ppt_preview` card refers to, stamped with the
-     * conversation it came from. Every card mount writes here — history replay
-     * included — so the pane and its launcher know a conversation produced a deck
+     * conversation it came from. Every card mount writes here - history replay
+     * included - so the pane and its launcher know a conversation produced a deck
      * without the card having to open anything.
      */
     setPreview(state, action: PayloadAction<{ sessionId: string; preview: PptPreviewPartData }>) {

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/pptPreviewSlice.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/pptPreviewSlice.ts
@@ -15,26 +15,22 @@
 // PPT-filler preview routing state.
 //
 // The `ppt_preview` chat part lives in the message stream; this slice holds the
-// small cross-component UI state the side panel and the chat cards share:
+// one piece of cross-component UI state the side panel and the chat cards share:
+// which deck the pane should render. A chat-part renderer sits far from the panel
+// host in the tree, so Redux replaces prop-drilling (mirrors writableDocumentSlice).
 //
-//   - `current`      — the preview the pane should render right now.
-//   - `openRequestId`— a monotonic counter. Bumping it is the signal for the chat
-//                      page to OPEN the ppt_filler side panel (the host owns the
-//                      column's open/closed state; a slice value can't call it, so
-//                      the page subscribes to this counter and opens on change).
-//
-// Mirrors the Kea `usePptPreview` hook's open/select behaviour, but as Redux state
-// so a chat-part renderer (which is far from the panel host in the tree) can drive
-// the panel without prop-drilling.
+// Opening the panel is NOT this slice's job: the card dispatches the
+// capability-agnostic `requestSidePanelOpen` for that, and the chat page stays the
+// single open-state authority.
 
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { PptPreviewPartData } from "./types";
 
 export interface PptPreviewState {
-  /** The preview the side panel should render, or null before any deck exists. */
+  /** The conversation `current` belongs to; a write from another one replaces it. */
+  sessionId: string | null;
+  /** The deck the side panel should render, or null before any deck exists. */
   current: PptPreviewPartData | null;
-  /** Monotonic; incrementing it asks the chat page to open the ppt_filler panel. */
-  openRequestId: number;
 }
 
 // Local root-state shape — avoids a circular import with common/store.tsx. The
@@ -43,46 +39,33 @@ interface PptPreviewRootState {
   pptPreview: PptPreviewState;
 }
 
-const initialState: PptPreviewState = { current: null, openRequestId: 0 };
+const initialState: PptPreviewState = { sessionId: null, current: null };
 
 export const pptPreviewSlice = createSlice({
   name: "pptPreview",
   initialState,
   reducers: {
     /**
-     * Select this preview AND request the panel to open (bumps `openRequestId`).
-     * Dispatched by a card's "Open preview" button and by the card auto-open
-     * heuristic when a freshly filled deck arrives live.
+     * Register the deck a rendered `ppt_preview` card refers to, stamped with the
+     * conversation it came from. Every card mount writes here — history replay
+     * included — so the pane and its launcher know a conversation produced a deck
+     * without the card having to open anything.
      */
-    openPreview(state, action: PayloadAction<PptPreviewPartData>) {
-      state.current = action.payload;
-      state.openRequestId += 1;
-    },
-
-    /**
-     * Update the current preview WITHOUT requesting an open — e.g. a re-fill of a
-     * deck whose panel is already open. The panel remounts on the new `version`;
-     * the open request is not re-fired so a closed panel stays closed.
-     */
-    setPreview(state, action: PayloadAction<PptPreviewPartData>) {
-      state.current = action.payload;
-    },
-
-    /** Clear the current preview (e.g. on session switch). */
-    clearPreview(state) {
-      state.current = null;
+    setPreview(state, action: PayloadAction<{ sessionId: string; preview: PptPreviewPartData }>) {
+      state.sessionId = action.payload.sessionId;
+      state.current = action.payload.preview;
     },
   },
 });
 
-export const { openPreview, setPreview, clearPreview } = pptPreviewSlice.actions;
+export const { setPreview } = pptPreviewSlice.actions;
 
 // ── Selectors ─────────────────────────────────────────────────────────────────
 
-/** The preview the side panel should render, or null. */
+/** The registered deck, whichever conversation it came from (scope with the hook). */
 export const selectCurrentPreview = (state: PptPreviewRootState): PptPreviewPartData | null => state.pptPreview.current;
 
-/** The open-request counter the chat page subscribes to. */
-export const selectPptOpenRequestId = (state: PptPreviewRootState): number => state.pptPreview.openRequestId;
+/** The conversation the registered deck belongs to, or null. */
+export const selectPptPreviewSessionId = (state: PptPreviewRootState): string | null => state.pptPreview.sessionId;
 
 export default pptPreviewSlice.reducer;

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.test.tsx
@@ -1,0 +1,74 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The registered deck is global state but belongs to ONE conversation. Without
+// the session stamp a deck filled in a previous conversation would light the
+// launcher up on a brand-new chat, which is the whole thing this scoping exists
+// to prevent.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { pptPreviewSlice, setPreview, type PptPreviewState } from "./pptPreviewSlice";
+import type { PptPreviewPartData } from "./types";
+
+const state = vi.hoisted(() => ({ session: "", ppt: null as unknown }));
+
+vi.mock("react-router-dom", () => ({
+  useSearchParams: () => [new URLSearchParams(state.session ? `session=${state.session}` : "")],
+}));
+
+vi.mock("react-redux", () => ({
+  useSelector: (selector: (s: { pptPreview: unknown }) => unknown) => selector({ pptPreview: state.ppt }),
+}));
+
+const { useSessionPptPreview } = await import("./useSessionPptPreview");
+
+const deck: PptPreviewPartData = {
+  type: "ppt_preview",
+  preview_id: "deck-1",
+  title: "Q3 review",
+  pdf_download_url: "/fs/download/deck-1.pdf",
+  version: "v1",
+};
+
+/** The slice's own reducer builds the state, so the test can't drift from it. */
+function sliceState(sessionId: string): PptPreviewState {
+  return pptPreviewSlice.reducer(undefined, setPreview({ sessionId, preview: deck }));
+}
+
+function read(openSession: string, ppt: PptPreviewState): PptPreviewPartData | null {
+  let seen: PptPreviewPartData | null = null;
+  state.session = openSession;
+  state.ppt = ppt;
+  function Probe() {
+    seen = useSessionPptPreview();
+    return null;
+  }
+  renderToStaticMarkup(<Probe />);
+  return seen;
+}
+
+describe("useSessionPptPreview", () => {
+  it("returns the deck the open conversation registered", () => {
+    expect(read("s1", sliceState("s1"))).toEqual(deck);
+  });
+
+  it("ignores a deck registered by another conversation", () => {
+    expect(read("s2", sliceState("s1"))).toBeNull();
+  });
+
+  it("returns nothing while no conversation is open", () => {
+    expect(read("", sliceState("s1"))).toBeNull();
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.ts
@@ -1,0 +1,38 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The deck the OPEN conversation produced, or null.
+//
+// The slice keeps the last registered deck globally; scoping it to the open
+// conversation (URL `?session=`, the rework convention) is what keeps a deck from
+// a previous conversation out of the pane — and, more visibly, keeps the panel's
+// launcher dark on a conversation that never produced one.
+
+import { useSelector } from "react-redux";
+import { useSearchParams } from "react-router-dom";
+import { selectCurrentPreview, selectPptPreviewSessionId } from "./pptPreviewSlice";
+import type { PptPreviewPartData } from "./types";
+
+export function useSessionPptPreview(): PptPreviewPartData | null {
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get("session") ?? "";
+  const current = useSelector(selectCurrentPreview);
+  const previewSessionId = useSelector(selectPptPreviewSessionId);
+  return sessionId !== "" && previewSessionId === sessionId ? current : null;
+}
+
+/** Launcher visibility for the ppt_filler side panel — see `CapabilitySidePanelSpec`. */
+export function useHasPptPreview(): boolean {
+  return useSessionPptPreview() !== null;
+}

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.ts
@@ -15,24 +15,27 @@
 // The deck the OPEN conversation produced, or null.
 //
 // The slice keeps the last registered deck globally; scoping it to the open
-// conversation (URL `?session=`, the rework convention) is what keeps a deck from
-// a previous conversation out of the pane — and, more visibly, keeps the panel's
-// launcher dark on a conversation that never produced one.
+// conversation is what keeps a deck from a previous conversation out of the pane -
+// and, more visibly, keeps the panel's launcher dark on a conversation that never
+// produced one.
+//
+// Unlike writable_document, ppt_filler has no list endpoint to ask: the slice, fed
+// by every rendered `ppt_preview` card, IS the "this conversation produced a deck"
+// signal, so the launcher appears once the cards have rendered.
 
 import { useSelector } from "react-redux";
-import { useSearchParams } from "react-router-dom";
+import { useOpenSessionId } from "../useOpenSessionId";
 import { selectCurrentPreview, selectPptPreviewSessionId } from "./pptPreviewSlice";
 import type { PptPreviewPartData } from "./types";
 
 export function useSessionPptPreview(): PptPreviewPartData | null {
-  const [searchParams] = useSearchParams();
-  const sessionId = searchParams.get("session") ?? "";
+  const sessionId = useOpenSessionId();
   const current = useSelector(selectCurrentPreview);
   const previewSessionId = useSelector(selectPptPreviewSessionId);
   return sessionId !== "" && previewSessionId === sessionId ? current : null;
 }
 
-/** Launcher visibility for the ppt_filler side panel — see `CapabilitySidePanelSpec`. */
+/** Launcher visibility for the ppt_filler side panel - see `CapabilitySidePanelSpec`. */
 export function useHasPptPreview(): boolean {
   return useSessionPptPreview() !== null;
 }

--- a/apps/frontend/src/rework/features/capabilities/sidePanelRegistry.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/sidePanelRegistry.test.tsx
@@ -24,7 +24,10 @@ function StubPanel(_props: CapabilitySidePanelProps) {
 }
 
 describe("sidePanelRegistry (#1979)", () => {
-  const withPanel: CapabilityUiPlugin = { id: "demo_echo", sidePanels: { demo_notes: StubPanel } };
+  const withPanel: CapabilityUiPlugin = {
+    id: "demo_echo",
+    sidePanels: { demo_notes: { Component: StubPanel, icon: "edit_note" } },
+  };
   const withoutPanel: CapabilityUiPlugin = { id: "plain", partRenderers: {} };
 
   it("resolves the panels an active capability contributes", () => {
@@ -32,7 +35,23 @@ describe("sidePanelRegistry (#1979)", () => {
     const entries = sidePanelsForCapabilities(["demo_echo"], registry);
 
     expect(entries).toHaveLength(1);
-    expect(entries[0]).toMatchObject({ capabilityId: "demo_echo", widget: "demo_notes", Component: StubPanel });
+    expect(entries[0]).toMatchObject({
+      capabilityId: "demo_echo",
+      widget: "demo_notes",
+      Component: StubPanel,
+      icon: "edit_note",
+    });
+  });
+
+  it("carries the plugin's launcher-visibility hook to the host", () => {
+    const useHasContent = () => false;
+    const gated: CapabilityUiPlugin = {
+      id: "gated",
+      sidePanels: { gated_panel: { Component: StubPanel, icon: "slideshow", useHasContent } },
+    };
+    const entries = sidePanelsForCapabilities(["gated"], buildSidePanelRegistry([gated]));
+
+    expect(entries[0].useHasContent).toBe(useHasContent);
   });
 
   it("skips capabilities that declare no side panel", () => {
@@ -46,7 +65,10 @@ describe("sidePanelRegistry (#1979)", () => {
   });
 
   it("preserves the order the capabilities are supplied", () => {
-    const other: CapabilityUiPlugin = { id: "other", sidePanels: { other_panel: StubPanel } };
+    const other: CapabilityUiPlugin = {
+      id: "other",
+      sidePanels: { other_panel: { Component: StubPanel, icon: "edit_note" } },
+    };
     const registry = buildSidePanelRegistry([withPanel, other]);
     const entries = sidePanelsForCapabilities(["other", "demo_echo"], registry);
 

--- a/apps/frontend/src/rework/features/capabilities/sidePanelRegistry.ts
+++ b/apps/frontend/src/rework/features/capabilities/sidePanelRegistry.ts
@@ -23,15 +23,13 @@
 //   contributes nothing (silent skip, never a crash)
 
 import { capabilityUiPlugins } from "./index";
-import type { CapabilityUiPlugin, CapabilitySidePanel } from "./types";
+import type { CapabilityUiPlugin, CapabilitySidePanelSpec } from "./types";
 
-export interface SidePanelEntry {
+export interface SidePanelEntry extends CapabilitySidePanelSpec {
   /** Owning capability id (`manifest.id`). */
   capabilityId: string;
   /** `SidePanelSpec.widget` id. */
   widget: string;
-  /** The component to render in the right column. */
-  Component: CapabilitySidePanel;
 }
 
 export function buildSidePanelRegistry(
@@ -43,7 +41,7 @@ export function buildSidePanelRegistry(
     if (panels.length === 0) continue;
     registry.set(
       plugin.id,
-      panels.map(([widget, Component]) => ({ capabilityId: plugin.id, widget, Component })),
+      panels.map(([widget, spec]) => ({ capabilityId: plugin.id, widget, ...spec })),
     );
   }
   return registry;

--- a/apps/frontend/src/rework/features/capabilities/types.ts
+++ b/apps/frontend/src/rework/features/capabilities/types.ts
@@ -63,7 +63,7 @@ export interface CapabilitySidePanelSpec {
   icon: IconType;
   /**
    * Does this panel have anything to show for the OPEN conversation? A false
-   * answer hides the launcher — a button onto an empty panel is noise. Omitted
+   * answer hides the launcher - a button onto an empty panel is noise. Omitted
    * means "always offer it". Called from the launcher's own component, so a
    * capability going in or out of a session never shifts hook order.
    */

--- a/apps/frontend/src/rework/features/capabilities/types.ts
+++ b/apps/frontend/src/rework/features/capabilities/types.ts
@@ -68,6 +68,13 @@ export interface CapabilitySidePanelSpec {
    * capability going in or out of a session never shifts hook order.
    */
   useHasContent?: () => boolean;
+  /**
+   * This panel renders its own title band (and its own close button, from the
+   * `onClose` it receives), so the host drops the drawer's. Two stacked title
+   * rows - the drawer naming the panel, the pane naming the artefact - said the
+   * same thing twice and ate the top of the column.
+   */
+  ownsHeader?: boolean;
 }
 
 /** The RAG-scope closed set (RuntimeContext `search_rag_scope`, RFC §3.3). */

--- a/apps/frontend/src/rework/features/capabilities/types.ts
+++ b/apps/frontend/src/rework/features/capabilities/types.ts
@@ -20,6 +20,7 @@
 // skipped so a frontend build older than a pod never crashes on new parts.
 
 import type { ComponentType } from "react";
+import type { IconType } from "@shared/utils/Type";
 import type { RawUiPart } from "@rework/types/parts";
 import type { SearchPolicyName } from "../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 
@@ -53,6 +54,21 @@ export type CapabilitySessionProbe = ComponentType<{ capabilityId: string }>;
  * right column when its owning capability is active in the session.
  */
 export type CapabilitySidePanel = ComponentType<CapabilitySidePanelProps>;
+
+/** One side panel's declaration: what to mount, and how to launch it. */
+export interface CapabilitySidePanelSpec {
+  /** The component mounted in the reserved right column. */
+  Component: CapabilitySidePanel;
+  /** Glyph of the panel's launcher in the floating rail. */
+  icon: IconType;
+  /**
+   * Does this panel have anything to show for the OPEN conversation? A false
+   * answer hides the launcher — a button onto an empty panel is noise. Omitted
+   * means "always offer it". Called from the launcher's own component, so a
+   * capability going in or out of a session never shifts hook order.
+   */
+  useHasContent?: () => boolean;
+}
 
 /** The RAG-scope closed set (RuntimeContext `search_rag_scope`, RFC §3.3). */
 export type RagScopeName = "corpus_only" | "hybrid" | "general_only";
@@ -179,7 +195,7 @@ export interface CapabilityUiPlugin {
    * right column; unknown widget ids never occur here (the plugin IS the
    * declaration) but the host skips capabilities with no plugin entry.
    */
-  sidePanels?: Record<string, CapabilitySidePanel>;
+  sidePanels?: Record<string, CapabilitySidePanelSpec>;
   /**
    * Headless session probes (#1905 auto-open), mounted by the side-panel host
    * for every ACTIVE capability whether or not its panel is open. The one

--- a/apps/frontend/src/rework/features/capabilities/useCapabilityRouted.ts
+++ b/apps/frontend/src/rework/features/capabilities/useCapabilityRouted.ts
@@ -1,0 +1,35 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// "Is this capability's own router reachable yet?" - the skip guard every query
+// on a capability API needs.
+//
+// `createCapabilityBaseQuery` resolves the pod's base URL from
+// `capabilityRoutingSlice` AT REQUEST TIME and fails loudly when it is not there
+// yet. On a hard page load the catalog/prep answer lands after the first render,
+// so a query fired before it gets that failure cached against unchanged args and
+// never retries - the capability then looks empty for the rest of the page load,
+// while a client-side navigation into the same conversation works (routing is
+// already in the store). Skipping until the base URL exists turns that into a
+// normal deferred fetch: RTK Query fires it the moment the guard flips.
+
+import { useSelector } from "react-redux";
+import { selectCapabilityBaseUrl, type CapabilityRoutingState } from "../../../common/capabilityRoutingSlice";
+
+export function useCapabilityRouted(capabilityId: string): boolean {
+  return useSelector(
+    (state: { capabilityRouting: CapabilityRoutingState }) =>
+      selectCapabilityBaseUrl(state, capabilityId) !== undefined,
+  );
+}

--- a/apps/frontend/src/rework/features/capabilities/useOpenSessionId.ts
+++ b/apps/frontend/src/rework/features/capabilities/useOpenSessionId.ts
@@ -1,0 +1,46 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The open conversation's id, the scoping key for every piece of capability state.
+//
+// Capability slices are global while their content belongs to one conversation, so
+// each of them stamps what it stores with the id these hooks return. One definition
+// of the `?session=` read (and of the "no conversation open" value, `""`) beats the
+// copy every renderer used to carry.
+
+import { useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/** The conversation currently open, or `""` when there is none. */
+export function useOpenSessionId(): string {
+  const [searchParams] = useSearchParams();
+  return searchParams.get("session") ?? "";
+}
+
+/**
+ * The conversation a chat-part renderer was mounted for, or `""` once the user has
+ * navigated away from it.
+ *
+ * Switching conversations re-renders the OUTGOING conversation's cards once (the
+ * thread is cleared in a parent effect, which runs after theirs), so a card reading
+ * the URL directly would stamp its part with the INCOMING conversation's id - and
+ * light that capability's panel up on a chat that never produced anything.
+ */
+export function useMountSessionId(): string {
+  const sessionId = useOpenSessionId();
+  const mounted = useRef<string | null>(null);
+  // Lazy init, idempotent - a card mounted before the id exists adopts the first one.
+  if (mounted.current === null && sessionId !== "") mounted.current = sessionId;
+  return mounted.current === sessionId ? sessionId : "";
+}

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentAutoOpenProbe.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentAutoOpenProbe.tsx
@@ -43,7 +43,9 @@ export function WritableDocumentAutoOpenProbe() {
   const sessionId = searchParams.get("session") ?? "";
 
   const routed = useCapabilityRouted(CAPABILITY_ID);
-  const { data: listed } = useListWritableDocumentsQuery(
+  // `currentData`: `data` would answer with the conversation just left, and this
+  // probe evaluates ONCE per conversation-open - a wrong first answer sticks.
+  const { currentData: listed } = useListWritableDocumentsQuery(
     { sessionId },
     { skip: !sessionId || !routed, refetchOnMountOrArgChange: true },
   );

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentAutoOpenProbe.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentAutoOpenProbe.tsx
@@ -33,6 +33,7 @@ import { useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { useSearchParams } from "react-router-dom";
 import { requestSidePanelOpen } from "../sidePanelOpenRequestSlice";
+import { useCapabilityRouted } from "../useCapabilityRouted";
 import { useListWritableDocumentsQuery } from "./api/writableDocumentCapabilityOpenApi";
 import { CAPABILITY_ID } from "./api/writableDocumentCapabilityApi";
 
@@ -41,9 +42,10 @@ export function WritableDocumentAutoOpenProbe() {
   const [searchParams] = useSearchParams();
   const sessionId = searchParams.get("session") ?? "";
 
+  const routed = useCapabilityRouted(CAPABILITY_ID);
   const { data: listed } = useListWritableDocumentsQuery(
     { sessionId },
-    { skip: !sessionId, refetchOnMountOrArgChange: true },
+    { skip: !sessionId || !routed, refetchOnMountOrArgChange: true },
   );
 
   // Last session already evaluated — switching back re-evaluates (a re-open).

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentCardRenderer.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentCardRenderer.tsx
@@ -30,11 +30,11 @@
 
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
 import Button from "@shared/atoms/Button/Button";
 import { requestSidePanelOpen } from "../sidePanelOpenRequestSlice";
+import { useMountSessionId } from "../useOpenSessionId";
 import type { UiPartRendererProps } from "../types";
 import type { WritableDocumentPartData } from "./types";
 import { selectWritableDocument, upsertFromPart } from "./writableDocumentSlice";
@@ -50,8 +50,7 @@ const AUTO_OPEN_MIN_AGE_MS = 5000;
 export function WritableDocumentCardRenderer({ part }: UiPartRendererProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const [searchParams] = useSearchParams();
-  const sessionId = searchParams.get("session") ?? "";
+  const sessionId = useMountSessionId();
   const doc = part as unknown as WritableDocumentPartData;
 
   const key = `${doc.document_id}:${doc.updated_at}`;

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentCardRenderer.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentCardRenderer.tsx
@@ -89,7 +89,7 @@ export function WritableDocumentCardRenderer({ part }: UiPartRendererProps) {
     <div className={styles.card} role="note" aria-label={t("capability.writable_document.card.aria")}>
       <div className={styles.header}>
         <span className={styles.icon} aria-hidden>
-          <Icon category="outlined" type="edit_note" />
+          <Icon category="outlined" type="edit_document" />
         </span>
         <span className={styles.title} title={title}>
           {title}
@@ -104,7 +104,7 @@ export function WritableDocumentCardRenderer({ part }: UiPartRendererProps) {
           color="primary"
           variant="text"
           size="small"
-          icon={{ category: "outlined", type: "edit_note" }}
+          icon={{ category: "outlined", type: "edit_document" }}
           onClick={openPane}
         >
           {t("capability.writable_document.card.open")}

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentDownloadButton.tsx
@@ -88,7 +88,7 @@ export default function WritableDocumentDownloadButton({
       iconButton={{
         color: "on-surface",
         variant: "icon",
-        size: "small",
+        size: "2xs",
         icon: { category: "outlined", type: "download" },
         disabled: isDownloading,
         "aria-label": downloadLabel,

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentDownloadButton.tsx
@@ -88,7 +88,7 @@ export default function WritableDocumentDownloadButton({
       iconButton={{
         color: "on-surface",
         variant: "icon",
-        size: "2xs",
+        size: "small",
         icon: { category: "outlined", type: "download" },
         disabled: isDownloading,
         "aria-label": downloadLabel,

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentPane.module.css
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentPane.module.css
@@ -28,9 +28,9 @@
 .header {
   display: flex;
   align-items: center;
-  gap: var(--spacing-s);
+  gap: var(--spacing-xs);
   border-bottom: 1px solid var(--outline-muted);
-  padding: var(--spacing-xs) var(--spacing-m);
+  padding: var(--spacing-2xs) var(--spacing-s);
 }
 
 .titleGroup {
@@ -169,7 +169,7 @@
   border-bottom: 1px solid var(--outline-muted);
   border-radius: 0;
   background-color: var(--surface-container-high);
-  padding: var(--spacing-xs) var(--spacing-s);
+  padding: var(--spacing-2xs) var(--spacing-s);
   overflow-x: visible;
 }
 

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentPane.tsx
@@ -53,6 +53,7 @@ import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
+import IconButton from "@shared/atoms/IconButton/IconButton";
 import type { CapabilitySidePanelProps } from "../types";
 import { useWritableDocuments } from "./useWritableDocuments";
 import WritableDocumentDownloadButton from "./WritableDocumentDownloadButton";
@@ -61,7 +62,7 @@ import styles from "./WritableDocumentPane.module.css";
 const isDarkTheme = () =>
   typeof document !== "undefined" && document.documentElement.getAttribute("data-theme") === "dark";
 
-export function WritableDocumentPane(_props: CapabilitySidePanelProps) {
+export function WritableDocumentPane({ onClose }: CapabilitySidePanelProps) {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const sessionId = searchParams.get("session") ?? "";
@@ -92,6 +93,18 @@ export function WritableDocumentPane(_props: CapabilitySidePanelProps) {
             title={selected.title}
           />
         )}
+        <IconButton
+          variant="icon"
+          size="small"
+          icon={{ category: "outlined", type: "close" }}
+          aria-label="Close panel"
+          // Blur first: closing flips aria-hidden on the drawer, which the browser
+          // blocks while a descendant still holds focus (InlineDrawer does the same).
+          onClick={(e) => {
+            e.currentTarget.blur();
+            onClose();
+          }}
+        />
       </div>
 
       {!sessionId && <div className={styles.empty}>{t("capability.writable_document.noSession")}</div>}

--- a/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/WritableDocumentPane.tsx
@@ -81,7 +81,7 @@ export function WritableDocumentPane(_props: CapabilitySidePanelProps) {
     <div className={styles.pane}>
       <div className={styles.header}>
         <div className={styles.titleGroup}>
-          <Icon category="outlined" type="edit_note" />
+          <Icon category="outlined" type="edit_document" />
           <span className={styles.title}>{selected?.title || untitled}</span>
         </div>
         {isSaving && <span className={styles.saving}>{t("capability.writable_document.saving")}</span>}

--- a/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
@@ -21,13 +21,21 @@ import type { CapabilityUiPlugin } from "../types";
 import { WritableDocumentAutoOpenProbe } from "./WritableDocumentAutoOpenProbe";
 import { WritableDocumentCardRenderer } from "./WritableDocumentCardRenderer";
 import { WritableDocumentPane } from "./WritableDocumentPane";
+import { useHasWritableDocuments } from "./useHasWritableDocuments";
 
 export const writableDocumentCapability: CapabilityUiPlugin = {
   id: "writable_document",
   // Keyed by the backend chat part's `type` discriminator (#1977).
   partRenderers: { writable_document: WritableDocumentCardRenderer },
-  // Keyed by the backend manifest's SidePanelSpec.widget (#1979).
-  sidePanels: { writable_document_pane: WritableDocumentPane },
+  // Keyed by the backend manifest's SidePanelSpec.widget (#1979). `edit_note` is
+  // the glyph the card's own Open button uses — the launcher opens the same editor.
+  sidePanels: {
+    writable_document_pane: {
+      Component: WritableDocumentPane,
+      icon: "edit_note",
+      useHasContent: useHasWritableDocuments,
+    },
+  },
   // A conversation that already holds documents re-opens straight in the editor.
   sessionProbes: [WritableDocumentAutoOpenProbe],
 };

--- a/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
@@ -27,12 +27,12 @@ export const writableDocumentCapability: CapabilityUiPlugin = {
   id: "writable_document",
   // Keyed by the backend chat part's `type` discriminator (#1977).
   partRenderers: { writable_document: WritableDocumentCardRenderer },
-  // Keyed by the backend manifest's SidePanelSpec.widget. `article` is what
-  // fileIconSpec gives a .docx, so a document reads the same in chat and Resources.
+  // Keyed by the backend manifest's SidePanelSpec.widget. `edit_document` is the
+  // glyph the whole writable_document surface uses - card, Open button, pane header.
   sidePanels: {
     writable_document_pane: {
       Component: WritableDocumentPane,
-      icon: "article",
+      icon: "edit_document",
       useHasContent: useHasWritableDocuments,
     },
   },

--- a/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
@@ -27,12 +27,12 @@ export const writableDocumentCapability: CapabilityUiPlugin = {
   id: "writable_document",
   // Keyed by the backend chat part's `type` discriminator (#1977).
   partRenderers: { writable_document: WritableDocumentCardRenderer },
-  // Keyed by the backend manifest's SidePanelSpec.widget (#1979). `edit_note` is
-  // the glyph the card's own Open button uses — the launcher opens the same editor.
+  // Keyed by the backend manifest's SidePanelSpec.widget. `article` is what
+  // fileIconSpec gives a .docx, so a document reads the same in chat and Resources.
   sidePanels: {
     writable_document_pane: {
       Component: WritableDocumentPane,
-      icon: "edit_note",
+      icon: "article",
       useHasContent: useHasWritableDocuments,
     },
   },

--- a/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/plugin.ts
@@ -34,6 +34,7 @@ export const writableDocumentCapability: CapabilityUiPlugin = {
       Component: WritableDocumentPane,
       icon: "edit_document",
       useHasContent: useHasWritableDocuments,
+      ownsHeader: true,
     },
   },
   // A conversation that already holds documents re-opens straight in the editor.

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.test.tsx
@@ -1,0 +1,93 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Two sources answer "does this conversation have a document?" and each is blind
+// on its own: the list API lags a live agent write by one refetch, and the live
+// snapshots outlive the conversation that produced them (the slice only drops
+// them on its next upsert). Both halves have to be right or the launcher either
+// misses a fresh write or lingers on an empty chat.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { WritableDocumentState } from "./writableDocumentSlice";
+import type { WritableDocumentPartData } from "./types";
+
+const state = vi.hoisted(() => ({ session: "", doc: null as unknown, listed: undefined as unknown }));
+
+vi.mock("react-router-dom", () => ({
+  useSearchParams: () => [new URLSearchParams(state.session ? `session=${state.session}` : "")],
+}));
+
+vi.mock("react-redux", () => ({
+  useSelector: (selector: (s: { writableDocument: unknown }) => unknown) => selector({ writableDocument: state.doc }),
+}));
+
+vi.mock("./api/writableDocumentCapabilityOpenApi", () => ({
+  useListWritableDocumentsQuery: (_args: unknown, opts: { skip: boolean }) => ({
+    data: opts.skip ? undefined : state.listed,
+  }),
+}));
+
+const { useHasWritableDocuments } = await import("./useHasWritableDocuments");
+
+const liveDoc = { document_id: "d1", title: "Notes", content_md: "" } as WritableDocumentPartData;
+
+function sliceState(sessionId: string | null, docs: WritableDocumentPartData[]): WritableDocumentState {
+  return {
+    sessionId,
+    liveById: Object.fromEntries(docs.map((d) => [d.document_id, d])),
+    selectedId: null,
+  };
+}
+
+function read(openSession: string, doc: WritableDocumentState, listed: unknown): boolean {
+  let seen = false;
+  state.session = openSession;
+  state.doc = doc;
+  state.listed = listed;
+  function Probe() {
+    seen = useHasWritableDocuments();
+    return null;
+  }
+  renderToStaticMarkup(<Probe />);
+  return seen;
+}
+
+const empty = sliceState(null, []);
+
+describe("useHasWritableDocuments", () => {
+  it("is false on a conversation with no document", () => {
+    expect(read("s1", empty, [])).toBe(false);
+  });
+
+  it("is true once the list API reports a document", () => {
+    expect(read("s1", empty, [{ document_id: "d1" }])).toBe(true);
+  });
+
+  it("is true on a live agent write the list has not caught up with yet", () => {
+    expect(read("s1", sliceState("s1", [liveDoc]), [])).toBe(true);
+  });
+
+  it("ignores live snapshots left over from another conversation", () => {
+    expect(read("s2", sliceState("s1", [liveDoc]), [])).toBe(false);
+  });
+
+  it("is false while the list answer has not arrived", () => {
+    expect(read("s1", empty, undefined)).toBe(false);
+  });
+
+  it("is false while no conversation is open", () => {
+    expect(read("", sliceState("s1", [liveDoc]), [{ document_id: "d1" }])).toBe(false);
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.test.tsx
@@ -30,6 +30,8 @@ const state = vi.hoisted(() => ({
   // a previous conversation is expressible, the way RTK Query's `data` exposes one.
   listedFor: "",
   listed: undefined as unknown,
+  // Whether the catalog/prep answer that carries the pod's base URL has landed.
+  routed: true,
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -37,7 +39,11 @@ vi.mock("react-router-dom", () => ({
 }));
 
 vi.mock("react-redux", () => ({
-  useSelector: (selector: (s: { writableDocument: unknown }) => unknown) => selector({ writableDocument: state.doc }),
+  useSelector: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      writableDocument: state.doc,
+      capabilityRouting: { baseUrls: state.routed ? { writable_document: "https://pod" } : {} },
+    }),
 }));
 
 vi.mock("./api/writableDocumentCapabilityOpenApi", () => ({
@@ -62,12 +68,19 @@ function sliceState(sessionId: string | null, docs: WritableDocumentPartData[]):
   };
 }
 
-function read(openSession: string, doc: WritableDocumentState, listed: unknown, listedFor = openSession): boolean {
+function read(
+  openSession: string,
+  doc: WritableDocumentState,
+  listed: unknown,
+  listedFor = openSession,
+  routed = true,
+): boolean {
   let seen = false;
   state.session = openSession;
   state.doc = doc;
   state.listed = listed;
   state.listedFor = listedFor;
+  state.routed = routed;
   function Probe() {
     seen = useHasWritableDocuments();
     return null;
@@ -101,6 +114,13 @@ describe("useHasWritableDocuments", () => {
 
   it("ignores the list answer still held from the conversation just left", () => {
     expect(read("s2", empty, [{ document_id: "d1" }], "s1")).toBe(false);
+  });
+
+  it("holds the query until the capability's pod base URL is known", () => {
+    // Fired before it lands, the query fails on args that never change again and
+    // the launcher stays dark for the whole page load (hard reload only - a
+    // client-side navigation finds routing already in the store).
+    expect(read("s1", empty, [{ document_id: "d1" }], "s1", false)).toBe(false);
   });
 
   it("is false while no conversation is open", () => {

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.test.tsx
@@ -23,7 +23,14 @@ import { describe, expect, it, vi } from "vitest";
 import type { WritableDocumentState } from "./writableDocumentSlice";
 import type { WritableDocumentPartData } from "./types";
 
-const state = vi.hoisted(() => ({ session: "", doc: null as unknown, listed: undefined as unknown }));
+const state = vi.hoisted(() => ({
+  session: "",
+  doc: null as unknown,
+  // What the query resolved for, and what it resolved to - so a stale answer from
+  // a previous conversation is expressible, the way RTK Query's `data` exposes one.
+  listedFor: "",
+  listed: undefined as unknown,
+}));
 
 vi.mock("react-router-dom", () => ({
   useSearchParams: () => [new URLSearchParams(state.session ? `session=${state.session}` : "")],
@@ -34,8 +41,12 @@ vi.mock("react-redux", () => ({
 }));
 
 vi.mock("./api/writableDocumentCapabilityOpenApi", () => ({
-  useListWritableDocumentsQuery: (_args: unknown, opts: { skip: boolean }) => ({
+  // `data` keeps the last resolved result across an arg change; `currentData` is
+  // undefined until the answer belongs to the CURRENT args. Modelling both is what
+  // makes the stale-conversation case below fail on the wrong one.
+  useListWritableDocumentsQuery: (args: { sessionId: string }, opts: { skip: boolean }) => ({
     data: opts.skip ? undefined : state.listed,
+    currentData: opts.skip || state.listedFor !== args.sessionId ? undefined : state.listed,
   }),
 }));
 
@@ -51,11 +62,12 @@ function sliceState(sessionId: string | null, docs: WritableDocumentPartData[]):
   };
 }
 
-function read(openSession: string, doc: WritableDocumentState, listed: unknown): boolean {
+function read(openSession: string, doc: WritableDocumentState, listed: unknown, listedFor = openSession): boolean {
   let seen = false;
   state.session = openSession;
   state.doc = doc;
   state.listed = listed;
+  state.listedFor = listedFor;
   function Probe() {
     seen = useHasWritableDocuments();
     return null;
@@ -85,6 +97,10 @@ describe("useHasWritableDocuments", () => {
 
   it("is false while the list answer has not arrived", () => {
     expect(read("s1", empty, undefined)).toBe(false);
+  });
+
+  it("ignores the list answer still held from the conversation just left", () => {
+    expect(read("s2", empty, [{ document_id: "d1" }], "s1")).toBe(false);
   });
 
   it("is false while no conversation is open", () => {

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.ts
@@ -25,15 +25,18 @@
 
 import { useSelector } from "react-redux";
 import { useListWritableDocumentsQuery } from "./api/writableDocumentCapabilityOpenApi";
+import { CAPABILITY_ID } from "./api/writableDocumentCapabilityApi";
+import { useCapabilityRouted } from "../useCapabilityRouted";
 import { useOpenSessionId } from "../useOpenSessionId";
 import { selectWritableDocumentSessionId, selectWritableDocumentsById } from "./writableDocumentSlice";
 
 export function useHasWritableDocuments(): boolean {
   const sessionId = useOpenSessionId();
+  const routed = useCapabilityRouted(CAPABILITY_ID);
   // `currentData`, not `data`: RTK Query keeps the last resolved result across an
   // arg change, so on a switch out of a conversation WITH documents `data` would
   // keep the launcher lit on the new one until the request lands.
-  const { currentData: listed } = useListWritableDocumentsQuery({ sessionId }, { skip: !sessionId });
+  const { currentData: listed } = useListWritableDocumentsQuery({ sessionId }, { skip: !sessionId || !routed });
   const liveById = useSelector(selectWritableDocumentsById);
   const liveSessionId = useSelector(selectWritableDocumentSessionId);
 

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.ts
@@ -12,26 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Launcher visibility for the writable_document side panel — see
+// Launcher visibility for the writable_document side panel - see
 // `CapabilitySidePanelSpec`.
 //
 // "Has content" = the OPEN conversation holds at least one document. The list API
 // is authoritative but lags a live agent write by one refetch, so the live
-// snapshots count too — scoped to the open conversation, since the slice only
+// snapshots count too - scoped to the open conversation, since the slice only
 // drops a previous conversation's snapshots on its next upsert.
 //
 // The query is the same one the auto-open probe and the pane subscribe to: RTK
 // Query dedupes it, so the launcher costs no extra request.
 
 import { useSelector } from "react-redux";
-import { useSearchParams } from "react-router-dom";
 import { useListWritableDocumentsQuery } from "./api/writableDocumentCapabilityOpenApi";
+import { useOpenSessionId } from "../useOpenSessionId";
 import { selectWritableDocumentSessionId, selectWritableDocumentsById } from "./writableDocumentSlice";
 
 export function useHasWritableDocuments(): boolean {
-  const [searchParams] = useSearchParams();
-  const sessionId = searchParams.get("session") ?? "";
-  const { data: listed } = useListWritableDocumentsQuery({ sessionId }, { skip: !sessionId });
+  const sessionId = useOpenSessionId();
+  // `currentData`, not `data`: RTK Query keeps the last resolved result across an
+  // arg change, so on a switch out of a conversation WITH documents `data` would
+  // keep the launcher lit on the new one until the request lands.
+  const { currentData: listed } = useListWritableDocumentsQuery({ sessionId }, { skip: !sessionId });
   const liveById = useSelector(selectWritableDocumentsById);
   const liveSessionId = useSelector(selectWritableDocumentSessionId);
 

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useHasWritableDocuments.ts
@@ -1,0 +1,40 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Launcher visibility for the writable_document side panel — see
+// `CapabilitySidePanelSpec`.
+//
+// "Has content" = the OPEN conversation holds at least one document. The list API
+// is authoritative but lags a live agent write by one refetch, so the live
+// snapshots count too — scoped to the open conversation, since the slice only
+// drops a previous conversation's snapshots on its next upsert.
+//
+// The query is the same one the auto-open probe and the pane subscribe to: RTK
+// Query dedupes it, so the launcher costs no extra request.
+
+import { useSelector } from "react-redux";
+import { useSearchParams } from "react-router-dom";
+import { useListWritableDocumentsQuery } from "./api/writableDocumentCapabilityOpenApi";
+import { selectWritableDocumentSessionId, selectWritableDocumentsById } from "./writableDocumentSlice";
+
+export function useHasWritableDocuments(): boolean {
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get("session") ?? "";
+  const { data: listed } = useListWritableDocumentsQuery({ sessionId }, { skip: !sessionId });
+  const liveById = useSelector(selectWritableDocumentsById);
+  const liveSessionId = useSelector(selectWritableDocumentSessionId);
+
+  const hasLive = sessionId !== "" && liveSessionId === sessionId && Object.keys(liveById).length > 0;
+  return hasLive || (listed?.length ?? 0) > 0;
+}

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useWritableDocuments.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useWritableDocuments.test.tsx
@@ -1,0 +1,96 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Which documents the editor offers as tabs.
+//
+// The set is a merge of two sources that expire differently: the API list is
+// scoped to the conversation asked for, while the live snapshots sit in a global
+// slice the next conversation only clears when it upserts one of its own. A
+// conversation whose documents all come from the API never upserts, so an
+// unguarded merge showed the PREVIOUS conversation's document as an extra tab -
+// someone else's document, in an editor that autosaves.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { WritableDocumentPartData } from "./types";
+import type { WritableDocumentView } from "./useWritableDocuments";
+
+const state = vi.hoisted(() => ({
+  live: null as unknown,
+  listedFor: "",
+  listed: [] as unknown[],
+}));
+
+vi.mock("react-redux", () => ({
+  useDispatch: () => () => undefined,
+  useSelector: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      writableDocument: state.live,
+      capabilityRouting: { baseUrls: { writable_document: "https://pod" } },
+    }),
+}));
+
+vi.mock("./api/writableDocumentCapabilityOpenApi", () => ({
+  useListWritableDocumentsQuery: (args: { sessionId: string }, opts: { skip: boolean }) => ({
+    data: opts.skip ? undefined : state.listed,
+    currentData: opts.skip || state.listedFor !== args.sessionId ? undefined : state.listed,
+    refetch: () => undefined,
+  }),
+  useUpdateWritableDocumentMutation: () => [() => ({ unwrap: async () => undefined })],
+}));
+
+const { useWritableDocuments } = await import("./useWritableDocuments");
+
+const doc = (id: string, title: string) =>
+  ({ document_id: id, title, content_md: "", updated_at: "2026-08-28T10:00:00Z" }) as WritableDocumentPartData;
+
+function titlesFor(openSession: string, liveSessionId: string | null, live: WritableDocumentPartData[]): string[] {
+  state.live = {
+    sessionId: liveSessionId,
+    liveById: Object.fromEntries(live.map((d) => [d.document_id, d])),
+    selectedId: null,
+  };
+  let seen: WritableDocumentView[] = [];
+  function Probe() {
+    seen = useWritableDocuments(openSession).documents;
+    return null;
+  }
+  renderToStaticMarkup(<Probe />);
+  return seen.map((d) => d.title).sort();
+}
+
+describe("useWritableDocuments", () => {
+  it("offers the live snapshots of the open conversation", () => {
+    state.listedFor = "s1";
+    state.listed = [];
+
+    expect(titlesFor("s1", "s1", [doc("d1", "Résumé des logs")])).toEqual(["Résumé des logs"]);
+  });
+
+  it("never offers a document left over from another conversation", () => {
+    state.listedFor = "s2";
+    state.listed = [doc("d2", "Résumé des logs")];
+
+    // The slice still holds s1's document: s2's came from the API, so nothing
+    // upserted and nothing reset the map.
+    expect(titlesFor("s2", "s1", [doc("d1", "Le Bitcoin en 3 lignes")])).toEqual(["Résumé des logs"]);
+  });
+
+  it("offers nothing while the list still answers for the conversation just left", () => {
+    state.listedFor = "s1";
+    state.listed = [doc("d1", "Le Bitcoin en 3 lignes")];
+
+    expect(titlesFor("s2", null, [])).toEqual([]);
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useWritableDocuments.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useWritableDocuments.ts
@@ -39,6 +39,8 @@ import {
   useUpdateWritableDocumentMutation,
   type WritableDocumentResponse,
 } from "./api/writableDocumentCapabilityOpenApi";
+import { CAPABILITY_ID } from "./api/writableDocumentCapabilityApi";
+import { useCapabilityRouted } from "../useCapabilityRouted";
 import type { WritableDocumentPartData } from "./types";
 import {
   selectWritableDocument,
@@ -88,9 +90,10 @@ export function useWritableDocuments(sessionId: string | undefined): UseWritable
   const liveById = useSelector(selectWritableDocumentsById);
   const selectedId = useSelector(selectWritableDocumentSelectedId);
 
+  const routed = useCapabilityRouted(CAPABILITY_ID);
   const { data: listed, refetch } = useListWritableDocumentsQuery(
     { sessionId: sessionId || "" },
-    { skip: !sessionId, refetchOnMountOrArgChange: true },
+    { skip: !sessionId || !routed, refetchOnMountOrArgChange: true },
   );
   const [updateDocument] = useUpdateWritableDocumentMutation();
 

--- a/apps/frontend/src/rework/features/capabilities/writable_document/useWritableDocuments.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/useWritableDocuments.ts
@@ -46,6 +46,7 @@ import {
   selectWritableDocument,
   selectWritableDocumentsById,
   selectWritableDocumentSelectedId,
+  selectWritableDocumentSessionId,
 } from "./writableDocumentSlice";
 import { tsMs } from "./writableDocumentUtils";
 
@@ -88,10 +89,14 @@ const responseToView = (r: WritableDocumentResponse): WritableDocumentView => ({
 export function useWritableDocuments(sessionId: string | undefined): UseWritableDocuments {
   const dispatch = useDispatch();
   const liveById = useSelector(selectWritableDocumentsById);
+  const liveSessionId = useSelector(selectWritableDocumentSessionId);
   const selectedId = useSelector(selectWritableDocumentSelectedId);
 
   const routed = useCapabilityRouted(CAPABILITY_ID);
-  const { data: listed, refetch } = useListWritableDocumentsQuery(
+  // `currentData`, not `data`: `data` keeps the last resolved list across an arg
+  // change, so on a conversation switch the editor would show the documents of the
+  // one just left until the new request lands.
+  const { currentData: listed, refetch } = useListWritableDocumentsQuery(
     { sessionId: sessionId || "" },
     { skip: !sessionId || !routed, refetchOnMountOrArgChange: true },
   );
@@ -107,7 +112,14 @@ export function useWritableDocuments(sessionId: string | undefined): UseWritable
   // kept in a ref so onEditDocument can stamp localBaseTs without extra re-renders.
   const authTsRef = useRef<Record<string, number>>({});
 
-  const liveDocs = useMemo(() => Object.values(liveById).map(partToView), [liveById]);
+  // Live snapshots outlive the conversation that produced them: the slice only
+  // drops them when the NEXT conversation upserts one. A conversation whose
+  // documents all come from the API list never upserts, so without this guard the
+  // previous conversation's documents show up as extra tabs in the editor.
+  const liveDocs = useMemo(
+    () => (liveSessionId !== null && liveSessionId === sessionId ? Object.values(liveById).map(partToView) : []),
+    [liveById, liveSessionId, sessionId],
+  );
 
   // Track the newest authoritative updated_at per document (stream + API, no local edits).
   useEffect(() => {

--- a/apps/frontend/src/rework/features/capabilities/writable_document/writableDocumentSlice.ts
+++ b/apps/frontend/src/rework/features/capabilities/writable_document/writableDocumentSlice.ts
@@ -93,6 +93,10 @@ export const selectWritableDocumentsById = (
   state: WritableDocumentRootState,
 ): Record<string, WritableDocumentPartData> => state.writableDocument.liveById;
 
+/** The conversation the live snapshots belong to, or null. */
+export const selectWritableDocumentSessionId = (state: WritableDocumentRootState): string | null =>
+  state.writableDocument.sessionId;
+
 /** The document_id the pane should show, or null. */
 export const selectWritableDocumentSelectedId = (state: WritableDocumentRootState): string | null =>
   state.writableDocument.selectedId;

--- a/docs/swift/capabilities/AUTHORING.md
+++ b/docs/swift/capabilities/AUTHORING.md
@@ -233,6 +233,32 @@ fall back to a generic capability icon in the admin catalog.
 
 ---
 
+## Ships a side panel? Declare its launcher (#2459)
+
+A side panel is declared in the capability's frontend plugin
+(`apps/frontend/src/rework/features/capabilities/<id>/plugin.ts`), keyed by the
+manifest's `SidePanelSpec.widget`. The value is a spec, not a bare component:
+
+```ts
+sidePanels: {
+  ppt_preview_pane: { Component: PptPreviewPane, icon: "slideshow", useHasContent: useHasPptPreview },
+},
+```
+
+- `icon` — the glyph of the panel's launcher in the chat page's floating rail, from
+  the same `materialIcons` set as the manifest icon above. Pick the glyph the
+  capability's own chat card already uses for the same action, so the launcher and
+  the card read as one affordance (`slideshow` for the ppt_filler preview,
+  `edit_note` for the writable_document editor).
+- `useHasContent` — a hook answering "does this panel have anything to show for the
+  OPEN conversation?". Omit it and the launcher is always offered; a capability that
+  produces something on demand should implement it, or every session that merely
+  ACTIVATES the capability gets a button onto an empty panel. Scope the answer to the
+  conversation in the URL (`?session=`) — capability slices are global, so state from
+  a previous conversation otherwise lights the launcher up on a fresh chat.
+
+---
+
 ## Ships a router? Regenerate its API slice (#1979)
 
 A capability whose manifest declares a `router` gets its own OpenAPI doc and its own

--- a/docs/swift/capabilities/AUTHORING.md
+++ b/docs/swift/capabilities/AUTHORING.md
@@ -246,10 +246,10 @@ sidePanels: {
 ```
 
 - `icon` - the glyph of the panel's launcher in the chat page's floating rail, from
-  the same `materialIcons` set as the manifest icon above. Pick what
-  `apps/frontend/src/rework/utils/fileIconSpec.ts` already gives the artefact the
-  panel holds (`slideshow` for a deck, `article` for a document) so a file type
-  reads the same in the chat as in Resources.
+  the same `materialIcons` set as the manifest icon above. Reuse the glyph the
+  capability's own chat card and pane header already carry, so the launcher reads as
+  the same thing they open (`slideshow` for the ppt_filler deck, `edit_document` for
+  the writable_document editor).
 - `useHasContent` - a hook answering "does this panel have anything to show for the
   OPEN conversation?". Omit it and the launcher is always offered; a capability that
   produces something on demand should implement it, or every session that merely

--- a/docs/swift/capabilities/AUTHORING.md
+++ b/docs/swift/capabilities/AUTHORING.md
@@ -245,17 +245,21 @@ sidePanels: {
 },
 ```
 
-- `icon` — the glyph of the panel's launcher in the chat page's floating rail, from
-  the same `materialIcons` set as the manifest icon above. Pick the glyph the
-  capability's own chat card already uses for the same action, so the launcher and
-  the card read as one affordance (`slideshow` for the ppt_filler preview,
-  `edit_note` for the writable_document editor).
-- `useHasContent` — a hook answering "does this panel have anything to show for the
+- `icon` - the glyph of the panel's launcher in the chat page's floating rail, from
+  the same `materialIcons` set as the manifest icon above. Pick what
+  `apps/frontend/src/rework/utils/fileIconSpec.ts` already gives the artefact the
+  panel holds (`slideshow` for a deck, `article` for a document) so a file type
+  reads the same in the chat as in Resources.
+- `useHasContent` - a hook answering "does this panel have anything to show for the
   OPEN conversation?". Omit it and the launcher is always offered; a capability that
   produces something on demand should implement it, or every session that merely
   ACTIVATES the capability gets a button onto an empty panel. Scope the answer to the
-  conversation in the URL (`?session=`) — capability slices are global, so state from
-  a previous conversation otherwise lights the launcher up on a fresh chat.
+  conversation in the URL - capability slices are global, so state from a previous
+  conversation otherwise lights the launcher up on a fresh chat. Read the id with
+  `useOpenSessionId()` (`features/capabilities/useOpenSessionId.ts`), and answer from
+  the capability's own list endpoint when it has one: `writable_document` does, so its
+  launcher is right as soon as the conversation loads, while `ppt_filler` has to wait
+  for its chat cards to render and register their deck.
 
 ---
 

--- a/docs/swift/capabilities/AUTHORING.md
+++ b/docs/swift/capabilities/AUTHORING.md
@@ -276,6 +276,23 @@ cd apps/frontend && make update-<id>-capability-api    # e.g. update-demo-echo-c
 The generated slice + dumped schema are `.prettierignore`d (see `apps/frontend/Makefile`
 and `apps/frontend/.prettierignore`). Never hand-edit them.
 
+**Skip every query until the capability is routed.** `createCapabilityBaseQuery`
+resolves the pod's base URL from `capabilityRoutingSlice` at request time and fails
+loudly when it is not there yet. On a hard page load that answer lands after the
+first render, so a query fired too early gets its failure cached against args that
+never change again - the capability then looks empty for the whole page load, while a
+client-side navigation into the same page works (routing is already in the store).
+Guard every hook on the capability's own API:
+
+```ts
+const routed = useCapabilityRouted(CAPABILITY_ID);
+const { currentData } = useListThingsQuery({ sessionId }, { skip: !sessionId || !routed });
+```
+
+Prefer `currentData` over `data` for anything scoped to the open conversation: `data`
+deliberately keeps the last resolved result across an arg change, so on a session
+switch it answers for the conversation the user just left.
+
 ---
 
 ## Testing expectations

--- a/docs/swift/rfc/AGENT-CAPABILITY-PRESENTATION.html
+++ b/docs/swift/rfc/AGENT-CAPABILITY-PRESENTATION.html
@@ -523,7 +523,7 @@
   <span class="f">configWidgets</span>:    { <span class="f">template_upload</span>: <span class="t">TemplateUploadField</span> },
   <span class="f">chatTurnControls</span>: { <span class="c">/* none */</span> },
   <span class="f">partRenderers</span>:    { <span class="f">ppt_preview</span>: <span class="t">PptPreviewCard</span> },
-  <span class="f">sidePanels</span>:       { <span class="f">ppt_preview_pane</span>: <span class="t">PptPreviewPane</span> },
+  <span class="f">sidePanels</span>:       { <span class="f">ppt_preview_pane</span>: { <span class="f">Component</span>: <span class="t">PptPreviewPane</span>, <span class="f">icon</span>: <span class="s">"slideshow"</span>, <span class="f">useHasContent</span> } },
 };</pre>
       <p class="muted" style="margin-top:14px; font-size:18px;">One folder per capability, registered in <strong>one index</strong> — the only shared edit.</p>
     </div>

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3598,19 +3598,21 @@ a session's active capabilities declare. Two changes (#2459):
   holds a document); a panel that omits the hook stays always-on. The rail is invisible
   chrome until the agent actually produces something.
 - **Each panel carries its own glyph** instead of the `edit_note` the host hardcoded for
-  every one of them. `ppt_filler` → `slideshow`, `writable_document` → `article` - the
-  same icons `fileIconSpec.ts` gives a `.pptx` and a `.docx` in Resources, so a file
-  type reads the same across the app. Colour stays the rail's neutral
+  every one of them. `ppt_filler` → `slideshow`, `writable_document` → `edit_document`
+  (a new entry in `materialIcons`, the page-with-a-pencil glyph) - each the one that
+  capability's own card and pane header already carry, so the launcher reads as the
+  thing it opens. The whole writable_document surface moved off `edit_note` to
+  `edit_document` in the same pass (2026-08-28). Colour stays the rail's neutral
   `on-surface-retreat`: the launchers sit in the same floating-chrome band as the trace
   and attachments buttons, and tinting only these two would break that band.
 - **The rail dropped to 68px from the top** (2026-08-28). Its 48px offset was computed
   against a one-line top bar; the bar now stacks a 24px title over a 20px agent name, so
   the first launcher sat on the band.
-- **The rail only floats while every panel is closed** (2026-08-28). It is absolutely
+- **The rail retires entirely while a panel is open** (2026-08-28). It is absolutely
   positioned against the whole slot, drawer included, so with a panel open it landed on
-  that drawer's own close button. Open, the remaining launchers render as the
-  `InlineDrawer`'s `headerActions` instead - no overlap, and switching panels stays one
-  click.
+  that drawer's own close button. Moving the remaining launchers into the drawer's
+  `headerActions` was tried the same day and dropped: closing the open panel to reach
+  another one is cheap, and one home for the launchers beats two (developer decision).
 - **Both panes' header bands were trimmed** (2026-08-28) - `PptPreviewPane` and
   `WritableDocumentPane` share the same title + actions row, padded down from
   `8px/16px` to `4px/12px`; the editor toolbar under it lost the same 4px. Two

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3633,3 +3633,9 @@ a session's active capabilities declare. Two changes (#2459):
 
 Both capability slices now stamp the conversation their state belongs to, so a deck or a
 document from a previous conversation can no longer light a launcher up on a fresh chat.
+The writable_document editor applies the same scoping to its TAB STRIP (2026-08-28): its
+document set merges the API list with the live snapshots, and the snapshots outlive the
+conversation that produced them (the slice only drops them when the next conversation
+upserts one of its own). A conversation whose documents all come from the API never
+upserts, so the previous conversation's document showed up as an extra tab - someone
+else's document, in an editor that autosaves.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3606,6 +3606,16 @@ a session's active capabilities declare. Two changes (#2459):
 - **The rail dropped to 68px from the top** (2026-08-28). Its 48px offset was computed
   against a one-line top bar; the bar now stacks a 24px title over a 20px agent name, so
   the first launcher sat on the band.
+- **The rail only floats while every panel is closed** (2026-08-28). It is absolutely
+  positioned against the whole slot, drawer included, so with a panel open it landed on
+  that drawer's own close button. Open, the remaining launchers render as the
+  `InlineDrawer`'s `headerActions` instead — no overlap, and switching panels stays one
+  click.
+- **Both panes' header bands were trimmed** (2026-08-28) — `PptPreviewPane` and
+  `WritableDocumentPane` share the same title + actions row, padded down from
+  `8px/16px` to `4px/12px` with their download control on the 24px `2xs` tier
+  (`small` before); the editor toolbar under it lost the same 4px. Two stacked bands
+  (the drawer's own header, then the pane's) were eating the top of the panel.
 
 Both capability slices now stamp the conversation their state belongs to, so a deck or a
 document from a previous conversation can no longer light a launcher up on a fresh chat.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3598,9 +3598,9 @@ a session's active capabilities declare. Two changes (#2459):
   holds a document); a panel that omits the hook stays always-on. The rail is invisible
   chrome until the agent actually produces something.
 - **Each panel carries its own glyph** instead of the `edit_note` the host hardcoded for
-  every one of them. `ppt_filler` → `slideshow`, `writable_document` → `edit_note` — each
-  one the glyph that capability's own chat card already uses for "open this", so the
-  launcher and the card read as one affordance. Colour stays the rail's neutral
+  every one of them. `ppt_filler` → `slideshow`, `writable_document` → `article` - the
+  same icons `fileIconSpec.ts` gives a `.pptx` and a `.docx` in Resources, so a file
+  type reads the same across the app. Colour stays the rail's neutral
   `on-surface-retreat`: the launchers sit in the same floating-chrome band as the trace
   and attachments buttons, and tinting only these two would break that band.
 - **The rail dropped to 68px from the top** (2026-08-28). Its 48px offset was computed
@@ -3609,13 +3609,14 @@ a session's active capabilities declare. Two changes (#2459):
 - **The rail only floats while every panel is closed** (2026-08-28). It is absolutely
   positioned against the whole slot, drawer included, so with a panel open it landed on
   that drawer's own close button. Open, the remaining launchers render as the
-  `InlineDrawer`'s `headerActions` instead — no overlap, and switching panels stays one
+  `InlineDrawer`'s `headerActions` instead - no overlap, and switching panels stays one
   click.
-- **Both panes' header bands were trimmed** (2026-08-28) — `PptPreviewPane` and
+- **Both panes' header bands were trimmed** (2026-08-28) - `PptPreviewPane` and
   `WritableDocumentPane` share the same title + actions row, padded down from
-  `8px/16px` to `4px/12px` with their download control on the 24px `2xs` tier
-  (`small` before); the editor toolbar under it lost the same 4px. Two stacked bands
-  (the drawer's own header, then the pane's) were eating the top of the panel.
+  `8px/16px` to `4px/12px`; the editor toolbar under it lost the same 4px. Two
+  stacked bands (the drawer's own header, then the pane's) were eating the top of
+  the panel. The download controls keep `size="small"`: those components are shared
+  with the chat cards, where the smaller tier would have broken alignment.
 
 Both capability slices now stamp the conversation their state belongs to, so a deck or a
 document from a previous conversation can no longer light a launcher up on a fresh chat.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3613,6 +3613,17 @@ a session's active capabilities declare. Two changes (#2459):
   that drawer's own close button. Moving the remaining launchers into the drawer's
   `headerActions` was tried the same day and dropped: closing the open panel to reach
   another one is cheap, and one home for the launchers beats two (developer decision).
+- **The drawer's own title band is gone for both panes** (2026-08-28). A pane that
+  names the artefact it holds does not also need the drawer naming the panel above
+  it - two title rows said the same thing twice and ate the top of the column. A
+  panel declares `ownsHeader: true` on its `sidePanels` spec; the host then passes
+  `InlineDrawer`'s new `hideHeader` (the drawer keeps `title` as its accessible
+  name) plus `flushBody`, and the pane renders its own close button. `demo_echo`,
+  which has no header of its own, keeps the drawer's.
+- **Switching conversations closes any open push drawer** (2026-08-28). Opening one
+  is a statement about one conversation and every panel reads the open session, so
+  a drawer carried across sat there empty. A capability whose new conversation
+  warrants its panel asks for it again through the open-request counter.
 - **Both panes' header bands were trimmed** (2026-08-28) - `PptPreviewPane` and
   `WritableDocumentPane` share the same title + actions row, padded down from
   `8px/16px` to `4px/12px`; the editor toolbar under it lost the same 4px. Two

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -3577,3 +3577,35 @@ root card above the table was tried on 2026-08-21 and removed the same day
   option silently missing.
 - All affordances are display-only mirrors; every action is re-checked
   server-side (403/404/409 mapped to toasts via `useApiErrorToast`).
+
+---
+
+### Capability side-panel launcher rail (2026-08-28)
+
+**Location:** `src/rework/features/capabilities/CapabilitySidePanelHost.tsx`,
+`src/rework/features/capabilities/<id>/plugin.ts`
+
+**Status:** `Functional`
+
+The floating rail on the chat page's right edge, one small icon button per side panel
+a session's active capabilities declare. Two changes (#2459):
+
+- **A launcher appears only once its panel has something to show.** The rail used to
+  render one button per DECLARED panel, so activating `ppt_filler` + `writable_document`
+  put two buttons onto empty panels from the first message. Each plugin now answers for
+  the open conversation through a `useHasContent` hook on its `sidePanels` spec
+  (ppt_filler: a deck was rendered; writable_document: the list API or a live snapshot
+  holds a document); a panel that omits the hook stays always-on. The rail is invisible
+  chrome until the agent actually produces something.
+- **Each panel carries its own glyph** instead of the `edit_note` the host hardcoded for
+  every one of them. `ppt_filler` → `slideshow`, `writable_document` → `edit_note` — each
+  one the glyph that capability's own chat card already uses for "open this", so the
+  launcher and the card read as one affordance. Colour stays the rail's neutral
+  `on-surface-retreat`: the launchers sit in the same floating-chrome band as the trace
+  and attachments buttons, and tinting only these two would break that band.
+- **The rail dropped to 68px from the top** (2026-08-28). Its 48px offset was computed
+  against a one-line top bar; the bar now stacks a 24px title over a 20px agent name, so
+  the first launcher sat on the band.
+
+Both capability slices now stamp the conversation their state belongs to, so a deck or a
+document from a previous conversation can no longer light a launcher up on a fresh chat.


### PR DESCRIPTION
Closes #2459.

> **Merge order:** reads best **after** #2464. The two touch disjoint files so either order merges cleanly, but this PR makes the PPT launcher conditional and #2464 is what gives it a signal that survives a reload.

## What changes

**Before**: the chat page's floating rail rendered one icon per *declared* side panel. A session with `ppt_filler` + `writable_document` active showed two buttons onto empty panels from the very first message, and both carried the same `edit_note` glyph hardcoded in the host.

**After**: a launcher appears only when its panel has something to show for the open conversation, and each capability picks its own glyph.

| Capability | Glyph | Shown when |
| --- | --- | --- |
| `ppt_filler` | `slideshow` | a deck card was rendered in the conversation |
| `writable_document` | `edit_document` | the conversation holds at least one document (list API or live snapshot) |
| `demo_echo` | `edit_note` | always (no hook, unchanged) |

`edit_document` (the page-with-a-pencil) is a new `materialIcons` entry; the whole `writable_document` surface moves onto it - card, Open button, pane header - so the launcher carries the glyph of what it opens.

## Plugin contract

`CapabilityUiPlugin.sidePanels` goes from `Record<widget, Component>` to a descriptor:

```ts
sidePanels: {
  ppt_preview_pane: {
    Component: PptPreviewPane,
    icon: "slideshow",
    useHasContent: useHasPptPreview,
    ownsHeader: true,
  },
},
```

`useHasContent` is optional - without it the launcher is always offered. The host renders each launcher as its own component, otherwise the hook would shift position the moment a session gains or loses a capability.

## Launcher rail

- **Dropped to 68px.** The 48px offset was computed against a one-line top bar; the bar now stacks a title (24px) over the agent name (20px), so the first launcher sat on the band.
- **Retired entirely while a panel is open.** It is absolutely positioned over the whole slot, drawer included, so it landed on the drawer's own close button. Moving the remaining launchers into the drawer's `headerActions` was tried and dropped: closing the open panel to reach another one is cheap, and one home for the launchers beats two.

## Panel headers

- **The drawer's own title band is gone for both panes.** A pane that names the artefact it holds does not also need the drawer naming the panel above it. A panel declares `ownsHeader: true`; the host passes `InlineDrawer`'s new `hideHeader` (the drawer keeps `title` as its accessible name) plus `flushBody`, and the pane renders its own close button. `demo_echo`, which has no header of its own, keeps the drawer's.
- The shared title + actions row went from `8px/16px` to `4px/12px`; the editor toolbar lost the same 4px. The download controls keep `size="small"`: those components are shared with the chat cards, where the smaller tier broke alignment.

## Session leaks fixed

Both capability slices now stamp the conversation their state belongs to. Without it, a deck or a document from a previous conversation lit the launcher up on a fresh chat.

On the ppt side that let `openRequestId` go (a counter nothing read) and collapsed `openPreview`/`setPreview` into one action: every rendered card registers its deck, history replay included, and only a live fill asks the page to open the panel.

Three more, all the same class:

- **The conversation stamp comes from mount, not from the URL.** On a conversation switch the *outgoing* conversation's cards re-render once (the thread is cleared in a parent effect, which runs after theirs), so they stamped their part with the *incoming* conversation's id. Both card renderers go through `useMountSessionId()`, next to a `useOpenSessionId()` that replaces the copy of the `?session=` read each renderer carried.
- **`currentData` instead of `data`** for writable_document's visibility, its editor pane and its auto-open probe - `data` keeps the last resolved result across an arg change, so all three answered for the conversation just left.
- **The editor's tab strip is scoped too.** Live snapshots outlive the conversation that produced them (the slice only drops them when the next conversation upserts one of its own), so a conversation whose documents all came from the API showed the previous conversation's document as an extra tab - someone else's document, in an editor that autosaves.

## Two more bugs fixed along the way

- **Capability queries fired before routing was known.** On a hard page load the catalog/prep answer carrying a capability's base URL lands after the first render. `createCapabilityBaseQuery` fails loudly when it is missing and RTK Query caches that failure against args that never change again, so `writable_document` looked empty for the whole page load - no launcher, no auto-open, empty editor - while navigating back into the same conversation worked. Every hook on a capability API now waits on `useCapabilityRouted`.
- **Switching conversations closes any open push drawer.** Opening one is a statement about one conversation and every panel reads the open session, so a drawer carried across sat there empty.

## Known limitation

The PPT launcher stays dark after a hard reload, because its cards are not replayed from history and it has no list endpoint to compensate. Root cause and fix in **#2462** / PR #2464.

## Tests

- `CapabilitySidePanelHost.test.tsx` (new) - rail hidden without content, shown with, per-panel glyph, rail retired while a panel is open, drawer title band dropped for a panel that owns one.
- `useSessionPptPreview.test.tsx` (new) - a deck from another conversation does not count.
- `useHasWritableDocuments.test.tsx` (new) - live write the list has not caught up with, leftover snapshots from another conversation, answer not yet arrived, answer still held from the conversation just left, capability not yet routed.
- `useWritableDocuments.test.tsx` (new) - another conversation's document never reaches the tab strip.
- `sidePanelRegistry.test.tsx` - adapted to the descriptor, plus the hook reaching the host.

Root `make code-quality` green, 1496 frontend tests green.

## Docs

- `docs/swift/capabilities/AUTHORING.md` - declaring a panel and its launcher, plus the "skip until the capability is routed / `currentData` for anything scoped to the open conversation" rule.
- `docs/swift/ux/COMPONENT-UX.md` - dated entry for the launcher rail.
- `docs/swift/rfc/AGENT-CAPABILITY-PRESENTATION.html` - the slide's `sidePanels` snippet showed the old shape.
