### PR TITLE
fix(#2479): ReAct V2 HITL resume 409 - align reads on the namespace LangGraph actually writes

### DIFF
--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -4430,4 +4430,4 @@ namespace is real.
 goal of #2415. `checkpoint_ns` cannot deliver it for a root graph - the only
 LangGraph-native lever is `thread_id`, which touches
 `checkpoint_thread_owner`, per-user erasure, and session deletion. Tracked
-separately; ReAct agents currently share the session's checkpoint thread.
+in issue #2481; ReAct agents currently share the session's checkpoint thread.

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -2252,7 +2252,8 @@ already-resumed, HITL prompt:
    `interrupt_id` raises — no scalar fallback exists.
 4. **Durable, atomic, fenced claim** (`FredSqlCheckpointer`'s
    `checkpoint_hitl_claim` table, key `(thread_id, checkpoint_ns,
-   interrupt_id)`), acquired as LATE as possible — inside
+   interrupt_id)`, with `checkpoint_ns` always `""` for ReAct V2 — see
+   §8.61), acquired as LATE as possible — inside
    `agent_app._iterate_runtime_event_payloads`, immediately before
    `executor.stream(...)`, never in the read-only gate. State machine
    `claimed -> started -> consumed`, every operation fenced by an opaque
@@ -4393,3 +4394,37 @@ the team could not be switched on at all - flip it, the missing member is never
 added, the derived state reads false again - while switching it off still
 stripped the rest. It now takes `availableIds` and derives from the members the
 team can actually select.
+
+### 8.61 ✅ ReAct V2 checkpoints are always unnamespaced - issue #2479 (2026-08-31)
+
+**Was**: every ReAct V2 HITL resume dead-ended in
+`409 "No pending checkpoint was found for this session."`. The paused
+checkpoint existed, with its `__interrupt__` write; the admission gate
+(§8.39 layer 2) was reading in the wrong place.
+
+**Why**: LangGraph resets `checkpoint_ns` to `""` for every non-nested run
+(`pregel/_loop.py::PregelLoop.__init__`). A per-agent namespace configured
+on a compiled root graph therefore never reaches storage. The executor
+passed one anyway, while the gate and the `checkpoint_hitl_claim` key both
+read at `agent_instance_id` - so the write and the read never met. The
+hand-rolled Graph runtime is unaffected: it calls `aput` itself, so its
+namespace is real.
+
+**Now**:
+
+- ReAct V2 stores and reads unnamespaced. The executor no longer configures
+  a `checkpoint_ns` (it was inert), and the HITL claim keys on `""`.
+- `_resume_checkpoint_namespaces` picks the candidate namespace from the
+  request's own resume identifier - `checkpoint_id` is Graph V2's,
+  `interrupt_id` is ReAct V2's - and keeps the other as a fallback, since a
+  Graph pause can legitimately carry no `checkpoint_id`. The gate runs
+  before target resolution, so it cannot know the runtime kind directly.
+- `test_langgraph_resets_root_checkpoint_namespace` pins the LangGraph
+  behaviour: a version bump that changed it fails a test instead of
+  silently moving live checkpoints out of the gate's reach.
+
+**Still open**: isolating agent checkpoints within a shared session, the
+goal of #2415. `checkpoint_ns` cannot deliver it for a root graph - the only
+LangGraph-native lever is `thread_id`, which touches
+`checkpoint_thread_owner`, per-user erasure, and session deletion. Tracked
+separately; ReAct agents currently share the session's checkpoint thread.

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -4416,9 +4416,12 @@ namespace is real.
   a `checkpoint_ns` (it was inert), and the HITL claim keys on `""`.
 - `_resume_checkpoint_namespaces` picks the candidate namespace from the
   request's own resume identifier - `checkpoint_id` is Graph V2's,
-  `interrupt_id` is ReAct V2's - and keeps the other as a fallback, since a
-  Graph pause can legitimately carry no `checkpoint_id`. The gate runs
-  before target resolution, so it cannot know the runtime kind directly.
+  `interrupt_id` is ReAct V2's. A `checkpoint_id` resume probes the agent
+  namespace only, since the Graph executor reads nowhere else and a gate
+  that waved it through would fail mid-stream, past the point a 409 can be
+  sent. An `interrupt_id` resume probes `""` first, keeping the agent
+  namespace for a Graph pause that never stamped a `checkpoint_id`. The gate
+  runs before target resolution, so it cannot know the runtime kind directly.
 - `test_langgraph_resets_root_checkpoint_namespace` pins the LangGraph
   behaviour: a version bump that changed it fails a test instead of
   silently moving live checkpoints out of the gate's reach.

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -1884,6 +1884,33 @@ def _pending_react_v2_interrupt_ids(
     return frozenset(ids)
 
 
+def _resume_checkpoint_namespaces(request: RuntimeExecuteRequest) -> tuple[str, ...]:
+    """
+    Checkpoint namespaces a resume-capable request may target, best first.
+
+    ReAct V2 checkpoints are ALWAYS stored unnamespaced, whatever the runtime
+    configures: LangGraph resets `checkpoint_ns` to `""` for every root-graph
+    run (`pregel/_loop.py::PregelLoop.__init__`, pinned by
+    `test_langgraph_resets_root_checkpoint_namespace`). Only the hand-rolled
+    Graph runtime, which writes through `aput` itself, actually reaches
+    storage under the per-agent namespace.
+
+    This gate runs before the target agent is resolved, so it cannot know
+    which runtime it is talking to. It orders the two candidates by the
+    request's own resume identifier — `checkpoint_id` is Graph V2's,
+    `interrupt_id` is ReAct V2's (mutually exclusive by contract) — and keeps
+    the other as a fallback, because a Graph pause can legitimately carry no
+    `checkpoint_id` (`graph_runtime.py` only stamps one when it has it).
+    """
+
+    agent_ns = checkpoint_namespace(
+        agent_instance_id=request.agent_instance_id,
+        agent_id=request.agent_id or request.agent_instance_id or "",
+    )
+    ordered = ("", agent_ns) if request.checkpoint_id is None else (agent_ns, "")
+    return tuple(dict.fromkeys(ordered))
+
+
 async def _validate_session_checkpoint_access(
     request: RuntimeExecuteRequest,
 ) -> None:
@@ -1960,37 +1987,36 @@ async def _validate_session_checkpoint_access(
     if checkpointer is None:
         return
 
-    checkpoint_ns = checkpoint_namespace(
-        agent_instance_id=request.agent_instance_id,
-        agent_id=request.agent_id or request.agent_instance_id or "",
-    )
-
-    loaded = await load_checkpoint(
-        checkpointer,
-        thread_id=session_id,
-        checkpoint_id=request.checkpoint_id,
-        checkpoint_ns=checkpoint_ns,
-    )
-    if (
-        loaded is None
-        and request.resume_payload is not None
-        and request.checkpoint_id is not None
-    ):
-        # The exact-id lookup above is the only path the legacy Graph runtime
-        # ever needs (its checkpoint_id is real). Retry against the thread's
-        # latest checkpoint only once that has failed, on a genuine resume
-        # attempt. ReAct V2 never populates checkpoint_id at all, so its
-        # requests already resolve to "latest checkpoint" on the primary
-        # lookup above (checkpoint_id=None) and never reach this branch —
-        # kept for the legacy Graph runtime's own unknown-checkpoint_id
-        # recovery path (a clean "does not match pending" 409 instead of a
-        # blunt "unknown checkpoint" one), preserving its exact prior
-        # behavior.
+    loaded = None
+    for checkpoint_ns in _resume_checkpoint_namespaces(request):
         loaded = await load_checkpoint(
             checkpointer,
             thread_id=session_id,
+            checkpoint_id=request.checkpoint_id,
             checkpoint_ns=checkpoint_ns,
         )
+        if (
+            loaded is None
+            and request.resume_payload is not None
+            and request.checkpoint_id is not None
+        ):
+            # The exact-id lookup above is the only path the legacy Graph
+            # runtime ever needs (its checkpoint_id is real). Retry against the
+            # thread's latest checkpoint only once that has failed, on a
+            # genuine resume attempt. ReAct V2 never populates checkpoint_id at
+            # all, so its requests already resolve to "latest checkpoint" on
+            # the primary lookup above (checkpoint_id=None) and never reach
+            # this branch — kept for the legacy Graph runtime's own
+            # unknown-checkpoint_id recovery path (a clean "does not match
+            # pending" 409 instead of a blunt "unknown checkpoint" one),
+            # preserving its exact prior behavior.
+            loaded = await load_checkpoint(
+                checkpointer,
+                thread_id=session_id,
+                checkpoint_ns=checkpoint_ns,
+            )
+        if loaded is not None:
+            break
 
     if loaded is None:
         detail = (
@@ -3487,14 +3513,14 @@ async def _iterate_runtime_event_payloads(
             # docstring for the full claimed → started lifecycle and the
             # guarantees it does and does not provide.
             hitl_claim: _HitlResumeClaim | None = None
-            hitl_checkpoint_ns = checkpoint_namespace(
-                agent_instance_id=portable_context.baggage.get("agent_instance_id"),
-                agent_id=definition.agent_id,
-            )
             if request.resume_payload is not None and request.interrupt_id:
                 hitl_claim = await _claim_hitl_resume_before_invocation(
                     session_id=ctx.get("session_id"),
-                    checkpoint_ns=hitl_checkpoint_ns,
+                    # Unnamespaced: this branch is ReAct-only, and LangGraph
+                    # stores every root-graph checkpoint at ns "" whatever the
+                    # runtime configures — the claim must key on the same
+                    # occurrence the early gate validated.
+                    checkpoint_ns="",
                     interrupt_id=request.interrupt_id,
                 )
 

--- a/libs/fred-runtime/fred_runtime/app/agent_app.py
+++ b/libs/fred-runtime/fred_runtime/app/agent_app.py
@@ -1896,19 +1896,24 @@ def _resume_checkpoint_namespaces(request: RuntimeExecuteRequest) -> tuple[str, 
     storage under the per-agent namespace.
 
     This gate runs before the target agent is resolved, so it cannot know
-    which runtime it is talking to. It orders the two candidates by the
-    request's own resume identifier — `checkpoint_id` is Graph V2's,
-    `interrupt_id` is ReAct V2's (mutually exclusive by contract) — and keeps
-    the other as a fallback, because a Graph pause can legitimately carry no
-    `checkpoint_id` (`graph_runtime.py` only stamps one when it has it).
+    which runtime it is talking to — it goes by the request's own resume
+    identifier instead (`checkpoint_id` is Graph V2's, `interrupt_id` is ReAct
+    V2's, mutually exclusive by contract).
     """
 
     agent_ns = checkpoint_namespace(
         agent_instance_id=request.agent_instance_id,
         agent_id=request.agent_id or request.agent_instance_id or "",
     )
-    ordered = ("", agent_ns) if request.checkpoint_id is None else (agent_ns, "")
-    return tuple(dict.fromkeys(ordered))
+    if request.checkpoint_id is not None:
+        # Graph V2, whose executor reads its own namespace and nowhere else.
+        # Probing "" as well would wave a pre-namespacing pause past this gate
+        # only to have it die mid-stream, where a 409 can no longer be sent.
+        return (agent_ns,)
+    # ReAct V2 — always unnamespaced. `agent_ns` stays as a fallback for a
+    # Graph pause that never stamped a checkpoint_id (`graph_runtime.py` only
+    # stamps one when it has it); nothing is ever stored there for ReAct.
+    return ("", agent_ns)
 
 
 async def _validate_session_checkpoint_access(

--- a/libs/fred-runtime/fred_runtime/react/react_message_codec.py
+++ b/libs/fred-runtime/fred_runtime/react/react_message_codec.py
@@ -204,11 +204,7 @@ def final_assistant_message(
     raise RuntimeError("ReAct execution completed without an assistant message.")
 
 
-def to_runnable_config(
-    config: ExecutionConfig,
-    *,
-    checkpoint_ns: str | None = None,
-) -> Mapping[str, object] | None:
+def to_runnable_config(config: ExecutionConfig) -> Mapping[str, object] | None:
     """
     Convert Fred execution config to LangChain runnable config.
 
@@ -232,9 +228,6 @@ def to_runnable_config(
     if config.session_id is not None:
         # session_id is Fred's public identity; thread_id is LangGraph's internal key.
         configurable["thread_id"] = config.session_id
-
-    if checkpoint_ns is not None:
-        configurable["checkpoint_ns"] = checkpoint_ns
 
     if configurable:
         merged["configurable"] = configurable

--- a/libs/fred-runtime/fred_runtime/react/react_runtime.py
+++ b/libs/fred-runtime/fred_runtime/react/react_runtime.py
@@ -80,7 +80,6 @@ from langchain_core.tools import BaseTool
 from langgraph.types import Checkpointer
 
 from fred_runtime.capabilities.assembly import CapabilityAgentBlock
-from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
 from fred_runtime.runtime_support.trace_payloads import to_langfuse_usage
 
 # Everything imported from `react_langchain_adapter` below is SDK-bound glue.
@@ -270,12 +269,10 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         compiled_agent: _CompiledReActAgent,
         binding: BoundRuntimeContext,
         services: RuntimeServices,
-        checkpoint_ns: str = "",
     ) -> None:
         self._compiled_agent = compiled_agent
         self._binding = binding
         self._services = services
-        self._checkpoint_ns = checkpoint_ns
 
     async def invoke(
         self, input_model: ReActInput, config: ExecutionConfig
@@ -299,10 +296,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         try:
             result = await self._compiled_agent.ainvoke(
                 _graph_input(input_model, config),
-                config=_to_runnable_config(
-                    config,
-                    checkpoint_ns=self._checkpoint_ns,
-                ),
+                config=_to_runnable_config(config),
             )
             transcript = tuple(
                 _from_langchain_message_adapter(
@@ -439,10 +433,7 @@ class _TransportBackedReActExecutor(Executor[ReActInput, ReActOutput]):
         try:
             async for raw_event in self._compiled_agent.astream(
                 _graph_input(input_model, config),
-                config=_to_runnable_config(
-                    config,
-                    checkpoint_ns=self._checkpoint_ns,
-                ),
+                config=_to_runnable_config(config),
                 stream_mode=["messages", "updates"],
             ):
                 mode, update = _split_stream_event_mode(raw_event)
@@ -872,18 +863,10 @@ class ReActRuntime(AgentRuntime[ReActAgentDefinition, ReActInput, ReActOutput]):
             max_tool_calls_per_turn=policy.tool_selection.max_tool_calls_per_turn,
             capability_block=self._capability_block,
         )
-
-        portable = binding.portable_context
-        react_checkpoint_ns = checkpoint_namespace(
-            agent_instance_id=portable.baggage.get("agent_instance_id"),
-            agent_id=self.definition.agent_id,
-        )
-
         return _TransportBackedReActExecutor(
             compiled_agent=compiled_agent,
             binding=binding,
             services=self.services,
-            checkpoint_ns=react_checkpoint_ns,
         )
 
     async def on_dispose(self) -> None:

--- a/libs/fred-runtime/fred_runtime/runtime_support/checkpoints.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/checkpoints.py
@@ -76,6 +76,11 @@ def checkpoint_namespace(
 
     Managed agent instances are isolated by their concrete instance id.
     SDK-defined agents fall back to their stable agent id.
+
+    Only reaches storage for the hand-rolled Graph runtime, which calls `aput`
+    itself: LangGraph resets `checkpoint_ns` to `""` on every root-graph run
+    (`pregel/_loop.py::PregelLoop.__init__`), so a compiled graph's checkpoints
+    are always unnamespaced however its config is built.
     """
     return agent_instance_id or agent_id
 

--- a/libs/fred-runtime/tests/test_agent_app.py
+++ b/libs/fred-runtime/tests/test_agent_app.py
@@ -2962,7 +2962,6 @@ async def _write_react_v2_checkpoint(
     checkpointer,
     *,
     thread_id: str,
-    checkpoint_ns: str = "",
     channel_values: dict[str, Any],
 ):
     """
@@ -2970,6 +2969,10 @@ async def _write_react_v2_checkpoint(
     (the same `aput` production code uses, `graph_runtime.py::_store_pending_checkpoint`'s
     non-legacy counterpart) — no `runtime_kind`/`pending` markers, since ReAct
     V2's `create_agent()` never stamps those (#2179).
+
+    Always UNNAMESPACED, like production: LangGraph resets `checkpoint_ns` to
+    `""` on every root-graph run, so a compiled ReAct agent's checkpoints can
+    only ever land there (`test_langgraph_resets_root_checkpoint_namespace`).
     """
 
     checkpoint = empty_checkpoint()
@@ -2977,10 +2980,7 @@ async def _write_react_v2_checkpoint(
     checkpoint["channel_values"] = channel_values
     checkpoint["channel_versions"] = {key: checkpoint_id for key in channel_values}
     return await checkpointer.aput(
-        checkpoint_config(
-            thread_id=thread_id,
-            checkpoint_ns=checkpoint_ns,
-        ),
+        checkpoint_config(thread_id=thread_id),
         checkpoint,
         {"source": "update", "step": 0, "parents": {}},
         dict(checkpoint["channel_versions"]),
@@ -2992,7 +2992,6 @@ async def _write_react_v2_interrupt(
     *,
     thread_id: str,
     interrupt_id: str,
-    checkpoint_ns: str = "",
     task_id: str = "task-1",
     channel_values: dict[str, Any] | None = None,
 ):
@@ -3009,7 +3008,6 @@ async def _write_react_v2_interrupt(
     stored_config = await _write_react_v2_checkpoint(
         checkpointer,
         thread_id=thread_id,
-        checkpoint_ns=checkpoint_ns,
         channel_values=channel_values or {"messages": []},
     )
     await checkpointer.aput_writes(
@@ -3087,7 +3085,6 @@ def test_resume_accepts_react_v2_checkpoint_via_pending_interrupt_write(
                 checkpointer,
                 thread_id="session-react-v2",
                 interrupt_id="xxh3-routing-hash-not-a-real-checkpoint-id",
-                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3138,7 +3135,6 @@ def test_resume_rejects_react_v2_checkpoint_without_pending_interrupt(
             _write_react_v2_checkpoint(
                 checkpointer,
                 thread_id="session-react-v2-done",
-                checkpoint_ns=definition.agent_id,
                 channel_values={"messages": []},
             )
         )
@@ -3241,7 +3237,6 @@ def test_resume_builds_react_input_without_raising(monkeypatch, tmp_path) -> Non
                 checkpointer,
                 thread_id="session-react-input-resume",
                 interrupt_id="xxh3-routing-hash-not-a-real-checkpoint-id",
-                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3385,7 +3380,6 @@ def test_resume_reuses_exchange_id_from_the_interrupted_turn(
                 checkpointer,
                 thread_id="session-exchange-continuity",
                 interrupt_id="xxh3-routing-hash-not-a-real-checkpoint-id",
-                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3528,7 +3522,6 @@ def test_resume_stale_response_cannot_approve_a_later_interrupt(
                 checkpointer,
                 thread_id=session_id,
                 interrupt_id="interrupt-a",
-                checkpoint_ns=definition.agent_id,
             )
         )
         resume_a = client.post(
@@ -3551,7 +3544,6 @@ def test_resume_stale_response_cannot_approve_a_later_interrupt(
                 checkpointer,
                 thread_id=session_id,
                 interrupt_id="interrupt-b",
-                checkpoint_ns=definition.agent_id,
             )
         )
         assert "interrupt-a" != "interrupt-b"
@@ -3635,7 +3627,6 @@ def test_resume_replay_after_success_does_not_execute_again(
                 checkpointer,
                 thread_id=session_id,
                 interrupt_id="interrupt-a",
-                checkpoint_ns=definition.agent_id,
             )
         )
         payload = {
@@ -3699,7 +3690,6 @@ def test_resume_rejects_non_matching_interrupt_id_variants(
                 checkpointer,
                 thread_id=session_id,
                 interrupt_id="interrupt-real",
-                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3747,7 +3737,6 @@ def test_resume_rejects_token_belonging_to_another_thread(
                 checkpointer,
                 thread_id="session-thread-a",
                 interrupt_id="interrupt-a",
-                checkpoint_ns=definition.agent_id,
             )
         )
         asyncio.run(
@@ -3755,7 +3744,6 @@ def test_resume_rejects_token_belonging_to_another_thread(
                 checkpointer,
                 thread_id="session-thread-b",
                 interrupt_id="interrupt-b",
-                checkpoint_ns=definition.agent_id,
             )
         )
 
@@ -3806,14 +3794,13 @@ async def test_concurrent_duplicate_resumes_have_exactly_one_winner(
             checkpointer,
             thread_id="session-concurrent",
             interrupt_id="interrupt-a",
-            checkpoint_ns=definition.agent_id,
         )
 
         async def _attempt():
             try:
                 claim = await agent_app_module._claim_hitl_resume_before_invocation(
                     session_id="session-concurrent",
-                    checkpoint_ns=definition.agent_id,
+                    checkpoint_ns="",
                     interrupt_id="interrupt-a",
                 )
                 return "ok" if claim is not None else "none"
@@ -3866,7 +3853,6 @@ async def test_concurrent_duplicate_resumes_execute_the_tool_at_most_once(
             checkpointer,
             thread_id=session_id,
             interrupt_id="interrupt-a",
-            checkpoint_ns=definition.agent_id,
         )
 
         payload = {
@@ -3955,7 +3941,6 @@ def test_resume_runtime_setup_failure_leaves_no_claim_and_retry_succeeds(
                 checkpointer,
                 thread_id=session_id,
                 interrupt_id="interrupt-a",
-                checkpoint_ns=definition.agent_id,
             )
         )
         payload = {
@@ -4032,7 +4017,6 @@ def test_resume_start_failure_releases_the_claim_for_a_retry(
                 checkpointer,
                 thread_id=session_id,
                 interrupt_id="interrupt-a",
-                checkpoint_ns=definition.agent_id,
             )
         )
         payload = {
@@ -4138,7 +4122,6 @@ async def test_cancellation_after_start_leaves_the_claim_stuck_not_released(
             checkpointer,
             thread_id=session_id,
             interrupt_id="interrupt-a",
-            checkpoint_ns=definition.agent_id,
         )
         payload = {
             "agent_id": "rags.sample.echo",

--- a/libs/fred-runtime/tests/test_hitl_resume_langgraph_integration.py
+++ b/libs/fred-runtime/tests/test_hitl_resume_langgraph_integration.py
@@ -43,6 +43,10 @@ Proves, in one continuous run:
   E. a targeted resume with B's own id executes B's tool exactly once
   F. a resume with no interrupt_id at all fails closed (codec-level)
 
+A second test pins WHERE that pending interrupt is stored: LangGraph
+discards a root graph's `checkpoint_ns`, so the resume gate must read
+unnamespaced or find nothing.
+
 Does NOT use fake pending-write dictionaries for any of this — every
 interrupt and every resume goes through the real compiled graph and the
 real checkpointer.
@@ -53,9 +57,14 @@ from __future__ import annotations
 from typing import Any, cast
 
 import pytest
+from fred_runtime.app.agent_app import _pending_react_v2_interrupt_ids
 from fred_runtime.react.react_message_codec import graph_input_from_react_input
 from fred_runtime.react.react_stream_adapter import extract_interrupt_request
 from fred_runtime.react.react_tool_loop import build_tool_loop_compiled_react_agent
+from fred_runtime.runtime_support.checkpoints import (
+    AsyncCheckpointReader,
+    load_checkpoint,
+)
 from fred_runtime.runtime_support.sql_checkpointer import FredSqlCheckpointer
 from fred_sdk.contracts.context import (
     BoundRuntimeContext,
@@ -296,5 +305,83 @@ async def test_hitl_resume_identity_model_against_real_langgraph_and_sql_checkpo
                 ),
                 sanitize_tool_name=lambda name: name,
             )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_paused_checkpoint_is_stored_unnamespaced_whatever_the_config_asks(
+    tmp_path,
+) -> None:
+    """
+    A per-agent `checkpoint_ns` on a root graph never reaches storage, so the
+    resume gate must not look for one.
+
+    Driven through the real tool loop and a real `FredSqlCheckpointer`, with
+    the namespaced config the ReAct executor used to build: LangGraph resets
+    `checkpoint_ns` to `""` (`pregel/_loop.py::PregelLoop.__init__`), the
+    paused checkpoint and its `__interrupt__` write land there, and a read at
+    the per-agent namespace finds nothing at all — which is what turned every
+    ReAct V2 HITL resume into a 409.
+    """
+
+    @tool
+    def update_ticket(ticket_id: str) -> str:
+        """Update one ticket (approval-gated)."""
+
+        return f"updated {ticket_id}"
+
+    model = _RecordingModel(
+        script=[
+            AIMessage(
+                content="",
+                tool_calls=[_tool_call("update_ticket", {"ticket_id": "INC-1"}, "c-1")],
+            )
+        ]
+    )
+
+    db_path = tmp_path / "hitl_namespace.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        checkpointer = FredSqlCheckpointer(engine, prefix="v2_")
+        reader = cast(AsyncCheckpointReader, checkpointer)
+        agent: Any = build_tool_loop_compiled_react_agent(
+            model=model,
+            tools=[update_ticket],
+            system_prompt="You update tickets.",
+            binding=_binding(),
+            approval_policy=ToolApprovalPolicy(
+                enabled=True, always_require_tools=("update_ticket",)
+            ),
+            checkpointer=cast(Checkpointer, checkpointer),
+            definition=cast(ReActAgentDefinition, _FakeDefinition()),
+            available_tool_names={"update_ticket"},
+        )
+        thread_id = "t-namespace-integration"
+        agent_ns = "instance-namespace-integration"
+
+        updates: list[dict[str, Any]] = []
+        async for mode, update in agent.astream(
+            {"messages": [HumanMessage(content="update INC-1")]},
+            config={
+                "configurable": {"thread_id": thread_id, "checkpoint_ns": agent_ns}
+            },
+            stream_mode=["messages", "updates"],
+        ):
+            if mode == "updates" and isinstance(update, dict):
+                updates.append(update)
+
+        interrupt = _interrupt_object(_find_interrupt_update(updates))
+
+        assert (
+            await load_checkpoint(reader, thread_id=thread_id, checkpoint_ns=agent_ns)
+            is None
+        )
+        loaded = await load_checkpoint(reader, thread_id=thread_id)
+        assert loaded is not None
+        _, pending_writes = loaded
+        assert _pending_react_v2_interrupt_ids(pending_writes) == frozenset(
+            {interrupt.id}
+        )
     finally:
         await engine.dispose()

--- a/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
@@ -146,12 +146,12 @@ def test_react_resume_probes_the_unnamespaced_checkpoint_first() -> None:
     assert _resume_checkpoint_namespaces(request) == ("", "instance-123")
 
 
-def test_graph_resume_probes_the_agent_namespace_first() -> None:
+def test_graph_resume_probes_only_the_agent_namespace() -> None:
     """
     The hand-rolled Graph runtime writes through `aput` itself, so its
-    per-agent namespace does reach storage — a `checkpoint_id`-carrying resume
-    looks there first, keeping `""` only as a fallback for a Graph pause that
-    never stamped a checkpoint_id.
+    per-agent namespace does reach storage — and its executor reads nowhere
+    else. A `checkpoint_id`-carrying resume must not be waved past the gate on
+    an unnamespaced checkpoint it would then fail to load mid-stream.
     """
 
     request = RuntimeExecuteRequest(
@@ -161,11 +161,11 @@ def test_graph_resume_probes_the_agent_namespace_first() -> None:
         resume_payload={"choice_id": "proceed"},
     )
 
-    assert _resume_checkpoint_namespaces(request) == ("instance-123", "")
+    assert _resume_checkpoint_namespaces(request) == ("instance-123",)
 
 
-def test_resume_namespaces_deduplicate_for_a_template_agent() -> None:
-    """A namespace equal to `""` must not be probed twice."""
+def test_resume_namespaces_fall_back_to_the_template_agent_id() -> None:
+    """An unmanaged (template) agent has no instance id to namespace on."""
 
     request = RuntimeExecuteRequest(
         agent_id="react.agent",

--- a/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
+++ b/libs/fred-runtime/tests/test_react_checkpoint_namespace.py
@@ -1,9 +1,26 @@
+"""
+Where a ReAct V2 checkpoint actually lands, and which namespaces the resume
+gate probes for it.
+
+The namespace a root graph is configured with never reaches storage: LangGraph
+resets `checkpoint_ns` to `""` for every non-nested run. Passing a per-agent
+namespace into `compiled_agent.astream(...)` therefore isolates nothing, and a
+reader that looks for it finds no checkpoint at all — which dead-ended every
+ReAct V2 HITL resume in a 409 until the reader was aligned back on `""`.
+"""
+
+from typing import Any, TypedDict, cast
+
 import pytest
+from fred_runtime.app.agent_app import _resume_checkpoint_namespaces
 from fred_runtime.react.react_message_codec import to_runnable_config
 from fred_runtime.react.react_runtime import _TransportBackedReActExecutor
 from fred_runtime.runtime_support.checkpoints import checkpoint_namespace
+from fred_sdk.contracts.execution import RuntimeExecuteRequest
 from fred_sdk.contracts.react_contract import ReActInput, ReActMessage, ReActMessageRole
 from fred_sdk.contracts.runtime import ExecutionConfig
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
 
 
 class _FakePortable:
@@ -42,31 +59,122 @@ class _RecordingCompiledAgent:
         }
 
 
+class _CounterState(TypedDict):
+    n: int
+
+
+def test_langgraph_resets_root_checkpoint_namespace() -> None:
+    """
+    Pin the LangGraph behaviour every read path now depends on: a root graph
+    stores its checkpoints under `""`, discarding whatever `checkpoint_ns` the
+    caller configured (`pregel/_loop.py::PregelLoop.__init__`). A version bump
+    that changed this must fail here rather than silently re-namespace live
+    checkpoints out of reach of the resume gate.
+    """
+
+    def _step(state: _CounterState) -> _CounterState:
+        return {"n": state["n"] + 1}
+
+    graph = StateGraph(_CounterState)
+    graph.add_node("step", _step)
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    saver = InMemorySaver()
+    compiled = graph.compile(checkpointer=saver)
+
+    compiled.invoke(
+        {"n": 0},
+        config={"configurable": {"thread_id": "t1", "checkpoint_ns": "instance-123"}},
+    )
+
+    stored = {
+        cast(dict[str, Any], tuple_.config.get("configurable", {})).get("checkpoint_ns")
+        for tuple_ in saver.list(None)
+    }
+    assert stored == {""}
+    assert (
+        saver.get_tuple(
+            {"configurable": {"thread_id": "t1", "checkpoint_ns": "instance-123"}}
+        )
+        is None
+    )
+
+
 @pytest.mark.asyncio
-async def test_react_executor_passes_checkpoint_namespace_to_langgraph() -> None:
+async def test_react_executor_does_not_configure_a_checkpoint_namespace() -> None:
+    """The executor stops asking for a namespace LangGraph would throw away."""
+
     compiled = _RecordingCompiledAgent()
     executor = _TransportBackedReActExecutor(
         compiled_agent=compiled,  # type: ignore[arg-type]
         binding=_FakeBinding(),  # type: ignore[arg-type]
         services=_FakeServices(),  # type: ignore[arg-type]
-        checkpoint_ns="instance-123",
     )
 
     input_model = ReActInput(
         messages=(ReActMessage(role=ReActMessageRole.USER, content="hi"),)
     )
 
-    await executor.invoke(
-        input_model,
-        ExecutionConfig(session_id="session-1"),
+    await executor.invoke(input_model, ExecutionConfig(session_id="session-1"))
+
+    assert compiled.config == {"configurable": {"thread_id": "session-1"}}
+
+
+def test_to_runnable_config_carries_only_the_thread_id() -> None:
+    runnable = to_runnable_config(ExecutionConfig(session_id="session-1"))
+
+    assert runnable is not None
+    configurable = runnable["configurable"]
+    assert isinstance(configurable, dict)
+    assert configurable == {"thread_id": "session-1"}
+
+
+def test_react_resume_probes_the_unnamespaced_checkpoint_first() -> None:
+    """
+    A ReAct V2 resume (`interrupt_id`, never `checkpoint_id`) must look under
+    `""` — where its checkpoint really is — before the per-agent namespace,
+    even though the request carries a managed instance id.
+    """
+
+    request = RuntimeExecuteRequest(
+        agent_instance_id="instance-123",
+        session_id="session-1",
+        interrupt_id="interrupt-a",
+        resume_payload={"choice_id": "proceed"},
     )
 
-    assert compiled.config == {
-        "configurable": {
-            "thread_id": "session-1",
-            "checkpoint_ns": "instance-123",
-        }
-    }
+    assert _resume_checkpoint_namespaces(request) == ("", "instance-123")
+
+
+def test_graph_resume_probes_the_agent_namespace_first() -> None:
+    """
+    The hand-rolled Graph runtime writes through `aput` itself, so its
+    per-agent namespace does reach storage — a `checkpoint_id`-carrying resume
+    looks there first, keeping `""` only as a fallback for a Graph pause that
+    never stamped a checkpoint_id.
+    """
+
+    request = RuntimeExecuteRequest(
+        agent_instance_id="instance-123",
+        session_id="session-1",
+        checkpoint_id="stored-checkpoint-id",
+        resume_payload={"choice_id": "proceed"},
+    )
+
+    assert _resume_checkpoint_namespaces(request) == ("instance-123", "")
+
+
+def test_resume_namespaces_deduplicate_for_a_template_agent() -> None:
+    """A namespace equal to `""` must not be probed twice."""
+
+    request = RuntimeExecuteRequest(
+        agent_id="react.agent",
+        session_id="session-1",
+        interrupt_id="interrupt-a",
+        resume_payload={"choice_id": "proceed"},
+    )
+
+    assert _resume_checkpoint_namespaces(request) == ("", "react.agent")
 
 
 def test_react_checkpoint_namespace_uses_managed_instance_when_available() -> None:
@@ -77,18 +185,3 @@ def test_react_checkpoint_namespace_uses_managed_instance_when_available() -> No
         )
         == "managed-456"
     )
-
-
-def test_to_runnable_config_adds_agent_checkpoint_namespace() -> None:
-    config = ExecutionConfig(session_id="session-1")
-
-    runnable = to_runnable_config(
-        config,
-        checkpoint_ns="instance-123",
-    )
-
-    assert runnable is not None
-    configurable = runnable["configurable"]
-    assert isinstance(configurable, dict)
-    assert configurable["thread_id"] == "session-1"
-    assert configurable["checkpoint_ns"] == "instance-123"


### PR DESCRIPTION
Closes #2479.

## Le bug

Toute reprise HITL sur un agent ReAct V2 échouait en
`409 "No pending checkpoint was found for this session."`. Le checkpoint en pause
existait pourtant, avec son write `__interrupt__` - la porte d'admission le
cherchait au mauvais endroit.

LangGraph remet `checkpoint_ns` à `""` pour toute invocation non imbriquée
(`pregel/_loop.py::PregelLoop.__init__`). Le namespace par agent que #2415 passait
à `compiled_agent.astream(...)` n'atteignait donc jamais le stockage, pendant que
la porte d'admission et la clé `checkpoint_hitl_claim` lisaient à
`agent_instance_id`. L'écriture et la lecture ne se rencontraient jamais.

Constaté en base sur une session en échec : `select distinct checkpoint_ns from
v2_langgraph_checkpoint` ne renvoie que `''`, et `v2_checkpoint_hitl_claim` est
vide - la requête mourait avant le claim.

Le runtime Graph legacy n'est pas concerné : il appelle `aput` lui-même, son
namespace est donc réel.

## Le correctif

- ReAct écrit et lit sans namespace. Le plumbing `checkpoint_ns` de l'exécuteur et
  de `to_runnable_config` disparaît - il était inerte - et le claim HITL, qui est
  un chemin exclusivement ReAct, se clé sur `""`.
- `_resume_checkpoint_namespaces` choisit le namespace candidat à partir de
  l'identifiant de reprise porté par la requête. Une reprise `checkpoint_id`
  (Graph V2) ne sonde que le namespace de l'agent : son exécuteur ne lit nulle
  part ailleurs, et laisser passer un checkpoint non namespacé donnerait un 200
  puis une mort en plein stream, trop tard pour un 409. Une reprise `interrupt_id`
  (ReAct V2) sonde `""` d'abord, le namespace agent restant pour une pause Graph
  qui n'a jamais estampillé de `checkpoint_id`.
- Le runtime Graph garde son namespace par agent.

## Tests

- `test_langgraph_resets_root_checkpoint_namespace` épingle le comportement
  LangGraph : un bump de version qui le changerait casse un test au lieu de
  déplacer silencieusement les checkpoints hors de portée de la porte.
- Nouveau test d'intégration dans `test_hitl_resume_langgraph_integration.py` :
  vraie boucle d'outils, vrai `FredSqlCheckpointer`, config namespacée en entrée -
  le checkpoint et son `__interrupt__` atterrissent à `""`, la lecture au
  namespace agent ne trouve rien.
- Les fixtures ReAct de `test_agent_app.py` sèment désormais à `""`, la vraie
  disposition. Vérifié : 18 tests tombent si on remet la lecture namespacée.

`make code-quality` racine vert, 1069 tests fred-runtime au vert.

## Reste ouvert

L'objectif annoncé de #2415 - isoler les checkpoints par agent dans une session
partagée - n'a jamais fonctionné côté ReAct et ne peut pas passer par
`checkpoint_ns` sur un graphe racine. Le seul levier LangGraph est le `thread_id`,
qui touche `checkpoint_thread_owner`, l'effacement par utilisateur et la
suppression de session : à traiter dans une issue séparée. Documenté dans
`RUNTIME-EXECUTION-CONTRACT.md` §8.61.
