### PR TITLE
fix(resources): folder rename + multi-file download reliability

### DIFF
--- a/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
+++ b/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
@@ -24,8 +24,7 @@ import {
 } from "../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { useTranslation } from "react-i18next";
-import { downloadFile } from "../../../utils/downloadUtils";
-import { useLazyDownloadRawContentBlobQuery } from "../../../slices/knowledgeFlow/knowledgeFlowApi.blob";
+import { downloadFile, fetchAuthedBlob } from "../../../utils/downloadUtils";
 import { collectDescendantTags, rewriteTagUnderFolder, type TagNode } from "../../../shared/utils/tagTree";
 
 type DocumentRefreshers = {
@@ -48,7 +47,6 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
   const [renameDocumentMutation] = useRenameDocumentKnowledgeFlowV1DocumentMetadataDocumentUidNamePutMutation();
   const [mutateLabelsMutation] = useMutateDocumentLabelsMutation();
   const [fetchAllDocuments] = useSearchDocumentMetadataKnowledgeFlowV1DocumentsMetadataSearchPostMutation();
-  const [triggerDownloadBlob] = useLazyDownloadRawContentBlobQuery();
   const [previewTarget, setPreviewTarget] = useState<DocumentPreviewTarget | null>(null);
   const refresh = useCallback(
     async (tagId?: string) => {
@@ -185,9 +183,14 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
   // directly: zipping N documents needs every blob before any of them can
   // be saved, so it can't go through `download`'s fetch+save-immediately
   // shape.
+  // Plain authed fetch, NOT an RTK Query lazy trigger: the lazy hook has a single
+  // subscription, so firing it concurrently for N documents (a bulk zip download)
+  // drops all but the last request and the whole download fails. A direct fetch
+  // per document is independent — the same path FilesystemWorkspace already uses.
   const fetchBlob = useCallback(
-    (doc: DocumentMetadata) => triggerDownloadBlob({ documentUid: doc.identity.document_uid }).unwrap(),
-    [triggerDownloadBlob],
+    (doc: DocumentMetadata) =>
+      fetchAuthedBlob(`/knowledge-flow/v1/raw_content/${encodeURIComponent(doc.identity.document_uid)}`),
+    [],
   );
   const download = useCallback(
     async (doc: DocumentMetadata) => {

--- a/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
+++ b/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
@@ -26,6 +26,7 @@ import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { useTranslation } from "react-i18next";
 import { downloadFile } from "../../../utils/downloadUtils";
 import { useLazyDownloadRawContentBlobQuery } from "../../../slices/knowledgeFlow/knowledgeFlowApi.blob";
+import { collectDescendantTags, rewriteTagUnderFolder, type TagNode } from "../../../shared/utils/tagTree";
 
 type DocumentRefreshers = {
   refetchTags?: () => Promise<any>;
@@ -204,22 +205,29 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
     [fetchBlob, showError],
   );
   // Corpus folder rename (RFC §13.8) — reuses the existing tag-update path
-  // (`PUT /tags/{tag_id}`) already used elsewhere in this hook, no new
-  // endpoint. `refresh` re-derives the tag tree so the renamed node's new
-  // path/name shows up without a manual reload.
-  const renameTag = useCallback(
-    async (tag: TagWithItemsId, newName: string) => {
+  // (`PUT /tags/{tag_id}`), no new endpoint. A folder is a path PREFIX, not a
+  // single tag: renaming it must rewrite the leading segment of EVERY tag
+  // at-or-under the node (the tag ending there AND every descendant), else the
+  // descendants keep the old path and re-materialize the old folder — the rename
+  // then appears to do nothing. `refresh` re-derives the tag tree afterward.
+  const renameFolder = useCallback(
+    async (node: TagNode, newName: string) => {
+      const oldFull = node.full;
+      const cut = oldFull.lastIndexOf("/");
+      const parentPath = cut >= 0 ? oldFull.slice(0, cut) : "";
+      const newFull = parentPath ? `${parentPath}/${newName}` : newName;
+      const tags = collectDescendantTags(node);
       try {
-        await updateTag({
-          tagId: tag.id,
-          tagUpdate: {
-            name: newName,
-            path: tag.path,
-            description: tag.description,
-            type: tag.type,
-            item_ids: tag.item_ids,
-          },
-        }).unwrap();
+        // Independent per-id updates (each carries its final name/path), so order
+        // does not matter; a mid-way failure leaves a partial rename the user can
+        // retry (no folder-rename transaction exists server-side).
+        for (const tag of tags) {
+          const { name, path } = rewriteTagUnderFolder(tag, oldFull, newFull);
+          await updateTag({
+            tagId: tag.id,
+            tagUpdate: { name, path, description: tag.description, type: tag.type, item_ids: tag.item_ids },
+          }).unwrap();
+        }
         await refresh();
       } catch (e: any) {
         showError?.({
@@ -288,7 +296,7 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
     toggleRetrievable,
     removeFromLibrary,
     bulkRemoveFromLibraryForTag,
-    renameTag,
+    renameFolder,
     renameDocument,
     mutateLabels,
     preview,

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/DocumentWorkspace/DocumentWorkspace.tsx
@@ -1823,8 +1823,7 @@ function DocumentWorkspace({ teamId, isPersonalTeam, onDocumentsChanged }: Docum
           lockedSuffix={renameTarget.kind === "document" ? documentExtension(renameTarget.doc) : undefined}
           onSubmit={async (newName) => {
             if (renameTarget.kind === "folder") {
-              const tag = renameTarget.node.tagsHere[0];
-              if (tag) await commands.renameTag(tag as unknown as TagWithItemsId, newName);
+              await commands.renameFolder(renameTarget.node, newName);
             } else {
               await commands.renameDocument(renameTarget.doc, newName, currentTag?.id);
             }

--- a/apps/frontend/src/shared/utils/tagTree.test.ts
+++ b/apps/frontend/src/shared/utils/tagTree.test.ts
@@ -1,0 +1,79 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Folder rename is a path-PREFIX rewrite: renaming a corpus folder must update
+// every tag at-or-under it (the tag ending there AND every descendant), or the
+// descendants keep the old path and re-materialize the old folder — the rename
+// then appears to do nothing. These cover the two helpers that make that correct.
+
+import { describe, expect, it } from "vitest";
+import { buildTree, collectDescendantTags, findNode, fullPath, rewriteTagUnderFolder } from "./tagTree";
+
+// A folder ("Reports") that has BOTH its own tag and nested sub-folders — the
+// exact shape whose rename previously touched only the one terminating tag.
+const tags = [
+  { id: "t-reports", name: "Reports", path: "", type: "document", item_ids: ["d0"] },
+  { id: "t-q1", name: "Q1", path: "Reports", type: "document", item_ids: ["d1"] },
+  { id: "t-jan", name: "Jan", path: "Reports/Q1", type: "document", item_ids: ["d2"] },
+  { id: "t-other", name: "Other", path: "", type: "document", item_ids: ["d3"] },
+] as never;
+
+describe("collectDescendantTags", () => {
+  it("returns the node's own tag plus every descendant, and nothing outside it", () => {
+    const node = findNode(buildTree(tags), "Reports");
+    const ids = collectDescendantTags(node).map((t) => t.id);
+    expect(new Set(ids)).toEqual(new Set(["t-reports", "t-q1", "t-jan"]));
+    expect(ids).not.toContain("t-other");
+  });
+});
+
+describe("rewriteTagUnderFolder", () => {
+  it("renames the folder's own tag (leaf of the rename)", () => {
+    const tag = { name: "Reports", path: "" };
+    expect(rewriteTagUnderFolder(tag, "Reports", "Rapports")).toEqual({ name: "Rapports", path: "" });
+  });
+
+  it("rewrites the old prefix of a descendant tag, preserving its deeper path", () => {
+    expect(rewriteTagUnderFolder({ name: "Q1", path: "Reports" }, "Reports", "Rapports")).toEqual({
+      name: "Q1",
+      path: "Rapports",
+    });
+    expect(rewriteTagUnderFolder({ name: "Jan", path: "Reports/Q1" }, "Reports", "Rapports")).toEqual({
+      name: "Jan",
+      path: "Rapports/Q1",
+    });
+  });
+
+  it("handles renaming a nested folder (parent path preserved)", () => {
+    // Rename Reports/Q1 -> Reports/Trimestre1.
+    expect(rewriteTagUnderFolder({ name: "Q1", path: "Reports" }, "Reports/Q1", "Reports/Trimestre1")).toEqual({
+      name: "Trimestre1",
+      path: "Reports",
+    });
+    expect(rewriteTagUnderFolder({ name: "Jan", path: "Reports/Q1" }, "Reports/Q1", "Reports/Trimestre1")).toEqual({
+      name: "Jan",
+      path: "Reports/Trimestre1",
+    });
+  });
+
+  it("moves the WHOLE subtree so the old folder no longer re-materializes", () => {
+    const node = findNode(buildTree(tags), "Reports");
+    const renamed = collectDescendantTags(node).map((t) => rewriteTagUnderFolder(t, "Reports", "Rapports"));
+    // Every rewritten tag now lives under the new name; none references the old.
+    for (const r of renamed) {
+      expect(fullPath(r).startsWith("Rapports")).toBe(true);
+      expect(fullPath(r).startsWith("Reports")).toBe(false);
+    }
+  });
+});

--- a/apps/frontend/src/shared/utils/tagTree.ts
+++ b/apps/frontend/src/shared/utils/tagTree.ts
@@ -75,6 +75,41 @@ export function collectDescendantTagIds(node: TagNode): string[] {
 }
 
 /**
+ * Every tag at-or-under `node` (the node's own `tagsHere` plus every descendant's).
+ * Used to rename a whole folder: a folder is a path prefix, so renaming it must
+ * rewrite the path of every tag beneath it, not just the one ending at the node.
+ */
+export function collectDescendantTags(node: TagNode): TagWithPermissions[] {
+  const tags: TagWithPermissions[] = [];
+  function dfs(n: TagNode) {
+    n.tagsHere.forEach((t) => tags.push(t));
+    n.children.forEach((child) => dfs(child));
+  }
+  dfs(node);
+  return tags;
+}
+
+/**
+ * The new `{ name, path }` for one tag when its containing folder is renamed from
+ * `oldFull` to `newFull`. The tag's leading `oldFull` prefix is swapped for
+ * `newFull`, then the result is split back into leaf name + parent path. `tag`
+ * must be at-or-under the folder (`fullPath(tag)` equals `oldFull` or starts with
+ * `oldFull + "/"`); callers get that set from `collectDescendantTags`.
+ */
+export function rewriteTagUnderFolder(
+  tag: Pick<TagWithItemsId, "name" | "path">,
+  oldFull: string,
+  newFull: string,
+): { name: string; path: string } {
+  const nextFull = `${newFull}${fullPath(tag).slice(oldFull.length)}`;
+  const seg = nextFull.lastIndexOf("/");
+  return {
+    name: seg >= 0 ? nextFull.slice(seg + 1) : nextFull,
+    path: seg >= 0 ? nextFull.slice(0, seg) : "",
+  };
+}
+
+/**
  * Every `document_uid` tagged under `node`, its sub-folders included — a tag's
  * own `item_ids` never cover nested tags, same reason `collectDescendantTagIds`
  * exists. Deduplicated: a document is tagged into exactly one folder, but the

--- a/apps/frontend/src/utils/downloadUtils.test.ts
+++ b/apps/frontend/src/utils/downloadUtils.test.ts
@@ -83,6 +83,23 @@ describe("downloadManyAsZip", () => {
     expect(await zip.file("b.txt")!.async("string")).toBe("B");
   });
 
+  it("keeps every file's bytes when zipping several (no 0-byte entries)", async () => {
+    // Guards the Firefox 0-byte regression: JSZip read Blobs lazily during
+    // generateAsync, dropping all but one entry to empty. Every entry must carry
+    // its full content.
+    const contents = { "a.txt": "alpha", "b.txt": "beta", "c.txt": "gamma" };
+    await downloadManyAsZip(
+      Object.entries(contents).map(([filename, text]) => ({ filename, fetchBlob: async () => blob(text) })),
+      "resources.zip",
+    );
+
+    const zip = await JSZip.loadAsync(createdUrls[0]);
+    expect(Object.keys(zip.files).sort()).toEqual(["a.txt", "b.txt", "c.txt"]);
+    for (const [name, text] of Object.entries(contents)) {
+      expect(await zip.file(name)!.async("string")).toBe(text);
+    }
+  });
+
   it("disambiguates same-named files instead of one overwriting the other", async () => {
     await downloadManyAsZip(
       [

--- a/apps/frontend/src/utils/downloadUtils.tsx
+++ b/apps/frontend/src/utils/downloadUtils.tsx
@@ -94,12 +94,16 @@ export async function downloadManyAsZip(files: DownloadableFile[], zipFilename: 
     return;
   }
   const zip = new JSZip();
-  const blobs = await Promise.all(files.map((f) => f.fetchBlob()));
+  // Read each file into an ArrayBuffer BEFORE adding it. Handing `zip.file` a Blob
+  // makes JSZip read it LAZILY during generateAsync, and reading several Blobs
+  // there drops all but one entry to 0 bytes (seen on Firefox). A buffer is
+  // consumed synchronously, so every entry keeps its bytes.
+  const buffers = await Promise.all(files.map(async (f) => (await f.fetchBlob()).arrayBuffer()));
   const usedNames = new Set<string>();
   files.forEach((f, i) => {
     const name = uniqueName(f.filename, usedNames);
     usedNames.add(name);
-    zip.file(name, blobs[i]);
+    zip.file(name, buffers[i]);
   });
   downloadFile(await zip.generateAsync({ type: "blob" }), zipFilename);
 }

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/minio_content_store.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/stores/content/minio_content_store.py
@@ -219,7 +219,13 @@ class MinioStorageBackend(BaseContentStore):
     def get_preview_bytes(self, doc_path: str) -> bytes:
         try:
             response = self.client.get_object(self.document_bucket, doc_path)
-            return response.read()
+            try:
+                return response.read()
+            finally:
+                # release_conn() returns the urllib3 connection to the pool; without
+                # it every preview fetch leaks one and eventually exhausts the pool.
+                response.close()
+                response.release_conn()
         except S3Error as e:
             logger.error(f"[CONTENT][MINIO] Error fetching preview path={doc_path}: {e}")
             raise FileNotFoundError(f"Preview image not found for document {doc_path}")

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/content/content_controller.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/content/content_controller.py
@@ -239,6 +239,8 @@ class ContentController:
                     content=stream,
                     media_type=content_type,
                     headers={"Content-Disposition": build_content_disposition_header("attachment", file_name)},
+                    # Release the store stream (MinIO connection) after sending.
+                    background=BackgroundTask(getattr(stream, "close", lambda: None)),
                 )
             except FileNotFoundError as e:
                 raise HTTPException(status_code=404, detail=str(e))
@@ -271,6 +273,11 @@ class ContentController:
                 content=stream,
                 media_type=media_type,
                 headers={"Content-Disposition": build_content_disposition_header("attachment", file_name)},
+                # Close the store stream after sending: for MinIO it releases the
+                # urllib3 connection back to the pool (get_content wraps it in
+                # _ResponseRaw). Without this every download leaks a connection and
+                # the pool is exhausted — concurrent downloads then fail.
+                background=BackgroundTask(getattr(stream, "close", lambda: None)),
             )
 
         @router.get(
@@ -293,6 +300,8 @@ class ContentController:
                     content=stream,
                     media_type=content_type,
                     headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+                    # Release the store stream (MinIO connection) after sending.
+                    background=BackgroundTask(getattr(stream, "close", lambda: None)),
                 )
             except FileNotFoundError as e:
                 raise HTTPException(status_code=404, detail=str(e))

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/tag/tag_service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/tag/tag_service.py
@@ -316,7 +316,14 @@ class TagService:
             *(item_service.remove_tag_id_from_item(user, removed_id, tag_id) for removed_id in removed_ids),
         )
 
-        # Update tag
+        # Apply the editable metadata from the request. Without this the endpoint
+        # saved the tag loaded from the store unchanged, so every rename (name or
+        # path) was silently dropped — a folder rename appeared to do nothing.
+        # `type` is intentionally not mutated here: it selected `item_service`
+        # above, so changing it would desynchronize the item diff already applied.
+        tag.name = tag_data.name
+        tag.path = tag_data.path
+        tag.description = tag_data.description
         tag.updated_at = datetime.now()
         updated_tag = await self._tag_store.update_tag_by_id(tag_id, tag)
 

--- a/apps/knowledge-flow-backend/tests/features/test_tag_update_applies_fields.py
+++ b/apps/knowledge-flow-backend/tests/features/test_tag_update_applies_fields.py
@@ -1,0 +1,96 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`update_tag_for_user` must persist name/path/description changes.
+
+Regression: the service loaded the stored tag, diffed only its item_ids, and
+saved it back unchanged — so every rename (folder or tag) was silently dropped
+and appeared to do nothing in the UI.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fred_core.security.structure import KeycloakUser
+
+import knowledge_flow_backend.features.tag.tag_service as tag_service_module
+from knowledge_flow_backend.features.tag.structure import Tag, TagType, TagUpdate
+
+TagService = tag_service_module.TagService
+
+
+class _FakeRebac:
+    async def check_user_permission_or_raise(self, user, permission, tag_id):
+        return None
+
+
+class _FakeTagStore:
+    def __init__(self, tag: Tag) -> None:
+        self._tag = tag
+        self.saved: Tag | None = None
+
+    async def get_tag_by_id(self, tag_id: str) -> Tag:
+        return self._tag
+
+    async def update_tag_by_id(self, tag_id: str, tag: Tag) -> Tag:
+        self.saved = tag
+        return tag
+
+
+class _FakeItemService:
+    async def retrieve_items_ids_for_tag(self, user, tag_id):
+        return []
+
+    async def add_tag_id_to_item(self, user, item_id, tag_id):
+        return None
+
+    async def remove_tag_id_from_item(self, user, item_id, tag_id):
+        return None
+
+
+def _user() -> KeycloakUser:
+    return KeycloakUser(uid="u", username="u", roles=[], email=None)
+
+
+@pytest.mark.asyncio
+async def test_update_applies_name_and_path(monkeypatch):
+    now = datetime.now(timezone.utc)
+    existing = Tag(
+        id="t1",
+        created_at=now,
+        updated_at=now,
+        owner_id="u",
+        name="Reports",
+        path=None,
+        description="old",
+        type=TagType.DOCUMENT,
+    )
+    store = _FakeTagStore(existing)
+    monkeypatch.setattr(tag_service_module, "get_specific_tag_item_service", lambda _type: _FakeItemService())
+
+    svc = TagService.__new__(TagService)
+    svc.rebac = _FakeRebac()
+    svc._tag_store = store
+
+    await svc.update_tag_for_user(
+        "t1",
+        TagUpdate(name="Rapports", path="Archive", description="new", type=TagType.DOCUMENT, item_ids=[]),
+        _user(),
+    )
+
+    assert store.saved is not None
+    assert store.saved.name == "Rapports"
+    assert store.saved.path == "Archive"
+    assert store.saved.description == "new"
+    assert store.saved.full_path == "Archive/Rapports"

--- a/apps/knowledge-flow-backend/tests/stores/content/test_minio_content_store.py
+++ b/apps/knowledge-flow-backend/tests/stores/content/test_minio_content_store.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from knowledge_flow_backend.core.stores.content.minio_content_store import MinioStorageBackend
 
@@ -81,6 +82,29 @@ def test_put_file_uses_direct_minio_file_upload(monkeypatch, tmp_path):
     assert store.client.fput_calls == [("objects", "tabular/doc-1/rev/data.parquet", str(parquet_file), "application/vnd.apache.parquet")]
     assert stored.size == len(b"parquet-data")
     assert stored.file_name == "data.parquet"
+
+
+def test_get_preview_bytes_releases_connection(monkeypatch):
+    # get_object returns a urllib3 response that must be released back to the pool;
+    # without it every preview fetch leaks a connection and the pool is exhausted.
+    monkeypatch.setattr("knowledge_flow_backend.core.stores.content.minio_content_store.Minio", _FakeMinio)
+    store = MinioStorageBackend(
+        endpoint="http://internal-minio:9000",
+        access_key="minio",
+        secret_key="minio-secret",  # pragma: allowlist secret
+        document_bucket="documents",
+        object_bucket="objects",
+        secure=False,
+    )
+    resp = MagicMock()
+    resp.read.return_value = b"image-bytes"
+    store.client.get_object = MagicMock(return_value=resp)
+
+    data = store.get_preview_bytes("doc-1/preview.png")
+
+    assert data == b"image-bytes"
+    resp.close.assert_called_once()
+    resp.release_conn.assert_called_once()
 
 
 def test_internal_presigned_url_uses_internal_minio_client(monkeypatch):

--- a/libs/fred-core/fred_core/filesystem/minio_filesystem.py
+++ b/libs/fred-core/fred_core/filesystem/minio_filesystem.py
@@ -131,9 +131,14 @@ class MinioFilesystem(BaseFilesystem):
         resolved = self._resolve_path(path)
         logger.info("[MINIO_READ] bucket=%s path=%s", self.bucket_name, resolved)
         obj = self.client.get_object(self.bucket_name, resolved)
-        data = obj.read()
-        obj.close()
-        return data
+        try:
+            return obj.read()
+        finally:
+            # release_conn() — not just close() — returns the urllib3 connection to
+            # the pool. Without it every read leaks a connection; after a few (e.g.
+            # a multi-file zip download) the pool is exhausted and later reads fail.
+            obj.close()
+            obj.release_conn()
 
     async def write(self, path: str, data: bytes | str) -> None:
         """

--- a/libs/fred-core/fred_core/tests/filesystem/test_minio_filesystem.py
+++ b/libs/fred-core/fred_core/tests/filesystem/test_minio_filesystem.py
@@ -1,0 +1,63 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MinioFilesystem.read must release the connection back to the pool.
+
+Regression: read() called get_object().read() then only close() — never
+release_conn() — so every read leaked a urllib3 connection. A multi-file zip
+download exhausted the pool and later reads failed with a generic download error.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fred_core.filesystem.minio_filesystem import MinioFilesystem
+
+
+def _fs_with_response(response: MagicMock) -> MinioFilesystem:
+    # Bypass __init__ (it connects to a live MinIO); wire only what read() touches.
+    fs = MinioFilesystem.__new__(MinioFilesystem)
+    fs.bucket_name = "bucket"
+    fs.prefix = None
+    fs.client = MagicMock()
+    fs.client.get_object.return_value = response
+    return fs
+
+
+@pytest.mark.asyncio
+async def test_read_releases_connection():
+    resp = MagicMock()
+    resp.read.return_value = b"hello"
+    fs = _fs_with_response(resp)
+
+    data = await fs.read("notes.txt")
+
+    assert data == b"hello"
+    resp.close.assert_called_once()
+    resp.release_conn.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_read_releases_connection_even_on_error():
+    resp = MagicMock()
+    resp.read.side_effect = RuntimeError("boom")
+    fs = _fs_with_response(resp)
+
+    with pytest.raises(RuntimeError):
+        await fs.read("notes.txt")
+
+    # The finally clause must run so the connection is never leaked on failure.
+    resp.close.assert_called_once()
+    resp.release_conn.assert_called_once()

--- a/libs/fred-core/fred_core/tests/filesystem/test_minio_filesystem.py
+++ b/libs/fred-core/fred_core/tests/filesystem/test_minio_filesystem.py
@@ -22,7 +22,6 @@ download exhausted the pool and later reads failed with a generic download error
 from unittest.mock import MagicMock
 
 import pytest
-
 from fred_core.filesystem.minio_filesystem import MinioFilesystem
 
 


### PR DESCRIPTION
Five independent bug fixes in the Resources area, grouped as one review since they all touch resource browsing/downloading.

## Fixes

1. **Corpus folder/tag rename did nothing** (`5cd2d8d4`)
   - Backend: `update_tag_for_user` loaded the tag, diffed only `item_ids`, and saved it back — it never applied the request's new `name`/`path`/`description`, so every rename was silently dropped.
   - Frontend: a corpus folder is a path PREFIX, so rename now rewrites the whole subtree (`collectDescendantTags` + `rewriteTagUnderFolder`), not just the tag ending at the node.

2. **Multi-file zip download produced 0-byte entries** (`19462d73`)
   - `downloadManyAsZip` handed each Blob to JSZip, which reads it lazily during `generateAsync` and drops all but one entry to 0 bytes (Firefox). Read each file into an `ArrayBuffer` first.

3. **MinIO connection leak — filesystem read** (`9c8145ee`)
   - `MinioFilesystem.read` called `close()` but never `release_conn()`, leaking a urllib3 connection per read until the pool was exhausted. Wrap in `try/finally` with both.

4. **MinIO connection leak — content download streaming** (`31786dfd`)
   - The document download endpoints returned `StreamingResponse(content=stream)` where `stream` releases its MinIO connection only on `close()`, but Starlette never closes a file-like `content`. Attach `BackgroundTask(stream.close)` (the pattern `stream_document` already used). Also fix `get_preview_bytes`.

5. **Corpus multi-file download failed while a single one worked** (`66c6ffdb`)
   - The bulk zip fetched each document's blob through an RTK Query lazy trigger; a lazy hook has one subscription slot, so firing it concurrently drops all but the last request and the whole `Promise.all` rejects (it also stored a Blob in the Redux store). Fetch each blob with a plain authed fetch to `/raw_content/{uid}` — the same independent-per-call path FilesystemWorkspace uses.

## Verification
- Backend: `test_tag_update_applies_fields`, `test_minio_filesystem` (release on success + error), `test_minio_content_store` (release); ruff/format green.
- Frontend: `tagTree` subtree-rewrite tests, `downloadUtils` 3-file no-0-byte test; tsc/eslint/prettier green; full suite passing.
- Reproduced end to end: the backend + Vite proxy serve concurrent downloads fine (12 concurrent, all 200, full bytes); the remaining failure was the frontend RTK lazy trigger (fix #5).

No migrations, no contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)