### PR TITLE
feat(chat): full-height viewer side panels, in-flow rail, and HTML viewer overhaul

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -15,7 +15,6 @@
         "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.2",
         "file-selector": "^0.4.0",
-        "html-to-image": "^1.11.13",
         "http-proxy-middleware": "^3.0.2",
         "i18next": "^25.2.1",
         "i18next-browser-languagedetector": "^8.2.0",
@@ -9710,12 +9709,6 @@
       "dependencies": {
         "void-elements": "3.1.0"
       }
-    },
-    "node_modules/html-to-image": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
-      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
-      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.2",
         "file-selector": "^0.4.0",
+        "html-to-image": "^1.11.13",
         "http-proxy-middleware": "^3.0.2",
         "i18next": "^25.2.1",
         "i18next-browser-languagedetector": "^8.2.0",
@@ -9709,6 +9710,12 @@
       "dependencies": {
         "void-elements": "3.1.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -27,7 +27,6 @@
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "file-selector": "^0.4.0",
-    "html-to-image": "^1.11.13",
     "http-proxy-middleware": "^3.0.2",
     "i18next": "^25.2.1",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -27,6 +27,7 @@
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "file-selector": "^0.4.0",
+    "html-to-image": "^1.11.13",
     "http-proxy-middleware": "^3.0.2",
     "i18next": "^25.2.1",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -290,8 +290,16 @@
       },
       "untitled": "HTML artifact",
       "close": "Close panel",
-      "download": "Download .html",
+      "download": "Download",
+      "downloadHtml": "HTML",
+      "downloadPdf": "PDF",
+      "downloadPng": "PNG",
       "openInNewTab": "Open in a new tab",
+      "copy": "Copy to clipboard",
+      "copied": "Copied to clipboard",
+      "copyFailed": "Could not copy.",
+      "exportFailed": "Could not export the {{format}}.",
+      "fitWidth": "Fit width",
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
       "resetZoom": "Reset zoom",
@@ -299,11 +307,6 @@
       "card": {
         "aria": "HTML artifact",
         "open": "Open preview"
-      },
-      "tabs": {
-        "preview": "Preview",
-        "html": "HTML",
-        "css": "CSS"
       }
     },
     "ppt_filler": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -290,8 +290,16 @@
       },
       "untitled": "Artefact HTML",
       "close": "Fermer le panneau",
-      "download": "Télécharger .html",
+      "download": "Télécharger",
+      "downloadHtml": "HTML",
+      "downloadPdf": "PDF",
+      "downloadPng": "PNG",
       "openInNewTab": "Ouvrir dans un nouvel onglet",
+      "copy": "Copier dans le presse-papier",
+      "copied": "Copié dans le presse-papier",
+      "copyFailed": "Impossible de copier.",
+      "exportFailed": "Impossible d'exporter le {{format}}.",
+      "fitWidth": "Ajuster la largeur",
       "zoomIn": "Zoom avant",
       "zoomOut": "Zoom arrière",
       "resetZoom": "Réinitialiser le zoom",
@@ -299,11 +307,6 @@
       "card": {
         "aria": "Artefact HTML",
         "open": "Ouvrir l'aperçu"
-      },
-      "tabs": {
-        "preview": "Aperçu",
-        "html": "HTML",
-        "css": "CSS"
       }
     },
     "ppt_filler": {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -1,15 +1,17 @@
 /* ── Page shell ────────────────────────────────────────────────────────── */
-/* Column layout: [ full-width header ] on top, [ content row ] below. The
-   header always spans the whole page and stays put; only the content row
-   reflows when a push drawer opens, so the panel slides UNDER the header
-   instead of shrinking it. */
+/* Row layout: [ pageBody (header + content) ][ launcher rail ]. A push drawer
+   inside the body reflows the whole left stack (header included); the rail is a
+   page-root sibling reserving its own column at the far right. */
 .page {
   /* Single source of truth for the composer field width — the RichInputField
      .field and the top bar's inner row both read it so they stay aligned. */
   --composer-max-width: 720px;
   display: flex;
   position: relative;
-  flex-direction: column;
+  /* Row so the launcher rail reserves its own column to the right of the body:
+     [ pageBody (flex:1) ][ rail ]. Overlay drawers (trace / debug) are fixed, so
+     they don't participate. */
+  flex-direction: row;
   background: var(--surface-main);
   height: 100%;
   overflow: hidden;
@@ -24,6 +26,7 @@
   display: flex;
   flex: 1 1 0;
   flex-direction: row;
+  min-width: 0;
   min-height: 0;
   overflow: hidden;
 }
@@ -93,10 +96,14 @@
   font: var(--font-label-large);
 }
 
-/* ── Session title bar — full-width surface, keeps its intrinsic height ─── */
+/* ── Session title bar — inset rounded card, keeps its intrinsic height ─── */
 .topBar {
   display: flex;
   flex-shrink: 0;
+  /* Inset the header as a rounded card on top/left/right, flush at the bottom
+     against the conversation below. */
+  margin: var(--spacing-s) var(--spacing-s) 0;
+  border-radius: var(--radius-s);
   background: var(--surface-container);
   /* Horizontal padding matches the composer's .bar so the inner row lines up
      with the field at narrow widths too. */

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -16,10 +16,28 @@
   color: var(--on-surface);
 }
 
-/* ── Content row — [ main column (flex) ][ push drawer ] ─────────────────── */
-/* Sits below the full-width header. A push drawer (attachments / capability /
-   document-scope) takes layout space on the right so the chat column shifts
-   left when open, while the header above is untouched. */
+/* ── Page body — [ left stack (flex) ][ push drawer ] ────────────────────── */
+/* The flex row a push drawer (attachments / capability / document-scope) reflows
+   against: opening one takes layout space on the right, shifting the whole left
+   stack — header included — left, so the drawer spans the full page height. */
+.pageBody {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: row;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ── Left stack — the conversation column: header above, content below ───── */
+.leftStack {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ── Content row — holds the main column below the header ────────────────── */
 .contentRow {
   display: flex;
   flex: 1 1 0;

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.test.tsx
@@ -94,7 +94,10 @@ vi.mock("@shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog", () =>
 }));
 vi.mock("@shared/atoms/IconButton/IconButton", () => ({ default: () => null }));
 vi.mock("@shared/molecules/TokenUsageBadge/TokenUsageBadge", () => ({ TokenUsageBadge: () => null }));
-vi.mock("../../../features/capabilities/CapabilitySidePanelHost", () => ({ CapabilitySidePanelHost: () => null }));
+vi.mock("../../../features/capabilities/CapabilitySidePanelHost", () => ({
+  CapabilitySidePanelHost: () => null,
+  CapabilityLauncherRail: () => null,
+}));
 vi.mock("../../../features/capabilities/ComposerControlSlot", () => ({ ComposerControlSlot: () => null }));
 vi.mock("../../../features/capabilities/ComposerOptionChips", () => ({
   COMPOSER_CHIP_WIDGETS: new Set<string>(),

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -29,7 +29,10 @@ import { findTraceEntry, traceEntryKey, type TraceEntry } from "../../../utils/t
 import { ComposerActionsMenu } from "@shared/molecules/ComposerActionsMenu/ComposerActionsMenu";
 import { UploadWarningAckDialog } from "@shared/molecules/UploadWarningAckDialog/UploadWarningAckDialog";
 import IconButton from "@shared/atoms/IconButton/IconButton";
-import { CapabilitySidePanelHost } from "../../../features/capabilities/CapabilitySidePanelHost";
+import {
+  CapabilityLauncherRail,
+  CapabilitySidePanelHost,
+} from "../../../features/capabilities/CapabilitySidePanelHost";
 import { ComposerControlSlot } from "../../../features/capabilities/ComposerControlSlot";
 import { COMPOSER_CHIP_WIDGETS, ReasoningChip } from "../../../features/capabilities/ReasoningChip";
 import { selectSidePanelOpenRequest } from "../../../features/capabilities/sidePanelOpenRequestSlice";
@@ -538,6 +541,14 @@ export default function ManagedChatPage() {
           )}
         </div>
         {/* /pageBody */}
+
+        {/* Launcher rail — page-root sibling of the body (not inside it) so it
+            reserves its own in-flow column at the far right. */}
+        <CapabilityLauncherRail
+          capabilityIds={chat.capabilityIds}
+          activeKey={activePushDrawer?.kind === "capability" ? activePushDrawer.key : null}
+          onActiveKeyChange={(key) => setActivePushDrawer(key ? { kind: "capability", key } : null)}
+        />
 
         <TraceDetailDrawer entry={selectedTraceEntry} onClose={() => setSelectedTraceKey(null)} />
         {isAdmin && <DebugRawDrawer open={debugOpen} onClose={() => setDebugOpen(false)} messages={chat.messages} />}

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -385,112 +385,118 @@ export default function ManagedChatPage() {
             event.currentTarget.value = "";
           }}
         />
-        {/* Full-width header — always spans the whole page and stays above the
-            content row below, so an opened side panel slides UNDER it instead of
-            shrinking it. The inner row is capped to the composer field width so
-            title and composer stay aligned. data-picker-top-boundary: the
-            composer's anchored pickers (usePickerMenuMaxHeight) stop just below
-            this bar. */}
-        <div className={styles.topBar} data-picker-top-boundary>
-          <div className={styles.topBarInner}>
-            <div className={styles.topBarTitle}>
-              {chat.sessionId && chat.sessionTitle != null && (
-                <div className={styles.topBarTitleRow}>
-                  <span className={styles.titleLabel}>
-                    {chat.sessionTitle || t("chatbot.sessionTitleEditor.untitled")}
-                  </span>
-                  {/* Absolutely positioned: reserves no layout space, revealed on topBar hover */}
-                  <span className={styles.editButtonSlot}>
-                    <SessionTitleEditor title={chat.sessionTitle} onCommit={chat.commitTitle} />
-                  </span>
+        {/* Page body — a row of [ left stack ][ full-height push drawers ]. A
+            side panel now reflows the WHOLE left stack (header included) instead
+            of sliding under the header, so viewers span the full page height. */}
+        <div className={styles.pageBody}>
+          <div className={styles.leftStack}>
+            {/* Conversation header. When a side panel opens it reflows left
+            together with the content below — the panel sits at the page body's
+            right edge at full height, no longer under this bar. The inner row is
+            capped to the composer field width so title and composer stay aligned.
+            data-picker-top-boundary: the composer's anchored pickers
+            (usePickerMenuMaxHeight) stop just below this bar. */}
+            <div className={styles.topBar} data-picker-top-boundary>
+              <div className={styles.topBarInner}>
+                <div className={styles.topBarTitle}>
+                  {chat.sessionId && chat.sessionTitle != null && (
+                    <div className={styles.topBarTitleRow}>
+                      <span className={styles.titleLabel}>
+                        {chat.sessionTitle || t("chatbot.sessionTitleEditor.untitled")}
+                      </span>
+                      {/* Absolutely positioned: reserves no layout space, revealed on topBar hover */}
+                      <span className={styles.editButtonSlot}>
+                        <SessionTitleEditor title={chat.sessionTitle} onCommit={chat.commitTitle} />
+                      </span>
+                    </div>
+                  )}
+                  <div className={styles.topBarAgentName}>{chat.agentDisplayName}</div>
                 </div>
-              )}
-              <div className={styles.topBarAgentName}>{chat.agentDisplayName}</div>
-            </div>
-            <div className={styles.topBarRight}>
-              {conversationTokens.total_tokens > 0 && (
-                <span className={styles.conversationTokens}>
-                  {t("chatbot.conversationTokenUsage.total", { count: conversationTokens.total_tokens })}
-                </span>
-              )}
-              <div className={styles.topBarActions}>
-                {attachmentsCount > 0 && (
-                  <button
-                    type="button"
-                    className={styles.conversationFilesButton}
-                    onClick={() =>
-                      setActivePushDrawer((v) => (v?.kind === "attachments" ? null : { kind: "attachments" }))
-                    }
-                  >
-                    <span className={styles.conversationFilesLabel}>{t("chatbot.conversationFiles")}</span>
-                    <span className={styles.conversationFilesBadge}>{attachmentsCount}</span>
-                  </button>
-                )}
-                {isAdmin && (
-                  <IconButton
-                    variant="icon"
-                    size="small"
-                    icon={{ category: "outlined", type: "build" }}
-                    aria-label={t("chatbot.toggleDebugDrawer")}
-                    onClick={() => setDebugOpen((v) => !v)}
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Content row: [ chat main column (flex) ][ push drawer ]. The push
-            drawer reflows the chat left while the full-width header above stays
-            put and the panel slides under it. */}
-        <div className={styles.contentRow}>
-          <div className={styles.mainColumn}>
-            {allowChatAttachments && dragActive && (
-              <div className={styles.dropOverlay} aria-hidden>
-                <div className={styles.dropOverlayContent}>
-                  <span className={styles.dropOverlayPlus}>+</span>
-                  <span className={styles.dropOverlayLabel}>{t("chatbot.dropFilesHere")}</span>
+                <div className={styles.topBarRight}>
+                  {conversationTokens.total_tokens > 0 && (
+                    <span className={styles.conversationTokens}>
+                      {t("chatbot.conversationTokenUsage.total", { count: conversationTokens.total_tokens })}
+                    </span>
+                  )}
+                  <div className={styles.topBarActions}>
+                    {attachmentsCount > 0 && (
+                      <button
+                        type="button"
+                        className={styles.conversationFilesButton}
+                        onClick={() =>
+                          setActivePushDrawer((v) => (v?.kind === "attachments" ? null : { kind: "attachments" }))
+                        }
+                      >
+                        <span className={styles.conversationFilesLabel}>{t("chatbot.conversationFiles")}</span>
+                        <span className={styles.conversationFilesBadge}>{attachmentsCount}</span>
+                      </button>
+                    )}
+                    {isAdmin && (
+                      <IconButton
+                        variant="icon"
+                        size="small"
+                        icon={{ category: "outlined", type: "build" }}
+                        aria-label={t("chatbot.toggleDebugDrawer")}
+                        onClick={() => setDebugOpen((v) => !v)}
+                      />
+                    )}
+                  </div>
                 </div>
               </div>
-            )}
+            </div>
 
-            <div
-              className={`${styles.chatArea} ${isInitialState ? styles.chatAreaInitial : ""}`}
-              ref={scrollContainerRef}
-            >
-              {isInitialState ? (
-                <div className={styles.initialStage}>
-                  <ManagedChatWelcome />
-                  <div className={styles.initialComposer}>
+            {/* Conversation column — holds only the main column now; the push drawers
+            moved up to the page body so they reflow the header too. */}
+            <div className={styles.contentRow}>
+              <div className={styles.mainColumn}>
+                {allowChatAttachments && dragActive && (
+                  <div className={styles.dropOverlay} aria-hidden>
+                    <div className={styles.dropOverlayContent}>
+                      <span className={styles.dropOverlayPlus}>+</span>
+                      <span className={styles.dropOverlayLabel}>{t("chatbot.dropFilesHere")}</span>
+                    </div>
+                  </div>
+                )}
+
+                <div
+                  className={`${styles.chatArea} ${isInitialState ? styles.chatAreaInitial : ""}`}
+                  ref={scrollContainerRef}
+                >
+                  {isInitialState ? (
+                    <div className={styles.initialStage}>
+                      <ManagedChatWelcome />
+                      <div className={styles.initialComposer}>
+                        {composer}
+                        <div className={styles.aiDisclaimer}>{t("chatbot.aiDisclaimer")}</div>
+                      </div>
+                    </div>
+                  ) : (
+                    <ConversationThread
+                      messages={chat.threadMessages}
+                      pendingHitl={chat.pendingHitl}
+                      isLoading={chat.isLoadingHistory}
+                      isStreaming={chat.waitResponse}
+                      scrollContainerRef={scrollContainerRef}
+                      onHitlAnswer={chat.handleHitlAnswer}
+                      maxChatInputChars={chat.maxChatInputChars}
+                      hitlFreeText={chat.hitlFreeText}
+                      onHitlFreeTextChange={chat.setHitlFreeText}
+                    />
+                  )}
+                </div>
+
+                {!isInitialState && (
+                  <div className={styles.inputOverlay}>
                     {composer}
                     <div className={styles.aiDisclaimer}>{t("chatbot.aiDisclaimer")}</div>
                   </div>
-                </div>
-              ) : (
-                <ConversationThread
-                  messages={chat.threadMessages}
-                  pendingHitl={chat.pendingHitl}
-                  isLoading={chat.isLoadingHistory}
-                  isStreaming={chat.waitResponse}
-                  scrollContainerRef={scrollContainerRef}
-                  onHitlAnswer={chat.handleHitlAnswer}
-                  maxChatInputChars={chat.maxChatInputChars}
-                  hitlFreeText={chat.hitlFreeText}
-                  onHitlFreeTextChange={chat.setHitlFreeText}
-                />
-              )}
-            </div>
-
-            {!isInitialState && (
-              <div className={styles.inputOverlay}>
-                {composer}
-                <div className={styles.aiDisclaimer}>{t("chatbot.aiDisclaimer")}</div>
+                )}
               </div>
-            )}
+            </div>
           </div>
 
-          {/* Capability side-panel slot (#1979) — mounts as a flex sibling of the
-            main column so its push drawer reflows the conversation left. */}
+          {/* Capability side-panel slot — full-height sibling of the left stack:
+            its push drawer reflows the header and the conversation together. */}
           <CapabilitySidePanelHost
             capabilityIds={chat.capabilityIds}
             activeKey={activePushDrawer?.kind === "capability" ? activePushDrawer.key : null}
@@ -531,6 +537,7 @@ export default function ManagedChatPage() {
             />
           )}
         </div>
+        {/* /pageBody */}
 
         <TraceDetailDrawer entry={selectedTraceEntry} onClose={() => setSelectedTraceKey(null)} />
         {isAdmin && <DebugRawDrawer open={debugOpen} onClose={() => setDebugOpen(false)} messages={chat.messages} />}

--- a/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.module.css
@@ -54,9 +54,8 @@
   transition:
     width 250ms ease-out,
     visibility 250ms;
-  /* Transparent shell so the panel's top/bottom inset (below) reads as a real
-     margin — the page shows through — and no flush divider: the panel is a
-     rounded card whose left edge is its own border-radius. */
+  /* Transparent shell — the panel below carries the visible surface (background
+     + left divider) so the shell only reserves the animated width. */
   background: transparent;
   width: 0;
   overflow: hidden;
@@ -81,17 +80,17 @@
 
 .drawer[data-layout="push"] .panel {
   position: absolute;
-  top: var(--spacing-xs);
+  top: 0;
   right: 0;
-  bottom: var(--spacing-xs);
+  bottom: 0;
   /* Fade the content with the width collapse so a closing panel dissolves
      instead of being clipped away (the host keeps it mounted for the duration). */
   opacity: 1;
   transition: opacity 200ms ease-out;
-  /* Rounded left corners, flush right against the viewport edge; clip the
-     content (iframe, header, tabs) to the radius. */
-  border-top-left-radius: var(--radius-m);
-  border-bottom-left-radius: var(--radius-m);
+  /* Full-height flush panel: a 1px left divider separates it from the content,
+     square corners, flush right against the viewport edge; clip the content
+     (iframe, header, tabs) to the edge. */
+  border-left: 1px solid var(--outline-muted);
   background: var(--drawer-background, var(--surface-container));
   width: var(--drawer-width);
   overflow: hidden;
@@ -191,8 +190,8 @@
   .drawer[data-layout="push"] .panel {
     top: 0;
     bottom: 0;
-    /* Full-screen panel: drop the card inset and corners. */
-    border-radius: 0;
+    /* Full-screen panel: no left divider, edge to edge. */
+    border-left: none;
     width: 100%;
   }
 

--- a/apps/frontend/src/rework/components/shared/utils/Type.ts
+++ b/apps/frontend/src/rework/components/shared/utils/Type.ts
@@ -96,6 +96,7 @@ export const materialIcons = [
   "check_box_outline_blank",
   "star",
   "content_copy",
+  "fit_width",
   "error",
   "error_outline",
   "warning",

--- a/apps/frontend/src/rework/features/capabilities/CapabilityLauncherRail.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilityLauncherRail.test.tsx
@@ -1,0 +1,98 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The launcher rail: what the user sees before opening anything. A session can
+// activate several document-producing capabilities from the start, so a launcher
+// that appears on declaration alone points at an empty panel - the plugin's
+// `useHasContent` is what turns it on, and its glyph is what tells two of them
+// apart.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CapabilityLauncherRail } from "./CapabilitySidePanelHost";
+
+const state = vi.hoisted(() => ({ entries: [] as unknown[] }));
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock("./sessionProbeRegistry", () => ({ sessionProbesForCapabilities: () => [] }));
+
+vi.mock("./sidePanelRegistry", () => ({ sidePanelsForCapabilities: () => state.entries }));
+
+vi.mock("@shared/atoms/IconButton/IconButton", () => ({
+  default: ({ icon, ...rest }: { icon: { type: string }; "aria-label": string }) => (
+    <button data-icon={icon.type} aria-label={rest["aria-label"]} />
+  ),
+}));
+
+function StubPanel() {
+  return <div data-panel />;
+}
+
+const entry = (capabilityId: string, icon: string, useHasContent?: () => boolean) => ({
+  capabilityId,
+  widget: `${capabilityId}_pane`,
+  Component: StubPanel,
+  icon,
+  useHasContent,
+  ownsHeader: false,
+});
+
+const render = (activeKey: string | null = null) =>
+  renderToStaticMarkup(
+    <CapabilityLauncherRail capabilityIds={["ppt_filler"]} activeKey={activeKey} onActiveKeyChange={() => undefined} />,
+  );
+
+describe("CapabilityLauncherRail", () => {
+  beforeEach(() => {
+    state.entries = [];
+  });
+
+  it("offers no launcher while the panel has nothing to show", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => false)];
+    expect(render()).not.toContain("<button");
+  });
+
+  it("offers the launcher once the panel has content", () => {
+    state.entries = [entry("ppt_filler", "slideshow", () => true)];
+    expect(render()).toContain('data-icon="slideshow"');
+  });
+
+  it("offers a panel that declares no visibility hook unconditionally", () => {
+    state.entries = [entry("demo_echo", "forum")];
+    expect(render()).toContain('data-icon="forum"');
+  });
+
+  it("gives each panel its own glyph", () => {
+    state.entries = [
+      entry("ppt_filler", "slideshow", () => true),
+      entry("writable_document", "edit_document", () => true),
+    ];
+    const html = render();
+
+    expect(html).toContain('data-icon="slideshow"');
+    expect(html).toContain('data-icon="edit_document"');
+  });
+
+  it("retires the whole rail while a panel is open, other panels included", () => {
+    // Opening one panel closes the rail entirely; the body-side push drawer takes
+    // over. Reaching another launcher means closing the open panel first.
+    state.entries = [
+      entry("ppt_filler", "slideshow", () => true),
+      entry("writable_document", "edit_document", () => true),
+    ];
+
+    expect(render("writable_document:writable_document_pane")).not.toContain("<button");
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.module.css
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.module.css
@@ -19,16 +19,16 @@
  * top clears ManagedChatPage's .topBar band, which is two lines tall (8px
  * padding + a 24px title line + a 20px agent-name line + 8px padding = 60px),
  * plus a breathing gap - a 48px offset sat on the band. */
+/* In-flow at the page root, to the right of the chat body: it reserves its own
+   column (reflowing the body left) instead of floating. Full page height, inset
+   12px on top/right/bottom; launchers stack from the top. */
 .rail {
   display: flex;
-  position: absolute;
-  top: calc(var(--spacing-4xl) + var(--spacing-s));
-  right: var(--spacing-s);
+  flex-shrink: 0;
   flex-direction: column;
   gap: var(--spacing-2xs);
-  z-index: 2;
+  margin: var(--spacing-s) var(--spacing-s) var(--spacing-s) 0;
   border-radius: var(--radius-s);
   background-color: var(--surface-container-low);
   padding: var(--spacing-xs);
-  pointer-events: auto;
 }

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.test.tsx
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The launcher rail: what the user sees before opening anything. A session can
-// activate several document-producing capabilities from the start, so a launcher
-// that appears on declaration alone points at an empty panel - the plugin's
-// `useHasContent` is what turns it on, and its glyph is what tells two of them
-// apart.
+// The panel drawer: once a launcher opens a panel, the host mounts it in an
+// InlineDrawer. A pane that renders its own header suppresses the drawer's title
+// band so the two don't stack. (The launcher rail itself lives in
+// CapabilityLauncherRail — see its own test.)
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -81,35 +80,9 @@ const render = (activeKey: string | null = null) =>
     />,
   );
 
-describe("CapabilitySidePanelHost launcher rail", () => {
+describe("CapabilitySidePanelHost panel drawer", () => {
   beforeEach(() => {
     state.entries = [];
-  });
-
-  it("offers no launcher while the panel has nothing to show", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => false)];
-    expect(render()).not.toContain("<button");
-  });
-
-  it("offers the launcher once the panel has content", () => {
-    state.entries = [entry("ppt_filler", "slideshow", () => true)];
-    expect(render()).toContain('data-icon="slideshow"');
-  });
-
-  it("offers a panel that declares no visibility hook unconditionally", () => {
-    state.entries = [entry("demo_echo", "forum")];
-    expect(render()).toContain('data-icon="forum"');
-  });
-
-  it("gives each panel its own glyph", () => {
-    state.entries = [
-      entry("ppt_filler", "slideshow", () => true),
-      entry("writable_document", "edit_document", () => true),
-    ];
-    const html = render();
-
-    expect(html).toContain('data-icon="slideshow"');
-    expect(html).toContain('data-icon="edit_document"');
   });
 
   it("drops the drawer's own title band for a panel that renders one", () => {
@@ -124,16 +97,5 @@ describe("CapabilitySidePanelHost launcher rail", () => {
     state.entries = [entry("demo_echo", "edit_note", undefined, false)];
 
     expect(render("demo_echo:demo_echo_pane")).toContain("data-drawer-title");
-  });
-
-  it("retires the whole rail while a panel is open, other panels included", () => {
-    // It floats over the right edge of the slot, drawer included, so it would land
-    // on the drawer's own close button. Closing the open panel brings it back.
-    state.entries = [
-      entry("ppt_filler", "slideshow", () => true),
-      entry("writable_document", "edit_document", () => true),
-    ];
-
-    expect(render("writable_document:writable_document_pane")).not.toContain("<button");
   });
 });

--- a/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
+++ b/apps/frontend/src/rework/features/capabilities/CapabilitySidePanelHost.tsx
@@ -12,27 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The capability side-panel slot (RFC §9 item 3) — the ONE host that mounts a
-// session's active capability panels in the reserved right column.
+// The capability side-panel slot (RFC §9 item 3): a single `InlineDrawer
+// layout="push"` (CapabilitySidePanelHost) that reflows the chat body, plus its
+// launcher rail (CapabilityLauncherRail). Which panels appear is driven entirely
+// by the session's `selected_capability_ids`, resolved through the one plugin
+// index.
 //
-// It generalizes the trace/attachments push-drawer pattern: a floating launcher
-// (one button per contributed panel, matching the chat page's floating chrome)
-// toggles a single `InlineDrawer layout="push"` that reflows the main column.
-// Which panels appear is driven entirely by the session's
-// `selected_capability_ids`, resolved through the one plugin index.
+// The two mount at different DOM levels: the host sits inside the chat body so
+// its push drawer reflows the conversation; the rail sits at the page root, a
+// flex sibling of the body, so in-flow it reserves its own right-hand column.
 //
 // A launcher is only offered once its panel has something to show: the plugin's
 // `useHasContent` hook answers for the open conversation, so a fresh chat with
 // ppt_filler and writable_document active shows no chrome at all until the agent
-// actually produces a deck or a document.
-//
-// The rail shows only while every panel is closed. It floats over the right edge
-// of the whole slot, drawer included, so with a panel open it would land on that
-// drawer's own close button - and closing the open panel to reach another one is
-// cheap enough not to be worth a second home for the launchers.
+// actually produces a deck or a document. The rail shows only while every panel
+// is closed; opening one retires it entirely.
 
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip";
 import { InlineDrawer } from "@shared/molecules/InlineDrawer/InlineDrawer";
@@ -57,6 +55,15 @@ const entryKey = (entry: SidePanelEntry): string => `${entry.capabilityId}:${ent
 
 const alwaysHasContent = () => true;
 
+// Each panel's launcher/drawer title resolves against the plugin's i18n keys; a
+// missing translation falls back to the widget id (never a blank label).
+const titleOf = (t: TFunction, entry: SidePanelEntry): string =>
+  t(`capability.${entry.capabilityId}.panel.${entry.widget}.title`, { defaultValue: entry.widget });
+// The rail button says which viewer it opens ("HTML/CSS viewer", …); it falls
+// back to the panel title when a capability declares no dedicated launcher label.
+const launcherLabelOf = (t: TFunction, entry: SidePanelEntry): string =>
+  t(`capability.${entry.capabilityId}.panel.${entry.widget}.launcher`, { defaultValue: titleOf(t, entry) });
+
 /**
  * One panel's launcher. It is its own component so each `useHasContent` runs in a
  * stable hook slot - mapping the hooks inline would reorder them the moment a
@@ -76,6 +83,32 @@ function PanelLauncher({ entry, label, onOpen }: { entry: SidePanelEntry; label:
         onClick={onOpen}
       />
     </Tooltip>
+  );
+}
+
+/**
+ * The launcher rail — one icon button per side panel the session's capabilities
+ * contribute. Mounts at the page root (a flex sibling of the chat body) so it
+ * reserves its own right-hand column in-flow. Shows only while every panel is
+ * closed; opening one (`activeKey` set) retires the whole rail.
+ */
+export function CapabilityLauncherRail({ capabilityIds, activeKey, onActiveKeyChange }: CapabilitySidePanelHostProps) {
+  const { t } = useTranslation();
+  const entries = useMemo(() => sidePanelsForCapabilities(capabilityIds), [capabilityIds]);
+  const active = entries.find((entry) => entryKey(entry) === activeKey) ?? null;
+  if (entries.length === 0 || active !== null) return null;
+
+  return (
+    <div className={styles.rail}>
+      {entries.map((entry) => (
+        <PanelLauncher
+          key={entryKey(entry)}
+          entry={entry}
+          label={launcherLabelOf(t, entry)}
+          onOpen={() => onActiveKeyChange(entryKey(entry))}
+        />
+      ))}
+    </div>
   );
 }
 
@@ -103,14 +136,6 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
   // (zero chrome). Probes mount even while every panel is closed: they are the
   // "observe the opened conversation" path (#1905 auto-open).
   if (entries.length === 0 && probes.length === 0) return null;
-  // Each panel's launcher/drawer title resolves against the plugin's i18n keys;
-  // a missing translation falls back to the widget id (never a blank label).
-  const titleOf = (entry: SidePanelEntry): string =>
-    t(`capability.${entry.capabilityId}.panel.${entry.widget}.title`, { defaultValue: entry.widget });
-  // The rail button says which viewer it opens ("HTML/CSS viewer", …); it falls
-  // back to the panel title when a capability declares no dedicated launcher label.
-  const launcherLabelOf = (entry: SidePanelEntry): string =>
-    t(`capability.${entry.capabilityId}.panel.${entry.widget}.launcher`, { defaultValue: titleOf(entry) });
 
   return (
     <>
@@ -118,37 +143,23 @@ export function CapabilitySidePanelHost({ capabilityIds, activeKey, onActiveKeyC
         <Probe key={`${capabilityId}:${index}`} capabilityId={capabilityId} />
       ))}
       {entries.length > 0 && (
-        <>
-          {active === null && (
-            <div className={styles.rail}>
-              {entries.map((entry) => (
-                <PanelLauncher
-                  key={entryKey(entry)}
-                  entry={entry}
-                  label={launcherLabelOf(entry)}
-                  onOpen={() => onActiveKeyChange(entryKey(entry))}
-                />
-              ))}
-            </div>
+        <InlineDrawer
+          open={active !== null}
+          onClose={() => onActiveKeyChange(null)}
+          title={rendered ? titleOf(t, rendered) : ""}
+          // A pane with its own header owns the whole column, insets included.
+          hideHeader={rendered?.ownsHeader ?? false}
+          flushBody={rendered?.ownsHeader ?? false}
+          layout="push"
+          // One shared width across every capability panel (writable-document
+          // editor, PPT preview, …) — the same behaviour the legacy chat's
+          // ResizablePaneShell had with its single persisted pane width.
+          resizable={{ persistKey: "capability-side-panel" }}
+        >
+          {rendered && (
+            <rendered.Component capabilityId={rendered.capabilityId} onClose={() => onActiveKeyChange(null)} />
           )}
-          <InlineDrawer
-            open={active !== null}
-            onClose={() => onActiveKeyChange(null)}
-            title={rendered ? titleOf(rendered) : ""}
-            // A pane with its own header owns the whole column, insets included.
-            hideHeader={rendered?.ownsHeader ?? false}
-            flushBody={rendered?.ownsHeader ?? false}
-            layout="push"
-            // One shared width across every capability panel (writable-document
-            // editor, PPT preview, …) — the same behaviour the legacy chat's
-            // ResizablePaneShell had with its single persisted pane width.
-            resizable={{ persistKey: "capability-side-panel" }}
-          >
-            {rendered && (
-              <rendered.Component capabilityId={rendered.capabilityId} onClose={() => onActiveKeyChange(null)} />
-            )}
-          </InlineDrawer>
-        </>
+        </InlineDrawer>
       )}
     </>
   );

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactDownloadButton.tsx
@@ -66,7 +66,8 @@ export default function HtmlArtifactDownloadButton({ html, css, title }: { html:
     } catch {
       showError({
         summary: t("capability.html_artifact.exportFailed", {
-          defaultValue: `Could not export the ${format.toUpperCase()}.`,
+          format: format.toUpperCase(),
+          defaultValue: "Could not export the {{format}}.",
         }),
       });
     }

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactDownloadButton.tsx
@@ -12,31 +12,74 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Download the composed self-contained .html for one artifact, shared by BOTH the
-// in-chat card and the pane header so the two stay DRY.
-//
-// Unlike ppt_filler / writable_document (whose bytes live behind a bearer-protected
-// download route), the html_artifact markup rides inline on the chat part, so this
-// is a plain client-side blob save — no network, no bearer.
+// Download menu for one artifact — HTML (self-contained file), PDF (via the
+// browser's print dialog), PNG (rasterized). Shared by the in-chat card and the
+// pane header so the two stay DRY. The markup rides inline on the chat part, so
+// HTML/PNG are plain client-side saves — no network, no bearer.
 
 import { useTranslation } from "react-i18next";
-import IconButton from "@shared/atoms/IconButton/IconButton";
-import { Tooltip } from "@shared/atoms/Tooltip/Tooltip";
+import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu";
+import { useToast } from "@shared/molecules/Toast/ToastProvider";
+import type { OptionModel } from "@models/Option.model.ts";
 import { downloadHtmlArtifact } from "./htmlArtifactDocument";
+import { downloadHtmlArtifactPng, printHtmlArtifact } from "./htmlArtifactExport";
+
+type DownloadFormat = "html" | "pdf" | "png";
 
 export default function HtmlArtifactDownloadButton({ html, css, title }: { html: string; css: string; title: string }) {
   const { t } = useTranslation();
-  const label = t("capability.html_artifact.download", { defaultValue: "Download .html" });
+  const { showError } = useToast();
+  const label = t("capability.html_artifact.download", { defaultValue: "Download" });
+
+  const options: OptionModel<DownloadFormat>[] = [
+    {
+      value: "html",
+      key: "html",
+      label: t("capability.html_artifact.downloadHtml", { defaultValue: "HTML" }),
+      icon: { category: "outlined", type: "code" },
+    },
+    {
+      value: "pdf",
+      key: "pdf",
+      label: t("capability.html_artifact.downloadPdf", { defaultValue: "PDF" }),
+      icon: { category: "outlined", type: "picture_as_pdf" },
+    },
+    {
+      value: "png",
+      key: "png",
+      label: t("capability.html_artifact.downloadPng", { defaultValue: "PNG" }),
+      icon: { category: "outlined", type: "image" },
+    },
+  ];
+
+  const onSelect = async (format: DownloadFormat) => {
+    if (format === "html") {
+      downloadHtmlArtifact(html, css, title);
+    } else if (format === "pdf") {
+      if (!printHtmlArtifact(html, css)) {
+        showError({
+          summary: t("capability.html_artifact.popupBlocked", { defaultValue: "Allow pop-ups to export as PDF." }),
+        });
+      }
+    } else {
+      try {
+        await downloadHtmlArtifactPng(html, css, title);
+      } catch {
+        showError({ summary: t("capability.html_artifact.pngFailed", { defaultValue: "Could not export the PNG." }) });
+      }
+    }
+  };
 
   return (
-    <Tooltip text={label}>
-      <IconButton
-        variant="icon"
-        size="small"
-        icon={{ category: "outlined", type: "download" }}
-        onClick={() => downloadHtmlArtifact(html, css, title)}
-        aria-label={label}
-      />
-    </Tooltip>
+    <IconButtonMenu
+      iconButton={{
+        variant: "icon",
+        size: "small",
+        icon: { category: "outlined", type: "download" },
+        "aria-label": label,
+      }}
+      options={options}
+      onSelect={onSelect}
+    />
   );
 }

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactDownloadButton.tsx
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactDownloadButton.tsx
@@ -22,7 +22,7 @@ import IconButtonMenu from "@shared/molecules/IconButtonMenu/IconButtonMenu";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import type { OptionModel } from "@models/Option.model.ts";
 import { downloadHtmlArtifact } from "./htmlArtifactDocument";
-import { downloadHtmlArtifactPng, printHtmlArtifact } from "./htmlArtifactExport";
+import { downloadHtmlArtifactPdf, downloadHtmlArtifactPng } from "./htmlArtifactExport";
 
 type DownloadFormat = "html" | "pdf" | "png";
 
@@ -55,18 +55,20 @@ export default function HtmlArtifactDownloadButton({ html, css, title }: { html:
   const onSelect = async (format: DownloadFormat) => {
     if (format === "html") {
       downloadHtmlArtifact(html, css, title);
-    } else if (format === "pdf") {
-      if (!printHtmlArtifact(html, css)) {
-        showError({
-          summary: t("capability.html_artifact.popupBlocked", { defaultValue: "Allow pop-ups to export as PDF." }),
-        });
-      }
-    } else {
-      try {
+      return;
+    }
+    try {
+      if (format === "pdf") {
+        await downloadHtmlArtifactPdf(html, css, title);
+      } else {
         await downloadHtmlArtifactPng(html, css, title);
-      } catch {
-        showError({ summary: t("capability.html_artifact.pngFailed", { defaultValue: "Could not export the PNG." }) });
       }
+    } catch {
+      showError({
+        summary: t("capability.html_artifact.exportFailed", {
+          defaultValue: `Could not export the ${format.toUpperCase()}.`,
+        }),
+      });
     }
   };
 

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.module.css
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.module.css
@@ -58,18 +58,22 @@
   text-align: center;
 }
 
-/* Both tab strips (artifact switcher + Preview/HTML/CSS) share this look. */
-.tabs {
+/* Controls bar: the artifact switcher tabs (scrollable) on the left, zoom on the
+   right. Always shown while an artifact is selected. */
+.controlsBar {
   display: flex;
-  gap: var(--spacing-2xs);
+  align-items: stretch;
   border-bottom: 1px solid var(--outline-muted);
+  background-color: var(--surface-container-low);
   padding: var(--spacing-2xs) var(--spacing-xs) 0;
-  overflow-x: auto;
 }
 
-/* The artifact switcher sits above the view tabs; keep it visually secondary. */
-.switcher {
-  background-color: var(--surface-container-low);
+/* One tab per artifact; scrolls horizontally so the zoom cluster keeps its place. */
+.artifactTabs {
+  display: flex;
+  gap: var(--spacing-2xs);
+  min-width: 0;
+  overflow-x: auto;
 }
 
 .tab {
@@ -79,7 +83,7 @@
   border-bottom: 2px solid transparent;
   background: transparent;
   padding: var(--spacing-xs) var(--spacing-s);
-  max-width: 14rem;
+  max-width: 6rem;
   overflow: hidden;
   color: var(--on-surface-retreat);
   font: var(--font-label-medium);
@@ -103,7 +107,7 @@
   overflow: hidden;
 }
 
-/* Zoom controls live at the far right of the view-tab row (Preview / HTML / CSS). */
+/* Zoom controls live at the far right of the controls bar. */
 .zoomCluster {
   display: flex;
   align-items: center;
@@ -165,11 +169,4 @@
   opacity: 0;
   z-index: 0;
   pointer-events: none;
-}
-
-/* Source tabs (HTML / CSS): the CodeBlock scrolls within the body. */
-.source {
-  height: 100%;
-  min-height: 0;
-  overflow: auto;
 }

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.module.css
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.module.css
@@ -91,7 +91,7 @@
   white-space: nowrap;
 }
 
-.tab:hover {
+.tab:not(.tabActive):hover {
   color: var(--on-surface);
 }
 

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.sandbox.test.tsx
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.sandbox.test.tsx
@@ -61,6 +61,14 @@ vi.mock("@shared/atoms/Tooltip/Tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => children,
 }));
 vi.mock("@shared/molecules/CodeBlock/CodeBlock", () => ({ CodeBlock: () => null }));
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({
+    showSuccess: () => undefined,
+    showError: () => undefined,
+    showInfo: () => undefined,
+    showWarn: () => undefined,
+  }),
+}));
 vi.mock("./HtmlArtifactDownloadButton", () => ({ default: () => null }));
 
 const { HtmlArtifactPane } = await import("./HtmlArtifactPane");

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.tsx
@@ -14,11 +14,11 @@
 
 // HtmlArtifactPane — the html_artifact capability's side panel (CapabilitySidePanel).
 //
-// A dedicated viewer opening right of the chat, READ-ONLY (v1), with three tabs:
-//  - Preview: the artifact rendered in a SANDBOXED iframe (see below);
-//  - HTML / CSS: the source, syntax-highlighted (the shared CodeBlock).
-// When the session holds several artifacts, a switcher strip above the tabs picks
-// one. The markup rides inline on the chat part (no fetch); the slice is the source.
+// A dedicated viewer opening right of the chat, READ-ONLY (v1): the artifact
+// rendered in a SANDBOXED iframe (see below), with a zoom control in the bar.
+// When the session holds several artifacts, a switcher strip in that bar picks
+// one (source is reachable via Download / open-in-new-tab). The markup rides
+// inline on the chat part (no fetch); the slice is the source.
 //
 // SECURITY (RFC §4.7): the Preview iframe is `sandbox=""` — the empty attribute
 // enables ALL sandbox restrictions, so NO script runs (no `allow-scripts`) and the
@@ -33,7 +33,6 @@ import { useTranslation } from "react-i18next";
 import Icon from "@shared/atoms/Icon/Icon";
 import IconButton from "@shared/atoms/IconButton/IconButton";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip";
-import { CodeBlock } from "@shared/molecules/CodeBlock/CodeBlock";
 import type { CapabilitySidePanelProps } from "../types";
 import { useOpenSessionId } from "../useOpenSessionId";
 import {
@@ -43,10 +42,9 @@ import {
   selectHtmlArtifactsById,
 } from "./htmlArtifactSlice";
 import { composeHtmlDocument, openHtmlArtifactInNewTab, zoomIn, zoomOut, ZOOM_LEVELS } from "./htmlArtifactDocument";
+import { nextBufferAction } from "./previewBuffers";
 import HtmlArtifactDownloadButton from "./HtmlArtifactDownloadButton";
 import styles from "./HtmlArtifactPane.module.css";
-
-type ViewTab = "preview" | "html" | "css";
 
 export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
   const { t } = useTranslation();
@@ -55,7 +53,6 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
   const sliceSessionId = useSelector(selectHtmlArtifactSessionId);
   const byId = useSelector(selectHtmlArtifactsById);
   const selectedId = useSelector(selectHtmlArtifactSelectedId);
-  const [tab, setTab] = useState<ViewTab>("preview");
   // Browser-like zoom for the Preview (reflows content via CSS `zoom`), so a wide
   // page can be shrunk to fit. Download / open-in-new-tab stay at 100%.
   const [zoom, setZoom] = useState(1);
@@ -88,40 +85,44 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
   // (sandboxed, no allow-scripts), so this hides that reload instead of avoiding it.
   const [buffers, setBuffers] = useState<[string, string]>(["", ""]);
   const [front, setFront] = useState<0 | 1>(0);
-  const pendingRef = useRef<0 | 1 | null>(null);
+  // What each buffer has actually painted. Switching back to an already-seen
+  // document doesn't reload the iframe (same srcDoc), so no onLoad fires — we must
+  // recognise "already painted here" and flip to it directly, or the pane freezes.
+  const paintedRef = useRef<[string, string]>(["", ""]);
   // On the very first open there is no prior frame to hold, so the empty front
   // iframe would flash its white background before the artifact paints. Keep both
   // frames hidden (the pane's own surface shows through) until that first paint.
   const [revealed, setRevealed] = useState(false);
 
   useEffect(() => {
-    if (!composed || buffers[front] === composed) return;
-    const back: 0 | 1 = front === 0 ? 1 : 0;
-    if (buffers[back] === composed) return; // already loading into the back buffer
-    pendingRef.current = back;
-    setBuffers((b) => {
-      const next: [string, string] = [b[0], b[1]];
-      next[back] = composed;
-      return next;
-    });
+    const action = nextBufferAction(composed, buffers, paintedRef.current, front);
+    if (action.kind === "flip") {
+      setFront(action.to);
+      setRevealed(true);
+    } else if (action.kind === "load") {
+      // This buffer is about to reload, so its previously-painted content is void:
+      // clear it now, or a quick switch back to that old doc would flip to this
+      // buffer mid-load (showing the new doc) instead of reloading the old one.
+      paintedRef.current[action.into] = "";
+      setBuffers((b) => {
+        const next: [string, string] = [b[0], b[1]];
+        next[action.into] = composed;
+        return next;
+      });
+    }
   }, [composed, front, buffers]);
 
   const handleFrameLoad = (idx: 0 | 1) => {
-    // Reveal the back buffer only once the doc we asked it to load has painted.
-    if (pendingRef.current === idx && buffers[idx] === composed) {
-      pendingRef.current = null;
+    paintedRef.current[idx] = buffers[idx];
+    // Reveal the freshly loaded buffer only once the doc we asked it to load has
+    // painted AND it is still the current target (a fast switch may have moved on).
+    if (buffers[idx] === composed && front !== idx) {
       setFront(idx);
       setRevealed(true);
     }
   };
 
   const untitled = t("capability.html_artifact.untitled", { defaultValue: "HTML artifact" });
-
-  const viewTabs: { id: ViewTab; label: string }[] = [
-    { id: "preview", label: t("capability.html_artifact.tabs.preview", { defaultValue: "Preview" }) },
-    { id: "html", label: t("capability.html_artifact.tabs.html", { defaultValue: "HTML" }) },
-    { id: "css", label: t("capability.html_artifact.tabs.css", { defaultValue: "CSS" }) },
-  ];
 
   return (
     <div className={styles.pane}>
@@ -166,91 +167,66 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
 
       {selected && (
         <>
-          {artifacts.length > 1 && (
-            <div className={`${styles.tabs} ${styles.switcher}`} role="tablist" aria-label="Artifacts">
-              {artifacts.map((a) => (
-                <button
-                  key={a.artifact_id}
-                  role="tab"
-                  aria-selected={a.artifact_id === selected.artifact_id}
-                  className={`${styles.tab} ${a.artifact_id === selected.artifact_id ? styles.tabActive : ""}`}
-                  onClick={() => dispatch(selectHtmlArtifact(a.artifact_id))}
-                >
-                  {a.title || untitled}
-                </button>
-              ))}
-            </div>
-          )}
-
-          <div className={styles.tabs} role="tablist" aria-label="View">
-            {viewTabs.map((v) => (
-              <button
-                key={v.id}
-                role="tab"
-                aria-selected={tab === v.id}
-                className={`${styles.tab} ${tab === v.id ? styles.tabActive : ""}`}
-                onClick={() => setTab(v.id)}
-              >
-                {v.label}
-              </button>
-            ))}
-            {tab === "preview" && (
-              <div className={styles.zoomCluster}>
-                <Tooltip text={t("capability.html_artifact.zoomOut", { defaultValue: "Zoom out" })}>
-                  <IconButton
-                    variant="icon"
-                    size="small"
-                    icon={{ category: "outlined", type: "zoom_out" }}
-                    onClick={() => setZoom(zoomOut)}
-                    disabled={zoom <= ZOOM_LEVELS[0]}
-                    aria-label={t("capability.html_artifact.zoomOut", { defaultValue: "Zoom out" })}
-                  />
-                </Tooltip>
-                <Tooltip text={t("capability.html_artifact.resetZoom", { defaultValue: "Reset zoom" })}>
-                  <button className={styles.zoomLabel} onClick={() => setZoom(1)}>
-                    {Math.round(zoom * 100)}%
-                  </button>
-                </Tooltip>
-                <Tooltip text={t("capability.html_artifact.zoomIn", { defaultValue: "Zoom in" })}>
-                  <IconButton
-                    variant="icon"
-                    size="small"
-                    icon={{ category: "outlined", type: "zoom_in" }}
-                    onClick={() => setZoom(zoomIn)}
-                    disabled={zoom >= ZOOM_LEVELS[ZOOM_LEVELS.length - 1]}
-                    aria-label={t("capability.html_artifact.zoomIn", { defaultValue: "Zoom in" })}
-                  />
-                </Tooltip>
-              </div>
-            )}
-          </div>
-
-          <div className={styles.body}>
-            {tab === "preview" && (
-              <div className={styles.previewFrameWrap}>
-                {([0, 1] as const).map((i) => (
-                  <iframe
-                    key={i}
-                    srcDoc={buffers[i]}
-                    className={`${styles.previewFrame} ${revealed && front === i ? styles.frameFront : styles.frameBack}`}
-                    title={selected.title || untitled}
-                    sandbox=""
-                    referrerPolicy="no-referrer"
-                    onLoad={() => handleFrameLoad(i)}
-                  />
+          <div className={styles.controlsBar}>
+            {artifacts.length > 1 && (
+              <div className={styles.artifactTabs} role="tablist" aria-label="Artifacts">
+                {artifacts.map((a) => (
+                  <Tooltip key={a.artifact_id} text={a.title || untitled} placement="top">
+                    <button
+                      role="tab"
+                      aria-selected={a.artifact_id === selected.artifact_id}
+                      className={`${styles.tab} ${a.artifact_id === selected.artifact_id ? styles.tabActive : ""}`}
+                      onClick={() => dispatch(selectHtmlArtifact(a.artifact_id))}
+                    >
+                      {a.title || untitled}
+                    </button>
+                  </Tooltip>
                 ))}
               </div>
             )}
-            {tab === "html" && (
-              <div className={styles.source}>
-                <CodeBlock code={selected.html} language="html" />
-              </div>
-            )}
-            {tab === "css" && (
-              <div className={styles.source}>
-                <CodeBlock code={selected.css} language="css" />
-              </div>
-            )}
+            <div className={styles.zoomCluster}>
+              <Tooltip text={t("capability.html_artifact.zoomOut", { defaultValue: "Zoom out" })}>
+                <IconButton
+                  variant="icon"
+                  size="small"
+                  icon={{ category: "outlined", type: "zoom_out" }}
+                  onClick={() => setZoom(zoomOut)}
+                  disabled={zoom <= ZOOM_LEVELS[0]}
+                  aria-label={t("capability.html_artifact.zoomOut", { defaultValue: "Zoom out" })}
+                />
+              </Tooltip>
+              <Tooltip text={t("capability.html_artifact.resetZoom", { defaultValue: "Reset zoom" })}>
+                <button className={styles.zoomLabel} onClick={() => setZoom(1)}>
+                  {Math.round(zoom * 100)}%
+                </button>
+              </Tooltip>
+              <Tooltip text={t("capability.html_artifact.zoomIn", { defaultValue: "Zoom in" })}>
+                <IconButton
+                  variant="icon"
+                  size="small"
+                  icon={{ category: "outlined", type: "zoom_in" }}
+                  onClick={() => setZoom(zoomIn)}
+                  disabled={zoom >= ZOOM_LEVELS[ZOOM_LEVELS.length - 1]}
+                  aria-label={t("capability.html_artifact.zoomIn", { defaultValue: "Zoom in" })}
+                />
+              </Tooltip>
+            </div>
+          </div>
+
+          <div className={styles.body}>
+            <div className={styles.previewFrameWrap}>
+              {([0, 1] as const).map((i) => (
+                <iframe
+                  key={i}
+                  srcDoc={buffers[i]}
+                  className={`${styles.previewFrame} ${revealed && front === i ? styles.frameFront : styles.frameBack}`}
+                  title={selected.title || untitled}
+                  sandbox=""
+                  referrerPolicy="no-referrer"
+                  onLoad={() => handleFrameLoad(i)}
+                />
+              ))}
+            </div>
           </div>
         </>
       )}

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.tsx
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/HtmlArtifactPane.tsx
@@ -41,14 +41,17 @@ import {
   selectHtmlArtifactSessionId,
   selectHtmlArtifactsById,
 } from "./htmlArtifactSlice";
+import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { composeHtmlDocument, openHtmlArtifactInNewTab, zoomIn, zoomOut, ZOOM_LEVELS } from "./htmlArtifactDocument";
 import { nextBufferAction } from "./previewBuffers";
+import { measureArtifactWidth } from "./htmlArtifactExport";
 import HtmlArtifactDownloadButton from "./HtmlArtifactDownloadButton";
 import styles from "./HtmlArtifactPane.module.css";
 
 export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const { showSuccess, showError } = useToast();
   const openSessionId = useOpenSessionId();
   const sliceSessionId = useSelector(selectHtmlArtifactSessionId);
   const byId = useSelector(selectHtmlArtifactsById);
@@ -56,6 +59,7 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
   // Browser-like zoom for the Preview (reflows content via CSS `zoom`), so a wide
   // page can be shrunk to fit. Download / open-in-new-tab stay at 100%.
   const [zoom, setZoom] = useState(1);
+  const previewWrapRef = useRef<HTMLDivElement>(null);
 
   // Only surface artifacts belonging to the conversation currently open.
   const artifacts = useMemo(
@@ -124,6 +128,32 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
 
   const untitled = t("capability.html_artifact.untitled", { defaultValue: "HTML artifact" });
 
+  const copyMarkup = async () => {
+    if (!selected) return;
+    try {
+      await navigator.clipboard.writeText(composeHtmlDocument(selected.html, selected.css));
+      showSuccess({ summary: t("capability.html_artifact.copied", { defaultValue: "Copied to clipboard" }) });
+    } catch {
+      showError({ summary: t("capability.html_artifact.copyFailed", { defaultValue: "Could not copy." }) });
+    }
+  };
+
+  // Fit width: measure the artifact's laid-out width in the panel (via a transient
+  // frame — the live preview is opaque) and set the zoom so overflow shrinks to fit;
+  // content that already fits resets to 100%.
+  const fitToWidth = async () => {
+    const wrap = previewWrapRef.current;
+    if (!selected || !wrap) return;
+    const available = wrap.clientWidth;
+    if (available <= 0) return;
+    try {
+      const content = await measureArtifactWidth(selected.html, selected.css, available);
+      setZoom(content > available ? Math.max(available / content, ZOOM_LEVELS[0]) : 1);
+    } catch {
+      /* leave the zoom unchanged */
+    }
+  };
+
   return (
     <div className={styles.pane}>
       <div className={styles.header}>
@@ -131,6 +161,17 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
           <Icon category="outlined" type="code" />
           <span className={styles.title}>{selected?.title || untitled}</span>
         </div>
+        {selected && (
+          <Tooltip text={t("capability.html_artifact.copy", { defaultValue: "Copy to clipboard" })}>
+            <IconButton
+              variant="icon"
+              size="small"
+              icon={{ category: "outlined", type: "content_copy" }}
+              onClick={() => void copyMarkup()}
+              aria-label={t("capability.html_artifact.copy", { defaultValue: "Copy to clipboard" })}
+            />
+          </Tooltip>
+        )}
         {selected && (
           <Tooltip text={t("capability.html_artifact.openInNewTab", { defaultValue: "Open in a new tab" })}>
             <IconButton
@@ -185,6 +226,15 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
               </div>
             )}
             <div className={styles.zoomCluster}>
+              <Tooltip text={t("capability.html_artifact.fitWidth", { defaultValue: "Fit width" })}>
+                <IconButton
+                  variant="icon"
+                  size="small"
+                  icon={{ category: "outlined", type: "fit_width" }}
+                  onClick={() => void fitToWidth()}
+                  aria-label={t("capability.html_artifact.fitWidth", { defaultValue: "Fit width" })}
+                />
+              </Tooltip>
               <Tooltip text={t("capability.html_artifact.zoomOut", { defaultValue: "Zoom out" })}>
                 <IconButton
                   variant="icon"
@@ -214,7 +264,7 @@ export function HtmlArtifactPane({ onClose }: CapabilitySidePanelProps) {
           </div>
 
           <div className={styles.body}>
-            <div className={styles.previewFrameWrap}>
+            <div ref={previewWrapRef} className={styles.previewFrameWrap}>
               {([0, 1] as const).map((i) => (
                 <iframe
                   key={i}

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactDocument.test.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactDocument.test.ts
@@ -235,4 +235,9 @@ describe("artifactFileName", () => {
     expect(artifactFileName("   ")).toBe("artifact.html");
     expect(artifactFileName("")).toBe("artifact.html");
   });
+
+  it("uses the given extension (e.g. png) when provided", () => {
+    expect(artifactFileName("My Landing Page!", "png")).toBe("my-landing-page.png");
+    expect(artifactFileName("", "png")).toBe("artifact.png");
+  });
 });

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactDocument.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactDocument.ts
@@ -119,15 +119,15 @@ export function zoomIn(z: number): number {
   return higher ?? ZOOM_LEVELS[ZOOM_LEVELS.length - 1];
 }
 
-/** A safe download filename derived from the artifact title (always ends in .html). */
-export function artifactFileName(title: string): string {
+/** A safe download filename derived from the artifact title (defaults to .html). */
+export function artifactFileName(title: string, ext = "html"): string {
   const base = (title || "artifact")
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 60);
-  return `${base || "artifact"}.html`;
+  return `${base || "artifact"}.${ext}`;
 }
 
 /**

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactDocument.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactDocument.ts
@@ -67,7 +67,10 @@ const VIEWPORT_META = '<meta name="viewport" content="width=device-width, initia
 // author's <style>, so intentional author rules still win (no !important).
 const FIT_STYLE =
   "<style>" +
-  "html{box-sizing:border-box}*,*::before,*::after{box-sizing:inherit}" +
+  "html{box-sizing:border-box}" +
+  // print-color-adjust:exact so backgrounds/colors survive print-to-PDF (browsers
+  // drop them by default); harmless on screen, only affects the print rendering.
+  "*,*::before,*::after{box-sizing:inherit;-webkit-print-color-adjust:exact;print-color-adjust:exact}" +
   "html,body{margin:0}body{padding:12px;overflow-wrap:break-word;word-break:break-word}" +
   "img,svg,video,canvas{max-width:100%;height:auto}" +
   "table{max-width:100%}pre{max-width:100%;overflow-x:auto}" +

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.test.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.test.ts
@@ -1,0 +1,53 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { buildImagePdf } from "./htmlArtifactExport";
+
+// A latin1 decode keeps a 1:1 byte↔char mapping, so string indices equal the PDF's
+// byte offsets — which is what the xref table records.
+async function pdfText(jpeg: Uint8Array): Promise<string> {
+  const blob = buildImagePdf(jpeg, 800, 600);
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  return new TextDecoder("latin1").decode(bytes);
+}
+
+describe("buildImagePdf", () => {
+  const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xd9, 0x00, 0x42]);
+
+  it("wraps the JPEG in a well-formed one-page PDF", async () => {
+    const text = await pdfText(jpeg);
+    expect(text.startsWith("%PDF-1.3")).toBe(true);
+    expect(text.trimEnd().endsWith("%%EOF")).toBe(true);
+    // The image stream declares the raw JPEG byte length and DCTDecode filter.
+    expect(text).toContain("/Filter/DCTDecode/Length 6");
+    expect(text).toContain("/MediaBox[0 0 595.28 446.46]"); // 595.28 * 600/800
+  });
+
+  it("records byte offsets that land exactly on each object header", async () => {
+    const text = await pdfText(jpeg);
+
+    const startxref = text.match(/startxref\n(\d+)\n%%EOF$/);
+    expect(startxref).toBeTruthy();
+    const xrefOffset = Number(startxref![1]);
+    expect(text.slice(xrefOffset, xrefOffset + 4)).toBe("xref");
+
+    const entries: string[] = text.slice(xrefOffset).match(/\d{10} 00000 n /g) ?? [];
+    expect(entries).toHaveLength(5);
+    entries.forEach((entry, i) => {
+      const offset = Number(entry.slice(0, 10));
+      expect(text.slice(offset).startsWith(`${i + 1} 0 obj`)).toBe(true);
+    });
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
@@ -103,6 +103,32 @@ async function renderArtifactToCanvas(html: string, css: string): Promise<HTMLCa
   }
 }
 
+/**
+ * Measure the artifact's laid-out content width at a given container width — the
+ * `scrollWidth` includes anything overflowing (a fixed-width layout wider than the
+ * panel). The live preview is `sandbox=""` (unreadable), so we lay the composed
+ * document out in a transient off-screen `allow-same-origin` frame just to measure.
+ * The caller turns this into a "fit width" zoom (containerWidth / contentWidth).
+ */
+export async function measureArtifactWidth(html: string, css: string, containerWidth: number): Promise<number> {
+  const composed = composeHtmlDocument(html, css);
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", "allow-same-origin");
+  iframe.setAttribute("referrerpolicy", "no-referrer");
+  iframe.style.cssText = `position:fixed;left:-99999px;top:0;width:${containerWidth}px;height:10px;border:0`;
+  iframe.srcdoc = composed;
+  document.body.appendChild(iframe);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      iframe.addEventListener("load", () => resolve(), { once: true });
+      iframe.addEventListener("error", () => reject(new Error("artifact failed to render")), { once: true });
+    });
+    return iframe.contentDocument?.documentElement.scrollWidth ?? containerWidth;
+  } finally {
+    iframe.remove();
+  }
+}
+
 /** Rasterize the artifact and download it as a PNG. */
 export async function downloadHtmlArtifactPng(html: string, css: string, title: string): Promise<void> {
   const canvas = await renderArtifactToCanvas(html, css);

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
@@ -1,0 +1,95 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// PDF and PNG export for an HTML artifact, alongside the plain .html download
+// (htmlArtifactDocument.downloadHtmlArtifact).
+//
+// SECURITY: both paths render the SAME `composeHtmlDocument` output, which is
+// already sanitized (Layer A) and carries a script-blocking CSP (Layer C). No
+// author script ever runs. They do drop the live preview's `sandbox=""` frame
+// (Layer B) because you cannot print an opaque-origin frame nor read its pixels;
+// the two remaining layers keep the export inert. The relaxations are scoped to a
+// transient print window / off-screen frame, never the in-app preview.
+
+import { composeHtmlDocument, artifactFileName } from "./htmlArtifactDocument";
+
+/**
+ * "Save as PDF" via the browser's print dialog: open the composed document in a
+ * new tab and trigger print once it has rendered. Real, selectable text (no
+ * rasterization). Returns false if the popup was blocked.
+ */
+export function printHtmlArtifact(html: string, css: string): boolean {
+  const composed = composeHtmlDocument(html, css);
+  const blob = new Blob([composed], { type: "text/html" });
+  const url = URL.createObjectURL(blob);
+  // Not `noopener`: we need the handle to call print(). Safe because the document
+  // runs no scripts (sanitized + CSP), so it can't reach back through window.opener.
+  const win = window.open(url, "_blank");
+  if (!win) {
+    URL.revokeObjectURL(url);
+    return false;
+  }
+  win.addEventListener("load", () => {
+    win.focus();
+    win.print();
+  });
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  return true;
+}
+
+// Off-screen render width (px) — a desktop-ish canvas so responsive artifacts lay
+// out sensibly; the capture then grows to the content's full height.
+const PNG_RENDER_WIDTH = 1024;
+
+/**
+ * Rasterize the artifact to a PNG and download it. The composed document renders
+ * in an off-screen iframe kept `sandbox="allow-same-origin"` — WITHOUT
+ * allow-scripts, so no author script runs — which is the minimum that lets us read
+ * the laid-out DOM to snapshot it. `html-to-image` is imported lazily so the PNG
+ * codepath adds nothing to the bundle for users who never export.
+ */
+export async function downloadHtmlArtifactPng(html: string, css: string, title: string): Promise<void> {
+  const composed = composeHtmlDocument(html, css);
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", "allow-same-origin");
+  iframe.setAttribute("referrerpolicy", "no-referrer");
+  iframe.style.cssText = `position:fixed;left:-99999px;top:0;width:${PNG_RENDER_WIDTH}px;height:768px;border:0;background:#fff`;
+  iframe.srcdoc = composed;
+  document.body.appendChild(iframe);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      iframe.addEventListener("load", () => resolve(), { once: true });
+      iframe.addEventListener("error", () => reject(new Error("artifact failed to render")), { once: true });
+    });
+    const doc = iframe.contentDocument;
+    if (!doc?.body) throw new Error("artifact document unavailable");
+    // Grow the frame to the full content so nothing is clipped in the snapshot.
+    const width = Math.max(doc.documentElement.scrollWidth, PNG_RENDER_WIDTH);
+    const height = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight, 1);
+    iframe.style.width = `${width}px`;
+    iframe.style.height = `${height}px`;
+
+    const { toPng } = await import("html-to-image");
+    const dataUrl = await toPng(doc.body, { width, height, backgroundColor: "#ffffff" });
+
+    const anchor = document.createElement("a");
+    anchor.href = dataUrl;
+    anchor.download = artifactFileName(title, "png");
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    iframe.remove();
+  }
+}

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
@@ -12,100 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// PDF and PNG export for an HTML artifact, alongside the plain .html download
-// (htmlArtifactDocument.downloadHtmlArtifact).
+// PNG and PDF export for an HTML artifact, alongside the plain .html download
+// (htmlArtifactDocument.downloadHtmlArtifact). Both rasterize the SAME faithful
+// render, so what you get is exactly the preview — background included, and none
+// of the browser print chrome (headers/footers/margins).
 //
-// SECURITY: both paths render the SAME `composeHtmlDocument` output, which is
-// already sanitized (Layer A: no <script>/on*-handlers) and carries a
-// script-blocking CSP (Layer C). No author script runs.
-//  - PDF opens the composed doc in a print window: relies on Layers A + C (you
-//    cannot print an opaque-origin sandboxed frame).
-//  - PNG serializes an off-screen render and rasterizes it through an
-//    `<svg><foreignObject>` loaded as an <img>. An SVG loaded via <img> runs in
-//    the browser's "secure static mode": no scripts, and NO external resource
-//    loads at all — the same "data: only" footprint as the live preview's CSP.
+// SECURITY: the render uses `composeHtmlDocument`, already sanitized (Layer A: no
+// <script>/on*-handlers) and CSP-locked (Layer C). We lay it out in an off-screen
+// iframe (no allow-scripts) purely to size it, then rasterize its serialized DOM
+// through an `<svg><foreignObject>` loaded as an <img>. An SVG loaded via <img>
+// runs in the browser's "secure static mode": no scripts, and NO external resource
+// loads at all — the same "data: only" footprint as the live preview's CSP.
 
 import { composeHtmlDocument, artifactFileName } from "./htmlArtifactDocument";
-
-/**
- * "Save as PDF" via the browser's print dialog: open the composed document in a
- * new tab and trigger print once it has rendered. Real, selectable text (no
- * rasterization). Returns false if the popup was blocked.
- */
-export function printHtmlArtifact(html: string, css: string): boolean {
-  const composed = composeHtmlDocument(html, css);
-  const blob = new Blob([composed], { type: "text/html" });
-  const url = URL.createObjectURL(blob);
-  // Not `noopener`: we need the handle to call print(). Safe because the document
-  // runs no scripts (sanitized + CSP), so it can't reach back through window.opener.
-  const win = window.open(url, "_blank");
-  if (!win) {
-    URL.revokeObjectURL(url);
-    return false;
-  }
-  win.addEventListener("load", () => {
-    win.focus();
-    win.print();
-  });
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
-  return true;
-}
 
 // Off-screen render width (px) — a desktop-ish canvas so responsive artifacts lay
 // out sensibly; the capture then grows to the content's full height.
 const PNG_RENDER_WIDTH = 1024;
+// A4 portrait width in PostScript points; the image PDF is one page this wide,
+// its height set from the render's aspect ratio.
+const A4_WIDTH_PT = 595.28;
 
-function triggerDownload(dataUrl: string, filename: string): void {
+function triggerDownload(url: string, filename: string): void {
   const anchor = document.createElement("a");
-  anchor.href = dataUrl;
+  anchor.href = url;
   anchor.download = filename;
   document.body.appendChild(anchor);
   anchor.click();
   anchor.remove();
 }
 
-// Render the (already-styled) serialized document through an SVG foreignObject and
-// draw it to a canvas. The styles ride along inside the serialized markup, so this
-// needs no computed-style inlining — unlike DOM-snapshot libraries, which read the
-// global window's getComputedStyle and therefore cannot see an iframe's nodes.
-async function rasterizeToPng(xhtml: string, width: number, height: number): Promise<string> {
-  const svg =
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
-    `<foreignObject x="0" y="0" width="100%" height="100%">${xhtml}</foreignObject>` +
-    `</svg>`;
-  const svgUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
-  try {
-    const img = new Image();
-    img.width = width;
-    img.height = height;
-    await new Promise<void>((resolve, reject) => {
-      img.onload = () => resolve();
-      img.onerror = () => reject(new Error("failed to rasterize the artifact"));
-      img.src = svgUrl;
-    });
-    const scale = window.devicePixelRatio || 1;
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.round(width * scale);
-    canvas.height = Math.round(height * scale);
-    const ctx = canvas.getContext("2d");
-    if (!ctx) throw new Error("canvas 2D context unavailable");
-    ctx.scale(scale, scale);
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, width, height);
-    ctx.drawImage(img, 0, 0);
-    return canvas.toDataURL("image/png");
-  } finally {
-    URL.revokeObjectURL(svgUrl);
-  }
-}
-
 /**
- * Rasterize the artifact to a PNG and download it. The composed document renders
- * in an off-screen iframe (`sandbox="allow-same-origin"`, no allow-scripts) purely
- * to lay it out and read its size; we then serialize that rendered DOM — styles
- * included — and paint it via `rasterizeToPng`.
+ * Render the artifact to a canvas at device resolution. The styles ride along
+ * inside the serialized markup, so this needs no computed-style inlining — unlike
+ * DOM-snapshot libraries, which read the global window's getComputedStyle and so
+ * cannot see an iframe's nodes.
  */
-export async function downloadHtmlArtifactPng(html: string, css: string, title: string): Promise<void> {
+async function renderArtifactToCanvas(html: string, css: string): Promise<HTMLCanvasElement> {
   const composed = composeHtmlDocument(html, css);
   const iframe = document.createElement("iframe");
   iframe.setAttribute("sandbox", "allow-same-origin");
@@ -125,9 +68,112 @@ export async function downloadHtmlArtifactPng(html: string, css: string, title: 
     iframe.style.height = `${Math.max(doc.documentElement.scrollHeight, 1)}px`;
     const height = Math.max(doc.documentElement.scrollHeight, doc.body?.scrollHeight ?? 0, 1);
     const serialized = new XMLSerializer().serializeToString(doc.documentElement);
-    const dataUrl = await rasterizeToPng(serialized, width, height);
-    triggerDownload(dataUrl, artifactFileName(title, "png"));
+
+    const svg =
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+      `<foreignObject x="0" y="0" width="100%" height="100%">${serialized}</foreignObject>` +
+      `</svg>`;
+    const svgUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+    try {
+      const img = new Image();
+      img.width = width;
+      img.height = height;
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error("failed to rasterize the artifact"));
+        img.src = svgUrl;
+      });
+      const scale = window.devicePixelRatio || 1;
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.round(width * scale);
+      canvas.height = Math.round(height * scale);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("canvas 2D context unavailable");
+      ctx.scale(scale, scale);
+      // Opaque white base so transparent regions read as a page, not black (JPEG).
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, width, height);
+      ctx.drawImage(img, 0, 0);
+      return canvas;
+    } finally {
+      URL.revokeObjectURL(svgUrl);
+    }
   } finally {
     iframe.remove();
   }
+}
+
+/** Rasterize the artifact and download it as a PNG. */
+export async function downloadHtmlArtifactPng(html: string, css: string, title: string): Promise<void> {
+  const canvas = await renderArtifactToCanvas(html, css);
+  triggerDownload(canvas.toDataURL("image/png"), artifactFileName(title, "png"));
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Build a minimal single-page PDF whose only content is `jpeg` scaled to fill an
+ * A4-width page (height from the image aspect). Hand-assembled — one image XObject
+ * (DCTDecode = raw JPEG bytes, no re-encode) — so no PDF library is needed. Byte
+ * offsets are tracked exactly for the xref table.
+ */
+export function buildImagePdf(jpeg: Uint8Array, imgWidth: number, imgHeight: number): Blob {
+  const pageWidth = A4_WIDTH_PT;
+  const pageHeight = (A4_WIDTH_PT * imgHeight) / imgWidth;
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  let offset = 0;
+  const offsets: number[] = [];
+  const push = (chunk: Uint8Array | string) => {
+    const bytes = typeof chunk === "string" ? encoder.encode(chunk) : chunk;
+    chunks.push(bytes);
+    offset += bytes.length;
+  };
+  const startObject = (n: number) => {
+    offsets[n] = offset;
+    push(`${n} 0 obj\n`);
+  };
+
+  push("%PDF-1.3\n");
+  startObject(1);
+  push("<</Type/Catalog/Pages 2 0 R>>\nendobj\n");
+  startObject(2);
+  push("<</Type/Pages/Kids[3 0 R]/Count 1>>\nendobj\n");
+  startObject(3);
+  push(
+    `<</Type/Page/Parent 2 0 R/MediaBox[0 0 ${pageWidth.toFixed(2)} ${pageHeight.toFixed(2)}]` +
+      `/Resources<</XObject<</Im0 4 0 R>>>>/Contents 5 0 R>>\nendobj\n`,
+  );
+  startObject(4);
+  push(
+    `<</Type/XObject/Subtype/Image/Width ${imgWidth}/Height ${imgHeight}` +
+      `/ColorSpace/DeviceRGB/BitsPerComponent 8/Filter/DCTDecode/Length ${jpeg.length}>>\nstream\n`,
+  );
+  push(jpeg);
+  push("\nendstream\nendobj\n");
+  const content = `q ${pageWidth.toFixed(2)} 0 0 ${pageHeight.toFixed(2)} 0 0 cm /Im0 Do Q`;
+  startObject(5);
+  push(`<</Length ${content.length}>>\nstream\n${content}\nendstream\nendobj\n`);
+
+  const xrefOffset = offset;
+  let xref = `xref\n0 6\n0000000000 65535 f \n`;
+  for (let n = 1; n <= 5; n += 1) xref += `${String(offsets[n]).padStart(10, "0")} 00000 n \n`;
+  push(xref);
+  push(`trailer\n<</Size 6/Root 1 0 R>>\nstartxref\n${xrefOffset}\n%%EOF`);
+
+  return new Blob(chunks as BlobPart[], { type: "application/pdf" });
+}
+
+/** Rasterize the artifact and download it as a single-page image PDF. */
+export async function downloadHtmlArtifactPdf(html: string, css: string, title: string): Promise<void> {
+  const canvas = await renderArtifactToCanvas(html, css);
+  const jpeg = base64ToBytes(canvas.toDataURL("image/jpeg", 0.92).split(",")[1]);
+  const url = URL.createObjectURL(buildImagePdf(jpeg, canvas.width, canvas.height));
+  triggerDownload(url, artifactFileName(title, "pdf"));
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/htmlArtifactExport.ts
@@ -16,11 +16,14 @@
 // (htmlArtifactDocument.downloadHtmlArtifact).
 //
 // SECURITY: both paths render the SAME `composeHtmlDocument` output, which is
-// already sanitized (Layer A) and carries a script-blocking CSP (Layer C). No
-// author script ever runs. They do drop the live preview's `sandbox=""` frame
-// (Layer B) because you cannot print an opaque-origin frame nor read its pixels;
-// the two remaining layers keep the export inert. The relaxations are scoped to a
-// transient print window / off-screen frame, never the in-app preview.
+// already sanitized (Layer A: no <script>/on*-handlers) and carries a
+// script-blocking CSP (Layer C). No author script runs.
+//  - PDF opens the composed doc in a print window: relies on Layers A + C (you
+//    cannot print an opaque-origin sandboxed frame).
+//  - PNG serializes an off-screen render and rasterizes it through an
+//    `<svg><foreignObject>` loaded as an <img>. An SVG loaded via <img> runs in
+//    the browser's "secure static mode": no scripts, and NO external resource
+//    loads at all — the same "data: only" footprint as the live preview's CSP.
 
 import { composeHtmlDocument, artifactFileName } from "./htmlArtifactDocument";
 
@@ -52,19 +55,62 @@ export function printHtmlArtifact(html: string, css: string): boolean {
 // out sensibly; the capture then grows to the content's full height.
 const PNG_RENDER_WIDTH = 1024;
 
+function triggerDownload(dataUrl: string, filename: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = dataUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+// Render the (already-styled) serialized document through an SVG foreignObject and
+// draw it to a canvas. The styles ride along inside the serialized markup, so this
+// needs no computed-style inlining — unlike DOM-snapshot libraries, which read the
+// global window's getComputedStyle and therefore cannot see an iframe's nodes.
+async function rasterizeToPng(xhtml: string, width: number, height: number): Promise<string> {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+    `<foreignObject x="0" y="0" width="100%" height="100%">${xhtml}</foreignObject>` +
+    `</svg>`;
+  const svgUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+  try {
+    const img = new Image();
+    img.width = width;
+    img.height = height;
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error("failed to rasterize the artifact"));
+      img.src = svgUrl;
+    });
+    const scale = window.devicePixelRatio || 1;
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(width * scale);
+    canvas.height = Math.round(height * scale);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("canvas 2D context unavailable");
+    ctx.scale(scale, scale);
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+    ctx.drawImage(img, 0, 0);
+    return canvas.toDataURL("image/png");
+  } finally {
+    URL.revokeObjectURL(svgUrl);
+  }
+}
+
 /**
  * Rasterize the artifact to a PNG and download it. The composed document renders
- * in an off-screen iframe kept `sandbox="allow-same-origin"` — WITHOUT
- * allow-scripts, so no author script runs — which is the minimum that lets us read
- * the laid-out DOM to snapshot it. `html-to-image` is imported lazily so the PNG
- * codepath adds nothing to the bundle for users who never export.
+ * in an off-screen iframe (`sandbox="allow-same-origin"`, no allow-scripts) purely
+ * to lay it out and read its size; we then serialize that rendered DOM — styles
+ * included — and paint it via `rasterizeToPng`.
  */
 export async function downloadHtmlArtifactPng(html: string, css: string, title: string): Promise<void> {
   const composed = composeHtmlDocument(html, css);
   const iframe = document.createElement("iframe");
   iframe.setAttribute("sandbox", "allow-same-origin");
   iframe.setAttribute("referrerpolicy", "no-referrer");
-  iframe.style.cssText = `position:fixed;left:-99999px;top:0;width:${PNG_RENDER_WIDTH}px;height:768px;border:0;background:#fff`;
+  iframe.style.cssText = `position:fixed;left:-99999px;top:0;width:${PNG_RENDER_WIDTH}px;height:10px;border:0;background:#fff`;
   iframe.srcdoc = composed;
   document.body.appendChild(iframe);
   try {
@@ -73,22 +119,14 @@ export async function downloadHtmlArtifactPng(html: string, css: string, title: 
       iframe.addEventListener("error", () => reject(new Error("artifact failed to render")), { once: true });
     });
     const doc = iframe.contentDocument;
-    if (!doc?.body) throw new Error("artifact document unavailable");
-    // Grow the frame to the full content so nothing is clipped in the snapshot.
+    if (!doc?.documentElement) throw new Error("artifact document unavailable");
+    // Grow the frame to the full content height so nothing is clipped, then measure.
     const width = Math.max(doc.documentElement.scrollWidth, PNG_RENDER_WIDTH);
-    const height = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight, 1);
-    iframe.style.width = `${width}px`;
-    iframe.style.height = `${height}px`;
-
-    const { toPng } = await import("html-to-image");
-    const dataUrl = await toPng(doc.body, { width, height, backgroundColor: "#ffffff" });
-
-    const anchor = document.createElement("a");
-    anchor.href = dataUrl;
-    anchor.download = artifactFileName(title, "png");
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
+    iframe.style.height = `${Math.max(doc.documentElement.scrollHeight, 1)}px`;
+    const height = Math.max(doc.documentElement.scrollHeight, doc.body?.scrollHeight ?? 0, 1);
+    const serialized = new XMLSerializer().serializeToString(doc.documentElement);
+    const dataUrl = await rasterizeToPng(serialized, width, height);
+    triggerDownload(dataUrl, artifactFileName(title, "png"));
   } finally {
     iframe.remove();
   }

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/previewBuffers.test.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/previewBuffers.test.ts
@@ -1,0 +1,53 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { nextBufferAction } from "./previewBuffers";
+
+describe("nextBufferAction", () => {
+  it("does nothing when there is no document", () => {
+    expect(nextBufferAction("", ["", ""], ["", ""], 0)).toEqual({ kind: "none" });
+  });
+
+  it("does nothing when the front buffer already shows the document", () => {
+    expect(nextBufferAction("docA", ["docA", ""], ["docA", ""], 0)).toEqual({ kind: "none" });
+  });
+
+  it("loads a fresh document into the hidden back buffer", () => {
+    expect(nextBufferAction("docA", ["", ""], ["", ""], 0)).toEqual({ kind: "load", into: 1 });
+  });
+
+  it("waits (no reset) while the back buffer is still loading that document", () => {
+    // srcDoc already set to docB but not painted yet — onLoad will flip; resetting
+    // it would restart the load.
+    expect(nextBufferAction("docB", ["docA", "docB"], ["docA", ""], 0)).toEqual({ kind: "none" });
+  });
+
+  it("flips to the back buffer when it already painted the document (the switch-back bug)", () => {
+    // Front shows docB; docA is still painted in buffer 1 from an earlier view.
+    // Re-selecting docA changes no srcDoc, so no onLoad fires — must flip directly,
+    // not sit frozen on docB.
+    expect(nextBufferAction("docA", ["docB", "docA"], ["docB", "docA"], 0)).toEqual({ kind: "flip", to: 1 });
+  });
+
+  it("toggling back and forth keeps resolving to the painted buffer, never freezing", () => {
+    // buffers/painted hold [docB, docA] after both were seen once.
+    const buffers: [string, string] = ["docB", "docA"];
+    const painted: [string, string] = ["docB", "docA"];
+    // front=0 (docB) → pick docA: flip to 1.
+    expect(nextBufferAction("docA", buffers, painted, 0)).toEqual({ kind: "flip", to: 1 });
+    // front=1 (docA) → pick docB: flip to 0.
+    expect(nextBufferAction("docB", buffers, painted, 1)).toEqual({ kind: "flip", to: 0 });
+  });
+});

--- a/apps/frontend/src/rework/features/capabilities/html_artifact/previewBuffers.ts
+++ b/apps/frontend/src/rework/features/capabilities/html_artifact/previewBuffers.ts
@@ -1,0 +1,48 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pure decision for the Preview's double-buffer (two stacked sandboxed iframes).
+// The subtlety this encodes: an iframe only fires `onLoad` when its `srcDoc`
+// actually changes, so switching BACK to a document a buffer already painted
+// produces no reload and no onLoad. The consumer must then flip to that buffer
+// directly — otherwise the pane freezes on the current frame (the switch-tab bug).
+
+export type BufferIndex = 0 | 1;
+
+export type BufferAction =
+  | { kind: "none" }
+  | { kind: "flip"; to: BufferIndex } // already painted elsewhere — reveal it, no reload
+  | { kind: "load"; into: BufferIndex }; // fresh doc — load into the hidden back buffer
+
+/**
+ * Decide what to do when `composed` is the document that should now be shown.
+ * `buffers` is each frame's current `srcDoc`; `painted` is what each frame has
+ * actually finished painting (from onLoad); `front` is the visible frame.
+ */
+export function nextBufferAction(
+  composed: string,
+  buffers: readonly [string, string],
+  painted: readonly [string, string],
+  front: BufferIndex,
+): BufferAction {
+  if (!composed || buffers[front] === composed) return { kind: "none" };
+  const back: BufferIndex = front === 0 ? 1 : 0;
+  // Already painted in the back buffer on an earlier view: no reload will fire,
+  // so flip to it now rather than waiting for an onLoad that never comes.
+  if (painted[back] === composed) return { kind: "flip", to: back };
+  // Its srcDoc is already `composed` but it hasn't painted yet — it's mid-load;
+  // the onLoad will flip to it. Don't reset the srcDoc (that would restart it).
+  if (buffers[back] === composed) return { kind: "none" };
+  return { kind: "load", into: back };
+}

--- a/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
+++ b/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
@@ -138,12 +138,16 @@ mirroring the `writable_document` plugin:
   auto-opens the panel on a live render (same heuristic/probe pattern already used
   by the two shipped capabilities).
 - **Side panel** `HtmlArtifactPane` — opens right of the chat. **This is the one
-  net-new UI primitive.** Tabbed, all **read-only**:
-  - **Preview** — a sandboxed `<iframe srcdoc={composed} sandbox="...">` (§4.7).
-  - **HTML** — the `html` source, syntax-highlighted, not editable. Reuses the
-    existing `CodeBlock` molecule (`react-syntax-highlighter`, already a frontend
-    dependency) — no new dependency (§9.3 resolved).
-  - **CSS** — the `css` source, via the same `CodeBlock`, not editable.
+  net-new UI primitive.** **Read-only.** Shipped as a tabbed pane (Preview / HTML /
+  CSS); **as of 2026-09-01 the source tabs were dropped** — the pane always shows
+  the Preview and the source stays reachable via Download / open-in-new-tab. The
+  code editor `CodeBlock` is no longer used here (the §9.3 "no new dependency"
+  point is moot). A single controls bar carries the multi-artifact switcher tabs
+  (max-width 6rem, full title on hover) on the left and the zoom controls on the
+  right.
+  - **Preview** — a sandboxed `<iframe srcdoc={composed} sandbox="...">` (§4.7),
+    double-buffered so a re-render/zoom never flashes the blank frame (see
+    `previewBuffers.nextBufferAction`).
   - **Download** — the composed self-contained `.html` (CSS inlined), via the
     existing authed/blob download pattern.
 - **Slice** `htmlArtifactSlice` — the cross-component bus (a card deep in the

--- a/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
+++ b/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
@@ -148,8 +148,11 @@ mirroring the `writable_document` plugin:
   - **Preview** — a sandboxed `<iframe srcdoc={composed} sandbox="...">` (§4.7),
     double-buffered so a re-render/zoom never flashes the blank frame (see
     `previewBuffers.nextBufferAction`).
-  - **Download** — the composed self-contained `.html` (CSS inlined), via the
-    existing authed/blob download pattern.
+  - **Download** — a format menu (2026-09-01): **HTML** (composed self-contained
+    file, CSS inlined), **PDF** (opens the composed doc and triggers the browser
+    print dialog — real text, no new heavy dep), **PNG** (rasterized via
+    `html-to-image` from an off-screen `allow-same-origin`/no-scripts frame). All
+    three render the same sanitized + CSP-locked document, so no author script runs.
 - **Slice** `htmlArtifactSlice` — the cross-component bus (a card deep in the
   thread drives the far-away panel), newest-`version`-wins per `artifact_id`.
   Mirrors `writableDocumentSlice`.

--- a/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
+++ b/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
@@ -149,12 +149,14 @@ mirroring the `writable_document` plugin:
     double-buffered so a re-render/zoom never flashes the blank frame (see
     `previewBuffers.nextBufferAction`).
   - **Download** — a format menu (2026-09-01): **HTML** (composed self-contained
-    file, CSS inlined), **PDF** (opens the composed doc and triggers the browser
-    print dialog — real text; `print-color-adjust:exact` keeps backgrounds), **PNG**
-    (renders off-screen, serializes the DOM, rasterizes it through an
-    `<svg><foreignObject>` loaded as an `<img>` — secure static mode: no scripts, no
-    external loads, no extra dependency). All three render the same sanitized +
-    CSP-locked document, so no author script runs.
+    file, CSS inlined), plus **PNG** and **PDF** built from the SAME faithful
+    render — the artifact is laid out off-screen, its DOM serialized, and rasterized
+    through an `<svg><foreignObject>` loaded as an `<img>` (secure static mode: no
+    scripts, no external loads). PNG is that canvas; PDF wraps the canvas JPEG in a
+    hand-assembled one-page document (no PDF library). Both capture the real
+    background and add none of the browser print chrome. (Print-to-PDF was tried
+    first and dropped: browsers omit backgrounds and inject header/footer/margins.)
+    All paths render the same sanitized + CSP-locked document, so no author script runs.
 - **Slice** `htmlArtifactSlice` — the cross-component bus (a card deep in the
   thread drives the far-away panel), newest-`version`-wins per `artifact_id`.
   Mirrors `writableDocumentSlice`.

--- a/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
+++ b/docs/swift/rfc/HTML-ARTIFACT-CAPABILITY-RFC.md
@@ -150,9 +150,11 @@ mirroring the `writable_document` plugin:
     `previewBuffers.nextBufferAction`).
   - **Download** — a format menu (2026-09-01): **HTML** (composed self-contained
     file, CSS inlined), **PDF** (opens the composed doc and triggers the browser
-    print dialog — real text, no new heavy dep), **PNG** (rasterized via
-    `html-to-image` from an off-screen `allow-same-origin`/no-scripts frame). All
-    three render the same sanitized + CSP-locked document, so no author script runs.
+    print dialog — real text; `print-color-adjust:exact` keeps backgrounds), **PNG**
+    (renders off-screen, serializes the DOM, rasterizes it through an
+    `<svg><foreignObject>` loaded as an `<img>` — secure static mode: no scripts, no
+    external loads, no extra dependency). All three render the same sanitized +
+    CSP-locked document, so no author script runs.
 - **Slice** `htmlArtifactSlice` — the cross-component bus (a card deep in the
   thread drives the far-away panel), newest-`version`-wins per `artifact_id`.
   Mirrors `writableDocumentSlice`.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -2398,7 +2398,9 @@ Opt-in **floating-card** variant (`floating` prop, push layout, 2026-08-06): the
 into a card inset from every edge — single `outline-muted` 1px border, `--radius-m` (16px)
 corners, subtle `--shadow-s` — dropping the flush edge border and the header divider. Width stays
 fixed during the open animation so content doesn't reflow. First consumer: the document-scope
-panel (see "Document-scope side panel"). Default panels stay flush.
+panel (see "Document-scope side panel"). Default push panels stay flush: full page height, square
+corners, a 1px `outline-muted` left divider, no top/bottom inset (2026-09-01 — previously a
+`--radius-m` rounded card with a small top/bottom margin and a transparent left edge).
 
 #### Open UX issues
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -2635,14 +2635,16 @@ Page-local composition that maps `ThreadMessage[]` to `UserTurn` / `AssistantTur
 **Location:** `src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx`
 **Status:** `Functional`
 
-Page composition (`.page` is a **flex column**, 2026-08-06): a full-width `topBar` (holding
-`SessionTitleEditor`) sits on top and always spans the whole page; below it a `.contentRow` (flex
-row) holds the main column (`chatArea` scroll container + sticky composer) on the left and the
-push drawers (capability / attachments / document-scope) on the right. Pulling the header out of
-the main column means an opening push drawer reflows only the content row — the panel slides
-**under** the full-width header instead of shrinking it. (Before this, the header lived inside the
-main column and shrank whenever a push drawer opened.) The `data-picker-top-boundary` attribute
-stays on the header so the composer's anchored pickers still stop just below it. The composer is
+Page composition (`.page` is a **flex column**): a `.pageBody` (**flex row**, 2026-09-01) holds
+the `.leftStack` on the left and the push drawers (capability / attachments / document-scope) on
+the right. `.leftStack` is a flex column — the `topBar` (holding `SessionTitleEditor`) above, the
+`.contentRow` → main column (`chatArea` scroll container + sticky composer) below. An opening push
+drawer reflows the **whole left stack, header included**, so the drawer spans the full page height
+for better viewer visualization (changed 2026-09-01 — previously the drawers lived inside
+`.contentRow` and reflowed only the content, the panel sliding **under** the full-width header;
+before that again the header lived inside the main column and shrank on open). The
+`data-picker-top-boundary` attribute stays on the header so the composer's anchored pickers still
+stop just below it. The composer is
 built once (a single `composer` element) and placed either centered in the empty "new
 conversation" state or in the sticky `inputOverlay` mid-conversation — same structure both times
 (2026-08-06, see `RichInputField`'s "Resolved" entry). `topSlot` holds `ComposerOptionChips` —

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -2637,14 +2637,17 @@ Page-local composition that maps `ThreadMessage[]` to `UserTurn` / `AssistantTur
 **Location:** `src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx`
 **Status:** `Functional`
 
-Page composition (`.page` is a **flex column**): a `.pageBody` (**flex row**, 2026-09-01) holds
-the `.leftStack` on the left and the push drawers (capability / attachments / document-scope) on
-the right. `.leftStack` is a flex column — the `topBar` (holding `SessionTitleEditor`) above, the
-`.contentRow` → main column (`chatArea` scroll container + sticky composer) below. An opening push
-drawer reflows the **whole left stack, header included**, so the drawer spans the full page height
-for better viewer visualization (changed 2026-09-01 — previously the drawers lived inside
-`.contentRow` and reflowed only the content, the panel sliding **under** the full-width header;
-before that again the header lived inside the main column and shrank on open). The
+Page composition (`.page` is a **flex row**, 2026-09-01): `[ .pageBody (flex:1) ][ launcher rail ]`.
+`.pageBody` (flex row) holds the `.leftStack` on the left and the push drawers (capability /
+attachments / document-scope) on the right. `.leftStack` is a flex column — the `topBar` (holding
+`SessionTitleEditor`) above, the `.contentRow` → main column (`chatArea` scroll container + sticky
+composer) below. An opening push drawer reflows the **whole left stack, header included**, so the
+drawer spans the full page height for better viewer visualization (changed 2026-09-01 — previously
+the drawers lived inside `.contentRow` and reflowed only the content, the panel sliding **under**
+the full-width header; before that again the header lived inside the main column and shrank on
+open). The `topBar` is an inset rounded card — `--radius-s` corners, 12px top/left/right margin,
+flush bottom (2026-09-01). The launcher rail is a **page-root in-flow column** at the far right
+(see "Capability side-panel launcher rail"), not part of `.pageBody`. The
 `data-picker-top-boundary` attribute stays on the header so the composer's anchored pickers still
 stop just below it. The composer is
 built once (a single `composer` element) and placed either centered in the empty "new
@@ -3591,8 +3594,14 @@ root card above the table was tried on 2026-08-21 and removed the same day
 
 **Status:** `Functional`
 
-The floating rail on the chat page's right edge, one small icon button per side panel
-a session's active capabilities declare. Two changes (#2459):
+The launcher rail on the chat page's right edge, one small icon button per side panel
+a session's active capabilities declare. **Since 2026-09-01 it is a page-root in-flow
+column** — extracted into `CapabilityLauncherRail` (a flex sibling of `.pageBody`, not
+inside it), `flex-shrink: 0`, full page height, 12px top/right/bottom margin — so it
+reserves its own space at the far right and reflows the chat body left, rather than
+floating over it as an absolutely-positioned overlay. Opening a panel retires the whole
+rail (returns `null`), so the body-side push drawer takes the full width. Earlier
+behaviour (#2459):
 
 - **A launcher appears only once its panel has something to show.** The rail used to
   render one button per DECLARED panel, so activating `ppt_filler` + `writable_document`
@@ -3609,14 +3618,15 @@ a session's active capabilities declare. Two changes (#2459):
   `edit_document` in the same pass (2026-08-28). Colour stays the rail's neutral
   `on-surface-retreat`: the launchers sit in the same floating-chrome band as the trace
   and attachments buttons, and tinting only these two would break that band.
-- **The rail dropped to 68px from the top** (2026-08-28). Its 48px offset was computed
-  against a one-line top bar; the bar now stacks a 24px title over a 20px agent name, so
-  the first launcher sat on the band.
-- **The rail retires entirely while a panel is open** (2026-08-28). It is absolutely
-  positioned against the whole slot, drawer included, so with a panel open it landed on
-  that drawer's own close button. Moving the remaining launchers into the drawer's
-  `headerActions` was tried the same day and dropped: closing the open panel to reach
-  another one is cheap, and one home for the launchers beats two (developer decision).
+- **The rail dropped to 68px from the top** (2026-08-28, superseded 2026-09-01). Back when
+  the rail was absolutely positioned, its top offset was tuned against the two-line top bar;
+  in-flow at the page root this offset is gone (the 12px top margin replaces it).
+- **The rail retires entirely while a panel is open** (2026-08-28, still current). When it was
+  an absolutely-positioned overlay this avoided landing on the open drawer's close button;
+  now that it is an in-flow column, retiring also hands its width back to the body so the
+  drawer fills the page. Moving the remaining launchers into the drawer's `headerActions` was
+  tried the same day and dropped: closing the open panel to reach another one is cheap, and
+  one home for the launchers beats two (developer decision).
 - **The drawer's own title band is gone for both panes** (2026-08-28). A pane that
   names the artefact it holds does not also need the drawer naming the panel above
   it - two title rows said the same thing twice and ate the top of the column. A


### PR DESCRIPTION
## What

Two related areas of the chat page.

### Side-panel layout
- Viewer/attachments/document-scope push drawers now open at the **page root** and span the **full page height**, reflowing the top bar together with the content instead of sliding under it.
- Push panels are **flush, full-height** with a 1px `outline-muted` left divider (no rounded card / top-bottom margin).
- The capability **launcher rail** moved out of the side-panel host to a **page-root in-flow column** at the far right (`.page` is now a flex row `[ body ][ rail ]`), so it reserves its own space instead of floating; extracted into `CapabilityLauncherRail`.
- The **top bar** is an inset rounded card (8px corners, 12px top/left/right margin).

### HTML artifact viewer
- **Fixed** the frozen preview on artifact switch: the double-buffer never flipped back to an already-painted frame (no `onLoad` fires when `srcDoc` is unchanged). Logic extracted to the pure, unit-tested `previewBuffers.nextBufferAction`.
- Dropped the Preview/HTML/CSS tab bar — the pane always shows the render; source stays reachable via download / open-in-new-tab. Single controls bar: artifact tabs (max-width 6rem, full title on hover) left, zoom right.
- **Download menu** — HTML, PDF and PNG. PNG and PDF both rasterize the same faithful render through an `<svg><foreignObject>` loaded as an `<img>` (secure static mode: no scripts, no external loads, no dependency); PDF wraps the canvas JPEG in a hand-assembled one-page document. (Print-to-PDF was tried and dropped — it lost backgrounds and injected browser header/footer/margins.)
- Added **copy to clipboard**, **fit width** (measures the artifact in a transient off-screen frame — the live preview stays `sandbox=""` — and zooms overflow to fit), and removed the hover state on the active tab.
- EN/FR translations for all the new labels.

## Tests
- `previewBuffers` (buffer-flip incl. the regression), `buildImagePdf` (structure + xref byte offsets), `artifactFileName`, plus the existing sandbox guard. Frontend `make code-quality` green; html_artifact suite green.

## Notes
- Browser-only paths (PNG/PDF rasterization, fit-width, print) can't be unit-tested in the node env — verified by reasoning + the extracted pure helpers; manual visual verification recommended.
- No new runtime dependency (html-to-image was tried then removed in favor of the native SVG path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)