### PR TITLE
refactor(#2497): mindmap reads documents through document_markdown

### DIFF
--- a/apps/fred-agents/fred_agents/mindmap/README.md
+++ b/apps/fred-agents/fred_agents/mindmap/README.md
@@ -19,8 +19,8 @@ flowchart TD
 ## What it does
 
 - Uses the Fred **Documents** picker and reads `runtime_context.selected_document_uids`
-- Reads each selected document through bounded Knowledge Flow filesystem pagination
-  on `/corpus/documents/{document_uid}/preview.md`
+- Reads each selected document through the bounded `document_markdown` port,
+  paginating on characters by document uid
 - Summarizes transcript pages incrementally instead of concatenating full
   document previews into one prompt
 - Merges page summaries into a global digest that preserves concrete transcript
@@ -34,7 +34,7 @@ flowchart TD
 ## Runtime dependencies
 
 - `MCP_SERVER_KNOWLEDGE_FLOW_TEXT`
-- `MCP_SERVER_KNOWLEDGE_FLOW_FS`
+- the `document_markdown` runtime port (`context.services.document_markdown`)
 
 `knowledge.search` is kept only as an explicit fallback path and is disabled by
 default. The normal mode is strict selected-document reading.
@@ -44,8 +44,8 @@ default. The normal mode is strict selected-document reading.
 1. The user selects one or more transcript/script documents with the
    **Documents** picker.
 2. The runtime passes those ids in `selected_document_uids`.
-3. The agent reads the selected document previews page by page with
-   `read_file_page`.
+3. The agent reads each selected document page by page through
+   `document_markdown`, deriving `Lx-Ly` segment labels from the returned text.
 4. The agent summarizes pages, merges the summaries into one digest, and
    generates the final mindmap with concrete transcript branches instead of
    generic labels whenever the source supports them.

--- a/apps/fred-agents/fred_agents/mindmap/graph_agent.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_agent.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from fred_core.store import VectorSearchHit
 from fred_sdk import (
-    MCP_SERVER_KNOWLEDGE_FLOW_FS,
     MCP_SERVER_KNOWLEDGE_FLOW_TEXT,
     TOOL_REF_KNOWLEDGE_SEARCH,
     FieldSpec,
@@ -61,14 +60,8 @@ class MindmapGraphAgent(GraphAgent):
         "knowledge-flow",
     )
 
-    # Filesystem is a functional dependency here (unlike general/deep assistant,
-    # which dropped it — #2334): the graph steps read picker-selected documents
-    # via bounded `read_file_page` calls, code-driven rather than LLM-steered.
-    # Still subject to the /fs team-scoping gap (AGENT-FILESYSTEM-HARDENING-RFC
-    # F1) until the runtime principal lands; admission remains admin-gated.
     default_mcp_servers: tuple[MCPServerRef, ...] = (
         MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_TEXT),
-        MCPServerRef(id=MCP_SERVER_KNOWLEDGE_FLOW_FS),
     )
 
     declared_tool_refs: tuple[ToolRefRequirement, ...] = (
@@ -100,16 +93,6 @@ class MindmapGraphAgent(GraphAgent):
                 "the Documents picker before generating a mindmap."
             ),
             default=True,
-            ui=UIHints(group="Document reading"),
-        ),
-        FieldSpec(
-            key="settings.page_line_limit",
-            type="integer",
-            title="Page line limit",
-            description="Maximum number of document lines read per paginated call.",
-            default=120,
-            min=20,
-            max=500,
             ui=UIHints(group="Document reading"),
         ),
         FieldSpec(

--- a/apps/fred-agents/fred_agents/mindmap/graph_state.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_state.py
@@ -23,14 +23,13 @@ class MindmapInput(BaseModel):
 
 class DocumentPage(BaseModel):
     document_uid: str
-    path: str
     page_index: int
+    # Line bounds are derived while paging: `document_markdown` windows on
+    # characters, and the digest labels segments as `Lx-Ly`.
     start_line: int | None = None
     end_line: int | None = None
-    total_lines: int | None = None
     has_more: bool = False
     next_offset: int | None = None
-    truncated: bool = False
     content: str = ""
 
 

--- a/apps/fred-agents/fred_agents/mindmap/graph_steps.py
+++ b/apps/fred-agents/fred_agents/mindmap/graph_steps.py
@@ -91,39 +91,6 @@ def _as_text(value: object) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
-def _coerce_text(value: object) -> str:
-    """
-    Convert a payload field to plain text without raising validation errors.
-
-    Why this exists:
-    - runtime tool payloads may be dicts, Pydantic models, or partial objects
-    - document-page parsing should stay defensive at the adapter boundary
-
-    How to use it:
-    - pass one raw field value from a runtime tool response
-    - receive a string or the empty string when the field is not text
-    """
-
-    return value if isinstance(value, str) else ""
-
-
-def _coerce_int(value: object) -> int | None:
-    """
-    Convert a payload field to an integer when possible.
-
-    Why this exists:
-    - filesystem pagination metadata should stay typed once it enters graph
-      state
-    - callers should not need repeated `isinstance` checks for every field
-
-    How to use it:
-    - pass one raw runtime-tool field
-    - receive an integer or `None` when the value is missing or invalid
-    """
-
-    return int(value) if isinstance(value, int | float) else None
-
-
 def _runtime_context_selected_uids(context: GraphNodeContext) -> list[str]:
     """
     Read the selected document uids from the bound runtime context.
@@ -232,36 +199,16 @@ def _allow_search_fallback(context: GraphNodeContext) -> bool:
     return _as_bool(context.tuning_values.get("settings.allow_search_fallback"), False)
 
 
-def _page_line_limit(context: GraphNodeContext) -> int:
-    """
-    Resolve the bounded filesystem line limit for one page read.
-
-    Why this exists:
-    - page size should be operator-tunable but still clamped to backend-safe
-      bounds
-    - every paginated read should use the same resolved limit
-
-    How to use it:
-    - call before invoking `read_file_page`
-    - the result is always between 20 and 500 lines
-    """
-
-    return max(
-        20,
-        min(500, _as_int(context.tuning_values.get("settings.page_line_limit"), 120)),
-    )
-
-
 def _page_max_chars(context: GraphNodeContext) -> int:
     """
     Resolve the bounded character budget for one page read.
 
     Why this exists:
     - large transcript pages must stay bounded before entering the model path
-    - the filesystem contract already exposes a safe upper bound we can mirror
+    - the port takes the same character budget, so one resolved value drives it
 
     How to use it:
-    - call before invoking `read_file_page`
+    - call before reading a page through `document_markdown`
     - the result is always between 4,000 and 50,000 characters
     """
 
@@ -526,33 +473,6 @@ def _line_range(page: DocumentPage) -> str:
     if page.end_line is None:
         return f"L{page.start_line}-L?"
     return f"L{page.start_line}-L{page.end_line}"
-
-
-def _normalize_page_payload(payload: object) -> dict[str, object]:
-    """
-    Normalize one runtime-tool page payload to a plain mapping.
-
-    Why this exists:
-    - `invoke_runtime_tool` may return dicts, Pydantic models, or similar
-      objects depending on runtime plumbing
-    - page parsing should work from one consistent mapping shape
-
-    How to use it:
-    - pass the raw result from `context.invoke_runtime_tool(...)`
-    - receive a best-effort `dict[str, object]`
-    """
-
-    if isinstance(payload, BaseModel):
-        return payload.model_dump(mode="python")
-    if hasattr(payload, "model_dump"):
-        model_dump = getattr(payload, "model_dump")
-        if callable(model_dump):
-            dumped = model_dump(mode="python")
-            if isinstance(dumped, dict):
-                return dumped
-    if isinstance(payload, dict):
-        return dict(payload)
-    return {}
 
 
 def _pseudo_hit_from_summary(summary: DocumentSegmentSummary) -> VectorSearchHit:
@@ -936,54 +856,56 @@ async def read_document_pages(
     context: GraphNodeContext,
     document_uid: str,
     *,
-    page_line_limit: int,
     page_max_chars: int,
     max_pages: int,
 ) -> list[DocumentPage]:
     """
-    Read one selected document through bounded filesystem pagination.
+    Read one selected document through the bounded `document_markdown` port.
 
     Why this exists:
     - exhaustive transcript coverage needs sequential reads instead of vector
       relevance sampling
-    - the helper centralizes pagination normalization and stop conditions
+    - the port paginates on characters, so line numbers are tracked here to keep
+      the `Lx-Ly` segment labels the digest and the coverage notes read
 
     How to use it:
     - pass the graph context plus one selected document uid and read bounds
     - continue summarization from the returned ordered page list
     """
 
-    path = f"/corpus/documents/{document_uid}/preview.md"
+    port = context.services.document_markdown
+    if port is None:
+        raise RuntimeError(
+            "The document_markdown port is required to read selected documents"
+        )
+
     pages: list[DocumentPage] = []
     offset = 0
+    lines_before = 0
 
     for page_index in range(max_pages):
-        raw_page = await context.invoke_runtime_tool(
-            "read_file_page",
-            {
-                "path": path,
-                "offset": offset,
-                "limit": page_line_limit,
-                "max_chars": page_max_chars,
-            },
+        result = await port.fetch_markdown(
+            document_uid,
+            offset=offset,
+            max_chars=page_max_chars,
         )
-        payload = _normalize_page_payload(raw_page)
+        text = result.text
+        newlines = text.count("\n")
+        # A window can end mid-line: that partial line is still the last one this
+        # page shows, so it counts for the label but not for the running total.
+        ends_mid_line = bool(text) and not text.endswith("\n")
         page = DocumentPage(
             document_uid=document_uid,
-            path=_coerce_text(payload.get("path")) or path,
             page_index=page_index,
-            start_line=_coerce_int(payload.get("start_line")),
-            end_line=_coerce_int(payload.get("end_line")),
-            total_lines=_coerce_int(payload.get("total_lines")),
-            has_more=_as_bool(payload.get("has_more"), False),
-            next_offset=_coerce_int(payload.get("next_offset")),
-            truncated=_as_bool(payload.get("truncated"), False),
-            content=_coerce_text(payload.get("content")).strip(),
+            start_line=lines_before + 1,
+            end_line=lines_before + newlines + (1 if ends_mid_line else 0),
+            has_more=result.next_offset is not None,
+            next_offset=result.next_offset,
+            content=text.strip(),
         )
         pages.append(page)
+        lines_before += newlines
 
-        if not page.has_more:
-            break
         if page.next_offset is None:
             break
         offset = page.next_offset
@@ -1290,7 +1212,6 @@ async def read_selected_documents_step(
     segment_summaries: list[DocumentSegmentSummary] = []
     source_refs: list[dict[str, object]] = []
     coverage_warnings = list(state.coverage_warnings)
-    page_line_limit = _page_line_limit(context)
     page_max_chars = _page_max_chars(context)
     max_pages = _max_pages_per_document(context)
 
@@ -1299,7 +1220,6 @@ async def read_selected_documents_step(
             pages = await read_document_pages(
                 context,
                 document_uid,
-                page_line_limit=page_line_limit,
                 page_max_chars=page_max_chars,
                 max_pages=max_pages,
             )
@@ -1332,10 +1252,6 @@ async def read_selected_documents_step(
         for page in pages:
             if not page.content:
                 continue
-            if page.truncated:
-                coverage_warnings.append(
-                    f"Document `{document_uid}` segment {_line_range(page)} was truncated by filesystem bounds."
-                )
             summary = await _summarize_document_page(context, page)
             segment_summaries.append(summary)
             source_refs.append(_pseudo_hit_from_summary(summary).model_dump())

--- a/apps/fred-agents/tests/test_mindmap_graph.py
+++ b/apps/fred-agents/tests/test_mindmap_graph.py
@@ -30,6 +30,43 @@ from fred_agents.mindmap.graph_steps import (
     resolve_selected_documents_step,
 )
 from fred_sdk import GraphNodeContext, load_agent_prompt_markdown
+from fred_sdk.contracts.runtime import DocumentMarkdownResult
+
+
+class _FakeMarkdownPort:
+    """
+    Character-paginated `document_markdown` stand-in.
+
+    Serves the configured page texts in order and chains `next_offset` on real
+    character counts, so the step under test derives its line bounds from the
+    same arithmetic a live port would produce.
+    """
+
+    def __init__(self, pages: list[str]) -> None:
+        self._pages = list(pages)
+        self.calls: list[tuple[str, int, int]] = []
+
+    async def fetch_markdown(
+        self,
+        document_uid: str,
+        *,
+        offset: int = 0,
+        max_chars: int = 8000,
+    ) -> DocumentMarkdownResult:
+        self.calls.append((document_uid, offset, max_chars))
+        index = len([c for c in self.calls]) - 1
+        if index >= len(self._pages):
+            raise AssertionError("No fake markdown page configured.")
+        text = self._pages[index]
+        consumed = offset + len(text)
+        is_last = index == len(self._pages) - 1
+        return DocumentMarkdownResult(
+            document_uid=document_uid,
+            text=text,
+            offset=offset,
+            next_offset=None if is_last else consumed,
+            total_chars=sum(len(p) for p in self._pages),
+        )
 
 
 class _FakeContext:
@@ -51,7 +88,7 @@ class _FakeContext:
         *,
         selected_document_uids: list[str] | None = None,
         tuning_values: dict[str, object] | None = None,
-        runtime_tool_pages: list[object] | None = None,
+        markdown_pages: list[str] | None = None,
     ) -> None:
         self.binding = SimpleNamespace(
             runtime_context=SimpleNamespace(
@@ -60,8 +97,8 @@ class _FakeContext:
         )
         self.tuning_values = dict(tuning_values or {})
         self.model = None
-        self._runtime_tool_pages = list(runtime_tool_pages or [])
-        self.runtime_tool_calls: list[tuple[str, dict[str, object]]] = []
+        self.markdown_port = _FakeMarkdownPort(markdown_pages or [])
+        self.services = SimpleNamespace(document_markdown=self.markdown_port)
         self.statuses: list[tuple[str, str | None]] = []
 
     def emit_status(self, status: str, detail: str | None = None) -> None:
@@ -72,10 +109,9 @@ class _FakeContext:
         tool_name: str,
         arguments: dict[str, object],
     ) -> object:
-        self.runtime_tool_calls.append((tool_name, dict(arguments)))
-        if not self._runtime_tool_pages:
-            raise AssertionError("No fake runtime tool payload configured.")
-        return self._runtime_tool_pages.pop(0)
+        raise AssertionError(
+            f"Unexpected runtime tool invocation in this test: {tool_name} {arguments}"
+        )
 
     async def invoke_tool(self, tool_ref: str, payload: dict[str, object]):
         raise AssertionError(
@@ -168,28 +204,7 @@ async def test_read_selected_documents_uses_paginated_preview_reads() -> None:
     )
     fake_context = _FakeContext(
         selected_document_uids=["doc-1"],
-        runtime_tool_pages=[
-            {
-                "path": "/corpus/documents/doc-1/preview.md",
-                "content": "1 | intro\n2 | agenda",
-                "start_line": 1,
-                "end_line": 2,
-                "total_lines": 4,
-                "has_more": True,
-                "next_offset": 2,
-                "truncated": False,
-            },
-            {
-                "path": "/corpus/documents/doc-1/preview.md",
-                "content": "3 | decision\n4 | action",
-                "start_line": 3,
-                "end_line": 4,
-                "total_lines": 4,
-                "has_more": False,
-                "next_offset": None,
-                "truncated": False,
-            },
-        ],
+        markdown_pages=["intro\nagenda\n", "decision\naction\n"],
     )
     context = cast(GraphNodeContext, fake_context)
 
@@ -207,26 +222,49 @@ async def test_read_selected_documents_uses_paginated_preview_reads() -> None:
     assert summaries[1].line_range == "L3-L4"
     assert len(source_refs) == 2
     assert result.state_update["done_reason"] is None
-    assert fake_context.runtime_tool_calls == [
-        (
-            "read_file_page",
-            {
-                "path": "/corpus/documents/doc-1/preview.md",
-                "offset": 0,
-                "limit": 120,
-                "max_chars": 18000,
-            },
-        ),
-        (
-            "read_file_page",
-            {
-                "path": "/corpus/documents/doc-1/preview.md",
-                "offset": 2,
-                "limit": 120,
-                "max_chars": 18000,
-            },
-        ),
+    # Character offsets chain on the port's own `next_offset`; the fs pack's
+    # line-based `limit` argument is gone.
+    assert fake_context.markdown_port.calls == [
+        ("doc-1", 0, 18000),
+        ("doc-1", len("intro\nagenda\n"), 18000),
     ]
+
+
+@pytest.mark.asyncio
+async def test_page_line_bounds_track_a_line_split_across_two_windows() -> None:
+    """
+    Verify line labelling when a character window ends mid-line.
+
+    Why this test exists:
+    - the port paginates on characters while the digest labels segments as
+      `Lx-Ly`, so the line bounds are derived here rather than reported by the
+      backend
+    - a window that cuts a line in half must count that partial line for its own
+      label and hand the same line number to the next window, otherwise every
+      later segment drifts by one
+    """
+
+    state = MindmapState(
+        latest_user_text="build a transcript mindmap",
+        selected_document_uids=["doc-1"],
+    )
+    # "agenda" is split: the first window stops inside it, the second finishes it.
+    fake_context = _FakeContext(
+        selected_document_uids=["doc-1"],
+        markdown_pages=["intro\nage", "nda\nclose\n"],
+    )
+    context = cast(GraphNodeContext, fake_context)
+
+    result = await read_selected_documents_step(state, context)
+
+    summaries = [
+        DocumentSegmentSummary.model_validate(raw)
+        for raw in cast(list[object], result.state_update["document_segment_summaries"])
+    ]
+    # Window 1 shows lines 1-2 (line 2 only partially); window 2 resumes ON line
+    # 2 and ends on line 3.
+    assert summaries[0].line_range == "L1-L2"
+    assert summaries[1].line_range == "L2-L3"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2497. Slice T1 of #2328.

## What changed

`mindmap/graph_agent.py` was the last default agent declaring
`MCP_SERVER_KNOWLEDGE_FLOW_FS`, for a single code-driven read: `read_file_page`
on `/corpus/documents/{uid}/preview.md`. That read now goes through the
`document_markdown` port, and the pack declaration is gone.

## The pagination difference, and what it cost

The two do not paginate the same way: `read_file_page` windows on **lines** and
reports `start_line`/`end_line`; `document_markdown` windows on **characters**
and reports `next_offset` only. The digest and the coverage notes label segments
`Lx-Ly`, so those bounds are now derived while paging rather than reported by
the backend.

The case worth reviewing is a window ending mid-line: that partial line counts
for the window's own label and the **same** line number is handed to the next
window, otherwise every later segment drifts by one. There is a dedicated test
for it (`test_page_line_bounds_track_a_line_split_across_two_windows`).

## Deletions the change makes possible

- `settings.page_line_limit` tuning field - character pagination leaves no
  line-based bound to tune, and a field that silently tunes nothing is worse
  than no field. **Operator-visible**: enrolled mindmap instances lose it from
  the form.
- the `truncated` page flag and the "truncated by filesystem bounds" coverage
  warning - a port window is never a partial read; `next_offset` alone says
  whether more text remains
- the `path` and `total_lines` page fields, neither of which was read
- `_normalize_page_payload`, `_coerce_int` and `_coerce_text`, left without a
  caller

## Verification

- `apps/fred-agents`: 50 passed (49 before, +1 for the straddling-line case)
- `make code-quality` on `apps/fred-agents`: clean, basedpyright 0 errors

## Still to check before this closes

The issue asks for a real-transcript validation of pagination equivalence. The
unit test covers the arithmetic; it does not prove the two backends return the
same bytes for the same document. T2 removes the fallback, so a silent
difference would only surface afterwards.

## Not in scope

The pack stays `enabled: true` in `mcp_catalog.yaml` - an operator can still
attach it to any agent. Turning it off platform-wide is T2.
