### PR TITLE
fix(#1645): keep md tables whole and return their chunks in order (on ingestion + retrieval)

### DIFF
--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -2118,7 +2118,7 @@ export type VectorSearchHit = {
   slide_id?: number | null;
   has_visual_evidence?: boolean | null;
   slide_image_uri?: string | null;
-  /** content (default, real ingested prose/data) or 'dataset_pointer' (a discovery pointer to a structured dataset, never citable as a source). */
+  /** content (default, real ingested prose/data) or 'dataset_pointer' (a discovery pointer to a structured dataset, never citable as a source) or 'markdown_table' (a Markdown table kept whole or split on row boundaries). */
   chunk_kind?: string | null;
   /** Document UID */
   uid: string;

--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -414,6 +414,15 @@ const injectedRtkApi = api.injectEndpoints({
     testPostSuccess: build.mutation<TestPostSuccessApiResponse, TestPostSuccessApiArg>({
       query: () => ({ url: `/knowledge-flow/v1/vector/test`, method: "POST" }),
     }),
+    getDocumentChunksOrdered: build.query<GetDocumentChunksOrderedApiResponse, GetDocumentChunksOrderedApiArg>({
+      query: (queryArg) => ({
+        url: `/knowledge-flow/v1/vector/document-chunks`,
+        params: {
+          document_uid: queryArg.documentUid,
+          limit: queryArg.limit,
+        },
+      }),
+    }),
     rerankDocuments: build.mutation<RerankDocumentsApiResponse, RerankDocumentsApiArg>({
       query: (queryArg) => ({ url: `/knowledge-flow/v1/vector/rerank`, method: "POST", body: queryArg.rerankRequest }),
     }),
@@ -1241,6 +1250,11 @@ export type GetVisualEvidenceArtifactApiArg = {
 };
 export type TestPostSuccessApiResponse = /** status 200 Successful Response */ VectorSearchHit[];
 export type TestPostSuccessApiArg = void;
+export type GetDocumentChunksOrderedApiResponse = /** status 200 Successful Response */ VectorSearchHit[];
+export type GetDocumentChunksOrderedApiArg = {
+  documentUid: string;
+  limit?: number;
+};
 export type RerankDocumentsApiResponse = /** status 200 Successful Response */ VectorSearchHit[];
 export type RerankDocumentsApiArg = {
   rerankRequest: RerankRequest;
@@ -2132,6 +2146,8 @@ export type VectorSearchHit = {
   /** Similarity score from vector search */
   score: number;
   rank?: number | null;
+  /** Position of the chunk inside its source document, used to restore document order */
+  chunk_index?: number | null;
   embedding_model?: string | null;
   vector_index?: string | null;
   token_count?: number | null;
@@ -2642,6 +2658,8 @@ export const {
   useGetVisualEvidenceArtifactQuery,
   useLazyGetVisualEvidenceArtifactQuery,
   useTestPostSuccessMutation,
+  useGetDocumentChunksOrderedQuery,
+  useLazyGetDocumentChunksOrderedQuery,
   useRerankDocumentsMutation,
   useGetDocumentTreeKnowledgeFlowV1DocumentsTreePostMutation,
   useSummarizeDocumentKnowledgeFlowV1DocumentsDocumentUidSummarizePostMutation,

--- a/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
+++ b/apps/frontend/src/slices/runtime/runtimeOpenApi.ts
@@ -518,7 +518,9 @@ export type RuntimeErrorEvent = {
 export type FinishReason = "stop" | "length" | "content_filter" | "tool_calls" | "error" | "other";
 export type VectorSearchHit = {
   author?: string | null;
-  /** content (default, real ingested prose/data) or 'dataset_pointer' (a discovery pointer to a structured dataset, never citable as a source). */
+  /** Position of the chunk inside its source document, used to restore document order */
+  chunk_index?: number | null;
+  /** content (default, real ingested prose/data) or 'dataset_pointer' (a discovery pointer to a structured dataset, never citable as a source) or 'markdown_table' (a Markdown table kept whole or split on row boundaries). */
   chunk_kind?: string | null;
   citation_url?: string | null;
   confidential?: boolean | null;

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/vectorization_processor/semantic_splitter.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/vectorization_processor/semantic_splitter.py
@@ -16,6 +16,7 @@ import logging
 import re
 from typing import List, Tuple
 
+from fred_core.store.vector_search import MARKDOWN_TABLE_CHUNK_KIND
 from langchain_core.documents import Document
 from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
 
@@ -63,6 +64,20 @@ def _build_ws_tolerant_pattern(needle: str) -> str:
     return "".join(parts)
 
 
+def _fragment_metadata(parent: dict, offset: int, length: int) -> dict:
+    """Metadata for a slice of a chunk, with the anchor narrowed to that slice.
+
+    Splitting a chunk around a table placeholder yields several fragments; copying the
+    parent anchor verbatim would deep-link them all at the same wrong span.
+    """
+    metadata = dict(parent or {})
+    start = metadata.get("char_start")
+    if isinstance(start, int):
+        metadata["char_start"] = start + offset
+        metadata["char_end"] = start + offset + length
+    return metadata
+
+
 class SemanticSplitter(BaseTextSplitter):
     def __init__(self, chunk_size: int = 1500, chunk_overlap: int = 150, preserve_tables: bool = True):
         """
@@ -106,6 +121,7 @@ class SemanticSplitter(BaseTextSplitter):
         auto_idx = 0
         in_fence = False
         fence_token: str | None = None
+        annotated = False
 
         while i < len(lines):
             line = lines[i]
@@ -140,6 +156,12 @@ class SemanticSplitter(BaseTextSplitter):
                     i += 1
                 continue
 
+            # A 4-space indent is an indented code block, not a table.
+            if line[:4] == "    ":
+                out.append(line)
+                i += 1
+                continue
+
             # Pipe table: a pipe-row immediately followed by a separator row.
             if i + 1 < len(lines) and _is_pipe_row(line) and _is_pipe_separator(lines[i + 1]):
                 start = i
@@ -152,12 +174,17 @@ class SemanticSplitter(BaseTextSplitter):
                     out.append(table_md)
                     out.append("<!-- TABLE_END -->")
                     auto_idx += 1
+                    annotated = True
                 continue
 
             out.append(line)
             i += 1
 
-        # Preserve a single trailing newline if the original text had one.
+        # Rebuilding through splitlines() would normalise CRLF and the exotic line
+        # breaks it splits on, shifting every char offset. Only pay that when a table
+        # was actually wrapped.
+        if not annotated:
+            return text
         result = "\n".join(out)
         if text.endswith("\n") and not result.endswith("\n"):
             result += "\n"
@@ -196,7 +223,10 @@ class SemanticSplitter(BaseTextSplitter):
 
         Preserves the table header + separator row in **every** chunk and stamps
         metadata so consumers can re-stitch the table or filter on
-        ``block_type=='markdown_table'``. Row order is preserved.
+        ``chunk_kind == MARKDOWN_TABLE_CHUNK_KIND``. Row order is preserved.
+
+        The ``table_*`` and ``row_*`` keys are splitter-local: metadata
+        sanitisation drops them, only ``chunk_kind`` is persisted.
 
         Args:
             table_md (str): The Markdown string of the full table.
@@ -211,8 +241,7 @@ class SemanticSplitter(BaseTextSplitter):
                 Document(
                     page_content=table_md,
                     metadata={
-                        "is_table": True,
-                        "block_type": "markdown_table",
+                        "chunk_kind": MARKDOWN_TABLE_CHUNK_KIND,
                         "table_id": table_id,
                         "table_chunk_id": 0,
                         "table_part": 0,
@@ -239,8 +268,7 @@ class SemanticSplitter(BaseTextSplitter):
                 Document(
                     page_content=f"{header}\n{chr(10).join(current_rows)}",
                     metadata={
-                        "is_table": True,
-                        "block_type": "markdown_table",
+                        "chunk_kind": MARKDOWN_TABLE_CHUNK_KIND,
                         "table_id": table_id,
                         "table_chunk_id": chunk_index,
                         "table_part": chunk_index,
@@ -377,12 +405,14 @@ class SemanticSplitter(BaseTextSplitter):
 
             prev_end = 0
             for m in _placeholder_re.finditer(chunk_text):
-                before = chunk_text[prev_end : m.start()].strip()
+                raw_before = chunk_text[prev_end : m.start()]
+                before = raw_before.strip()
                 if before:
+                    offset = prev_end + len(raw_before) - len(raw_before.lstrip())
                     final_chunks.append(
                         Document(
                             page_content=before,
-                            metadata=dict(chunk.metadata or {}),
+                            metadata=_fragment_metadata(chunk.metadata, offset, len(before)),
                         )
                     )
 
@@ -394,8 +424,7 @@ class SemanticSplitter(BaseTextSplitter):
                             Document(
                                 page_content=table_md,
                                 metadata={
-                                    "is_table": True,
-                                    "block_type": "markdown_table",
+                                    "chunk_kind": MARKDOWN_TABLE_CHUNK_KIND,
                                     "table_id": table_id,
                                     "table_chunk_id": 0,
                                     "table_part": 0,
@@ -407,12 +436,14 @@ class SemanticSplitter(BaseTextSplitter):
 
                 prev_end = m.end()
 
-            tail = chunk_text[prev_end:].strip()
+            raw_tail = chunk_text[prev_end:]
+            tail = raw_tail.strip()
             if tail:
+                offset = prev_end + len(raw_tail) - len(raw_tail.lstrip())
                 final_chunks.append(
                     Document(
                         page_content=tail,
-                        metadata=dict(chunk.metadata or {}),
+                        metadata=_fragment_metadata(chunk.metadata, offset, len(tail)),
                     )
                 )
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/vectorization_processor/semantic_splitter.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/output/vectorization_processor/semantic_splitter.py
@@ -25,6 +25,27 @@ logger = logging.getLogger(__name__)
 
 _WS_CLASS = r"[ \t\r\n\u00A0]+"  # space, tabs, CR/LF, NBSP
 
+# Marker shape used to protect tables across the pipeline. The PDF/DOCX
+# processors emit numeric ids; here we use an "auto_" prefix so we never
+# collide with annotations produced upstream.
+_TABLE_START_RE = re.compile(r"^\s*<!--\s*TABLE_START:id=([^\s>]+?)\s*-->\s*$")
+_TABLE_END_RE = re.compile(r"^\s*<!--\s*TABLE_END\s*-->\s*$")
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def _is_pipe_row(line: str) -> bool:
+    s = line.strip()
+    return "|" in s and not s.startswith("```") and not s.startswith("~~~")
+
+
+def _is_pipe_separator(line: str) -> bool:
+    """Markdown table separator: only `|`, `-`, `:`, whitespace; at least one of each
+    `|` and `-`."""
+    s = line.strip()
+    if "|" not in s or "-" not in s:
+        return False
+    return all(ch in "|-: \t" for ch in s)
+
 
 def _build_ws_tolerant_pattern(needle: str) -> str:
     """Turn needle into a regex: collapse any whitespace runs to [_WS_CLASS]+."""
@@ -49,11 +70,98 @@ class SemanticSplitter(BaseTextSplitter):
         Args:
             chunk_size (int, optional): The maximum number of characters in each chunk. Defaults to 1500.
             chunk_overlap (int, optional): The number of overlapping characters between consecutive chunks. Defaults to 150.
-            preserve_tables (bool, optional): If true, keep annotated markdown tables intact. Defaults to True.
+            preserve_tables (bool, optional): If true, plain Markdown pipe tables are detected and
+                kept as atomic blocks. Tables already annotated by the PDF/DOCX processors are
+                preserved either way. Defaults to True.
         """
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
         self.preserve_tables = preserve_tables
+
+    def _auto_annotate_unmarked_tables(self, text: str) -> str:
+        """
+        Detect plain (unannotated) Markdown pipe tables and wrap them with
+        ``<!-- TABLE_START:id=auto_N --> ... <!-- TABLE_END -->`` markers so the
+        rest of the splitter pipeline treats them as atomic blocks.
+
+        Why:
+            Table rows must not be split across chunks. Upstream
+            processors (DOCX, PDF) already annotate; ``.md`` / ``.txt`` and the
+            lightweight processors do not. Doing the detection here means light,
+            medium and rich ingestion modes all benefit without per-processor
+            duplication.
+
+        Detection rules (intentionally conservative):
+            - skip pre-existing TABLE_START/TABLE_END blocks untouched
+            - skip lines inside fenced code blocks (``` or ~~~)
+            - a table starts on a pipe-row whose next non-empty line is a
+              Markdown separator row (only ``|``, ``-``, ``:``, whitespace and
+              at least one of ``|`` and ``-``)
+            - the table extends through subsequent contiguous pipe-rows; a
+              blank line ends it
+        """
+        lines = text.splitlines()
+        out: list[str] = []
+        i = 0
+        auto_idx = 0
+        in_fence = False
+        fence_token: str | None = None
+
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.lstrip()
+
+            # Track fenced code blocks; pipes inside them are never tables.
+            if _FENCE_RE.match(line):
+                token = stripped[:3]
+                if not in_fence:
+                    in_fence = True
+                    fence_token = token
+                elif token == fence_token:
+                    in_fence = False
+                    fence_token = None
+                out.append(line)
+                i += 1
+                continue
+            if in_fence:
+                out.append(line)
+                i += 1
+                continue
+
+            # Preserve existing annotations untouched.
+            if _TABLE_START_RE.match(line):
+                out.append(line)
+                i += 1
+                while i < len(lines):
+                    out.append(lines[i])
+                    if _TABLE_END_RE.match(lines[i]):
+                        i += 1
+                        break
+                    i += 1
+                continue
+
+            # Pipe table: a pipe-row immediately followed by a separator row.
+            if i + 1 < len(lines) and _is_pipe_row(line) and _is_pipe_separator(lines[i + 1]):
+                start = i
+                i += 2  # consume header + separator
+                while i < len(lines) and lines[i].strip() and _is_pipe_row(lines[i]):
+                    i += 1
+                table_md = "\n".join(lines[start:i]).rstrip()
+                if table_md:
+                    out.append(f"<!-- TABLE_START:id=auto_{auto_idx} -->")
+                    out.append(table_md)
+                    out.append("<!-- TABLE_END -->")
+                    auto_idx += 1
+                continue
+
+            out.append(line)
+            i += 1
+
+        # Preserve a single trailing newline if the original text had one.
+        result = "\n".join(out)
+        if text.endswith("\n") and not result.endswith("\n"):
+            result += "\n"
+        return result
 
     def _extract_and_replace_tables(self, text: str) -> Tuple[str, dict]:
         """
@@ -86,7 +194,9 @@ class SemanticSplitter(BaseTextSplitter):
         """
         Splits a large Markdown table into smaller chunks based on the configured chunk size.
 
-        Preserves the table header in each chunk and adds metadata including table ID and chunk index.
+        Preserves the table header + separator row in **every** chunk and stamps
+        metadata so consumers can re-stitch the table or filter on
+        ``block_type=='markdown_table'``. Row order is preserved.
 
         Args:
             table_md (str): The Markdown string of the full table.
@@ -97,27 +207,61 @@ class SemanticSplitter(BaseTextSplitter):
         """
         lines = table_md.strip().split("\n")
         if len(lines) < 3:
-            return [Document(page_content=table_md, metadata={"is_table": True, "table_id": table_id, "table_chunk_id": 0})]
+            return [
+                Document(
+                    page_content=table_md,
+                    metadata={
+                        "is_table": True,
+                        "block_type": "markdown_table",
+                        "table_id": table_id,
+                        "table_chunk_id": 0,
+                        "table_part": 0,
+                        "row_start": 0,
+                        "row_end": max(len(lines) - 2, 0),
+                    },
+                )
+            ]
 
         header = f"{lines[0]}\n{lines[1]}"
         rows = lines[2:]
 
-        sub_tables = []
-        current_rows = []
+        sub_tables: List[Document] = []
+        current_rows: list[str] = []
         chunk_index = 0
+        chunk_row_start = 0
+        cursor = 0  # zero-based row index into ``rows``
+
+        def _flush(end_exclusive: int) -> None:
+            nonlocal chunk_index, chunk_row_start
+            if not current_rows:
+                return
+            sub_tables.append(
+                Document(
+                    page_content=f"{header}\n{chr(10).join(current_rows)}",
+                    metadata={
+                        "is_table": True,
+                        "block_type": "markdown_table",
+                        "table_id": table_id,
+                        "table_chunk_id": chunk_index,
+                        "table_part": chunk_index,
+                        "row_start": chunk_row_start,
+                        "row_end": end_exclusive,
+                    },
+                )
+            )
+            chunk_index += 1
+            chunk_row_start = end_exclusive
 
         for row in rows:
-            if len(header) + len("\n".join(current_rows)) + len(row) > self.chunk_size:
-                if current_rows:
-                    sub_tables.append(Document(page_content=f"{header}\n{'\n'.join(current_rows)}", metadata={"is_table": True, "table_id": table_id, "table_chunk_id": chunk_index}))
-                    chunk_index += 1
+            projected = len(header) + 1 + len("\n".join(current_rows + [row]))
+            if current_rows and projected > self.chunk_size:
+                _flush(cursor)
                 current_rows = [row]
             else:
                 current_rows.append(row)
+            cursor += 1
 
-        if current_rows:
-            sub_tables.append(Document(page_content=f"{header}\n{'\n'.join(current_rows)}", metadata={"is_table": True, "table_id": table_id, "table_chunk_id": chunk_index}))
-
+        _flush(cursor)
         return sub_tables
 
     def semantic_chunking(self, text: str) -> List[Document]:
@@ -133,6 +277,12 @@ class SemanticSplitter(BaseTextSplitter):
         Returns:
             List[Document]: A list of Document chunks, including text sections and individual table chunks.
         """
+
+        # 0. Auto-annotate plain Markdown tables that upstream processors did
+        #    not wrap (``.md``/``.txt`` and the lightweight PDF/DOCX/PPTX paths).
+        #    Idempotent: existing markers are preserved.
+        if self.preserve_tables:
+            text = self._auto_annotate_unmarked_tables(text)
 
         # 1. Extract tables + replace with placeholder
         text_with_placeholders, table_map = self._extract_and_replace_tables(text)
@@ -198,42 +348,73 @@ class SemanticSplitter(BaseTextSplitter):
                 else:
                     cursor = idx + len(txt)
 
-                # No content preview here — this logger feeds the generic
+                # No content preview here - this logger feeds the generic
                 # app-log store (see docs/swift/platform/OBSERVABILITY-AND-AUDIT.md
                 # §7: "Content ... Nowhere in any observability or audit stream").
                 logger.debug("anchor ok  | chunk=%d len=%d idx=%d cursor->%d fallback=%s", i, len(txt), idx, cursor, fb)
             else:
-                # Diagnostics for misses — lengths only, no needle/haystack text.
+                # Diagnostics for misses - lengths only, no needle/haystack text.
                 window_len = len(text_with_placeholders[cursor : cursor + max(0, len(txt) + 200)])
                 logger.debug("anchor miss| chunk=%d len=%d cursor=%d haystack_win_len=%d", i, len(txt), cursor, window_len)
 
         logger.info("Anchoring summary: %d/%d chunks anchored (fallback used on %d).", ok, total, used_fb)
 
-        # 4. Reinsert tables
+        # 4. Reinsert tables - walk each chunk in text order so that content
+        #    before a placeholder stays before the table and content after it
+        #    stays after. The previous implementation stripped all placeholders
+        #    at once and emitted tables in a batch at the end, which collapsed
+        #    surrounding text into one merged chunk and placed every table after
+        #    it, breaking document order.
         final_chunks = []
+        _placeholder_re = re.compile(r"<<TABLE_(.*?)>>")
+
         for chunk in sub_chunks:
             chunk_text = chunk.page_content
-            placeholders = re.findall(r"<<TABLE_(.*?)>>", chunk_text)
 
-            if not placeholders:
+            if "<<TABLE_" not in chunk_text:
                 final_chunks.append(chunk)
                 continue
 
-            # Clean up chunk text
-            chunk_text_cleaned = re.sub(r"<<TABLE_.*?>>", "", chunk_text).strip()
-            if chunk_text_cleaned:
-                chunk.page_content = chunk_text_cleaned
-                final_chunks.append(chunk)
+            prev_end = 0
+            for m in _placeholder_re.finditer(chunk_text):
+                before = chunk_text[prev_end : m.start()].strip()
+                if before:
+                    final_chunks.append(
+                        Document(
+                            page_content=before,
+                            metadata=dict(chunk.metadata or {}),
+                        )
+                    )
 
-            for table_id in placeholders:
-                table_md = table_map[table_id]
-                if self.preserve_tables:
-                    final_chunks.append(Document(page_content=table_md, metadata={"is_table": True, "table_id": table_id, "table_chunk_id": 0}))
-                else:
+                table_id = m.group(1)
+                table_md = table_map.get(table_id, "")
+                if table_md:
                     if len(table_md) <= self.chunk_size:
-                        final_chunks.append(Document(page_content=table_md, metadata={"is_table": True, "table_id": table_id, "table_chunk_id": 0}))
+                        final_chunks.append(
+                            Document(
+                                page_content=table_md,
+                                metadata={
+                                    "is_table": True,
+                                    "block_type": "markdown_table",
+                                    "table_id": table_id,
+                                    "table_chunk_id": 0,
+                                    "table_part": 0,
+                                },
+                            )
+                        )
                     else:
                         final_chunks.extend(self._split_large_table(table_md, table_id))
+
+                prev_end = m.end()
+
+            tail = chunk_text[prev_end:].strip()
+            if tail:
+                final_chunks.append(
+                    Document(
+                        page_content=tail,
+                        metadata=dict(chunk.metadata or {}),
+                    )
+                )
 
         return final_chunks
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_controller.py
@@ -15,7 +15,7 @@
 import logging
 from typing import List, Literal, Union
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.concurrency import run_in_threadpool
 from fred_core import (
     DocumentPermission,
@@ -205,6 +205,33 @@ class VectorSearchController:
             dummy_hit = VectorSearchHit(content="This is a test document chunk.", uid="test-doc-001", title="Dummy Test Document", score=0.99, rank=1, type="test")
 
             return [dummy_hit]
+
+        @router.get(
+            "/vector/document-chunks",
+            tags=["Vector Search"],
+            summary="Fetch a document's chunks in index order",
+            description=(
+                "Returns a document's stored chunks sorted by chunk_index, capped at `limit`. "
+                "A direct store fetch with no similarity ranking, so a whole table comes back "
+                "intact. Requires READ on the document."
+            ),
+            response_model=List[VectorSearchHit],
+            operation_id="get_document_chunks_ordered",
+            status_code=status.HTTP_200_OK,
+        )
+        async def get_document_chunks_ordered(
+            document_uid: str,
+            limit: int = Query(default=200, ge=1, le=1000),
+            user: KeycloakUser = Depends(get_current_user),
+        ) -> List[VectorSearchHit]:
+            rebac = get_rebac_engine()
+            await rebac.check_user_permission_or_raise(user, DocumentPermission.READ, document_uid)
+            async with phase_timer(self.kpi, "vector_document_chunks"):
+                return await self.service.get_document_chunks_ordered(
+                    user=user,
+                    document_uid=document_uid,
+                    limit=limit,
+                )
 
         @router.post(
             "/vector/rerank",

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
@@ -257,7 +257,14 @@ class VectorSearchService:
                 logger.debug("Could not resolve tag id=%s: %s", tid, e)
         return names, full_paths
 
-    async def _to_hit(self, doc: Document, score: float, rank: int, user: KeycloakUser) -> VectorSearchHit:
+    async def _to_hit(
+        self,
+        doc: Document,
+        score: float,
+        rank: int,
+        user: KeycloakUser,
+        tags_meta: tuple[list[str], list[str]] | None = None,
+    ) -> VectorSearchHit:
         """
         Convert a LangChain Document + score into a VectorSearchHit UI DTO.
         Rationale:
@@ -267,7 +274,7 @@ class VectorSearchService:
 
         # Pull both ids and names (UI displays names; filters might use ids)
         tag_ids = md.get("tag_ids") or []
-        tag_names, tag_full_paths = await self._tags_meta_from_ids(tag_ids, user)
+        tag_names, tag_full_paths = tags_meta if tags_meta is not None else await self._tags_meta_from_ids(tag_ids, user)
         uid = md.get("document_uid") or "Unknown"
         vf = md.get("viewer_fragment")
         preview_url = f"/documents/{uid}"
@@ -957,6 +964,11 @@ class VectorSearchService:
 
         The ReBAC READ check belongs to the caller, as for every other route on
         this controller.
+
+        Known cost: `limit` bounds the response, not the store read - every backend's
+        `get_chunks_for_document` fetches the whole document (OpenSearch caps at 10k)
+        and the slice happens here. Pushing the bound into the stores is a separate
+        change; this route is no worse than the existing callers of that method.
         """
         try:
             raw_chunks = await asyncio.to_thread(self.vector_store.get_chunks_for_document, document_uid)
@@ -966,17 +978,31 @@ class VectorSearchService:
         if not raw_chunks:
             return []
 
-        raw_chunks.sort(key=lambda c: _coerce_chunk_index((c.get("metadata") or {}).get("chunk_index")) or 0)
+        def _order(chunk: dict) -> tuple[bool, int]:
+            # None last, matching the runtime adapter: an unindexed legacy chunk
+            # degrades to the end rather than jumping ahead of chunk 0.
+            index = _coerce_chunk_index((chunk.get("metadata") or {}).get("chunk_index"))
+            return (index is None, index or 0)
+
+        raw_chunks.sort(key=_order)
         truncated = len(raw_chunks) > limit
-        hits = [
-            await self._to_hit(
-                Document(page_content=entry.get("text") or "", metadata=entry.get("metadata") or {}),
-                score=0.0,
-                rank=rank,
-                user=user,
+
+        tags_cache: dict[tuple[str, ...], tuple[list[str], list[str]]] = {}
+        hits: List[VectorSearchHit] = []
+        for rank, entry in enumerate(raw_chunks[:limit]):
+            metadata = entry.get("metadata") or {}
+            tag_ids = tuple(metadata.get("tag_ids") or [])
+            if tag_ids not in tags_cache:
+                tags_cache[tag_ids] = await self._tags_meta_from_ids(list(tag_ids), user)
+            hits.append(
+                await self._to_hit(
+                    Document(page_content=entry.get("text") or "", metadata=metadata),
+                    score=0.0,
+                    rank=rank,
+                    user=user,
+                    tags_meta=tags_cache[tag_ids],
+                )
             )
-            for rank, entry in enumerate(raw_chunks[:limit])
-        ]
         logger.info(
             "[VECTOR][DOC_CHUNKS] document_uid=%s returned=%d of %d truncated=%s",
             document_uid,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/vector_search/vector_search_service.py
@@ -118,6 +118,20 @@ def _merge_corpus_scope_hits(*hit_groups: List[VectorSearchHit], top_k: int) -> 
     return sorted(merged_by_key.values(), key=lambda h: h.score or 0.0, reverse=True)[:top_k]
 
 
+def _coerce_chunk_index(raw: Any) -> Optional[int]:
+    """Stores return chunk_index as int, float or string depending on the backend."""
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    if isinstance(raw, str):
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None
+
+
 class VectorSearchService:
     """
     Fred — Vector Search Service (policy-driven).
@@ -311,6 +325,7 @@ class VectorSearchService:
             # metrics & provenance
             score=score,
             rank=rank,
+            chunk_index=_coerce_chunk_index(md.get("chunk_index")),
             embedding_model=str(md.get("embedding_model") or "unknown_model"),
             vector_index=md.get("vector_index") or "unknown_index",
             token_count=md.get("token_count"),
@@ -926,3 +941,47 @@ class VectorSearchService:
                 actor=self._kpi_actor(user=None),
             )
             return reranked_documents
+
+    async def get_document_chunks_ordered(
+        self,
+        *,
+        user: KeycloakUser,
+        document_uid: str,
+        limit: int,
+    ) -> List[VectorSearchHit]:
+        """Return a document's stored chunks in chunk_index order, capped at `limit`.
+
+        A direct store fetch, not a search: similarity ranking cannot guarantee that
+        every row of a large table comes back, so callers that need a whole table ask
+        for the document itself.
+
+        The ReBAC READ check belongs to the caller, as for every other route on
+        this controller.
+        """
+        try:
+            raw_chunks = await asyncio.to_thread(self.vector_store.get_chunks_for_document, document_uid)
+        except NotImplementedError:
+            logger.warning("[VECTOR][DOC_CHUNKS] store %s cannot fetch chunks by document", type(self.vector_store).__name__)
+            return []
+        if not raw_chunks:
+            return []
+
+        raw_chunks.sort(key=lambda c: _coerce_chunk_index((c.get("metadata") or {}).get("chunk_index")) or 0)
+        truncated = len(raw_chunks) > limit
+        hits = [
+            await self._to_hit(
+                Document(page_content=entry.get("text") or "", metadata=entry.get("metadata") or {}),
+                score=0.0,
+                rank=rank,
+                user=user,
+            )
+            for rank, entry in enumerate(raw_chunks[:limit])
+        ]
+        logger.info(
+            "[VECTOR][DOC_CHUNKS] document_uid=%s returned=%d of %d truncated=%s",
+            document_uid,
+            len(hits),
+            len(raw_chunks),
+            truncated,
+        )
+        return hits

--- a/apps/knowledge-flow-backend/tests/features/vector_search/test_document_chunks_authz.py
+++ b/apps/knowledge-flow-backend/tests/features/vector_search/test_document_chunks_authz.py
@@ -1,0 +1,99 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Authz gate for the ordered document-chunks route.
+
+The route hands back a document's raw stored text with no similarity filter, so it
+is gated on ReBAC DocumentPermission.READ for the requested document - the same
+per-document gate the rerank route uses, not an org-level capability.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from fred_core import AuthorizationError, DocumentPermission, KeycloakUser, Resource, get_current_user
+from fred_core.common import register_exception_handlers
+from fred_core.kpi import NoOpKPIWriter
+
+from knowledge_flow_backend.features.vector_search import vector_search_controller as controller_module
+from knowledge_flow_backend.features.vector_search.vector_search_controller import VectorSearchController
+
+
+class _FakeRebac:
+    def __init__(self, *, deny: bool) -> None:
+        self.deny = deny
+        self.calls: list[tuple[object, str]] = []
+
+    async def check_user_permission_or_raise(self, user, permission, resource_id, **_kw) -> None:
+        self.calls.append((permission, resource_id))
+        if self.deny:
+            raise AuthorizationError(user.uid, str(permission), Resource.DOCUMENTS)
+
+
+class _FakeService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def get_document_chunks_ordered(self, *, user, document_uid, limit):
+        self.calls.append({"document_uid": document_uid, "limit": limit})
+        return []
+
+
+def _build_client(monkeypatch, rebac: _FakeRebac) -> tuple[TestClient, _FakeService]:
+    service = _FakeService()
+    monkeypatch.setattr(controller_module, "VectorSearchService", lambda: service)
+    monkeypatch.setattr(controller_module, "get_kpi_writer", lambda: NoOpKPIWriter())
+    monkeypatch.setattr(controller_module, "get_rebac_engine", lambda: rebac)
+
+    router = APIRouter()
+    VectorSearchController(router)
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: KeycloakUser(uid="alice", username="alice", roles=[], email=None)
+    return TestClient(app), service
+
+
+def test_route_checks_document_read(monkeypatch) -> None:
+    rebac = _FakeRebac(deny=False)
+    client, service = _build_client(monkeypatch, rebac)
+
+    response = client.get("/vector/document-chunks", params={"document_uid": "doc-1"})
+
+    assert response.status_code == 200
+    assert (DocumentPermission.READ, "doc-1") in rebac.calls
+    assert service.calls == [{"document_uid": "doc-1", "limit": 200}]
+
+
+def test_route_denies_caller_without_document_read(monkeypatch) -> None:
+    rebac = _FakeRebac(deny=True)
+    client, service = _build_client(monkeypatch, rebac)
+
+    response = client.get("/vector/document-chunks", params={"document_uid": "doc-1"})
+
+    assert response.status_code == 403
+    assert service.calls == []
+
+
+@pytest.mark.parametrize("limit", [0, 1001])
+def test_limit_is_bounded(monkeypatch, limit) -> None:
+    """The cap is the whole point: an unbounded fetch would blow up the prompt."""
+    client, service = _build_client(monkeypatch, _FakeRebac(deny=False))
+
+    response = client.get("/vector/document-chunks", params={"document_uid": "doc-1", "limit": limit})
+
+    assert response.status_code == 422
+    assert service.calls == []

--- a/apps/knowledge-flow-backend/tests/features/vector_search/test_document_chunks_authz.py
+++ b/apps/knowledge-flow-backend/tests/features/vector_search/test_document_chunks_authz.py
@@ -55,7 +55,7 @@ class _FakeService:
 def _build_client(monkeypatch, rebac: _FakeRebac) -> tuple[TestClient, _FakeService]:
     service = _FakeService()
     monkeypatch.setattr(controller_module, "VectorSearchService", lambda: service)
-    monkeypatch.setattr(controller_module, "get_kpi_writer", lambda: NoOpKPIWriter())
+    monkeypatch.setattr(controller_module, "get_kpi_writer", NoOpKPIWriter)
     monkeypatch.setattr(controller_module, "get_rebac_engine", lambda: rebac)
 
     router = APIRouter()

--- a/apps/knowledge-flow-backend/tests/processors/output/vectorization_processor/test_semantic_splitter_tables.py
+++ b/apps/knowledge-flow-backend/tests/processors/output/vectorization_processor/test_semantic_splitter_tables.py
@@ -19,6 +19,7 @@ The three ingestion modes share the same chunker (``SemanticSplitter``), so
 covering it here covers all three.
 """
 
+from fred_core.store.vector_search import MARKDOWN_TABLE_CHUNK_KIND
 from langchain_core.documents import Document
 
 from knowledge_flow_backend.core.processors.output.vectorization_processor.semantic_splitter import (
@@ -29,11 +30,11 @@ SMALL_TABLE = "| col1 | col2 | col3 |\n| --- | --- | --- |\n| a | b | c |\n| d |
 
 
 def _table_chunks(chunks):
-    return [c for c in chunks if c.metadata.get("block_type") == "markdown_table"]
+    return [c for c in chunks if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND]
 
 
 def _non_table_chunks(chunks):
-    return [c for c in chunks if c.metadata.get("block_type") != "markdown_table"]
+    return [c for c in chunks if c.metadata.get("chunk_kind") != MARKDOWN_TABLE_CHUNK_KIND]
 
 
 def test_small_table_remains_in_one_chunk():
@@ -44,7 +45,7 @@ def test_small_table_remains_in_one_chunk():
     tables = _table_chunks(chunks)
     assert len(tables) == 1
     assert tables[0].page_content.strip() == SMALL_TABLE.strip()
-    assert tables[0].metadata.get("is_table") is True
+    assert tables[0].metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND
     assert tables[0].metadata.get("table_id")  # id was assigned
 
 
@@ -193,7 +194,7 @@ def test_chunk_order_text_before_table_then_text_after():
     chunks = splitter.split(Document(page_content=text))
 
     # Locate the single table chunk and check its position in the list.
-    table_positions = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    table_positions = [i for i, c in enumerate(chunks) if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND]
     assert len(table_positions) == 1, "Expected exactly one table chunk"
     table_pos = table_positions[0]
 
@@ -214,7 +215,7 @@ def test_chunk_order_multiple_tables_interleaved_text():
     text = f"# Doc\n\n{SMALL_TABLE}\nMiddle prose.\n\n{SMALL_TABLE}\nTrailing prose.\n"
     chunks = splitter.split(Document(page_content=text))
 
-    table_positions = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    table_positions = [i for i, c in enumerate(chunks) if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND]
     assert len(table_positions) == 2, "Expected two table chunks"
 
     middle_positions = [i for i, c in enumerate(chunks) if "Middle prose." in c.page_content]
@@ -233,7 +234,7 @@ def test_heading_paragraph_table_paragraph_document_order():
     text = f"# Title\n\nIntroduction paragraph.\n\n{SMALL_TABLE}\nConclusion paragraph.\n"
     chunks = splitter.split(Document(page_content=text))
 
-    table_idx = next((i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"), None)
+    table_idx = next((i for i, c in enumerate(chunks) if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND), None)
     assert table_idx is not None
 
     intro_idx = next((i for i, c in enumerate(chunks) if "Introduction paragraph." in c.page_content), None)
@@ -254,7 +255,7 @@ def test_table_followed_by_list_preserves_order():
     text = f"# List after table\n\n{SMALL_TABLE}\n- item one\n- item two\n- item three\n"
     chunks = splitter.split(Document(page_content=text))
 
-    table_idx = next((i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"), None)
+    table_idx = next((i for i, c in enumerate(chunks) if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND), None)
     assert table_idx is not None
 
     list_idx = next((i for i, c in enumerate(chunks) if "item one" in c.page_content), None)
@@ -270,7 +271,7 @@ def test_large_table_crossing_chunk_boundary_order_with_surrounding_text():
     text = f"Header prose.\n\n{big_table}\nFooter prose.\n"
     chunks = splitter.split(Document(page_content=text))
 
-    table_indices = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    table_indices = [i for i, c in enumerate(chunks) if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND]
     assert len(table_indices) > 1, "Large table must split into multiple parts"
 
     header_idx = next((i for i, c in enumerate(chunks) if "Header prose." in c.page_content), None)
@@ -354,7 +355,7 @@ def test_200_row_table_with_intro_text_preserves_document_order():
     doc = Document(page_content=intro + _build_200_row_table())
     chunks = splitter.split(doc)
 
-    table_indices = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    table_indices = [i for i, c in enumerate(chunks) if c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND]
     intro_indices = [i for i, c in enumerate(chunks) if "Large Configuration Reference" in c.page_content]
 
     assert table_indices, "Table chunks must exist"
@@ -370,5 +371,36 @@ def test_preserve_tables_false_leaves_plain_markdown_tables_unannotated():
     splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0, preserve_tables=False)
     chunks = splitter.split(Document(page_content=SMALL_TABLE))
 
-    assert not any(c.metadata.get("block_type") == "markdown_table" for c in chunks)
+    assert not any(c.metadata.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND for c in chunks)
     assert not any("TABLE_START" in c.page_content for c in chunks)
+
+
+def test_table_chunk_kind_survives_metadata_sanitisation():
+    """chunk_kind is the persisted vocabulary; the table_* keys are splitter-local."""
+    from knowledge_flow_backend.core.processors.output.vectorization_processor.vectorization_utils import (
+        sanitize_chunk_metadata,
+    )
+
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    table = _table_chunks(splitter.split(Document(page_content=SMALL_TABLE)))[0]
+
+    kept, _ = sanitize_chunk_metadata(table.metadata)
+
+    assert kept.get("chunk_kind") == MARKDOWN_TABLE_CHUNK_KIND
+
+
+def test_fragments_around_a_table_get_distinct_anchors():
+    """Copying the parent anchor would deep-link intro and outro at the same span."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    text = f"Intro paragraph.\n{SMALL_TABLE}\nOutro paragraph.\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    intro = next(c for c in chunks if "Intro paragraph." in c.page_content)
+    outro = next(c for c in chunks if "Outro paragraph." in c.page_content)
+
+    spans = [(c.metadata.get("char_start"), c.metadata.get("char_end")) for c in (intro, outro)]
+    assert all(start is not None for start, _ in spans)
+    assert spans[0] != spans[1]
+    assert spans[0][1] <= spans[1][0]
+    for chunk, (start, end) in zip((intro, outro), spans):
+        assert end - start == len(chunk.page_content)

--- a/apps/knowledge-flow-backend/tests/processors/output/vectorization_processor/test_semantic_splitter_tables.py
+++ b/apps/knowledge-flow-backend/tests/processors/output/vectorization_processor/test_semantic_splitter_tables.py
@@ -287,8 +287,6 @@ def test_large_table_crossing_chunk_boundary_order_with_surrounding_text():
 # Large production table (200 rows)
 # ---------------------------------------------------------------------------
 
-_200_ROW_TABLE_COLS = 9  # matches large-table-test_pd1.md schema
-
 
 def _build_200_row_table() -> str:
     """Reproduce the shape of large-table-test_pd1.md (200 rows, 9 cols,

--- a/apps/knowledge-flow-backend/tests/processors/output/vectorization_processor/test_semantic_splitter_tables.py
+++ b/apps/knowledge-flow-backend/tests/processors/output/vectorization_processor/test_semantic_splitter_tables.py
@@ -1,0 +1,374 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests: Markdown tables must be preserved as a
+whole during ingestion across light/medium/rich modes.
+
+The three ingestion modes share the same chunker (``SemanticSplitter``), so
+covering it here covers all three.
+"""
+
+from langchain_core.documents import Document
+
+from knowledge_flow_backend.core.processors.output.vectorization_processor.semantic_splitter import (
+    SemanticSplitter,
+)
+
+SMALL_TABLE = "| col1 | col2 | col3 |\n| --- | --- | --- |\n| a | b | c |\n| d | e | f |\n"
+
+
+def _table_chunks(chunks):
+    return [c for c in chunks if c.metadata.get("block_type") == "markdown_table"]
+
+
+def _non_table_chunks(chunks):
+    return [c for c in chunks if c.metadata.get("block_type") != "markdown_table"]
+
+
+def test_small_table_remains_in_one_chunk():
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    doc = Document(page_content=f"# Heading\n\n{SMALL_TABLE}\n")
+    chunks = splitter.split(doc)
+
+    tables = _table_chunks(chunks)
+    assert len(tables) == 1
+    assert tables[0].page_content.strip() == SMALL_TABLE.strip()
+    assert tables[0].metadata.get("is_table") is True
+    assert tables[0].metadata.get("table_id")  # id was assigned
+
+
+def test_text_before_and_after_table_chunked_separately():
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    text = f"# Heading\n\nParagraph before the table.\n\n{SMALL_TABLE}\nParagraph after the table.\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    tables = _table_chunks(chunks)
+    assert len(tables) == 1
+    assert "| col1 | col2 | col3 |" in tables[0].page_content
+
+    non_tables = _non_table_chunks(chunks)
+    joined = "\n".join(c.page_content for c in non_tables)
+    assert "Paragraph before the table." in joined
+    assert "Paragraph after the table." in joined
+    # The table marker placeholders must never leak into produced chunks.
+    for c in chunks:
+        assert "<<TABLE_" not in c.page_content
+        assert "TABLE_START" not in c.page_content
+        assert "TABLE_END" not in c.page_content
+
+
+def _build_large_table(num_rows: int, cols: int = 3) -> str:
+    header = "| " + " | ".join(f"col{i}" for i in range(cols)) + " |"
+    sep = "| " + " | ".join("---" for _ in range(cols)) + " |"
+    rows = []
+    for r in range(num_rows):
+        rows.append("| " + " | ".join(f"r{r}c{i}" for i in range(cols)) + " |")
+    return "\n".join([header, sep, *rows]) + "\n"
+
+
+def test_large_table_splits_only_on_row_boundaries_and_repeats_header():
+    big_table = _build_large_table(num_rows=80, cols=4)
+    splitter = SemanticSplitter(chunk_size=400, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=big_table))
+
+    tables = _table_chunks(chunks)
+    assert len(tables) > 1, "Large table must split into multiple parts"
+
+    seen_rows: list[str] = []
+    for idx, t in enumerate(tables):
+        lines = t.page_content.splitlines()
+        # Header + separator must repeat in EVERY part.
+        assert lines[0].startswith("| col0 | col1 | col2 | col3 |"), f"part {idx} missing header"
+        assert lines[1].startswith("| --- | --- | --- | --- |"), f"part {idx} missing separator"
+        # Subsequent lines must each be a complete pipe row (no row was split mid-way).
+        for line in lines[2:]:
+            assert line.startswith("| r"), f"part {idx} has a non-row line: {line!r}"
+            assert line.endswith("|"), f"part {idx} has a truncated row: {line!r}"
+            seen_rows.append(line)
+        # Metadata identifies the part and its row range.
+        assert t.metadata["table_part"] == idx
+        assert t.metadata["row_start"] < t.metadata["row_end"]
+
+    # All 80 rows must be present in original order across parts.
+    expected_rows = [line for line in big_table.splitlines()[2:] if line.strip()]
+    assert seen_rows == expected_rows
+
+
+def test_multiple_tables_are_each_preserved_independently():
+    text = f"# Tables\n\n{SMALL_TABLE}\nSome prose between the two tables.\n\n{SMALL_TABLE}\n"
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=text))
+
+    tables = _table_chunks(chunks)
+    assert len(tables) == 2
+    ids = {t.metadata["table_id"] for t in tables}
+    assert len(ids) == 2  # distinct ids for distinct tables
+    for t in tables:
+        assert t.page_content.strip() == SMALL_TABLE.strip()
+
+
+def test_pipe_text_without_separator_row_is_not_treated_as_table():
+    # Lines containing pipes that are NOT a markdown table must stay as prose
+    # and never be wrapped or chunk-protected as a table.
+    text = "# Notes\n\nUse the command `foo | bar` to pipe output.\nAnother sentence | with an embedded pipe character.\nAnd one more line.\n"
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=text))
+
+    tables = _table_chunks(chunks)
+    assert tables == []
+
+
+def test_fenced_code_block_with_pipes_is_not_treated_as_table():
+    text = "# Snippet\n\n```\n| a | b |\n| --- | --- |\n| 1 | 2 |\n```\nFollowing prose.\n"
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=text))
+
+    assert _table_chunks(chunks) == []
+    # Code fence content must still appear in some chunk.
+    joined = "\n".join(c.page_content for c in chunks)
+    assert "| --- | --- |" in joined
+
+
+def test_pre_annotated_tables_are_idempotent():
+    annotated = f"<!-- TABLE_START:id=docx_1 -->\n{SMALL_TABLE.rstrip()}\n<!-- TABLE_END -->\n"
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=annotated))
+
+    tables = _table_chunks(chunks)
+    assert len(tables) == 1
+    assert tables[0].metadata["table_id"] == "docx_1"
+    assert tables[0].page_content.strip() == SMALL_TABLE.strip()
+
+
+def test_auto_annotation_does_not_misdetect_separator_inside_text():
+    # A line of pipes followed by something that *looks* like a separator
+    # but is missing a pipe - must not be detected.
+    text = "# Notes\n\nSome line | with pipes\n----------- (no pipes here, so not a separator row)\nAnother line.\n"
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=text))
+    assert _table_chunks(chunks) == []
+
+
+def test_split_preserves_row_order_in_metadata():
+    big_table = _build_large_table(num_rows=40, cols=3)
+    splitter = SemanticSplitter(chunk_size=300, chunk_overlap=0)
+    chunks = splitter.split(Document(page_content=big_table))
+    tables = _table_chunks(chunks)
+    assert len(tables) >= 2
+
+    # row_start ranges must be monotonically increasing and contiguous.
+    prev_end = 0
+    for t in tables:
+        assert t.metadata["row_start"] == prev_end
+        assert t.metadata["row_end"] > t.metadata["row_start"]
+        prev_end = t.metadata["row_end"]
+    # Last part covers up to the last data row (40 rows total).
+    assert prev_end == 40
+
+
+# ---------------------------------------------------------------------------
+# Order-preservation tests
+# ---------------------------------------------------------------------------
+
+
+def _chunk_contents(chunks):
+    return [c.page_content for c in chunks]
+
+
+def test_chunk_order_text_before_table_then_text_after():
+    """Content before a table must appear before the table chunk, not after."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    text = f"# Section\n\nParagraph before.\n\n{SMALL_TABLE}\nParagraph after.\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    # Locate the single table chunk and check its position in the list.
+    table_positions = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    assert len(table_positions) == 1, "Expected exactly one table chunk"
+    table_pos = table_positions[0]
+
+    # The chunk containing "before" must come before the table.
+    before_positions = [i for i, c in enumerate(chunks) if "Paragraph before." in c.page_content]
+    assert before_positions, "Paragraph before not found in any chunk"
+    assert before_positions[0] < table_pos, "Text before table must precede the table chunk"
+
+    # The chunk containing "after" must come after the table.
+    after_positions = [i for i, c in enumerate(chunks) if "Paragraph after." in c.page_content]
+    assert after_positions, "Paragraph after not found in any chunk"
+    assert after_positions[0] > table_pos, "Text after table must follow the table chunk"
+
+
+def test_chunk_order_multiple_tables_interleaved_text():
+    """With two tables, prose between them must sit between the two table chunks."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    text = f"# Doc\n\n{SMALL_TABLE}\nMiddle prose.\n\n{SMALL_TABLE}\nTrailing prose.\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    table_positions = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    assert len(table_positions) == 2, "Expected two table chunks"
+
+    middle_positions = [i for i, c in enumerate(chunks) if "Middle prose." in c.page_content]
+    assert middle_positions, "Middle prose not found in any chunk"
+    # Middle prose must sit between the two tables.
+    assert table_positions[0] < middle_positions[0] < table_positions[1], "Middle prose must appear between the two table chunks"
+
+    trailing_positions = [i for i, c in enumerate(chunks) if "Trailing prose." in c.page_content]
+    assert trailing_positions, "Trailing prose not found in any chunk"
+    assert trailing_positions[0] > table_positions[1], "Trailing prose must follow the second table chunk"
+
+
+def test_heading_paragraph_table_paragraph_document_order():
+    """Full heading → paragraph → table → paragraph sequence preserves order."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    text = f"# Title\n\nIntroduction paragraph.\n\n{SMALL_TABLE}\nConclusion paragraph.\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    table_idx = next((i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"), None)
+    assert table_idx is not None
+
+    intro_idx = next((i for i, c in enumerate(chunks) if "Introduction paragraph." in c.page_content), None)
+    concl_idx = next((i for i, c in enumerate(chunks) if "Conclusion paragraph." in c.page_content), None)
+
+    assert intro_idx is not None, "Introduction paragraph missing"
+    assert concl_idx is not None, "Conclusion paragraph missing"
+    assert intro_idx < table_idx < concl_idx, f"Expected intro({intro_idx}) < table({table_idx}) < conclusion({concl_idx})"
+    # No placeholder artefacts in any chunk.
+    for c in chunks:
+        assert "<<TABLE_" not in c.page_content
+        assert "TABLE_START" not in c.page_content
+
+
+def test_table_followed_by_list_preserves_order():
+    """A table immediately followed by a bullet list keeps list after table."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    text = f"# List after table\n\n{SMALL_TABLE}\n- item one\n- item two\n- item three\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    table_idx = next((i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"), None)
+    assert table_idx is not None
+
+    list_idx = next((i for i, c in enumerate(chunks) if "item one" in c.page_content), None)
+    assert list_idx is not None, "List content missing from chunks"
+    assert list_idx > table_idx, "List must appear after the table chunk"
+
+
+def test_large_table_crossing_chunk_boundary_order_with_surrounding_text():
+    """A large table surrounded by text splits across chunk boundaries but
+    surrounding text retains correct relative order."""
+    splitter = SemanticSplitter(chunk_size=400, chunk_overlap=0)
+    big_table = _build_large_table(num_rows=30, cols=3)
+    text = f"Header prose.\n\n{big_table}\nFooter prose.\n"
+    chunks = splitter.split(Document(page_content=text))
+
+    table_indices = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    assert len(table_indices) > 1, "Large table must split into multiple parts"
+
+    header_idx = next((i for i, c in enumerate(chunks) if "Header prose." in c.page_content), None)
+    footer_idx = next((i for i, c in enumerate(chunks) if "Footer prose." in c.page_content), None)
+
+    assert header_idx is not None, "Header prose missing"
+    assert footer_idx is not None, "Footer prose missing"
+    assert header_idx < table_indices[0], "Header must precede all table parts"
+    assert footer_idx > table_indices[-1], "Footer must follow all table parts"
+
+
+# ---------------------------------------------------------------------------
+# Large production table (200 rows)
+# ---------------------------------------------------------------------------
+
+_200_ROW_TABLE_COLS = 9  # matches large-table-test_pd1.md schema
+
+
+def _build_200_row_table() -> str:
+    """Reproduce the shape of large-table-test_pd1.md (200 rows, 9 cols,
+    realistic description lengths) so the splitter is tested at production scale."""
+    header = "| Property | Type | Required | Default | Category | Environment | Version | Example | Description |"
+    sep = "|-----------|--------|----------|---------|----------|-------------|---------|---------|-------------|"
+    rows = []
+    for i in range(1, 201):
+        prop = f"property{i:02d}"
+        desc = f"Description for {prop} used in integration and validation pipelines."
+        rows.append(f"| {prop} | string | Yes | value{i:02d} | Core | DEV | 1.0 | sample{i:02d} | {desc} |")
+    return "\n".join([header, sep, *rows]) + "\n"
+
+
+def test_200_row_table_produces_multiple_chunks_all_rows_present():
+    """A 200-row production-scale table must be split into multiple chunks,
+    every row must appear exactly once, and no placeholder artefacts may leak."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    big_table = _build_200_row_table()
+    doc = Document(page_content=big_table)
+    chunks = splitter.split(doc)
+
+    tables = _table_chunks(chunks)
+    assert len(tables) > 1, "200-row table must produce multiple table chunks"
+
+    # Collect every data row seen across all table chunks.
+    all_rows: list[str] = []
+    for t in tables:
+        lines = t.page_content.splitlines()
+        # First two lines must be header + separator in EVERY chunk.
+        assert lines[0].startswith("| Property |"), f"header missing in chunk: {lines[0]!r}"
+        assert lines[1].startswith("|---"), f"separator missing in chunk: {lines[1]!r}"
+        all_rows.extend(lines[2:])
+
+    expected_rows = [line for line in big_table.splitlines()[2:] if line.strip()]
+    assert all_rows == expected_rows, "All 200 rows must appear in original order across chunks"
+
+    # No placeholder leakage.
+    for c in chunks:
+        assert "<<TABLE_" not in c.page_content
+        assert "TABLE_START" not in c.page_content
+
+
+def test_200_row_table_chunk_id_is_sequential_and_monotonic():
+    """chunk_id assigned by split() must be a strict 0-based sequence so
+    downstream vectorization can derive chunk_index correctly."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    doc = Document(page_content=_build_200_row_table())
+    chunks = splitter.split(doc)
+
+    ids = [c.metadata.get("chunk_id") for c in chunks]
+    assert ids == list(range(len(chunks))), "chunk_id must be 0-based sequential across all chunks"
+
+    table_chunks = _table_chunks(chunks)
+    table_ids = [c.metadata.get("chunk_id") for c in table_chunks]
+    assert table_ids == sorted(table_ids), "Table chunks must appear in document order (ascending chunk_id)"
+
+
+def test_200_row_table_with_intro_text_preserves_document_order():
+    """When a 200-row table is preceded by a heading and intro paragraph,
+    the intro text must come before all table chunks in the chunk list."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0)
+    intro = "# Large Configuration Reference\n\nThis document is used to test markdown table ingestion.\n\n"
+    doc = Document(page_content=intro + _build_200_row_table())
+    chunks = splitter.split(doc)
+
+    table_indices = [i for i, c in enumerate(chunks) if c.metadata.get("block_type") == "markdown_table"]
+    intro_indices = [i for i, c in enumerate(chunks) if "Large Configuration Reference" in c.page_content]
+
+    assert table_indices, "Table chunks must exist"
+    assert intro_indices, "Intro chunk must exist"
+    assert intro_indices[0] < table_indices[0], "Intro text must precede all table chunks"
+
+    table_ids = [chunks[i].metadata.get("chunk_id") for i in table_indices]
+    assert table_ids == sorted(table_ids), "Table chunks must be in ascending chunk_id order"
+
+
+def test_preserve_tables_false_leaves_plain_markdown_tables_unannotated():
+    """The flag gates auto-detection only; pre-annotated tables are unaffected."""
+    splitter = SemanticSplitter(chunk_size=1500, chunk_overlap=0, preserve_tables=False)
+    chunks = splitter.split(Document(page_content=SMALL_TABLE))
+
+    assert not any(c.metadata.get("block_type") == "markdown_table" for c in chunks)
+    assert not any("TABLE_START" in c.page_content for c in chunks)

--- a/docs/swift/platform/authz-endpoint-matrix.yaml
+++ b/docs/swift/platform/authz-endpoint-matrix.yaml
@@ -1280,6 +1280,11 @@ operations:
     review_status: pending_review
     required_permission: pending_review
   - service: knowledge-flow
+    method: GET
+    path: /knowledge-flow/v1/vector/document-chunks
+    review_status: approved
+    required_permission: document.read
+  - service: knowledge-flow
     method: POST
     path: /knowledge-flow/v1/vector/search
     review_status: pending_review

--- a/libs/fred-core/fred_core/store/vector_search.py
+++ b/libs/fred-core/fred_core/store/vector_search.py
@@ -85,6 +85,10 @@ class VectorSearchHit(BaseModel):
     # Metrics
     score: float = Field(..., description="Similarity score from vector search")
     rank: Optional[int] = None
+    chunk_index: Optional[int] = Field(
+        default=None,
+        description="Position of the chunk inside its source document, used to restore document order",
+    )
     embedding_model: Optional[str] = None
     vector_index: Optional[str] = None
     token_count: Optional[int] = None

--- a/libs/fred-core/fred_core/store/vector_search.py
+++ b/libs/fred-core/fred_core/store/vector_search.py
@@ -25,6 +25,10 @@ from pydantic import BaseModel, Field
 # and readers (document_access, knowledge.search) agree on the pointer value.
 DATASET_POINTER_CHUNK_KIND = "dataset_pointer"
 
+# A chunk holding one Markdown table, or one row-boundary slice of a large one.
+# Header and separator are repeated on every slice, so each chunk stands alone.
+MARKDOWN_TABLE_CHUNK_KIND = "markdown_table"
+
 # Default for `select_citable_sources`'s `min_score_ratio` — a hit scoring
 # below half the best hit's score in the same search call is treated as noise
 # relative to the strongest match, not a citable basis for an answer. Callers
@@ -47,7 +51,8 @@ class VectorSearchHit(BaseModel):
         description=(
             "content (default, real ingested prose/data) or "
             f"'{DATASET_POINTER_CHUNK_KIND}' (a discovery pointer to a structured "
-            "dataset, never citable as a source)."
+            f"dataset, never citable as a source) or '{MARKDOWN_TABLE_CHUNK_KIND}' "
+            "(a Markdown table kept whole or split on row boundaries)."
         ),
     )
 

--- a/libs/fred-runtime/fred_runtime/common/kf_vectorsearch_client.py
+++ b/libs/fred-runtime/fred_runtime/common/kf_vectorsearch_client.py
@@ -39,7 +39,7 @@ class VectorSearchClient(KfBaseClient):
     def __init__(self, agent: KnowledgeFlowAgentContext):
         super().__init__(
             agent=agent,
-            allowed_methods=frozenset({"POST"}),
+            allowed_methods=frozenset({"GET", "POST"}),
         )
 
     async def search(

--- a/libs/fred-runtime/fred_runtime/common/kf_vectorsearch_client.py
+++ b/libs/fred-runtime/fred_runtime/common/kf_vectorsearch_client.py
@@ -120,6 +120,31 @@ class VectorSearchClient(KfBaseClient):
             return []
         return _HITS.validate_python(raw)
 
+    async def get_document_chunks(
+        self,
+        *,
+        document_uid: str,
+        limit: int,
+    ) -> List[VectorSearchHit]:
+        """Fetch a document's chunks in chunk_index order, capped at `limit`.
+
+        Bypasses similarity ranking, so a table that spans more chunks than the
+        search top_k comes back whole.
+        """
+        r = await self._request_with_token_refresh(
+            method="GET",
+            path="/vector/document-chunks",
+            phase_name="kf_vector_document_chunks",
+            params={"document_uid": document_uid, "limit": limit},
+        )
+        r.raise_for_status()
+
+        raw = r.json()
+        if not isinstance(raw, list):
+            logger.warning("Unexpected document-chunks payload type: %s", type(raw))
+            return []
+        return _HITS.validate_python(raw)
+
     async def rerank(
         self,
         *,

--- a/libs/fred-runtime/fred_runtime/common/table_hits.py
+++ b/libs/fred-runtime/fred_runtime/common/table_hits.py
@@ -1,0 +1,164 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Table-aware post-processing shared by every RAG retrieval path.
+
+Similarity ranking returns a large table's chunks shuffled and cut off at top_k,
+and the splitter repeats the header on each one so it can stand alone. Handed to
+the model as-is, that reads as several small unrelated tables and answers row
+questions wrong.
+
+Three retrieval surfaces build LLM content from raw hits - the legacy
+`knowledge.search` invoker, `KfVectorSearchToolkit`, and the `DocumentSearchPort`
+behind `document_access`. They all need the same repair, so it lives here rather
+than being reimplemented a fourth time.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from fred_core.store.vector_search import VectorSearchHit
+
+logger = logging.getLogger(__name__)
+
+# A table chunk is a header row followed by a Markdown separator row. Matching on
+# the separator rather than a leading "|" also catches tables written without one.
+_TABLE_SEPARATOR_CHARS = set("|-: \t")
+
+# Ceiling for the whole-table fetch. A table is worth completing, but not at the
+# cost of an unbounded prompt: one document per call, capped in chunks. When a
+# document does not fit under the cap the fetch is abandoned rather than
+# truncated - the document's first N chunks are not the ones that matched.
+TABLE_EXPANSION_MAX_CHUNKS = 40
+
+# Fetches a document's chunks in index order, capped at `limit`.
+ChunkFetcher = Callable[..., Awaitable[list[VectorSearchHit]]]
+
+
+def table_header_span(content: str) -> int:
+    """Length in lines of the leading table header, or 0 when this is not a table chunk."""
+    lines = content.split("\n", 2)
+    if len(lines) < 2 or "|" not in lines[0]:
+        return 0
+    separator = lines[1].strip()
+    if "|" not in separator or "-" not in separator:
+        return 0
+    if set(separator) - _TABLE_SEPARATOR_CHARS:
+        return 0
+    return 2
+
+
+def restore_document_order(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
+    """Group hits per document and put each document's chunks back in index order.
+
+    Similarity ranking interleaves chunks, which reads as a shuffled table. Documents
+    keep their relative ranking: whichever scored best stays first.
+    """
+    per_doc: dict[str, list[VectorSearchHit]] = {}
+    for hit in hits:
+        per_doc.setdefault(hit.uid, []).append(hit)
+    ordered: list[VectorSearchHit] = []
+    for chunks in per_doc.values():
+        chunks.sort(key=lambda h: (h.chunk_index is None, h.chunk_index or 0))
+        ordered.extend(chunks)
+    return ordered
+
+
+def strip_repeated_table_headers(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
+    """Drop the header the splitter repeats on every table chunk, except the first.
+
+    Each chunk carries the header so it stands alone, but a run of them reads to the
+    model as separate tables. Strips only when the previous chunk of the same document
+    opened with the very same header, so a run of one table keeps exactly one header
+    and a second, different table in the document keeps its own.
+    """
+    out: list[VectorSearchHit] = []
+    prev_uid: str | None = None
+    prev_header: str | None = None
+    for hit in hits:
+        span = table_header_span(hit.content)
+        header = "\n".join(hit.content.split("\n")[:span]) if span else None
+        if span and hit.uid == prev_uid and header == prev_header:
+            body = "\n".join(hit.content.split("\n")[span:]).lstrip("\n")
+            hit = hit.model_copy(update={"content": body})
+        out.append(hit)
+        prev_uid = hit.uid
+        prev_header = header
+    return out
+
+
+async def complete_truncated_table(
+    hits: list[VectorSearchHit], fetch: ChunkFetcher
+) -> list[VectorSearchHit]:
+    """Refetch a whole table when top_k demonstrably cut one short.
+
+    Table chunks from one document at non-contiguous indices mean similarity ranking
+    returned a slice with a hole in it, and a sliced table answers row questions
+    wrong. Two adjacent chunks, or two separate small tables, are complete already
+    and are left alone.
+
+    Best-effort: on a failure, or on a document too large for the cap, the original
+    hits stand.
+    """
+    indices: dict[str, list[int]] = {}
+    for hit in hits:
+        if table_header_span(hit.content) and hit.chunk_index is not None:
+            indices.setdefault(hit.uid, []).append(hit.chunk_index)
+    gapped = {
+        uid: idx
+        for uid, idx in indices.items()
+        if len(idx) >= 2 and max(idx) - min(idx) + 1 > len(idx)
+    }
+    if not gapped:
+        return hits
+    uid = max(gapped, key=lambda u: len(gapped[u]))
+
+    try:
+        chunks = await fetch(document_uid=uid, limit=TABLE_EXPANSION_MAX_CHUNKS)
+    except Exception:
+        logger.warning("[TABLE] completion failed for uid=%s", uid, exc_info=True)
+        return hits
+
+    original = [hit for hit in hits if hit.uid == uid]
+    if len(chunks) <= len(original) or len(chunks) >= TABLE_EXPANSION_MAX_CHUNKS:
+        logger.info(
+            "[TABLE] completion skipped uid=%s fetched=%d had=%d cap=%d",
+            uid,
+            len(chunks),
+            len(original),
+            TABLE_EXPANSION_MAX_CHUNKS,
+        )
+        return hits
+
+    # The fetch has no similarity score of its own. Carry the document's best score
+    # over, or citation selection would drop the very table being answered from, and
+    # splice in place so the document keeps its rank.
+    best = max(hit.score for hit in original)
+    chunks = [chunk.model_copy(update={"score": best}) for chunk in chunks]
+    at = next(i for i, hit in enumerate(hits) if hit.uid == uid)
+    rest = [hit for hit in hits if hit.uid != uid]
+    logger.info(
+        "[TABLE] completion uid=%s chunks=%d->%d", uid, len(original), len(chunks)
+    )
+    return rest[:at] + chunks + rest[at:]
+
+
+async def repair_table_hits(
+    hits: list[VectorSearchHit], fetch: ChunkFetcher
+) -> list[VectorSearchHit]:
+    """Complete, reorder and de-duplicate table hits before they reach the model."""
+    hits = await complete_truncated_table(hits, fetch)
+    hits = restore_document_order(hits)
+    return strip_repeated_table_headers(hits)

--- a/libs/fred-runtime/fred_runtime/common/table_hits.py
+++ b/libs/fred-runtime/fred_runtime/common/table_hits.py
@@ -61,18 +61,37 @@ def table_header_span(content: str) -> int:
 
 
 def restore_document_order(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
-    """Group hits per document and put each document's chunks back in index order.
+    """Put a table document's chunks back in index order, leaving the rest alone.
 
-    Similarity ranking interleaves chunks, which reads as a shuffled table. Documents
-    keep their relative ranking: whichever scored best stays first.
+    Similarity ranking interleaves a table's chunks, which reads as a shuffled table,
+    and the header de-duplication below needs a document's chunks adjacent and in
+    order to tell one table's run from the next.
+
+    Only documents that actually contain a table chunk are regrouped. Reordering
+    every document would demote the single best-scoring hit of an ordinary prose
+    answer behind weak chunks of the same document, for no benefit - a table-free
+    hit set is returned exactly as it came in. A regrouped document takes the
+    position of its first hit, so cross-document ranking is preserved.
     """
-    per_doc: dict[str, list[VectorSearchHit]] = {}
+    table_docs = {hit.uid for hit in hits if table_header_span(hit.content)}
+    if not table_docs:
+        return hits
+
+    per_doc: dict[str, list[VectorSearchHit]] = {uid: [] for uid in table_docs}
     for hit in hits:
-        per_doc.setdefault(hit.uid, []).append(hit)
-    ordered: list[VectorSearchHit] = []
+        if hit.uid in table_docs:
+            per_doc[hit.uid].append(hit)
     for chunks in per_doc.values():
         chunks.sort(key=lambda h: (h.chunk_index is None, h.chunk_index or 0))
-        ordered.extend(chunks)
+
+    ordered: list[VectorSearchHit] = []
+    emitted: set[str] = set()
+    for hit in hits:
+        if hit.uid not in table_docs:
+            ordered.append(hit)
+        elif hit.uid not in emitted:
+            emitted.add(hit.uid)
+            ordered.extend(per_doc[hit.uid])
     return ordered
 
 

--- a/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/toolkit.py
+++ b/libs/fred-runtime/fred_runtime/integrations/kf_vector_search/toolkit.py
@@ -59,6 +59,7 @@ from langchain_core.tools import BaseTool, tool
 
 from fred_runtime.common.kf_base_client import KnowledgeFlowAgentContext
 from fred_runtime.common.kf_vectorsearch_client import VectorSearchClient
+from fred_runtime.common.table_hits import repair_table_hits
 from fred_runtime.runtime_support.request_context_helpers import (
     get_document_library_tags_ids,
     get_document_uids,
@@ -158,6 +159,8 @@ class KfVectorSearchToolkit:
                 include_session_scope=include_session_scope,
                 include_corpus_scope=include_corpus_scope,
             )
+
+            hits = await repair_table_hits(list(hits), client.get_document_chunks)
 
             logger.info(
                 "[KFVS][TOOL] question=%r top_k=%d hits=%d",

--- a/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
+++ b/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
@@ -109,6 +109,7 @@ from fred_runtime.common.kf_workspace_client import (
 )
 from fred_runtime.common.mcp_runtime import MCPRuntime
 from fred_runtime.common.structures import AgentSettingsLike
+from fred_runtime.common.table_hits import repair_table_hits
 from fred_runtime.runtime_context import get_runtime_context
 from fred_runtime.runtime_support import (
     get_document_library_tags_ids,
@@ -850,69 +851,6 @@ class _TraceAggregate(TypedDict):
     max_ms: int
 
 
-# A table chunk is a header row followed by a Markdown separator row. Matching on
-# the separator rather than a leading "|" also catches tables written without one.
-_TABLE_SEPARATOR_CHARS = set("|-: \t")
-
-# Ceiling for the whole-table fetch below. A table is worth completing, but not at
-# the cost of an unbounded prompt: one document per call, capped in chunks. When a
-# document does not fit under the cap the fetch is abandoned rather than truncated -
-# the document's first N chunks are not the ones that matched the query.
-_TABLE_EXPANSION_MAX_CHUNKS = 40
-
-
-def _restore_document_order(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
-    """Group hits per document and put each document's chunks back in index order.
-
-    Similarity ranking interleaves chunks, which reads as a shuffled table. Documents
-    keep their relative ranking: whichever scored best stays first.
-    """
-    per_doc: dict[str, list[VectorSearchHit]] = {}
-    for hit in hits:
-        per_doc.setdefault(hit.uid, []).append(hit)
-    ordered: list[VectorSearchHit] = []
-    for chunks in per_doc.values():
-        chunks.sort(key=lambda h: (h.chunk_index is None, h.chunk_index or 0))
-        ordered.extend(chunks)
-    return ordered
-
-
-def _strip_repeated_table_headers(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
-    """Drop the header the splitter repeats on every table chunk, except the first.
-
-    Each chunk carries the header so it stands alone, but a run of them reads to the
-    model as separate tables. Strips only when the previous chunk of the same document
-    opened with the very same header, so a run of one table keeps exactly one header
-    and a second, different table in the document keeps its own.
-    """
-    out: list[VectorSearchHit] = []
-    prev_uid: str | None = None
-    prev_header: str | None = None
-    for hit in hits:
-        span = _table_header_span(hit.content)
-        header = "\n".join(hit.content.split("\n")[:span]) if span else None
-        if span and hit.uid == prev_uid and header == prev_header:
-            body = "\n".join(hit.content.split("\n")[span:]).lstrip("\n")
-            hit = hit.model_copy(update={"content": body})
-        out.append(hit)
-        prev_uid = hit.uid
-        prev_header = header
-    return out
-
-
-def _table_header_span(content: str) -> int:
-    """Length in lines of the leading table header, or 0 when this is not a table chunk."""
-    lines = content.split("\n", 2)
-    if len(lines) < 2 or "|" not in lines[0]:
-        return 0
-    separator = lines[1].strip()
-    if "|" not in separator or "-" not in separator:
-        return 0
-    if set(separator) - _TABLE_SEPARATOR_CHARS:
-        return 0
-    return 2
-
-
 class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
     """
     First concrete Fred-side tool invoker for v2 agents.
@@ -952,71 +890,6 @@ class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
                 return await result
             return result
         raise RuntimeError(f"Unsupported Fred tool ref: {request.tool_ref!r}")
-
-    async def _complete_truncated_table(
-        self, hits: list[VectorSearchHit]
-    ) -> list[VectorSearchHit]:
-        """Refetch a whole table when top_k demonstrably cut one short.
-
-        Table chunks from one document at non-contiguous indices mean similarity
-        ranking returned a slice with a hole in it, and a sliced table answers row
-        questions wrong. Two adjacent chunks, or two separate small tables, are
-        complete already and are left alone.
-
-        Best-effort: on a failure, or on a document too large for the cap, the
-        original hits stand - the document's first N chunks are not the ones that
-        matched the query, so a truncated refetch would be worse than none.
-        """
-        indices: dict[str, list[int]] = {}
-        for hit in hits:
-            if _table_header_span(hit.content) and hit.chunk_index is not None:
-                indices.setdefault(hit.uid, []).append(hit.chunk_index)
-        gapped = {
-            uid: idx
-            for uid, idx in indices.items()
-            if len(idx) >= 2 and max(idx) - min(idx) + 1 > len(idx)
-        }
-        if not gapped:
-            return hits
-        uid = max(gapped, key=lambda u: len(gapped[u]))
-
-        try:
-            chunks = await self._search_client.get_document_chunks(
-                document_uid=uid, limit=_TABLE_EXPANSION_MAX_CHUNKS
-            )
-        except Exception:
-            logger.warning(
-                "[KNOWLEDGE_SEARCH] table completion failed for uid=%s",
-                uid,
-                exc_info=True,
-            )
-            return hits
-
-        original = [hit for hit in hits if hit.uid == uid]
-        if len(chunks) <= len(original) or len(chunks) >= _TABLE_EXPANSION_MAX_CHUNKS:
-            logger.info(
-                "[KNOWLEDGE_SEARCH] table completion skipped uid=%s fetched=%d had=%d cap=%d",
-                uid,
-                len(chunks),
-                len(original),
-                _TABLE_EXPANSION_MAX_CHUNKS,
-            )
-            return hits
-
-        # The fetch has no similarity score of its own. Carry the document's best
-        # score over, or citation selection would drop the very table being answered
-        # from, and splice in place so the document keeps its rank.
-        best = max(hit.score for hit in original)
-        chunks = [chunk.model_copy(update={"score": best}) for chunk in chunks]
-        at = next(i for i, hit in enumerate(hits) if hit.uid == uid)
-        rest = [hit for hit in hits if hit.uid != uid]
-        logger.info(
-            "[KNOWLEDGE_SEARCH] table completion uid=%s chunks=%d->%d",
-            uid,
-            len(original),
-            len(chunks),
-        )
-        return rest[:at] + chunks + rest[at:]
 
     async def _invoke_knowledge_search(
         self, request: ToolInvocationRequest
@@ -1072,9 +945,7 @@ class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
             include_corpus_scope=include_corpus_scope,
         )
 
-        hits = await self._complete_truncated_table(hits)
-        hits = _restore_document_order(hits)
-        hits = _strip_repeated_table_headers(hits)
+        hits = await repair_table_hits(hits, self._search_client.get_document_chunks)
 
         # Only expose the fields the LLM needs for citation and reasoning.
         # URL and operational fields are excluded to prevent the model from
@@ -1410,6 +1281,9 @@ class DocumentSearchAdapter(DocumentSearchPort):
             # so a 401 degraded to "the service call failed" instead of naming
             # the status. The capability never imports the HTTP stack itself.
             raise _wrap_document_port_error(exc) from exc
+        hits = await repair_table_hits(
+            list(hits), self._search_client.get_document_chunks
+        )
         return DocumentSearchResult(hits=tuple(hits))
 
 

--- a/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
+++ b/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
@@ -850,6 +850,66 @@ class _TraceAggregate(TypedDict):
     max_ms: int
 
 
+# A table chunk is a header row followed by a Markdown separator row. Matching on
+# the separator rather than a leading "|" also catches tables written without one.
+_TABLE_SEPARATOR_CHARS = set("|-: \t")
+
+# Ceilings for the whole-table fetch below. A table is worth completing, but not
+# at the cost of an unbounded prompt: one document per call, capped in chunks.
+_TABLE_EXPANSION_MIN_HITS = 2
+_TABLE_EXPANSION_MAX_CHUNKS = 40
+
+
+def _restore_document_order(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
+    """Group hits per document and put each document's chunks back in index order.
+
+    Similarity ranking interleaves chunks, which reads as a shuffled table. Documents
+    keep their relative ranking: whichever scored best stays first.
+    """
+    per_doc: dict[str, list[VectorSearchHit]] = {}
+    for hit in hits:
+        per_doc.setdefault(hit.uid, []).append(hit)
+    ordered: list[VectorSearchHit] = []
+    for chunks in per_doc.values():
+        chunks.sort(key=lambda h: (h.chunk_index is None, h.chunk_index or 0))
+        ordered.extend(chunks)
+    return ordered
+
+
+def _strip_repeated_table_headers(hits: list[VectorSearchHit]) -> list[VectorSearchHit]:
+    """Drop the header the splitter repeats on every table chunk, except the first.
+
+    Each chunk carries the header so it stands alone, but a run of them reads to the
+    model as separate tables. Only strips when the previous chunk of the same document
+    was also a table chunk, so the run keeps exactly one header.
+    """
+    out: list[VectorSearchHit] = []
+    prev_uid: str | None = None
+    prev_was_table = False
+    for hit in hits:
+        span = _table_header_span(hit.content)
+        if span and prev_was_table and hit.uid == prev_uid:
+            body = "\n".join(hit.content.split("\n")[span:]).lstrip("\n")
+            hit = hit.model_copy(update={"content": body})
+        out.append(hit)
+        prev_uid = hit.uid
+        prev_was_table = bool(span)
+    return out
+
+
+def _table_header_span(content: str) -> int:
+    """Length in lines of the leading table header, or 0 when this is not a table chunk."""
+    lines = content.split("\n", 2)
+    if len(lines) < 2 or "|" not in lines[0]:
+        return 0
+    separator = lines[1].strip()
+    if "|" not in separator or "-" not in separator:
+        return 0
+    if set(separator) - _TABLE_SEPARATOR_CHARS:
+        return 0
+    return 2
+
+
 class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
     """
     First concrete Fred-side tool invoker for v2 agents.
@@ -889,6 +949,49 @@ class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
                 return await result
             return result
         raise RuntimeError(f"Unsupported Fred tool ref: {request.tool_ref!r}")
+
+    async def _complete_truncated_table(
+        self, hits: list[VectorSearchHit]
+    ) -> list[VectorSearchHit]:
+        """Refetch a whole table when top_k clearly cut one short.
+
+        Several table chunks from one document means similarity ranking returned a
+        slice of a table, and a sliced table answers row questions wrong. Refetch that
+        document's chunks in index order instead. Best-effort: on any failure the
+        original hits stand.
+        """
+        counts: dict[str, int] = {}
+        for hit in hits:
+            if _table_header_span(hit.content):
+                counts[hit.uid] = counts.get(hit.uid, 0) + 1
+        if not counts:
+            return hits
+        uid, table_hits = max(counts.items(), key=lambda kv: kv[1])
+        if table_hits < _TABLE_EXPANSION_MIN_HITS:
+            return hits
+
+        try:
+            chunks = await self._search_client.get_document_chunks(
+                document_uid=uid, limit=_TABLE_EXPANSION_MAX_CHUNKS
+            )
+        except Exception:
+            logger.warning(
+                "[KNOWLEDGE_SEARCH] table completion failed for uid=%s",
+                uid,
+                exc_info=True,
+            )
+            return hits
+
+        already = sum(1 for hit in hits if hit.uid == uid)
+        if len(chunks) <= already:
+            return hits
+        logger.info(
+            "[KNOWLEDGE_SEARCH] table completion uid=%s chunks=%d->%d",
+            uid,
+            already,
+            len(chunks),
+        )
+        return [hit for hit in hits if hit.uid != uid] + chunks
 
     async def _invoke_knowledge_search(
         self, request: ToolInvocationRequest
@@ -943,6 +1046,10 @@ class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
             include_session_scope=include_session_scope,
             include_corpus_scope=include_corpus_scope,
         )
+
+        hits = await self._complete_truncated_table(hits)
+        hits = _restore_document_order(hits)
+        hits = _strip_repeated_table_headers(hits)
 
         # Only expose the fields the LLM needs for citation and reasoning.
         # URL and operational fields are excluded to prevent the model from

--- a/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
+++ b/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
@@ -854,9 +854,10 @@ class _TraceAggregate(TypedDict):
 # the separator rather than a leading "|" also catches tables written without one.
 _TABLE_SEPARATOR_CHARS = set("|-: \t")
 
-# Ceilings for the whole-table fetch below. A table is worth completing, but not
-# at the cost of an unbounded prompt: one document per call, capped in chunks.
-_TABLE_EXPANSION_MIN_HITS = 2
+# Ceiling for the whole-table fetch below. A table is worth completing, but not at
+# the cost of an unbounded prompt: one document per call, capped in chunks. When a
+# document does not fit under the cap the fetch is abandoned rather than truncated -
+# the document's first N chunks are not the ones that matched the query.
 _TABLE_EXPANSION_MAX_CHUNKS = 40
 
 
@@ -880,20 +881,22 @@ def _strip_repeated_table_headers(hits: list[VectorSearchHit]) -> list[VectorSea
     """Drop the header the splitter repeats on every table chunk, except the first.
 
     Each chunk carries the header so it stands alone, but a run of them reads to the
-    model as separate tables. Only strips when the previous chunk of the same document
-    was also a table chunk, so the run keeps exactly one header.
+    model as separate tables. Strips only when the previous chunk of the same document
+    opened with the very same header, so a run of one table keeps exactly one header
+    and a second, different table in the document keeps its own.
     """
     out: list[VectorSearchHit] = []
     prev_uid: str | None = None
-    prev_was_table = False
+    prev_header: str | None = None
     for hit in hits:
         span = _table_header_span(hit.content)
-        if span and prev_was_table and hit.uid == prev_uid:
+        header = "\n".join(hit.content.split("\n")[:span]) if span else None
+        if span and hit.uid == prev_uid and header == prev_header:
             body = "\n".join(hit.content.split("\n")[span:]).lstrip("\n")
             hit = hit.model_copy(update={"content": body})
         out.append(hit)
         prev_uid = hit.uid
-        prev_was_table = bool(span)
+        prev_header = header
     return out
 
 
@@ -953,22 +956,29 @@ class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
     async def _complete_truncated_table(
         self, hits: list[VectorSearchHit]
     ) -> list[VectorSearchHit]:
-        """Refetch a whole table when top_k clearly cut one short.
+        """Refetch a whole table when top_k demonstrably cut one short.
 
-        Several table chunks from one document means similarity ranking returned a
-        slice of a table, and a sliced table answers row questions wrong. Refetch that
-        document's chunks in index order instead. Best-effort: on any failure the
-        original hits stand.
+        Table chunks from one document at non-contiguous indices mean similarity
+        ranking returned a slice with a hole in it, and a sliced table answers row
+        questions wrong. Two adjacent chunks, or two separate small tables, are
+        complete already and are left alone.
+
+        Best-effort: on a failure, or on a document too large for the cap, the
+        original hits stand - the document's first N chunks are not the ones that
+        matched the query, so a truncated refetch would be worse than none.
         """
-        counts: dict[str, int] = {}
+        indices: dict[str, list[int]] = {}
         for hit in hits:
-            if _table_header_span(hit.content):
-                counts[hit.uid] = counts.get(hit.uid, 0) + 1
-        if not counts:
+            if _table_header_span(hit.content) and hit.chunk_index is not None:
+                indices.setdefault(hit.uid, []).append(hit.chunk_index)
+        gapped = {
+            uid: idx
+            for uid, idx in indices.items()
+            if len(idx) >= 2 and max(idx) - min(idx) + 1 > len(idx)
+        }
+        if not gapped:
             return hits
-        uid, table_hits = max(counts.items(), key=lambda kv: kv[1])
-        if table_hits < _TABLE_EXPANSION_MIN_HITS:
-            return hits
+        uid = max(gapped, key=lambda u: len(gapped[u]))
 
         try:
             chunks = await self._search_client.get_document_chunks(
@@ -982,16 +992,31 @@ class FredKnowledgeSearchToolInvoker(ToolInvokerPort):
             )
             return hits
 
-        already = sum(1 for hit in hits if hit.uid == uid)
-        if len(chunks) <= already:
+        original = [hit for hit in hits if hit.uid == uid]
+        if len(chunks) <= len(original) or len(chunks) >= _TABLE_EXPANSION_MAX_CHUNKS:
+            logger.info(
+                "[KNOWLEDGE_SEARCH] table completion skipped uid=%s fetched=%d had=%d cap=%d",
+                uid,
+                len(chunks),
+                len(original),
+                _TABLE_EXPANSION_MAX_CHUNKS,
+            )
             return hits
+
+        # The fetch has no similarity score of its own. Carry the document's best
+        # score over, or citation selection would drop the very table being answered
+        # from, and splice in place so the document keeps its rank.
+        best = max(hit.score for hit in original)
+        chunks = [chunk.model_copy(update={"score": best}) for chunk in chunks]
+        at = next(i for i, hit in enumerate(hits) if hit.uid == uid)
+        rest = [hit for hit in hits if hit.uid != uid]
         logger.info(
             "[KNOWLEDGE_SEARCH] table completion uid=%s chunks=%d->%d",
             uid,
-            already,
+            len(original),
             len(chunks),
         )
-        return [hit for hit in hits if hit.uid != uid] + chunks
+        return rest[:at] + chunks + rest[at:]
 
     async def _invoke_knowledge_search(
         self, request: ToolInvocationRequest

--- a/libs/fred-runtime/tests/test_kf_vector_search_toolkit.py
+++ b/libs/fred-runtime/tests/test_kf_vector_search_toolkit.py
@@ -77,6 +77,10 @@ class _FakeSearchClient:
             ),
         ]
 
+    async def get_document_chunks(self, **_kwargs: object) -> list[VectorSearchHit]:
+        """Part of the VectorSearchClient surface; no truncated table in these fixtures."""
+        return []
+
 
 class _FakeSearchClientWithNoise:
     """Stand-in returning one strong hit and one hit that's noise relative to it."""
@@ -93,6 +97,10 @@ class _FakeSearchClientWithNoise:
                 uid="d2", title="Doc 2", content="beta", score=0.05, type="document"
             ),
         ]
+
+    async def get_document_chunks(self, **_kwargs: object) -> list[VectorSearchHit]:
+        """Part of the VectorSearchClient surface; no truncated table in these fixtures."""
+        return []
 
 
 def _build_search_tool(

--- a/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
+++ b/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
@@ -272,3 +272,102 @@ async def test_a_failing_refetch_leaves_the_original_hits(
 
     contents = [hit["content"] for hit in result.blocks[0].data["hits"]]
     assert contents == [f"{HEADER}\n| a | 1 |", "| c | 3 |"]
+
+
+OTHER_HEADER = "| country | code |\n| --- | --- |"
+
+
+def test_a_second_distinct_table_keeps_its_own_header():
+    """Stripping on adjacency alone would reattribute these rows to the first table."""
+    hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |"),
+        _hit("d1", f"{OTHER_HEADER}\n| FR | 33 |"),
+    ]
+
+    out = adapters_module._strip_repeated_table_headers(hits)
+
+    assert out[1].content == f"{OTHER_HEADER}\n| FR | 33 |"
+
+
+@pytest.mark.asyncio
+async def test_contiguous_table_chunks_are_not_refetched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two adjacent chunks are a complete slice; there is nothing to complete."""
+    search_hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=4),
+        _hit("d1", f"{HEADER}\n| b | 2 |", chunk_index=5),
+    ]
+    client_cls, calls = _client_returning(search_hits, [])
+
+    await _invoke(monkeypatch, client_cls)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_document_larger_than_the_cap_is_left_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A head-truncated refetch would drop the chunks that actually matched."""
+    search_hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=60),
+        _hit("d1", f"{HEADER}\n| c | 3 |", chunk_index=62),
+    ]
+    fetched = [
+        _hit("d1", f"{HEADER}\n| r{i} | {i} |", chunk_index=i)
+        for i in range(adapters_module._TABLE_EXPANSION_MAX_CHUNKS)
+    ]
+    client_cls, _ = _client_returning(search_hits, fetched)
+
+    result = await _invoke(monkeypatch, client_cls)
+
+    contents = [hit["content"] for hit in result.blocks[0].data["hits"]]
+    assert contents == [f"{HEADER}\n| a | 1 |", "| c | 3 |"]
+
+
+@pytest.mark.asyncio
+async def test_refetched_chunks_keep_the_document_as_a_citable_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fetch carries no score of its own, so it inherits the document's best."""
+    search_hits = [
+        _hit("d2", "unrelated prose", chunk_index=0, score=0.8),
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=0, score=0.9),
+        _hit("d1", f"{HEADER}\n| c | 3 |", chunk_index=2, score=0.85),
+    ]
+    fetched = [
+        _hit("d1", f"{HEADER}\n| {row} | {i} |", chunk_index=i, score=0.0)
+        for i, row in enumerate("abc")
+    ]
+    client_cls, _ = _client_returning(search_hits, fetched)
+
+    result = await _invoke(monkeypatch, client_cls)
+
+    assert "d1" in {source.uid for source in result.sources}
+
+
+@pytest.mark.asyncio
+async def test_the_completed_document_keeps_its_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Appending the fetch at the end would demote the one document the fix serves."""
+    search_hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=0, score=0.95),
+        _hit("d1", f"{HEADER}\n| c | 3 |", chunk_index=2, score=0.94),
+        _hit("d2", "unrelated prose", chunk_index=0, score=0.5),
+    ]
+    fetched = [
+        _hit("d1", f"{HEADER}\n| {row} | {i} |", chunk_index=i)
+        for i, row in enumerate("abc")
+    ]
+    client_cls, _ = _client_returning(search_hits, fetched)
+
+    result = await _invoke(monkeypatch, client_cls)
+
+    assert [hit["uid"] for hit in result.blocks[0].data["hits"]] == [
+        "d1",
+        "d1",
+        "d1",
+        "d2",
+    ]

--- a/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
+++ b/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
@@ -83,21 +83,21 @@ def test_header_span_rejects_single_line():
 
 def test_chunks_of_one_document_are_reordered_by_index():
     hits = [
-        _hit("d1", "third", chunk_index=3),
-        _hit("d1", "first", chunk_index=1),
-        _hit("d1", "second", chunk_index=2),
+        _hit("d1", f"{HEADER}\n| third | 3 |", chunk_index=3),
+        _hit("d1", f"{HEADER}\n| first | 1 |", chunk_index=1),
+        _hit("d1", f"{HEADER}\n| second | 2 |", chunk_index=2),
     ]
 
     ordered = table_hits.restore_document_order(hits)
 
-    assert [h.content for h in ordered] == ["first", "second", "third"]
+    assert [h.chunk_index for h in ordered] == [1, 2, 3]
 
 
 def test_documents_keep_their_relative_ranking():
     hits = [
-        _hit("d2", "b", chunk_index=5),
-        _hit("d1", "a", chunk_index=1),
-        _hit("d2", "a", chunk_index=1),
+        _hit("d2", f"{HEADER}\n| b | 5 |", chunk_index=5),
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=1),
+        _hit("d2", f"{HEADER}\n| a | 1 |", chunk_index=1),
     ]
 
     ordered = table_hits.restore_document_order(hits)
@@ -107,11 +107,14 @@ def test_documents_keep_their_relative_ranking():
 
 def test_chunks_without_index_sort_last():
     """Documents indexed before chunk_index existed degrade, they do not jump the queue."""
-    hits = [_hit("d1", "legacy"), _hit("d1", "indexed", chunk_index=2)]
+    hits = [
+        _hit("d1", f"{HEADER}\n| legacy | x |"),
+        _hit("d1", f"{HEADER}\n| indexed | 2 |", chunk_index=2),
+    ]
 
     ordered = table_hits.restore_document_order(hits)
 
-    assert [h.content for h in ordered] == ["indexed", "legacy"]
+    assert [h.chunk_index for h in ordered] == [2, None]
 
 
 # --------------------------------------------------------------------------- #
@@ -368,4 +371,36 @@ async def test_the_completed_document_keeps_its_rank(
         "d1",
         "d1",
         "d2",
+    ]
+
+
+def test_a_table_free_hit_set_is_returned_untouched():
+    """Ordinary prose RAG must not be reordered: the best hit stays first."""
+    hits = [
+        _hit("docA", "most relevant prose", chunk_index=7, score=0.91),
+        _hit("docB", "other document", chunk_index=2, score=0.88),
+        _hit("docA", "weak intro", chunk_index=1, score=0.40),
+        _hit("docC", "third document", chunk_index=5, score=0.35),
+    ]
+
+    out = table_hits.restore_document_order(list(hits))
+
+    assert [(h.uid, h.chunk_index) for h in out] == [
+        (h.uid, h.chunk_index) for h in hits
+    ]
+
+
+def test_a_prose_document_keeps_its_place_while_a_table_document_is_grouped():
+    hits = [
+        _hit("prose", "unrelated paragraph", chunk_index=9, score=0.95),
+        _hit("tbl", f"{HEADER}\n| c | 3 |", chunk_index=3, score=0.90),
+        _hit("tbl", f"{HEADER}\n| a | 1 |", chunk_index=1, score=0.50),
+    ]
+
+    out = table_hits.restore_document_order(list(hits))
+
+    assert [(h.uid, h.chunk_index) for h in out] == [
+        ("prose", 9),
+        ("tbl", 1),
+        ("tbl", 3),
     ]

--- a/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
+++ b/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
@@ -1,0 +1,274 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Table-aware post-processing of `knowledge.search` hits.
+
+Similarity ranking returns a large table's chunks shuffled and truncated, and the
+splitter repeats the header on each one. Left alone the model reads that as several
+small unrelated tables and answers row questions wrong.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import fred_runtime.integrations.v2_runtime.adapters as adapters_module
+import pytest
+from fred_core.store.vector_search import VectorSearchHit
+from fred_sdk.contracts.context import (
+    BoundRuntimeContext,
+    PortableContext,
+    PortableEnvironment,
+    RuntimeContext,
+    ToolInvocationRequest,
+)
+from fred_sdk.contracts.models import AgentTuning, MCPServerRef
+from fred_sdk.support.builtins.catalog import TOOL_REF_KNOWLEDGE_SEARCH
+
+HEADER = "| name | default |\n| --- | --- |"
+NO_LEADING_PIPE = "name | default\n--- | ---"
+
+
+def _hit(
+    uid: str, content: str, *, chunk_index: int | None = None, score: float = 0.9
+) -> VectorSearchHit:
+    return VectorSearchHit(
+        uid=uid,
+        title=uid,
+        content=content,
+        score=score,
+        type="document",
+        chunk_index=chunk_index,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _table_header_span
+# --------------------------------------------------------------------------- #
+
+
+def test_header_span_detects_table_with_leading_pipe():
+    assert adapters_module._table_header_span(f"{HEADER}\n| a | 1 |") == 2
+
+
+def test_header_span_detects_table_without_leading_pipe():
+    """The splitter accepts these, so the dedup must recognise them too."""
+    assert adapters_module._table_header_span(f"{NO_LEADING_PIPE}\na | 1") == 2
+
+
+def test_header_span_rejects_prose_containing_pipes():
+    assert (
+        adapters_module._table_header_span("use a | b to pipe\nthen read the result")
+        == 0
+    )
+
+
+def test_header_span_rejects_single_line():
+    assert adapters_module._table_header_span("| name | default |") == 0
+
+
+# --------------------------------------------------------------------------- #
+# _restore_document_order
+# --------------------------------------------------------------------------- #
+
+
+def test_chunks_of_one_document_are_reordered_by_index():
+    hits = [
+        _hit("d1", "third", chunk_index=3),
+        _hit("d1", "first", chunk_index=1),
+        _hit("d1", "second", chunk_index=2),
+    ]
+
+    ordered = adapters_module._restore_document_order(hits)
+
+    assert [h.content for h in ordered] == ["first", "second", "third"]
+
+
+def test_documents_keep_their_relative_ranking():
+    hits = [
+        _hit("d2", "b", chunk_index=5),
+        _hit("d1", "a", chunk_index=1),
+        _hit("d2", "a", chunk_index=1),
+    ]
+
+    ordered = adapters_module._restore_document_order(hits)
+
+    assert [h.uid for h in ordered] == ["d2", "d2", "d1"]
+
+
+def test_chunks_without_index_sort_last():
+    """Documents indexed before chunk_index existed degrade, they do not jump the queue."""
+    hits = [_hit("d1", "legacy"), _hit("d1", "indexed", chunk_index=2)]
+
+    ordered = adapters_module._restore_document_order(hits)
+
+    assert [h.content for h in ordered] == ["indexed", "legacy"]
+
+
+# --------------------------------------------------------------------------- #
+# _strip_repeated_table_headers
+# --------------------------------------------------------------------------- #
+
+
+def test_only_the_first_chunk_of_a_table_run_keeps_its_header():
+    hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |"),
+        _hit("d1", f"{HEADER}\n| b | 2 |"),
+        _hit("d1", f"{HEADER}\n| c | 3 |"),
+    ]
+
+    out = adapters_module._strip_repeated_table_headers(hits)
+
+    assert out[0].content == f"{HEADER}\n| a | 1 |"
+    assert out[1].content == "| b | 2 |"
+    assert out[2].content == "| c | 3 |"
+
+
+def test_first_table_chunk_keeps_its_header_after_an_intro_chunk():
+    hits = [_hit("d1", "Intro paragraph."), _hit("d1", f"{HEADER}\n| a | 1 |")]
+
+    out = adapters_module._strip_repeated_table_headers(hits)
+
+    assert out[1].content == f"{HEADER}\n| a | 1 |"
+
+
+def test_headers_are_not_stripped_across_documents():
+    hits = [_hit("d1", f"{HEADER}\n| a | 1 |"), _hit("d2", f"{HEADER}\n| b | 2 |")]
+
+    out = adapters_module._strip_repeated_table_headers(hits)
+
+    assert out[1].content == f"{HEADER}\n| b | 2 |"
+
+
+# --------------------------------------------------------------------------- #
+# _complete_truncated_table, through the invoker
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSettings:
+    id: str = "agent-1"
+    team_id: str | None = "team-1"
+    tuning: AgentTuning | None = None
+    active_mcp_servers: Sequence[MCPServerRef] = ()
+
+
+def _binding() -> BoundRuntimeContext:
+    return BoundRuntimeContext(
+        runtime_context=RuntimeContext(session_id="s-1", team_id="team-1"),
+        portable_context=PortableContext(
+            request_id="request-1",
+            correlation_id="correlation-1",
+            actor="u-1",
+            tenant="team-1",
+            environment=PortableEnvironment.DEV,
+        ),
+    )
+
+
+def _client_returning(
+    search_hits: list[VectorSearchHit], fetched: list[VectorSearchHit]
+):
+    calls: list[dict[str, Any]] = []
+
+    class _FakeSearchClient:
+        def __init__(self, agent: object) -> None:
+            self._agent = agent
+
+        async def search(self, **_kwargs: Any) -> list[VectorSearchHit]:
+            return list(search_hits)
+
+        async def get_document_chunks(self, **kwargs: Any) -> list[VectorSearchHit]:
+            calls.append(kwargs)
+            return list(fetched)
+
+    return _FakeSearchClient, calls
+
+
+async def _invoke(monkeypatch: pytest.MonkeyPatch, client_cls) -> Any:
+    monkeypatch.setattr(adapters_module, "VectorSearchClient", client_cls)
+    binding = _binding()
+    invoker = adapters_module.FredKnowledgeSearchToolInvoker(
+        binding=binding, settings=_FakeSettings()
+    )
+    return await invoker.invoke(
+        ToolInvocationRequest(
+            tool_ref=TOOL_REF_KNOWLEDGE_SEARCH,
+            payload={"query": "what is the default of b?", "top_k": 2},
+            context=binding.portable_context,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncated_table_is_refetched_whole_with_a_bounded_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: the fetch is keyword-only and capped, and it must actually run."""
+    search_hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=0),
+        _hit("d1", f"{HEADER}\n| c | 3 |", chunk_index=2),
+    ]
+    fetched = [
+        _hit("d1", f"{HEADER}\n| {row} | {i} |", chunk_index=i)
+        for i, row in enumerate("abc")
+    ]
+    client_cls, calls = _client_returning(search_hits, fetched)
+
+    result = await _invoke(monkeypatch, client_cls)
+
+    assert calls == [
+        {"document_uid": "d1", "limit": adapters_module._TABLE_EXPANSION_MAX_CHUNKS}
+    ]
+    contents = [hit["content"] for hit in result.blocks[0].data["hits"]]
+    assert contents == [f"{HEADER}\n| a | 0 |", "| b | 1 |", "| c | 2 |"]
+
+
+@pytest.mark.asyncio
+async def test_a_single_table_chunk_does_not_trigger_a_refetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=0),
+        _hit("d2", "plain prose", chunk_index=0),
+    ]
+    client_cls, calls = _client_returning(search_hits, [])
+
+    await _invoke(monkeypatch, client_cls)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_failing_refetch_leaves_the_original_hits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_hits = [
+        _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=0),
+        _hit("d1", f"{HEADER}\n| c | 3 |", chunk_index=2),
+    ]
+
+    class _FailingClient:
+        def __init__(self, agent: object) -> None:
+            self._agent = agent
+
+        async def search(self, **_kwargs: Any) -> list[VectorSearchHit]:
+            return list(search_hits)
+
+        async def get_document_chunks(self, **_kwargs: Any) -> list[VectorSearchHit]:
+            raise RuntimeError("knowledge-flow is down")
+
+    result = await _invoke(monkeypatch, _FailingClient)
+
+    contents = [hit["content"] for hit in result.blocks[0].data["hits"]]
+    assert contents == [f"{HEADER}\n| a | 1 |", "| c | 3 |"]

--- a/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
+++ b/libs/fred-runtime/tests/test_knowledge_search_table_ordering.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+import fred_runtime.common.table_hits as table_hits
 import fred_runtime.integrations.v2_runtime.adapters as adapters_module
 import pytest
 from fred_core.store.vector_search import VectorSearchHit
@@ -59,23 +60,20 @@ def _hit(
 
 
 def test_header_span_detects_table_with_leading_pipe():
-    assert adapters_module._table_header_span(f"{HEADER}\n| a | 1 |") == 2
+    assert table_hits.table_header_span(f"{HEADER}\n| a | 1 |") == 2
 
 
 def test_header_span_detects_table_without_leading_pipe():
     """The splitter accepts these, so the dedup must recognise them too."""
-    assert adapters_module._table_header_span(f"{NO_LEADING_PIPE}\na | 1") == 2
+    assert table_hits.table_header_span(f"{NO_LEADING_PIPE}\na | 1") == 2
 
 
 def test_header_span_rejects_prose_containing_pipes():
-    assert (
-        adapters_module._table_header_span("use a | b to pipe\nthen read the result")
-        == 0
-    )
+    assert table_hits.table_header_span("use a | b to pipe\nthen read the result") == 0
 
 
 def test_header_span_rejects_single_line():
-    assert adapters_module._table_header_span("| name | default |") == 0
+    assert table_hits.table_header_span("| name | default |") == 0
 
 
 # --------------------------------------------------------------------------- #
@@ -90,7 +88,7 @@ def test_chunks_of_one_document_are_reordered_by_index():
         _hit("d1", "second", chunk_index=2),
     ]
 
-    ordered = adapters_module._restore_document_order(hits)
+    ordered = table_hits.restore_document_order(hits)
 
     assert [h.content for h in ordered] == ["first", "second", "third"]
 
@@ -102,7 +100,7 @@ def test_documents_keep_their_relative_ranking():
         _hit("d2", "a", chunk_index=1),
     ]
 
-    ordered = adapters_module._restore_document_order(hits)
+    ordered = table_hits.restore_document_order(hits)
 
     assert [h.uid for h in ordered] == ["d2", "d2", "d1"]
 
@@ -111,7 +109,7 @@ def test_chunks_without_index_sort_last():
     """Documents indexed before chunk_index existed degrade, they do not jump the queue."""
     hits = [_hit("d1", "legacy"), _hit("d1", "indexed", chunk_index=2)]
 
-    ordered = adapters_module._restore_document_order(hits)
+    ordered = table_hits.restore_document_order(hits)
 
     assert [h.content for h in ordered] == ["indexed", "legacy"]
 
@@ -128,7 +126,7 @@ def test_only_the_first_chunk_of_a_table_run_keeps_its_header():
         _hit("d1", f"{HEADER}\n| c | 3 |"),
     ]
 
-    out = adapters_module._strip_repeated_table_headers(hits)
+    out = table_hits.strip_repeated_table_headers(hits)
 
     assert out[0].content == f"{HEADER}\n| a | 1 |"
     assert out[1].content == "| b | 2 |"
@@ -138,7 +136,7 @@ def test_only_the_first_chunk_of_a_table_run_keeps_its_header():
 def test_first_table_chunk_keeps_its_header_after_an_intro_chunk():
     hits = [_hit("d1", "Intro paragraph."), _hit("d1", f"{HEADER}\n| a | 1 |")]
 
-    out = adapters_module._strip_repeated_table_headers(hits)
+    out = table_hits.strip_repeated_table_headers(hits)
 
     assert out[1].content == f"{HEADER}\n| a | 1 |"
 
@@ -146,7 +144,7 @@ def test_first_table_chunk_keeps_its_header_after_an_intro_chunk():
 def test_headers_are_not_stripped_across_documents():
     hits = [_hit("d1", f"{HEADER}\n| a | 1 |"), _hit("d2", f"{HEADER}\n| b | 2 |")]
 
-    out = adapters_module._strip_repeated_table_headers(hits)
+    out = table_hits.strip_repeated_table_headers(hits)
 
     assert out[1].content == f"{HEADER}\n| b | 2 |"
 
@@ -228,7 +226,7 @@ async def test_truncated_table_is_refetched_whole_with_a_bounded_limit(
     result = await _invoke(monkeypatch, client_cls)
 
     assert calls == [
-        {"document_uid": "d1", "limit": adapters_module._TABLE_EXPANSION_MAX_CHUNKS}
+        {"document_uid": "d1", "limit": table_hits.TABLE_EXPANSION_MAX_CHUNKS}
     ]
     contents = [hit["content"] for hit in result.blocks[0].data["hits"]]
     assert contents == [f"{HEADER}\n| a | 0 |", "| b | 1 |", "| c | 2 |"]
@@ -284,7 +282,7 @@ def test_a_second_distinct_table_keeps_its_own_header():
         _hit("d1", f"{OTHER_HEADER}\n| FR | 33 |"),
     ]
 
-    out = adapters_module._strip_repeated_table_headers(hits)
+    out = table_hits.strip_repeated_table_headers(hits)
 
     assert out[1].content == f"{OTHER_HEADER}\n| FR | 33 |"
 
@@ -316,7 +314,7 @@ async def test_a_document_larger_than_the_cap_is_left_alone(
     ]
     fetched = [
         _hit("d1", f"{HEADER}\n| r{i} | {i} |", chunk_index=i)
-        for i in range(adapters_module._TABLE_EXPANSION_MAX_CHUNKS)
+        for i in range(table_hits.TABLE_EXPANSION_MAX_CHUNKS)
     ]
     client_cls, _ = _client_returning(search_hits, fetched)
 

--- a/libs/fred-runtime/tests/test_knowledge_search_tool_invoker_sources.py
+++ b/libs/fred-runtime/tests/test_knowledge_search_tool_invoker_sources.py
@@ -62,6 +62,10 @@ class _FakeSearchClientWithNoise:
             ),
         ]
 
+    async def get_document_chunks(self, **_kwargs: object) -> list[VectorSearchHit]:
+        """Part of the VectorSearchClient surface; no truncated table in these fixtures."""
+        return []
+
 
 def _binding() -> BoundRuntimeContext:
     return BoundRuntimeContext(

--- a/libs/fred-runtime/tests/test_table_repair_wiring.py
+++ b/libs/fred-runtime/tests/test_table_repair_wiring.py
@@ -29,7 +29,12 @@ import fred_runtime.integrations.v2_runtime.adapters as adapters_module
 import pytest
 from fred_core.store.vector_search import VectorSearchHit
 from fred_runtime.common.structures import AgentSettingsLike
-from fred_sdk.contracts.context import RuntimeContext
+from fred_sdk.contracts.context import (
+    BoundRuntimeContext,
+    PortableContext,
+    PortableEnvironment,
+    RuntimeContext,
+)
 from fred_sdk.contracts.models import AgentTuning, MCPServerRef
 
 
@@ -51,6 +56,19 @@ class _FakeAgent:
 
     async def refresh_user_access_token(self) -> str:
         return "token"
+
+
+def _binding() -> BoundRuntimeContext:
+    return BoundRuntimeContext(
+        runtime_context=RuntimeContext(session_id="s-1", team_id="team-1"),
+        portable_context=PortableContext(
+            request_id="request-1",
+            correlation_id="correlation-1",
+            actor="u-1",
+            tenant="team-1",
+            environment=PortableEnvironment.DEV,
+        ),
+    )
 
 
 HEADER = "| name | default |\n| --- | --- |"
@@ -119,8 +137,6 @@ async def test_document_search_port_repairs_table_hits(
 ) -> None:
     client = _FakeClient()
     monkeypatch.setattr(adapters_module, "VectorSearchClient", lambda **_kw: client)
-
-    from tests.test_knowledge_search_tool_invoker_sources import _binding, _FakeSettings
 
     adapter = adapters_module.DocumentSearchAdapter(
         binding=_binding(), settings=_FakeSettings()

--- a/libs/fred-runtime/tests/test_table_repair_wiring.py
+++ b/libs/fred-runtime/tests/test_table_repair_wiring.py
@@ -1,0 +1,131 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Every retrieval surface repairs table hits, not just the legacy one.
+
+The fix first landed only on `knowledge.search`, while live agents call
+`search_documents_using_vectorization` - served by `KfVectorSearchToolkit` or by
+the `DocumentSearchPort` behind `document_access`. A shuffled table reaching the
+model through either of those is the same bug, so these lock the wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import fred_runtime.integrations.kf_vector_search.toolkit as toolkit_module
+import fred_runtime.integrations.v2_runtime.adapters as adapters_module
+import pytest
+from fred_core.store.vector_search import VectorSearchHit
+from fred_runtime.common.structures import AgentSettingsLike
+from fred_sdk.contracts.context import RuntimeContext
+from fred_sdk.contracts.models import AgentTuning, MCPServerRef
+
+
+class _FakeSettings:
+    """Matches the AgentSettingsLike protocol."""
+
+    id: str = "agent-1"
+    team_id: str | None = "team-1"
+    tuning: AgentTuning | None = None
+    active_mcp_servers: Sequence[MCPServerRef] = ()
+
+
+class _FakeAgent:
+    """Minimal shim matching what VectorSearchClient + the toolkit read."""
+
+    def __init__(self) -> None:
+        self.runtime_context = RuntimeContext(session_id="s-1", team_id="team-1")
+        self.agent_settings: AgentSettingsLike = _FakeSettings()
+
+    async def refresh_user_access_token(self) -> str:
+        return "token"
+
+
+HEADER = "| name | default |\n| --- | --- |"
+
+
+def _hit(
+    uid: str, content: str, *, chunk_index: int, score: float = 0.9
+) -> VectorSearchHit:
+    return VectorSearchHit(
+        uid=uid,
+        title=uid,
+        content=content,
+        score=score,
+        type="document",
+        chunk_index=chunk_index,
+    )
+
+
+# A table cut short by top_k: chunks 0 and 2 came back, chunk 1 did not.
+TRUNCATED = [
+    _hit("d1", f"{HEADER}\n| a | 1 |", chunk_index=0),
+    _hit("d1", f"{HEADER}\n| c | 3 |", chunk_index=2),
+]
+WHOLE = [
+    _hit("d1", f"{HEADER}\n| {row} | {i} |", chunk_index=i)
+    for i, row in enumerate("abc")
+]
+
+
+class _FakeClient:
+    """Stands in for VectorSearchClient on both surfaces."""
+
+    def __init__(self, *_a: Any, **_kw: Any) -> None:
+        self.fetched: list[dict[str, Any]] = []
+
+    async def search(self, **_kwargs: Any) -> list[VectorSearchHit]:
+        return list(TRUNCATED)
+
+    async def get_document_chunks(self, **kwargs: Any) -> list[VectorSearchHit]:
+        self.fetched.append(kwargs)
+        return list(WHOLE)
+
+
+def _assert_repaired(contents: list[str]) -> None:
+    # completed to three rows, in index order, with the repeated header dropped
+    assert contents == [f"{HEADER}\n| a | 0 |", "| b | 1 |", "| c | 2 |"]
+
+
+@pytest.mark.asyncio
+async def test_toolkit_repairs_table_hits(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(toolkit_module, "VectorSearchClient", lambda **_kw: client)
+
+    tools = toolkit_module.KfVectorSearchToolkit(agent=_FakeAgent()).tools()
+    result = await tools[0].ainvoke(
+        {"question": "what is the default of b?", "top_k": 2}
+    )
+
+    assert client.fetched == [{"document_uid": "d1", "limit": 40}]
+    _assert_repaired([hit["content"] for hit in result.blocks[0].data["hits"]])
+
+
+@pytest.mark.asyncio
+async def test_document_search_port_repairs_table_hits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(adapters_module, "VectorSearchClient", lambda **_kw: client)
+
+    from tests.test_knowledge_search_tool_invoker_sources import _binding, _FakeSettings
+
+    adapter = adapters_module.DocumentSearchAdapter(
+        binding=_binding(), settings=_FakeSettings()
+    )
+    result = await adapter.search("what is the default of b?", top_k=2)
+
+    assert client.fetched == [{"document_uid": "d1", "limit": 40}]
+    _assert_repaired([hit.content for hit in result.hits])


### PR DESCRIPTION
Closes #1645. Re-lands #1815 by @pdubey28-sketch, rebuilt on current `swift`.

## The bug

Ask an agent a row question over an ingested Markdown table and it answers from
the wrong rows, or says the row is not there. Two independent causes, one at
ingestion and one at retrieval.

**Ingestion.** `SemanticSplitter` only kept tables atomic when an upstream
processor had wrapped them in `<!-- TABLE_START -->` markers. The PDF and DOCX
processors do that; plain `.md`/`.txt` does not. So a Markdown table went
through the ordinary recursive splitter and got **cut mid-row**, leaving
fragments with no header and half a row of cells.

**Retrieval.** Even with clean chunks, similarity ranking hands back the
`top_k` most similar slices of a large table - a subset, in score order, with
holes. The model receives what looks like several small unrelated tables and
reasons over them as such.

## Ingestion fix

`_auto_annotate_unmarked_tables` detects plain pipe tables and wraps them, so
`.md`/`.txt` and the lightweight PDF/DOCX/PPTX paths get the same atomic
handling the rich processors already had. Detection is deliberately
conservative - a pipe row counts only when the next line is a Markdown
separator row - and skips fenced blocks and 4-space-indented blocks, which is
how documentation shows a table as an *example*.

A table that fits in `chunk_size` becomes one chunk. An oversized one splits
**only between rows**, repeating header and separator in every part so each
part stands alone.

A document with no table is returned byte-identical: rebuilding it through
`splitlines()` would normalise CRLF and the exotic line breaks Python splits
on, shifting every `char_start`/`char_end` in the document.

`preserve_tables` now gates that auto-detection. It had become dead - read
nowhere after the refactor - while still being a documented config knob wired
through `values.yaml`.

Table chunks are marked with the existing `chunk_kind` vocabulary rather than a
new `block_type`/`is_table` pair. `_ALLOWED_CHUNK_KEYS` whitelists `chunk_kind`
and not the others, so the parallel vocabulary was silently dropped by metadata
sanitisation and the "filter on `block_type`" contract was never true.

## Retrieval fix: chunk order

`VectorSearchHit` gains `chunk_index`, populated from store metadata. That one
field is what makes the rest possible - without it there is no way to tell
which slice of a table came first.

Three steps, in this order, in `fred_runtime.common.table_hits`:

**1. Complete.** Table chunks from one document at **non-contiguous**
`chunk_index` values are proof that `top_k` cut a table short - chunks 0 and 2
came back, 1 did not. That triggers a refetch of the document's chunks in index
order through a new endpoint that bypasses similarity entirely. Two *adjacent*
chunks, or two separate small tables, are complete already and trigger nothing.

The refetch is bounded: one document per call, 40 chunks. Past the cap it is
**abandoned rather than truncated** - the document's first 40 chunks are not the
ones that matched the query, so a head-truncated refetch is worse than none.
The fetched chunks inherit the document's best score, or `select_citable_sources`
(threshold = `max(score) * 0.5`) would drop the very table being answered from,
and they are spliced in at the position of the first hit they replace, so the
document keeps its rank.

**2. Reorder.** Hits are grouped per document and each document's chunks sorted
by `chunk_index` ascending. Cross-document ranking is preserved: whichever
document scored best stays first. Chunks with no `chunk_index` - documents
indexed before the field existed - sort last rather than jumping ahead of chunk 0.

**3. De-duplicate headers.** The splitter repeats the header on every part so a
chunk can stand alone, but a run of them reads to the model as separate tables.
The header is stripped from a chunk only when the previous chunk **of the same
document opened with the identical header**. Comparing headers, not just
adjacency, is what keeps a second, different table in the same document from
losing its own header and having its rows reattributed to the first.

Detection matches on the separator row rather than a leading `|`, so tables
written without leading pipes are handled too.

## Where it is wired

Three surfaces build LLM content from raw hits, and all three had the problem:

| Surface | Tool the model sees |
| --- | --- |
| `FredKnowledgeSearchToolInvoker` | `knowledge.search` (legacy ref) |
| `KfVectorSearchToolkit` | `search_documents_using_vectorization` |
| `DocumentSearchPort` behind `document_access` | `search_documents_using_vectorization` |

The repair lives in one shared module and all three call it, rather than a
fourth parallel implementation in a file that already carried three.

## New endpoint

`GET /knowledge-flow/v1/vector/document-chunks?document_uid=…&limit=…`

A direct store fetch sorted by `chunk_index`, no similarity ranking, so a whole
table comes back intact. `limit` is bounded 1..1000 (default 200). Gated on
ReBAC `DocumentPermission.READ` at the controller, like its neighbour `rerank` -
the original PR used an `@authorize` RBAC decorator whose import no longer
exists on `swift`. Registered in `authz-endpoint-matrix.yaml`; `openapi.json`
and both generated TS clients regenerated.

Known cost, documented in the code: `limit` bounds the response, not the store
read - `get_chunks_for_document` fetches the whole document on every backend.
Pushing the bound into the stores is a separate change.

## Verified live

```
[TABLE] completion uid=f33b57a1a6024479bbabed6e02124b38 chunks=10->28
GET /knowledge-flow/v1/vector/document-chunks?document_uid=…&limit=40  200  59ms
[VECTOR][DOC_CHUNKS] document_uid=… returned=28 of 28 truncated=False
```

A 200-row table ingested as 13 parts: search returned 10 shuffled slices
(scores 0.89 down to 0.008), the gap was detected, the document was refetched
whole and handed to the model in row order.

## Tests

- `test_semantic_splitter_tables.py` - atomic small tables, row-boundary
  splitting, order preservation, the three false-positive traps, CRLF
  preservation, distinct fragment anchors, `chunk_kind` surviving sanitisation
- `test_knowledge_search_table_ordering.py` - each of the three steps, plus the
  cap, the citation score, the rank, and the second-table case
- `test_table_repair_wiring.py` - the toolkit and the capability port each
  actually call the repair
- `test_document_chunks_authz.py` - the ReBAC gate and the `limit` bounds

`make code-quality` green from the monorepo root. knowledge-flow 993,
fred-runtime 1033, fred-core 526 offline.

## Divergence from #1815

An independent review of the ported code found 14 verified defects, each fixed
and locked by a test. The ones that would have shipped: header stripping
corrupting a second table, refetched chunks scoring 0.0 and losing their
citation, the head-truncated refetch discarding the matching chunks, CRLF
rewriting on every document, indented example tables being extracted, and a
`get_document_chunks(_uid)` positional call against a keyword-only signature -
swallowed by a bare `except`, so the feature never ran at all.
