### PR TITLE
docs(#2465): cap code comments at 2-3 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,14 @@ implement authorless, untracked work.
 
 **Step 4 — Implementation.** Write the code. Coding constraints: `docs/CONVENTIONS.md`.
 
+**Keep code comments to 2-3 lines.** Say the "why" the code cannot show, then
+stop. A comment that re-narrates the decision, lists the alternatives, or
+restates what the next line does is noise the next reader has to skim past —
+and it goes stale faster than the code. When the reasoning genuinely needs
+more room, write it in the relevant compact doc and point at it from the code
+("Full rationale: COMPONENT-UX.md"). This applies to file headers too: a few
+lines on what the module is for, not an essay.
+
 **Step 5 — Verification.** In the touched project root:
 
 ```


### PR DESCRIPTION
Closes #2465.

Adds one rule next to Step 4 of the task lifecycle in `CLAUDE.md`: say the "why" the code cannot show, then stop. A comment that re-narrates the decision, lists the alternatives, or restates the next line is noise the next reader skims past, and it goes stale faster than the code. Long reasoning goes in the relevant compact doc with a pointer from the code; file headers get a few lines on what the module is for, not an essay.

Instruction-only change - no code touched.