### PR TITLE
fix(#2471): home greeting reads given_name and falls back to none

### DIFF
--- a/apps/frontend/src/rework/components/pages/HomePage/HomePage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomePage.test.tsx
@@ -1,0 +1,54 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let givenName: string | null = null;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { name?: string }) => (opts?.name ? `${key}:${opts.name}` : key),
+  }),
+}));
+vi.mock("../../../../security/KeycloakService", () => ({
+  KeyCloakService: { GetUserGivenName: () => givenName },
+}));
+vi.mock("@shared/atoms/ButtonGroup/ButtonGroup.tsx", () => ({ default: () => null }));
+vi.mock("./HomeSearch/HomeSearch.tsx", () => ({ default: () => null }));
+vi.mock("./RecentAgents/RecentAgents.tsx", () => ({ default: () => null }));
+vi.mock("./ActivityKpis/ActivityKpis.tsx", () => ({ default: () => null }));
+vi.mock("./ResponsibleAiSection/ResponsibleAiSection.tsx", () => ({ default: () => null }));
+vi.mock("./TopAgents/TopAgents.tsx", () => ({ default: () => null }));
+vi.mock("./TopTeams/TopTeams.tsx", () => ({ default: () => null }));
+vi.mock("./MarketplaceTopPrompts/MarketplaceTopPrompts.tsx", () => ({ default: () => null }));
+
+import HomePage from "./HomePage";
+
+describe("HomePage greeting", () => {
+  beforeEach(() => {
+    givenName = null;
+  });
+
+  it("greets with the token given name, like the chat welcome does", () => {
+    givenName = "Ada";
+    expect(renderToStaticMarkup(<HomePage />)).toContain("rework.home.greetingNamed:Ada");
+  });
+
+  it("falls back to the unnamed greeting rather than showing an identifier", () => {
+    const html = renderToStaticMarkup(<HomePage />);
+    expect(html).toContain("rework.home.greeting<");
+    expect(html).not.toContain("greetingNamed");
+  });
+});

--- a/apps/frontend/src/rework/components/pages/HomePage/HomePage.tsx
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomePage.tsx
@@ -15,7 +15,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup.tsx";
-import { useFrontendBootstrap } from "../../../../hooks/useFrontendBootstrap";
+import { KeyCloakService } from "../../../../security/KeycloakService";
 import HomeSearch from "./HomeSearch/HomeSearch.tsx";
 import ActivityKpis from "./ActivityKpis/ActivityKpis.tsx";
 import RecentAgents from "./RecentAgents/RecentAgents.tsx";
@@ -36,12 +36,10 @@ const PERIODS: HomePeriod[] = [7, 30, 90];
  */
 export default function HomePage() {
   const { t } = useTranslation();
-  const { bootstrap } = useFrontendBootstrap();
-  const user = bootstrap?.current_user;
-  const rawFirstName = user?.first_name || user?.username || undefined;
-  // Capitalize the leading letter for the greeting (usernames often arrive
-  // lower-cased); the rest is left as-is so "jean-Marie" keeps its casing.
-  const firstName = rawFirstName ? rawFirstName.charAt(0).toUpperCase() + rawFirstName.slice(1) : undefined;
+  // Same source as the chat welcome: the `given_name` claim. The bootstrap
+  // payload has no first name and its `username` is an opaque identifier on
+  // real realms, so no name here means the unnamed greeting, never an id.
+  const firstName = KeyCloakService.GetUserGivenName() || undefined;
 
   // Default to 30 days (index 1 in PERIODS) — a fuller picture than 7 on landing.
   const [periodIndex, setPeriodIndex] = useState(1);


### PR DESCRIPTION
Closes #2471.

## Problem

In production the home page greets the user with a raw Keycloak identifier.
The chat start screen greets the same user correctly, because the two pages
resolve the name from two different sources.

## Fix

`HomePage` now reads `KeyCloakService.GetUserGivenName()` - the `given_name`
token claim, exactly what `ManagedChatWelcome` already uses. The bootstrap
fallback chain (`current_user.first_name || current_user.username`) is gone:
`UserSummary.from_keycloak_user` never fills `first_name`, and `username`
carries `preferred_username`, which is the opaque id on the prod realm. A
missing claim now yields the unnamed greeting instead of an identifier.

`HomePage` no longer subscribes to `useFrontendBootstrap` at all.

## Not done here

Filling `first_name` in `UserSummary.from_keycloak_user` would add a Keycloak
admin lookup to `/frontend/bootstrap`, the endpoint #2148 made cheaper. The
claim is already in the token, so it is not worth it for a greeting.

## Tests

New `HomePage.test.tsx`: named greeting from the claim, and unnamed fallback
when the claim is absent.