### PR TITLE
fix(personal-space): reuse the round user avatar in the team nav header

### DIFF
--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -24,6 +24,8 @@ import Button from "@shared/atoms/Button/Button.tsx";
 import Separator from "@shared/atoms/Separator/Separator.tsx";
 import TeamInitials from "@shared/atoms/TeamInitials/TeamInitials.tsx";
 import { teamColor } from "@shared/atoms/TeamInitials/teamColor.ts";
+import UserAvatar from "@shared/atoms/UserAvatar/UserAvatar.tsx";
+import { KeyCloakService } from "../../../../../../security/KeycloakService.ts";
 import ChatList from "@shared/organisms/ChatList/ChatList.tsx";
 import { useFrontendProperties } from "../../../../../../hooks/useFrontendProperties.ts";
 import { useSelectedTeam } from "../../../../../../hooks/useSelectedTeam.ts";
@@ -111,10 +113,13 @@ export default function TeamContentNavbar() {
   const showRoleLabel = !isPersonalTeam && !!selectedTeam?.is_member && relationsLoaded;
 
   // Team avatar (28×28, 4px): the custom image when set, else colour-tinted
-  // initials (same fallback as the Home team list). Square 4px on both, incl.
-  // the personal space.
+  // square initials (same fallback as the Home team list). The personal space
+  // reuses that list's round user avatar (UserAvatar) — the "this is you"
+  // signal — sized down to fit this compact header.
   const teamDisplayName = isPersonalTeam ? t("rework.sidebar.team.userTeam") : (selectedTeam?.name ?? "");
-  const teamAvatar = selectedTeam?.avatar_image_url ? (
+  const teamAvatar = isPersonalTeam ? (
+    <UserAvatar name={KeyCloakService.GetUserFullName()} size="x-small" />
+  ) : selectedTeam?.avatar_image_url ? (
     <img className={styles.teamPanelAvatar} src={selectedTeam.avatar_image_url} alt="" aria-hidden="true" />
   ) : (
     <TeamInitials


### PR DESCRIPTION
## What

In the personal space, the team navigation panel header rendered a generic square `TeamInitials` tile (initials of the "Espace personnel" label), which did not match the round user avatar shown for the "Espace personnel" item in the Home team list.

This reuses that exact component — `UserAvatar` (round, user initials from Keycloak) — in the team nav header when the personal space is active. Real teams are unchanged (custom image, else square initials tile).

## Details

- `TeamContentNavbar.tsx`: personal space now renders `<UserAvatar name={KeyCloakService.GetUserFullName()} size="x-small" />` instead of the square `TeamInitials`.
- Size dropped to `x-small` (24px) — the Home list uses `small` (32px) — to fit the compact header slot (the team tile is 28px).

## Testing

- `make code-quality` green (tsc + prettier + eslint).
- No unit test: no test file exists for this component and the change is purely visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)