### PR TITLE
fix(ci): ship fred-capability-html-artifact in the image and test it on PRs

### DIFF
--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -54,16 +54,18 @@ jobs:
               - 'apps/fred-agents/**'
             platform-ops:
               - 'libs/fred-capability-platform-ops/**'
+            html-artifact:
+              - 'libs/fred-capability-html-artifact/**'
 
   # Job to run code quality checks on the entire repository
   code-quality:
     runs-on: ubuntu-24.04
     needs: detect-changes
-    if: needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.platform-ops == 'true'
+    if: needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.html-artifact == 'true'
     strategy:
       fail-fast: false
       matrix:
-        directory: [apps/knowledge-flow-backend, libs/fred-core, apps/control-plane-backend, libs/fred-sdk, libs/fred-runtime, apps/fred-agents, libs/fred-capability-platform-ops]
+        directory: [apps/knowledge-flow-backend, libs/fred-core, apps/control-plane-backend, libs/fred-sdk, libs/fred-runtime, apps/fred-agents, libs/fred-capability-platform-ops, libs/fred-capability-html-artifact]
         check:
           - lint
           - format
@@ -93,6 +95,9 @@ jobs:
           # Platform-ops capability runs when it, fred-runtime, or fred-sdk changes
           - directory: libs/fred-capability-platform-ops
             condition: needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true'
+          # HTML-artifact capability runs when it, fred-runtime, or fred-sdk changes
+          - directory: libs/fred-capability-html-artifact
+            condition: needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true'
     name: Code Quality - ${{ matrix.directory }} - ${{ matrix.check }}
 
     steps:
@@ -118,7 +123,7 @@ jobs:
   backend-tests:
     runs-on: ubuntu-24.04
     needs: detect-changes
-    if: needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.platform-ops == 'true'
+    if: needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.html-artifact == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -158,6 +163,11 @@ jobs:
             unit-target: test
             needs-pandoc: false
             should-run: ${{ needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
+          - name: fred-capability-html-artifact
+            directory: libs/fred-capability-html-artifact
+            unit-target: test
+            needs-pandoc: false
+            should-run: ${{ needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
     name: Backend Tests - ${{ matrix.name }}
 
     steps:

--- a/apps/fred-agents/dockerfiles/Dockerfile-prod
+++ b/apps/fred-agents/dockerfiles/Dockerfile-prod
@@ -27,6 +27,7 @@ COPY libs/fred-sdk /workspace/libs/fred-sdk
 COPY libs/fred-capability-writable-document /workspace/libs/fred-capability-writable-document
 COPY libs/fred-capability-ppt-filler /workspace/libs/fred-capability-ppt-filler
 COPY libs/fred-capability-platform-ops /workspace/libs/fred-capability-platform-ops
+COPY libs/fred-capability-html-artifact /workspace/libs/fred-capability-html-artifact
 
 RUN make dev VENV=/app/venv TARGET=/app/target
 
@@ -59,6 +60,7 @@ COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-sdk /workspace/libs/fred-sdk
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-writable-document /workspace/libs/fred-capability-writable-document
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-ppt-filler /workspace/libs/fred-capability-ppt-filler
 COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-platform-ops /workspace/libs/fred-capability-platform-ops
+COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-html-artifact /workspace/libs/fred-capability-html-artifact
 
 # alembic.ini is a real file only at the repo root; the per-project ones are dev-only
 # symlinks kept out of the build context (see .dockerignore), because Kaniko would copy


### PR DESCRIPTION
## Problem

The `code/v2.1.39` release build failed 30 seconds in, taking the whole matrix with it — no images were published to `ghcr.io`.

```
error: Failed to generate package metadata for `fred-capability-html-artifact==0.1.0 @ editable+../../libs/fred-capability-html-artifact`
  Caused by: Distribution not found at: file:///workspace/libs/fred-capability-html-artifact
make: *** [python-deps.mk:11: /app/target/.compiled] Error 2
```

`fred-capability-html-artifact` (#2478) was registered as an editable path dependency of `fred-agents`, but never added to the two places that have to know about it. The same failure had already hit the `swift` push build on the preceding commit.

## Fix

- **`apps/fred-agents/dockerfiles/Dockerfile-prod`** — the Dockerfile copies each capability tree in by name; `html-artifact` was missing from both the builder and the runtime stage. The other three packages were all there.
- **`.github/workflows/Check-pending-requests.yml`** — code-quality and backend tests run off a per-directory matrix that had no entry for the package, so its unit tests have never run on a pull request. Adds the change filter, both job gates, and the two matrix entries, matching how `fred-capability-platform-ops` is wired.

## Verification

Built the exact image that failed, and confirmed the capability registers inside it:

```
$ docker build -f apps/fred-agents/dockerfiles/Dockerfile-prod -t fred-agents:verify .
=> naming to docker.io/library/fred-agents:verify

$ docker run --rm --entrypoint /app/venv/bin/python fred-agents:verify -c "..."
fred.capabilities: [..., 'document_similarity', 'html_artifact', 'platform_postgres', 'ppt_filler', 'writable_document']
OK
```

## Why CI did not catch this

`Build-and-push-docker.yml` triggers on `push` to `swift` and on `code/v*` tags only — there is **no `pull_request` trigger**, so no PR ever builds an image. A Dockerfile that cannot resolve its dependencies is invisible until it is already merged.

Worth deciding separately (not in this PR): whether to add a build-only (no push) image job to the PR workflow. Two related gaps also left alone here to keep this change single-purpose — `fred-capability-writable-document` and `fred-capability-ppt-filler` are in the root Makefile's `TEST_DIRS` but likewise absent from the CI matrix.