### PR TITLE
fix(#2492): docker-images build & push CI  fails due to a wrong cache condition

### DIFF
--- a/.github/workflows/Docker-images.yml
+++ b/.github/workflows/Docker-images.yml
@@ -130,5 +130,8 @@ jobs:
           push: ${{ inputs.publish }}
           tags: ${{ steps.meta.outputs.tags }} # oci://<registry>/<image>:<version>
           labels: ${{ steps.meta.outputs.labels }} # many various informations
-          cache-from: ${{ inputs.publish && '' || format('type=gha,scope={0}', matrix.name) }}
-          cache-to: ${{ inputs.publish && '' || format('type=gha,mode=max,scope={0}', matrix.name) }}
+          # The empty string is falsy in expressions, so it has to sit on the
+          # falsy side: `publish && '' || format(...)` returns the format branch
+          # for both values of publish and asks a driver-less builder to export.
+          cache-from: ${{ !inputs.publish && format('type=gha,scope={0}', matrix.name) || '' }}
+          cache-to: ${{ !inputs.publish && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}


### PR DESCRIPTION
Closes #2492.

`Build and Push Docker Images` has failed on every image since the image manifest
landed on `swift`, with `Cache export is not supported for the docker driver`.
Nothing has been pushed to ghcr since.

The publish path deliberately skips `Set up Docker Buildx` and builds on the
default `docker` builder, but the cache inputs read:

```yaml
cache-from: ${{ inputs.publish && '' || format('type=gha,scope={0}', matrix.name) }}
```

The empty string is falsy in Actions expressions, so `true && ''` yields `''`,
the `||` discards it, and the `format(...)` branch is returned for both values of
`publish`. Every build asked for the gha cache exporter; only the pre-merge path
had a builder able to provide it.

Moving the empty string to the falsy side restores the documented behaviour:
pull requests build cached on the container driver, publish builds uncached on
the default builder.

## Verification

- `Check docker images` on this PR exercises the `publish: false` path - it must
  still build all four images with the gha cache.
- The `publish: true` path can only be exercised by a push to `swift`, so the
  merge itself is the check: `Build and Push Docker Images` must go green and
  push the four `swift-dev` tags.