### PR TITLE
feat(home): autofocus the spotlight and show real team avatars in results

### DIFF
--- a/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/HomeSearch.module.scss
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/HomeSearch.module.scss
@@ -115,6 +115,14 @@
   font-size: 1.125rem;
 }
 
+.rowAvatar {
+  flex-shrink: 0;
+  border-radius: var(--radius-s);
+  width: 2rem;
+  height: 2rem;
+  object-fit: cover;
+}
+
 .rowText {
   display: flex;
   flex-direction: column;

--- a/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/HomeSearch.tsx
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/HomeSearch.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react"
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import Icon from "@shared/atoms/Icon/Icon.tsx";
+import TeamInitials from "@shared/atoms/TeamInitials/TeamInitials.tsx";
 import { resolveAgentIcon } from "@shared/utils/agentIcon.ts";
 import { useFrontendProperties } from "../../../../../hooks/useFrontendProperties.ts";
 import PromptViewDialog, { type PromptViewDetail } from "../../PromptsPage/PromptViewDialog/PromptViewDialog.tsx";
@@ -57,6 +58,12 @@ export default function HomeSearch() {
 
   const wrapRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Land on Home ready to type: focus the spotlight on mount. This also latches
+  // `active` (via onFocus) so the per-team aggregation warms up right away.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   const sources = useHomeSearchIndex(active);
   const results = useMemo(() => filterHomeSearch(sources, query), [sources, query]);
@@ -141,8 +148,24 @@ export default function HomeSearch() {
 
   const iconFor = (hit: SearchHit) => {
     if (hit.kind === "agent") return resolveAgentIcon(hit.instance, agentIconName);
-    if (hit.kind === "team") return "groups";
     return "description";
+  };
+
+  // Teams show their real avatar (custom image, else coloured initials) rather
+  // than a generic icon; agents and prompts keep the tinted icon tile.
+  const rowVisual = (hit: SearchHit) => {
+    if (hit.kind === "team") {
+      return hit.avatarImageUrl ? (
+        <img className={styles.rowAvatar} src={hit.avatarImageUrl} alt="" />
+      ) : (
+        <TeamInitials className={styles.rowAvatar} name={hit.name} size="small" shape="square" />
+      );
+    }
+    return (
+      <span className={styles.rowIcon}>
+        <Icon category="outlined" type={iconFor(hit)} />
+      </span>
+    );
   };
 
   const sublabelFor = (hit: SearchHit): string | undefined => {
@@ -171,9 +194,7 @@ export default function HomeSearch() {
         onMouseEnter={() => setActiveIndex(index)}
         onClick={() => activate(hit)}
       >
-        <span className={styles.rowIcon}>
-          <Icon category="outlined" type={iconFor(hit)} />
-        </span>
+        {rowVisual(hit)}
         <span className={styles.rowText}>
           <span className={styles.rowLabel}>{hit.name}</span>
           {sublabel && <span className={styles.rowSublabel}>{sublabel}</span>}

--- a/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/homeSearchIndex.test.ts
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/homeSearchIndex.test.ts
@@ -53,7 +53,7 @@ describe("filterHomeSearch", () => {
     ],
     teams: [
       { id: "t1", name: "Alpha" },
-      { id: "t2", name: "Contracts Team" },
+      { id: "t2", name: "Contracts Team", avatarImageUrl: "https://cdn/contracts.png" },
     ],
     prompts: unifyPrompts(
       [{ teamId: "t1", teamName: "Alpha", prompts: [teamPrompt("p1", "Contract summary", "summarize a contract")] }],
@@ -73,6 +73,11 @@ describe("filterHomeSearch", () => {
     expect(r.agents.map((a) => a.id)).toEqual(["a1"]);
     expect(r.teams.map((t) => t.id)).toEqual(["t2"]);
     expect(r.prompts.map((p) => p.id)).toEqual(["p1"]);
+  });
+
+  it("carries a team's avatar url onto its hit (drives the real avatar in the menu)", () => {
+    const r = filterHomeSearch(sources, "contracts team");
+    expect(r.teams.map((t) => t.avatarImageUrl)).toEqual(["https://cdn/contracts.png"]);
   });
 
   it("matches an agent on its role, not just its name", () => {

--- a/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/homeSearchIndex.ts
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/homeSearchIndex.ts
@@ -33,6 +33,8 @@ export interface AgentEntry {
 export interface TeamEntry {
   id: string;
   name: string;
+  /** Custom team avatar; when absent the row falls back to coloured initials. */
+  avatarImageUrl?: string | null;
 }
 export interface TeamPromptGroup {
   teamId: string;
@@ -53,6 +55,7 @@ export interface TeamHit {
   kind: "team";
   id: string;
   name: string;
+  avatarImageUrl?: string | null;
 }
 export interface PromptHit {
   kind: "prompt";
@@ -150,7 +153,7 @@ export function filterHomeSearch(
   const teams: TeamHit[] = [];
   for (const team of sources.teams) {
     if (matches(query, team.name)) {
-      teams.push({ kind: "team", id: team.id, name: team.name });
+      teams.push({ kind: "team", id: team.id, name: team.name, avatarImageUrl: team.avatarImageUrl });
       if (teams.length >= cap) break;
     }
   }

--- a/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/useHomeSearchIndex.ts
+++ b/apps/frontend/src/rework/components/pages/HomePage/HomeSearch/useHomeSearchIndex.ts
@@ -38,7 +38,10 @@ export function useHomeSearchIndex(active: boolean): SearchSources {
   const { availableTeams } = useFrontendBootstrap();
 
   const teamMeta = useMemo(
-    () => availableTeams.filter((team) => team.is_member).map((team) => ({ id: team.id, name: team.name })),
+    () =>
+      availableTeams
+        .filter((team) => team.is_member)
+        .map((team) => ({ id: team.id, name: team.name, avatarImageUrl: team.avatar_image_url ?? null })),
     [availableTeams],
   );
 


### PR DESCRIPTION
## What

Two small Home page refinements to the Spotlight search (`HomeSearch`):

1. **Autofocus on load** — the search field receives focus on mount, so landing on Home you can type immediately without clicking. This also latches the lazy per-team aggregation right away (via the existing `onFocus`).
2. **Real team avatars in results** — team rows in the results menu now render the team's avatar (custom image when set, otherwise coloured initials via `TeamInitials`) instead of the generic `groups` icon. Agents and prompts keep their tinted icon tile.

## How

- `useHomeSearchIndex` now carries each member team's `avatar_image_url` into the search sources.
- `TeamEntry` / `TeamHit` gain an optional `avatarImageUrl`, passed through `filterHomeSearch`.
- `HomeSearch` adds a mount `useEffect` for focus and a `rowVisual()` helper that renders the avatar for team hits.

The image-or-initials fallback mirrors the existing pattern in `TeamCard` / `TeamSelectionListItem` (there is no shared `TeamAvatar` atom).

## Tests

- Unit test added: `filterHomeSearch` carries `avatarImageUrl` onto team hits.
- `make code-quality` green (tsc + prettier + eslint); `homeSearchIndex` suite 6/6.

## Notes

- A broken `avatar_image_url` (e.g. expired URL) shows a broken image with no `onError` fallback — this matches current app behaviour in `TeamCard` / `TeamSelectionListItem`, not a regression.
- Runtime GUI verification is auth-gated (Keycloak) in local dev; visual confirmation of focus + avatars was done manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)