### PR TITLE
fix(#2468): PDFWorker.fromPort crash when a deck is re-filled

### DIFF
--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewCardRenderer.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewCardRenderer.tsx
@@ -26,10 +26,10 @@
 // once, and only if the page has been open for >5s (history replay happens in the
 // first moments after load; a live fill happens well after).
 //
-// Every mount still REGISTERS the deck (`setPreview`), replay included: that is
-// what tells the pane's launcher this conversation produced something, without
-// popping the panel open. It registers under the conversation the card was mounted
-// for (`useMountSessionId`), never the one the user just switched to.
+// Every mount REGISTERS the deck, replay included: that is what tells the pane's
+// launcher this conversation produced something. Registering never moves what the
+// pane shows - only an explicit open does, because the pane keys its pdf.js worker
+// on that value.
 
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
@@ -40,7 +40,7 @@ import { requestSidePanelOpen } from "../sidePanelOpenRequestSlice";
 import { useMountSessionId } from "../useOpenSessionId";
 import type { UiPartRendererProps } from "../types";
 import type { PptPreviewPartData } from "./types";
-import { setPreview } from "./pptPreviewSlice";
+import { openPreview, registerPreview } from "./pptPreviewSlice";
 import PptxDownloadButton from "./PptxDownloadButton";
 import styles from "./PptPreviewCardRenderer.module.css";
 
@@ -60,7 +60,7 @@ export function PptPreviewCardRenderer({ part }: UiPartRendererProps) {
   // Opening = register the deck AND signal the page to open the ppt_filler
   // side-panel column (the page owns the single-push-drawer state).
   const openPane = (data: PptPreviewPartData) => {
-    dispatch(setPreview({ sessionId, preview: data }));
+    dispatch(openPreview({ sessionId, preview: data }));
     dispatch(requestSidePanelOpen({ capabilityId: "ppt_filler", widget: "ppt_preview_pane" }));
   };
 
@@ -70,8 +70,8 @@ export function PptPreviewCardRenderer({ part }: UiPartRendererProps) {
     // Mark seen regardless, so a history-replay mount never auto-opens later and a
     // live fill only pops the panel the first time its part arrives.
     seenKeys.add(key);
+    dispatch(registerPreview({ sessionId, preview }));
     if (firstSighting && Date.now() - pageLoadedAt > AUTO_OPEN_MIN_AGE_MS) openPane(preview);
-    else dispatch(setPreview({ sessionId, preview }));
     // Intentionally keyed on the deck identity and conversation; `preview`/`dispatch`
     // are stable per that identity for this heuristic.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
@@ -89,6 +89,14 @@ export function PptPreviewPane({ onClose }: CapabilitySidePanelProps) {
   // effect below terminates the exact instance this run created.
   const workerRef = useRef<Worker | null>(null);
   useMemo(() => {
+    if (!objectUrl) {
+      // Nothing to load this round (no deck, or a re-fill in flight). Releasing
+      // the port is what lets the outgoing worker's cleanup see itself orphaned
+      // and terminate at once, instead of lingering until the pane unmounts.
+      pdfjs.GlobalWorkerOptions.workerPort = null;
+      workerRef.current = null;
+      return;
+    }
     if (typeof Worker === "undefined") {
       pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
       workerRef.current = null;

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.tsx
@@ -77,19 +77,18 @@ export function PptPreviewPane({ onClose }: CapabilitySidePanelProps) {
 
   // A re-fill (or switching decks) changes this key → react-pdf remounts the
   // <Document> and we provision a fresh worker for it.
-  const remountKey = current ? `${current.preview_id}:${current.version}` : NO_PREVIEW_KEY;
+  //
+  // The blob URL is part of it because pdf.js caches one PDFWorker per PORT: a
+  // second `getDocument` on a port whose worker is still tearing down throws
+  // "PDFWorker.fromPort - the worker is being destroyed". Keying on the deck alone
+  // let a new `file` reuse the port of the load it replaces, which is exactly that.
+  const remountKey = current ? `${current.preview_id}:${current.version}:${objectUrl ?? ""}` : NO_PREVIEW_KEY;
 
   // Provision a fresh worker for THIS remount before the child <Document> reads
   // GlobalWorkerOptions (useMemo runs during render, ahead of child effects). The
   // effect below terminates the exact instance this run created.
   const workerRef = useRef<Worker | null>(null);
   useMemo(() => {
-    // No deck for this conversation: the body renders the empty state, no
-    // <Document> reads the port, so a worker here would only wait to be killed.
-    if (remountKey === NO_PREVIEW_KEY) {
-      workerRef.current = null;
-      return;
-    }
     if (typeof Worker === "undefined") {
       pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl.toString();
       workerRef.current = null;

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.worker.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/PptPreviewPane.worker.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The pane's pdf.js worker budget, iteration after iteration.
+//
+// Each worker is a real thread loading the pdf.js bundle, and each PORT may serve
+// exactly one load - pdf.js caches a PDFWorker per port and throws
+// "the worker is being destroyed" on the second. So the invariant is narrow:
+// ONE worker per document actually loaded, none while a fetch is in flight, and
+// every one of them terminated. This test counts them across a re-fill loop,
+// which is what a user correcting a deck does over and over.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const workers = vi.hoisted(() => ({ created: [] as { terminated: boolean }[] }));
+
+class FakeWorker {
+  terminated = false;
+  constructor() {
+    workers.created.push(this);
+  }
+  terminate() {
+    this.terminated = true;
+  }
+}
+vi.stubGlobal("Worker", FakeWorker);
+
+const preview = vi.hoisted(() => ({ url: null as string | null }));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (_k: string, o?: { defaultValue?: string }) => o?.defaultValue ?? "" }),
+}));
+vi.mock("@shared/atoms/Icon/Icon", () => ({ default: () => null }));
+vi.mock("@shared/atoms/IconButton/IconButton", () => ({ default: () => null }));
+vi.mock("./PptxDownloadButton", () => ({ default: () => null }));
+vi.mock("react-pdf/dist/Page/AnnotationLayer.css", () => ({}));
+
+// react-pdf is the consumer of the port; the counts are what matter here.
+vi.mock("react-pdf", () => ({
+  Document: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: { workerPort: null as unknown, workerSrc: "" } },
+}));
+
+vi.mock("./usePptPreview", () => ({
+  usePptPreview: () => ({
+    objectUrl: preview.url,
+    isLoading: preview.url === null,
+    error: null,
+    refetch: () => undefined,
+  }),
+}));
+
+const deck = vi.hoisted(() => ({ current: null as unknown }));
+vi.mock("./useSessionPptPreview", () => ({ useSessionPptPreview: () => deck.current }));
+
+const { PptPreviewPane } = await import("./PptPreviewPane");
+
+let container: HTMLDivElement;
+let root: Root;
+
+const render = () =>
+  act(() => {
+    root.render(<PptPreviewPane capabilityId="ppt_filler" onClose={() => undefined} />);
+  });
+
+/** One fill: the fetch is in flight, then its blob lands. */
+function fill(version: string, url: string) {
+  deck.current = { type: "ppt_preview", preview_id: "p1", title: "d", pdf_download_url: "/d", version };
+  preview.url = null;
+  render();
+  preview.url = url;
+  render();
+}
+
+beforeEach(() => {
+  workers.created = [];
+  preview.url = null;
+  deck.current = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("PptPreviewPane pdf.js worker budget", () => {
+  it("spawns nothing while there is no deck to render", () => {
+    render();
+    expect(workers.created).toHaveLength(0);
+  });
+
+  it("spawns nothing while a fill is still fetching", () => {
+    deck.current = { type: "ppt_preview", preview_id: "p1", title: "d", pdf_download_url: "/d", version: "v1" };
+    render();
+
+    expect(workers.created).toHaveLength(0);
+  });
+
+  it("spawns exactly one worker per rendered document, ten re-fills deep", () => {
+    for (let i = 1; i <= 10; i++) fill(`v${i}`, `blob:${i}`);
+
+    expect(workers.created).toHaveLength(10);
+  });
+
+  it("leaves at most one worker alive: every superseded one is terminated", () => {
+    for (let i = 1; i <= 10; i++) fill(`v${i}`, `blob:${i}`);
+
+    expect(workers.created.filter((w) => !w.terminated)).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/pptPreviewSlice.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/pptPreviewSlice.ts
@@ -27,10 +27,16 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { PptPreviewPartData } from "./types";
 
 export interface PptPreviewState {
-  /** The conversation `current` belongs to; a write from another one replaces it. */
+  /** The conversation this state belongs to; a write from another one replaces it. */
   sessionId: string | null;
-  /** The deck the side panel should render, or null before any deck exists. */
+  /**
+   * The deck the pane renders. Only an explicit open moves it: the pane keys its
+   * pdf.js worker on this value, and that lifecycle does not survive a value that
+   * churns with re-renders.
+   */
   current: PptPreviewPartData | null;
+  /** This conversation produced at least one deck (drives the launcher). */
+  produced: boolean;
 }
 
 // Local root-state shape — avoids a circular import with common/store.tsx. The
@@ -39,33 +45,51 @@ interface PptPreviewRootState {
   pptPreview: PptPreviewState;
 }
 
-const initialState: PptPreviewState = { sessionId: null, current: null };
+const initialState: PptPreviewState = { sessionId: null, current: null, produced: false };
+
+/** A write from another conversation starts that conversation's state from scratch. */
+function rebase(state: PptPreviewState, sessionId: string): void {
+  if (state.sessionId === sessionId) return;
+  state.sessionId = sessionId;
+  state.current = null;
+  state.produced = false;
+}
 
 export const pptPreviewSlice = createSlice({
   name: "pptPreview",
   initialState,
   reducers: {
     /**
-     * Register the deck a rendered `ppt_preview` card refers to, stamped with the
-     * conversation it came from. Every card mount writes here - history replay
-     * included - so the pane and its launcher know a conversation produced a deck
-     * without the card having to open anything.
+     * Every rendered card registers its deck, history replay included: that is how
+     * the launcher knows this conversation produced one. It seeds `current` only
+     * while the pane has nothing, so later re-renders cannot move what it shows.
      */
-    setPreview(state, action: PayloadAction<{ sessionId: string; preview: PptPreviewPartData }>) {
-      state.sessionId = action.payload.sessionId;
+    registerPreview(state, action: PayloadAction<{ sessionId: string; preview: PptPreviewPartData }>) {
+      rebase(state, action.payload.sessionId);
+      state.produced = true;
+      if (state.current === null) state.current = action.payload.preview;
+    },
+
+    /** Show this deck in the pane - a card's Open button, or a live fill. */
+    openPreview(state, action: PayloadAction<{ sessionId: string; preview: PptPreviewPartData }>) {
+      rebase(state, action.payload.sessionId);
+      state.produced = true;
       state.current = action.payload.preview;
     },
   },
 });
 
-export const { setPreview } = pptPreviewSlice.actions;
+export const { registerPreview, openPreview } = pptPreviewSlice.actions;
 
 // ── Selectors ─────────────────────────────────────────────────────────────────
 
-/** The registered deck, whichever conversation it came from (scope with the hook). */
+/** The deck the pane should render, whichever conversation it came from. */
 export const selectCurrentPreview = (state: PptPreviewRootState): PptPreviewPartData | null => state.pptPreview.current;
 
-/** The conversation the registered deck belongs to, or null. */
+/** Did the registered conversation produce a deck at all? */
+export const selectPptPreviewProduced = (state: PptPreviewRootState): boolean => state.pptPreview.produced;
+
+/** The conversation this state belongs to, or null. */
 export const selectPptPreviewSessionId = (state: PptPreviewRootState): string | null => state.pptPreview.sessionId;
 
 export default pptPreviewSlice.reducer;

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/usePptPreview.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/usePptPreview.ts
@@ -65,6 +65,9 @@ export function usePptPreview(preview: PptPreviewPartData | null): UsePptPreview
 
     let cancelled = false;
     let created: string | null = null;
+    // The previous run's cleanup revoked its URL; keeping it in state would hand
+    // react-pdf a dead blob for the length of the re-fetch.
+    setObjectUrl(null);
     setIsLoading(true);
     setError(null);
 

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.test.tsx
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The registered deck is global state but belongs to ONE conversation. Without
-// the session stamp a deck filled in a previous conversation would light the
-// launcher up on a brand-new chat, which is the whole thing this scoping exists
-// to prevent.
+// Two things this state has to get right: the deck belongs to ONE conversation
+// (without the stamp, a deck filled earlier lights the launcher up on a brand-new
+// chat), and what the pane shows moves only on an explicit open - the pane keys
+// its pdf.js worker on it, and that lifecycle does not survive a churning value.
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { pptPreviewSlice, setPreview, type PptPreviewState } from "./pptPreviewSlice";
+import { openPreview, pptPreviewSlice, registerPreview, type PptPreviewState } from "./pptPreviewSlice";
 import type { PptPreviewPartData } from "./types";
 
 const state = vi.hoisted(() => ({ session: "", ppt: null as unknown }));
@@ -32,7 +32,7 @@ vi.mock("react-redux", () => ({
   useSelector: (selector: (s: { pptPreview: unknown }) => unknown) => selector({ pptPreview: state.ppt }),
 }));
 
-const { useSessionPptPreview } = await import("./useSessionPptPreview");
+const { useHasPptPreview, useSessionPptPreview } = await import("./useSessionPptPreview");
 
 const deck: PptPreviewPartData = {
   type: "ppt_preview",
@@ -42,9 +42,14 @@ const deck: PptPreviewPartData = {
   version: "v1",
 };
 
+const other: PptPreviewPartData = { ...deck, preview_id: "deck-2", title: "Kickoff", version: "v9" };
+
 /** The slice's own reducer builds the state, so the test can't drift from it. */
-function sliceState(sessionId: string): PptPreviewState {
-  return pptPreviewSlice.reducer(undefined, setPreview({ sessionId, preview: deck }));
+function sliceState(sessionId: string, ...actions: { type: string; payload: unknown }[]): PptPreviewState {
+  return actions.reduce(
+    (state, action) => pptPreviewSlice.reducer(state, action as never),
+    pptPreviewSlice.reducer(undefined, registerPreview({ sessionId, preview: deck })),
+  );
 }
 
 function read(openSession: string, ppt: PptPreviewState): PptPreviewPartData | null {
@@ -53,6 +58,18 @@ function read(openSession: string, ppt: PptPreviewState): PptPreviewPartData | n
   state.ppt = ppt;
   function Probe() {
     seen = useSessionPptPreview();
+    return null;
+  }
+  renderToStaticMarkup(<Probe />);
+  return seen;
+}
+
+function hasDeck(openSession: string, ppt: PptPreviewState): boolean {
+  let seen = false;
+  state.session = openSession;
+  state.ppt = ppt;
+  function Probe() {
+    seen = useHasPptPreview();
     return null;
   }
   renderToStaticMarkup(<Probe />);
@@ -70,5 +87,33 @@ describe("useSessionPptPreview", () => {
 
   it("returns nothing while no conversation is open", () => {
     expect(read("", sliceState("s1"))).toBeNull();
+  });
+
+  it("does not move the pane when another card registers its deck", () => {
+    // Registering is what lights the launcher up; moving the pane on it would
+    // rebuild the pdf.js worker under a document that is still loading.
+    const state = sliceState("s1", registerPreview({ sessionId: "s1", preview: other }));
+
+    expect(read("s1", state)).toEqual(deck);
+  });
+
+  it("moves the pane on an explicit open", () => {
+    const state = sliceState("s1", openPreview({ sessionId: "s1", preview: other }));
+
+    expect(read("s1", state)).toEqual(other);
+  });
+});
+
+describe("useHasPptPreview", () => {
+  it("is true once the open conversation has produced a deck", () => {
+    expect(hasDeck("s1", sliceState("s1"))).toBe(true);
+  });
+
+  it("ignores a deck produced by another conversation", () => {
+    expect(hasDeck("s2", sliceState("s1"))).toBe(false);
+  });
+
+  it("is false before any deck", () => {
+    expect(hasDeck("s1", pptPreviewSlice.reducer(undefined, { type: "init" }))).toBe(false);
   });
 });

--- a/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.ts
+++ b/apps/frontend/src/rework/features/capabilities/ppt_filler/useSessionPptPreview.ts
@@ -25,7 +25,7 @@
 
 import { useSelector } from "react-redux";
 import { useOpenSessionId } from "../useOpenSessionId";
-import { selectCurrentPreview, selectPptPreviewSessionId } from "./pptPreviewSlice";
+import { selectCurrentPreview, selectPptPreviewProduced, selectPptPreviewSessionId } from "./pptPreviewSlice";
 import type { PptPreviewPartData } from "./types";
 
 export function useSessionPptPreview(): PptPreviewPartData | null {
@@ -37,5 +37,8 @@ export function useSessionPptPreview(): PptPreviewPartData | null {
 
 /** Launcher visibility for the ppt_filler side panel - see `CapabilitySidePanelSpec`. */
 export function useHasPptPreview(): boolean {
-  return useSessionPptPreview() !== null;
+  const sessionId = useOpenSessionId();
+  const produced = useSelector(selectPptPreviewProduced);
+  const previewSessionId = useSelector(selectPptPreviewSessionId);
+  return produced && sessionId !== "" && previewSessionId === sessionId;
 }


### PR DESCRIPTION
Closes #2468.

## The crash

Ask an agent to correct an existing PowerPoint and the app drops to the React error screen:

```
PDFWorker.fromPort - the worker is being destroyed.
Please remember to await `PDFDocumentLoadingTask.destroy()`-calls.
```

## Cause

pdf.js caches **one `PDFWorker` per port object**, and `fromPort` throws exactly this when handed a port whose cached worker is already tearing down - a second `getDocument` on a port the previous load has not finished destroying.

`PptPreviewPane` provisions one worker per `remountKey` and publishes it through `GlobalWorkerOptions.workerPort`, with `<Document key={remountKey}>` so a port serves exactly one load. Two things broke that 1:1:

1. **`remountKey` did not include the blob URL.** `usePptPreview` hands react-pdf a new `file` on every re-fetch; with the key unchanged, react-pdf destroys the running load and starts another one **on the same port**. That is the throw, verbatim.
2. **The pane's deck churned on re-render.** Every rendered `ppt_preview` card wrote the slice's `current`, so any card render could move what the pane shows - rebuilding its worker under a document still loading.

## Fix

- The blob URL joins `remountKey`, so every load gets its own port and no port is reused for a second `getDocument`.
- **A worker is provisioned only when there is something to render**, and the port is released when there is not. Keying on the blob URL alone would have doubled the spawns - one worker for the round where the fetch is still in flight, another when the blob lands - and each is a real thread loading the pdf.js bundle. Releasing the port is also what lets the outgoing worker's cleanup recognise itself as orphaned and terminate at once, instead of lingering until the pane unmounts.
- `usePptPreview` clears its object URL when a re-fetch starts. The previous run's cleanup already revoked that URL, so exposing it any longer handed react-pdf a dead blob for the length of the re-fetch.
- `pptPreviewSlice` separates the two things it was conflating:

  | | Moved by | Read by |
  | --- | --- | --- |
  | `produced` | any rendered card | the launcher |
  | `current` | an explicit open, or a live fill | the pane (and its worker key) |

  A card registering its deck no longer moves the pane. It still seeds `current` while the pane has nothing, so opening from the launcher has something to show.
- Drops the "skip the worker when there is no deck" shortcut added in #2459: it left `GlobalWorkerOptions.workerPort` pointing at a worker `workerRef` no longer tracked, so the cleanup could not reason about it. The lifecycle is back to what it was.

## Worker budget, measured

`PptPreviewPane.worker.test.tsx` (new) mounts the real pane with a stubbed `Worker` and counts, across ten re-fills - what a user correcting a deck does over and over:

| | Workers spawned | Alive at the end |
| --- | --- | --- |
| Keyed on the blob URL alone | 20 | 1 |
| With the idle guard | **10** | 1 |

One per document actually rendered, none while a fetch is in flight, none for an empty pane. The "alive" column is the reassuring part: the surplus was waste, never accumulation - every superseded worker was already terminated.

## Tests

- `PptPreviewPane.worker.test.tsx` (new) - the budget above.
- `useSessionPptPreview.test.tsx` - registering another deck does not move the pane, an explicit open does; the launcher marker is scoped to the open conversation and false before any deck.

Root `make code-quality` green, 1505 frontend tests green.

## Verifying

The failing path is manual: open a conversation with a deck, ask the agent to correct it, and watch the preview swap in place without the error screen.
