### PR TITLE
ci: build every Dockerfile on pull requests from a single image manifest

### DIFF
--- a/.github/docker-images.json
+++ b/.github/docker-images.json
@@ -1,0 +1,53 @@
+{
+  "images": [
+    {
+      "name": "fred-agents",
+      "context": ".",
+      "dockerfile": "apps/fred-agents/dockerfiles/Dockerfile-prod",
+      "build_args": "",
+      "publish": true
+    },
+    {
+      "name": "knowledge-flow-backend",
+      "context": ".",
+      "dockerfile": "apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod",
+      "build_args": "PRODUCTION_FASTAPI_DOCS_ENABLED=false",
+      "publish": true
+    },
+    {
+      "name": "control-plane-backend",
+      "context": ".",
+      "dockerfile": "apps/control-plane-backend/dockerfiles/Dockerfile-prod",
+      "build_args": "PRODUCTION_FASTAPI_DOCS_ENABLED=false",
+      "publish": true
+    },
+    {
+      "name": "frontend",
+      "context": ".",
+      "dockerfile": "apps/frontend/dockerfiles/Dockerfile-prod",
+      "build_args": "",
+      "publish": true
+    },
+    {
+      "name": "ws-bench",
+      "context": "developer_tools/benchmarks",
+      "dockerfile": "developer_tools/benchmarks/Dockerfile",
+      "build_args": "",
+      "publish": false
+    }
+  ],
+  "excluded": [
+    {
+      "dockerfile": ".devcontainer/Dockerfile-devcontainer",
+      "reason": "Copies nothing from the repo but .devcontainer/scripts/, so no change under apps/ or libs/ can break it. Its build time is dominated by third-party downloads (nodesource, github releases, astral.sh) that would make a required PR gate slow and flaky."
+    },
+    {
+      "dockerfile": "apps/frontend/dockerfiles/Dockerfile-dev",
+      "reason": "Stale: copies frontend/ and scripts/ from a pre-monorepo layout, so it cannot build from any context. Its only consumer, deploy/docker-compose/docker-compose.yml, points at an equally stale path. Delete or repair, then move it to images."
+    },
+    {
+      "dockerfile": "apps/knowledge-flow-backend/dockerfiles/Dockerfile-dev",
+      "reason": "Stale: puts scripts/ at /app/scripts and the project at /app/knowledge-flow-backend, so the Makefile include ../../scripts/makefiles/config/INFO-knowledge-flow.mk misses and make dev fails. It also lays fred-core out at /app/fred-core while pyproject.toml resolves it at ../../libs/fred-core. Delete or repair, then move it to images."
+    }
+  ]
+}

--- a/.github/workflows/Build-and-push-docker.yml
+++ b/.github/workflows/Build-and-push-docker.yml
@@ -8,78 +8,18 @@ on:
 env:
   REGISTRY: ghcr.io
   REGISTRY_NAMESPACE: thalesgroup/fred-agent
-  PRODUCTION_FASTAPI_DOCS_ENABLED: "false"
 
 jobs:
+  # The image list, contexts and build args live in .github/docker-images.json
+  # and are built by the reusable workflow — the same one every pull request
+  # runs with publish: false.
   build-and-push:
-    runs-on: ubuntu-latest
-    #if: github.ref_type == 'tag' && github.event.base_ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      # matrix will trigger the creation of a different parallel job for each case
-      matrix:
-        include:
-          - name: fred-agents
-            context: .
-            dockerfile: ./apps/fred-agents/dockerfiles/Dockerfile-prod
-            image: fred-agents
-          - name: knowledge-flow-backend
-            context: ./
-            dockerfile: ./apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod
-            image: knowledge-flow-backend
-          - name: control-plane-backend
-            context: .
-            dockerfile: ./apps/control-plane-backend/dockerfiles/Dockerfile-prod
-            image: control-plane-backend
-          - name: frontend
-            context: .
-            dockerfile: ./apps/frontend/dockerfiles/Dockerfile-prod
-            image: frontend
-
-    # what each job will play
-
-    steps:
-      # For those preconfigured github actions, look here https://github.com/marketplace?type=actions
-      - name: Check out the repo
-        uses: actions/checkout@v5
-
-      - name: Login to Github Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # the next step define an "meta" variable
-      # containing the image path with associated tags
-      # Here only one tag : oci://registry/image:tag
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
-          tags: |
-            type=match,enable=${{ startsWith(github.ref, 'refs/tags/code/v') }},pattern=code/(v.*),group=1
-            type=raw,enable=${{ github.ref == 'refs/heads/swift' }},value=swift-dev
-            type=sha,enable=${{ github.ref == 'refs/heads/swift' }},prefix=swift-dev-,format=short
-
-      # Release tags keep the semver contract. Swift branch pushes publish
-      # dev images under dedicated tags so they never collide with main-line
-      # release automation.
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          build-args: |
-            PRODUCTION_FASTAPI_DOCS_ENABLED=${{ env.PRODUCTION_FASTAPI_DOCS_ENABLED }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }} # oci://<registry>/<image>:<version>
-          labels: ${{ steps.meta.outputs.labels }} # many various informations
+    uses: ./.github/workflows/Docker-images.yml
+    with:
+      publish: true
 
   create-release:
     needs: build-and-push

--- a/.github/workflows/Check-docker-images.yml
+++ b/.github/workflows/Check-docker-images.yml
@@ -1,0 +1,18 @@
+name: Check docker images
+
+# No paths filter on purpose: an image breaks from far outside its own directory
+# — a libs/ package added as a path dependency but never COPYed is exactly the
+# release-blocking bug this gate exists to catch.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-images:
+    uses: ./.github/workflows/Docker-images.yml
+    with:
+      publish: false

--- a/.github/workflows/Docker-images.yml
+++ b/.github/workflows/Docker-images.yml
@@ -1,0 +1,134 @@
+name: Docker images
+
+# Reusable: one definition of how every image in .github/docker-images.json is
+# built. Callers pass publish=false for a pre-merge check, publish=true to
+# release. Nothing else may hold a second copy of the image list.
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Push to the registry. Build-only (no login, no credentials) when false."
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_NAMESPACE: thalesgroup/fred-agent
+
+jobs:
+  resolve:
+    name: Resolve image matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.include }}
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      # A Dockerfile nobody listed is a Dockerfile nobody builds — that is how a
+      # missing COPY line reached a release tag. Adding one must be a conscious
+      # "build it" or "here is why not", never a silent omission.
+      - name: Every Dockerfile is accounted for
+        run: |
+          set -euo pipefail
+          manifest=.github/docker-images.json
+          failed=0
+
+          mapfile -t discovered < <(find . \
+            -type d \( -name .git -o -name node_modules -o -name .venv \) -prune -o \
+            -type f \( -name 'Dockerfile*' -o -name '*.Dockerfile' \) -print |
+            sed 's|^\./||' | sort)
+
+          # A discovery step that finds nothing would pass this guard vacuously,
+          # which is the very failure mode it exists to prevent.
+          if [ "${#discovered[@]}" -eq 0 ]; then
+            echo "::error file=$manifest::Found no Dockerfile at all. Discovery is broken, not the repository."
+            exit 1
+          fi
+          echo "Discovered ${#discovered[@]} Dockerfiles."
+
+          for dockerfile in "${discovered[@]}"; do
+            if ! jq -e --arg d "$dockerfile" '[.images[], .excluded[]] | any(.dockerfile == $d)' "$manifest" > /dev/null; then
+              echo "::error file=$dockerfile::Not listed in $manifest. Add it to .images so every pull request builds it, or to .excluded with a reason."
+              failed=1
+            fi
+          done
+
+          for dockerfile in $(jq -r '[.images[], .excluded[]] | .[].dockerfile' "$manifest"); do
+            if [ ! -f "$dockerfile" ]; then
+              echo "::error file=$manifest::Lists $dockerfile, which no longer exists. Remove or rename the entry."
+              failed=1
+            fi
+          done
+
+          exit $failed
+
+      - name: Build the matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          include=$(jq -c --argjson publish ${{ inputs.publish }} \
+            '[.images[] | select(($publish | not) or .publish)]' \
+            .github/docker-images.json)
+          echo "include=$include" >> "$GITHUB_OUTPUT"
+          echo "$include" | jq -r '.[] | "\(.name)\t\(.dockerfile)"'
+
+  build:
+    name: ${{ inputs.publish && 'Push' || 'Build' }} ${{ matrix.name }}
+    needs: resolve
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      # Only the pre-merge path needs it: the gha cache exporter requires the
+      # docker-container driver, and the publish path keeps the plain default
+      # builder it has always released from.
+      - name: Set up Docker Buildx
+        if: ${{ !inputs.publish }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Container Registry
+        if: inputs.publish
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Release tags keep the semver contract. Swift branch pushes publish
+      # dev images under dedicated tags so they never collide with main-line
+      # release automation.
+      - name: Extract metadata
+        id: meta
+        if: inputs.publish
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.name }}
+          tags: |
+            type=match,enable=${{ startsWith(github.ref, 'refs/tags/code/v') }},pattern=code/(v.*),group=1
+            type=raw,enable=${{ github.ref == 'refs/heads/swift' }},value=swift-dev
+            type=sha,enable=${{ github.ref == 'refs/heads/swift' }},prefix=swift-dev-,format=short
+
+      # Pre-merge builds read and write the Actions cache to stay affordable.
+      # The publish path stays uncached so a released image never reuses layers
+      # built from an unmerged branch.
+      - name: Build${{ inputs.publish && ' and push' || '' }} Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          build-args: ${{ matrix.build_args }}
+          push: ${{ inputs.publish }}
+          tags: ${{ steps.meta.outputs.tags }} # oci://<registry>/<image>:<version>
+          labels: ${{ steps.meta.outputs.labels }} # many various informations
+          cache-from: ${{ inputs.publish && '' || format('type=gha,scope={0}', matrix.name) }}
+          cache-to: ${{ inputs.publish && '' || format('type=gha,mode=max,scope={0}', matrix.name) }}


### PR DESCRIPTION
Closes #2489. Stacks on #2487, which is already merged into `swift` — this branch is cut from the merged `swift` head, so there is nothing to wait for.

## The problem

The v2.1.39 release build failed and published no images:

```
error: Failed to generate package metadata for `fred-capability-html-artifact==0.1.0 @ editable+../../libs/fred-capability-html-artifact`
  Caused by: Distribution not found at: file:///workspace/libs/fred-capability-html-artifact
```

`libs/fred-capability-html-artifact` was added as an editable path dependency of `apps/fred-agents` but never added to the explicit `COPY` list in `apps/fred-agents/dockerfiles/Dockerfile-prod`. #2487 fixed that one line.

This PR fixes the reason it reached `swift` at all. `Build-and-push-docker.yml` triggers only on `push` to `swift` and on `code/v*` tags; **no `pull_request` trigger anywhere built a container**. The first time a Dockerfile was compiled was on the release tag — the worst possible moment to find out it is broken.

There is a second defect underneath: the image list was hand-maintained inside the release workflow's matrix, and this incident *is* that list drifting out of sync with reality. Adding a `pull_request` copy of the same matrix would have reproduced the drift, in two places instead of one.

## The design

One manifest, `.github/docker-images.json`, holds every image's name, context, dockerfile and build args. One reusable workflow, `Docker-images.yml`, reads it and builds. Two callers:

| Caller | Trigger | `publish` |
| --- | --- | --- |
| `Check-docker-images.yml` (new) | `pull_request` | `false` — build only, no login, no credentials |
| `Build-and-push-docker.yml` (existing) | push to `swift`, `code/v*` tags | `true` |

A `resolve` job reads the manifest, filters it by `publish`, and emits the matrix via `fromJSON`. Before emitting, it **fails when a Dockerfile exists that the manifest neither builds nor explicitly excludes** — and also when the manifest names a file that no longer exists. Adding a Dockerfile is now a conscious "build it" or "here is why not"; it can no longer be a silent omission. The guard also refuses to pass if discovery finds zero Dockerfiles, since a guard that can vacuously succeed is the same bug in a new hat.

### Alternatives weighed

- **A composite action.** Rejected: a matrix is job-level, so a composite action cannot hold the image list. The one thing that actually needed to be DRY would have stayed duplicated.
- **Full auto-discovery, no manifest.** Rejected as the sole mechanism: each image needs its own context (`.` for the four apps, `developer_tools/benchmarks` for `ws-bench`) and two need a build arg, and three of the eight Dockerfiles in the tree cannot be built at all. Discovery alone would either guess wrong or wedge the gate. Keeping discovery as a *guard* over a declared manifest gets the drift-detection benefit without the guessing.
- **Duplicating the matrix into a second workflow.** Rejected: that is the failure being fixed.

## Coverage

Built on every pull request:

| Image | Context | Dockerfile | Published on release |
| --- | --- | --- | --- |
| `fred-agents` | `.` | `apps/fred-agents/dockerfiles/Dockerfile-prod` | yes |
| `knowledge-flow-backend` | `.` | `apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod` | yes |
| `control-plane-backend` | `.` | `apps/control-plane-backend/dockerfiles/Dockerfile-prod` | yes |
| `frontend` | `.` | `apps/frontend/dockerfiles/Dockerfile-prod` | yes |
| `ws-bench` | `developer_tools/benchmarks` | `developer_tools/benchmarks/Dockerfile` | no — built, never pushed |

`ws-bench` is new coverage: it was in nobody's matrix before. The `publish` flag lets the pre-merge gate cover more than the release publishes, without adding a fifth image to the registry.

### Excluded, explicitly

Each of these is a visible entry in the manifest with its reason, and the guard forces them to stay listed:

- **`.devcontainer/Dockerfile-devcontainer`** — copies nothing from the repo except `.devcontainer/scripts/`, so no change under `apps/` or `libs/` can break it; the only changes that can are visible in the diff. Its build time is dominated by third-party downloads (nodesource, GitHub releases, astral.sh) that would make a required gate slow and flaky. Excluded on cost/benefit, not oversight.
- **`apps/frontend/dockerfiles/Dockerfile-dev`** — **already broken.** It copies `frontend/` and `scripts/` from a pre-monorepo layout, so it cannot build from any context. Verified:
  ```
  #8 [5/8] COPY --chown=1000:1000 frontend/ /app/
  #8 ERROR: failed to calculate checksum of ref ...: "/frontend": not found
  ```
  Its only consumer, `deploy/docker-compose/docker-compose.yml`, points at an equally stale path (`frontend/dockerfiles/Dockerfile-dev`, and an `agentic-backend/` directory that no longer exists).
- **`apps/knowledge-flow-backend/dockerfiles/Dockerfile-dev`** — **also already broken.** Verified:
  ```
  #16 [12/15] RUN make dev
  #16 0.198 Makefile:1: ../../scripts/makefiles/config/INFO-knowledge-flow.mk: No such file or directory
  #16 0.198 make: *** No rule to make target '../../scripts/makefiles/config/INFO-knowledge-flow.mk'.  Stop.
  ```

Both dev images look like deletion candidates rather than repair candidates, but deleting them is a separate change and does not belong in this one. The manifest records why they are out, so whoever picks that up has the diagnosis already.

## The release path is unchanged

This was the risky half of making it DRY, so here is what was checked line by line against the previous file:

- **Triggers** — untouched: `push` to `swift`, `code/v*` tags.
- **Job id** — still `build-and-push`, so `create-release`'s `needs: build-and-push` still resolves. `create-release` itself is byte-identical, and the workflow keeps its top-level `REGISTRY` / `REGISTRY_NAMESPACE` that the release body interpolates.
- **Permissions** — `contents: read` + `packages: write` moved onto the calling job, which is how a reusable workflow receives them. The reusable workflow declares none of its own, so the pull-request caller can grant `contents: read` alone without a permissions conflict.
- **Registry, login, metadata** — identical `docker/login-action@v4`, identical namespace, and the `Extract metadata` tag block copied verbatim. The `github` context in a reusable workflow is the caller's, so `startsWith(github.ref, 'refs/tags/code/v')` and `github.ref == 'refs/heads/swift'` evaluate exactly as before. `matrix.image` became `matrix.name` because the two were equal for all four images.
- **Matrix** — the four published entries are the same four, in the same order. `context: ./` vs `.` and `./apps/…` vs `apps/…` are the same paths. Verified mechanically:
  ```
  --- matrix publish=true ---
  ["fred-agents","knowledge-flow-backend","control-plane-backend","frontend"]
  --- old release matrix ---
  ["fred-agents","knowledge-flow-backend","control-plane-backend","frontend"]
  ```
- **Build args** — `PRODUCTION_FASTAPI_DOCS_ENABLED=false` used to be passed to all four images; only `control-plane-backend` and `knowledge-flow-backend` declare that `ARG`. It now goes to exactly those two. The other two never consumed it, so the images are identical.
- **Builder and cache** — the publish path still uses the runner's default builder with no cache, exactly as before. `setup-buildx-action` and the `type=gha` cache are gated on `!inputs.publish`, because the gha cache exporter needs the `docker-container` driver and there is no reason to change the driver a release is built with. A published image also never reuses layers built from an unmerged branch.

The one genuinely new behaviour on the release path: `resolve` now gates `build`, so a manifest that lists a deleted Dockerfile would stop a release. That is deterministic `find` + `jq`, and it is the point of the guard.

## CI cost

No `paths` filter, on purpose. This bug was a change under `libs/` breaking an image under `apps/` — any filter narrow enough to skip a docs-only PR is wide enough to recreate exactly the blind spot being closed. Instead the cost is kept down by running the five images in parallel and giving the pre-merge path a per-image `type=gha` cache scope.

Known limitation, stated rather than hidden: Actions caches are branch-scoped, and this workflow never runs on a push to `swift`, so the first build on a new pull request is cold; subsequent pushes to the same PR are warm. Warming from `swift` would mean adding `cache-to` to the release path, which is a change to the release build that this PR deliberately does not make.

## Verification

**Every Dockerfile in the manifest was actually built locally**, driven straight from `.github/docker-images.json` so the context, dockerfile and build args under test are the exact fields the workflow uses:

```
=== BUILD fred-agents (context=. file=apps/fred-agents/dockerfiles/Dockerfile-prod args='') ===
PASS fred-agents (101s)
=== BUILD knowledge-flow-backend (context=. file=apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod args='PRODUCTION_FASTAPI_DOCS_ENABLED=false') ===
PASS knowledge-flow-backend (311s)
=== BUILD control-plane-backend (context=. file=apps/control-plane-backend/dockerfiles/Dockerfile-prod args='PRODUCTION_FASTAPI_DOCS_ENABLED=false') ===
PASS control-plane-backend (54s)
=== BUILD frontend (context=. file=apps/frontend/dockerfiles/Dockerfile-prod args='') ===
PASS frontend (58s)
=== BUILD ws-bench (context=developer_tools/benchmarks file=developer_tools/benchmarks/Dockerfile args='') ===
PASS ws-bench (24s)
=== DONE ===
```

Cold and sequential that is about 9 minutes; in CI the five run in parallel, so wall time is roughly the slowest one.

**YAML/JSON all parse:**

```
YAML OK  .github/workflows/Docker-images.yml
YAML OK  .github/workflows/Build-and-push-docker.yml
YAML OK  .github/workflows/Check-docker-images.yml
JSON OK  .github/docker-images.json
```

**`act` really ran the `resolve` job** (not a dry run) and it emitted the right matrix:

```
[Docker images/Resolve image matrix]   | Discovered 8 Dockerfiles.
[Docker images/Resolve image matrix]   ✅  Success - Main Every Dockerfile is accounted for
[Docker images/Resolve image matrix]   | fred-agents	apps/fred-agents/dockerfiles/Dockerfile-prod
[Docker images/Resolve image matrix]   | knowledge-flow-backend	apps/knowledge-flow-backend/dockerfiles/Dockerfile-prod
[Docker images/Resolve image matrix]   | control-plane-backend	apps/control-plane-backend/dockerfiles/Dockerfile-prod
[Docker images/Resolve image matrix]   | frontend	apps/frontend/dockerfiles/Dockerfile-prod
[Docker images/Resolve image matrix]   | ws-bench	developer_tools/benchmarks/Dockerfile
[Docker images/Resolve image matrix] 🏁  Job succeeded
```

`act pull_request --list` resolves the new job alongside the existing pull-request workflows. `act pull_request -n` walks the caller into the reusable workflow and passes every step of `resolve`, then stops at `Error while evaluating matrix: Invalid JSON` — a dry run never executes the step that produces `resolve`'s output, so `fromJSON('')` has nothing to parse. That is an `act` dry-run limitation, not a workflow defect; GitHub evaluates the matrix after `resolve` has really run, which is the path exercised above.

**The guard was tested in both directions**, not just the passing one:

- Passing: all 8 Dockerfiles matched, all 8 manifest entries exist on disk, exit 0.
- Adding an unlisted `libs/fred-core/Dockerfile-fake` → `::error file=libs/fred-core/Dockerfile-fake::Not listed in .github/docker-images.json`, exit 1.
- Adding an unlisted `libs/fred-core/x/prod.Dockerfile` (the other naming convention) → caught too, exit 1.

The first `act` run is what caught a real bug in this PR: the guard originally discovered Dockerfiles with `git ls-files`, which printed `fatal: not a git repository` and then **passed with zero files discovered**. It is now a `find` that does not need git, plus an explicit refusal to pass on an empty discovery.

## Note for whoever merges

`swift`'s branch protection currently has no required status checks (`contexts: []`, `checks: []`), so this gate will report but will not block a merge until `Check docker images / Build …` is added to the required list. Worth doing — the whole point is that it blocks.


## Verification on real CI

This PR's own run of the new gate ([run 33536699550](https://github.com/ThalesGroup/fred/actions/runs/33536699550)) — **all green**:

```
docker-images / Resolve image matrix: success (0.1 min)
docker-images / Build fred-agents: success (2.5 min)
docker-images / Build control-plane-backend: success (4 min)
docker-images / Build frontend: success (4.6 min)
docker-images / Build knowledge-flow-backend: success (21.7 min)
docker-images / Build ws-bench: success (0.8 min)
run conclusion: success — 21.9 min wall clock
```

The build-only contract holds on the real runner. Step list from `Build ws-bench`:

```
2. Check out the repo: success
3. Set up Docker Buildx: success
4. Login to Github Container Registry: skipped
5. Extract metadata: skipped
6. Build Docker image: success
```

No login, no metadata, no credentials, and the step is named `Build Docker image` rather than `Build and push` — the `publish` input gates all three as intended.

The Actions cache is really being written, with the per-image scope in effect:

```
$ gh api "repos/:owner/:repo/actions/caches?ref=refs/pull/2490/merge"
index-ws-bench-1-105c624c#1  6861 bytes
buildkit-blob-1-sha256:cc6ab78e...  21724050 bytes
buildkit-blob-1-sha256:afa154b4...  69364787 bytes
...
```

CodeQL's `Analyze (actions)` also passes over the new workflow files.

### Cost, stated plainly

`knowledge-flow-backend` is the long pole at **21.7 min cold** — it installs libreoffice and a large dependency tree — and it sets the gate's wall clock, since the other four finish in under 5 minutes each. The other four plus `resolve` are cheap. Pushes after the first on the same PR hit the warm cache. If 22 minutes proves too slow in practice the lever is that one image, not the design; nothing about the manifest changes.

### One pre-existing warning surfaced, not introduced

`docker/setup-buildx-action@v3` targets Node 20 and the runner now forces Node 24, so every build job carries a deprecation annotation. It is a warning from the upstream action, it does not fail anything, and it only appears on the pre-merge path (the publish path does not run that action). Left alone here rather than pinned to a newer SHA, which would be a different change.
