### PR TITLE
fix(#2500): a failed Actions cache export no longer fails the build

### DIFF
--- a/.github/workflows/Docker-images.yml
+++ b/.github/workflows/Docker-images.yml
@@ -134,4 +134,7 @@ jobs:
           # falsy side: `publish && '' || format(...)` returns the format branch
           # for both values of publish and asks a driver-less builder to export.
           cache-from: ${{ !inputs.publish && format('type=gha,scope={0}', matrix.name) || '' }}
-          cache-to: ${{ !inputs.publish && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}
+          # ignore-error: the cache is an optimisation, so a GitHub cache-service
+          # timeout must cost a slower build next time, not a red check on an
+          # image that already compiled.
+          cache-to: ${{ !inputs.publish && format('type=gha,mode=max,scope={0},ignore-error=true', matrix.name) || '' }}


### PR DESCRIPTION
Closes #2500.

The pre-merge docker builds read and write the GitHub Actions cache purely to stay
affordable - the workflow comment on those very lines says so. But a cache-service
timeout on the **write** side was fatal. On PR #2496 the frontend image compiled, and
only then did the job die:

```
#20 exporting to GitHub Actions Cache
#20 preparing build cache for export 25.2s done
#20 sending cache export 30.0s done
#20 ERROR: Post ".../CacheService/GetCacheEntryDownloadURL": dial tcp 140.82.112.21:443: i/o timeout
ERROR: failed to build: failed to solve: DeadlineExceeded
```

Nothing was wrong with the image or the PR; the only recovery was a manual re-run.

`ignore-error=true` on the gha cache exporter makes that transient failure cost a
slower build next time instead of a red check. `cache-from` is deliberately untouched:
a cache import miss is already non-fatal, and the failure observed was on export.

Same workflow and the same two lines as #2492 - that one fixed *which* builds get the
cache, this fixes *what happens when writing it fails*.

Verification is the workflow running on this PR itself: the docker-images jobs must
still build and still populate the cache. There is nothing to unit-test.
