### PR TITLE
feat(#2506): delete a team from the admin registry behind a critical-action dialog

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2261,13 +2261,14 @@
         "empty": "No teams yet.",
         "table": {
           "name": "Team",
-          "admins": "Admin(s)"
+          "admins": "Admin(s)",
+          "actions": "Actions"
         }
       },
       "deleteTeam": {
         "action": "Delete team {{name}}",
         "dialogTitle": "Delete {{name}}?",
-        "dialogMessage": "This permanently removes the team from the registry, along with every access relation attached to it. Members lose access immediately. This cannot be undone.",
+        "dialogMessage": "{{name}} is removed from the registry and every access relation involving it is dropped. Members lose access immediately, and the team's document libraries, agents and prompts are left with no owner - their content stays on disk but nobody can reach it. This cannot be undone.",
         "confirm": "Delete team",
         "cancel": "Cancel",
         "successSummary": "Team deleted",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2264,6 +2264,19 @@
           "admins": "Admin(s)"
         }
       },
+      "deleteTeam": {
+        "action": "Delete team {{name}}",
+        "dialogTitle": "Delete {{name}}?",
+        "dialogMessage": "This permanently removes the team from the registry, along with every access relation attached to it. Members lose access immediately. This cannot be undone.",
+        "confirm": "Delete team",
+        "cancel": "Cancel",
+        "successSummary": "Team deleted",
+        "errors": {
+          "summary": "Failed to delete team",
+          "fallbackDetail": "Could not delete the team. Please try again.",
+          "forbiddenDetail": "You are not allowed to delete teams."
+        }
+      },
       "createTeam": {
         "title": "Create team",
         "nameLabel": "Team name",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2261,13 +2261,14 @@
         "empty": "Aucune équipe pour l'instant.",
         "table": {
           "name": "Équipe",
-          "admins": "Administrateur(s)"
+          "admins": "Administrateur(s)",
+          "actions": "Actions"
         }
       },
       "deleteTeam": {
         "action": "Supprimer l'équipe {{name}}",
         "dialogTitle": "Supprimer {{name}} ?",
-        "dialogMessage": "L'équipe est définitivement retirée du registre, ainsi que toutes les relations d'accès qui la référencent. Les membres perdent l'accès immédiatement. Cette action est irréversible.",
+        "dialogMessage": "{{name}} est retirée du registre et toutes les relations d'accès qui la concernent sont supprimées. Les membres perdent l'accès immédiatement, et les bibliothèques de documents, agents et prompts de l'équipe se retrouvent sans propriétaire : leur contenu reste stocké mais devient inaccessible. Cette action est irréversible.",
         "confirm": "Supprimer l'équipe",
         "cancel": "Annuler",
         "successSummary": "Équipe supprimée",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2264,6 +2264,19 @@
           "admins": "Administrateur(s)"
         }
       },
+      "deleteTeam": {
+        "action": "Supprimer l'équipe {{name}}",
+        "dialogTitle": "Supprimer {{name}} ?",
+        "dialogMessage": "L'équipe est définitivement retirée du registre, ainsi que toutes les relations d'accès qui la référencent. Les membres perdent l'accès immédiatement. Cette action est irréversible.",
+        "confirm": "Supprimer l'équipe",
+        "cancel": "Annuler",
+        "successSummary": "Équipe supprimée",
+        "errors": {
+          "summary": "Échec de la suppression de l'équipe",
+          "fallbackDetail": "Impossible de supprimer l'équipe. Veuillez réessayer.",
+          "forbiddenDetail": "Vous n'avez pas les droits pour supprimer des équipes."
+        }
+      },
       "createTeam": {
         "title": "Créer une équipe",
         "nameLabel": "Nom de l'équipe",

--- a/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Team deletion drops the registry row AND every ReBAC relation pointing at
+// it — there is no undo on the backend, so the guarantee under test is that
+// the request cannot leave the client without a confirmed dialog. The real
+// ConfirmationDialogProvider is mounted (not stubbed) so the assertions run
+// against the dialog users actually see.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const h = vi.hoisted(() => ({
+  /** Every team id the delete mutation was fired for, in call order. */
+  deleted: [] as string[],
+  deleteFails: false,
+  errors: [] as string[],
+  successes: [] as string[],
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts?.name ? `${key}:${String(opts.name)}` : key),
+    i18n: { language: "en" },
+  }),
+}));
+
+vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
+  useListUsersQuery: () => ({ data: [] }),
+  useListAllTeamsQuery: () => ({
+    data: [
+      { id: "team-a", name: "Swiftpost", admins: [] },
+      { id: "team-b", name: "Fredlab", admins: [] },
+    ],
+  }),
+  useCreateTeamMutation: () => [vi.fn(), { isLoading: false }],
+  useDeleteTeamMutation: () => [
+    (args: { teamId: string }) => ({
+      unwrap: async () => {
+        h.deleted.push(args.teamId);
+        if (h.deleteFails) throw new Error("boom");
+        return null;
+      },
+    }),
+    { isLoading: false },
+  ],
+}));
+
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({
+    showSuccess: (arg: { summary?: string }) => h.successes.push(arg?.summary ?? ""),
+    showError: (arg: { summary?: string }) => h.errors.push(arg?.summary ?? ""),
+    showWarn: vi.fn(),
+    showInfo: vi.fn(),
+  }),
+}));
+
+const { default: AdminTeamsPage } = await import("./AdminTeamsPage");
+const { ConfirmationDialogProvider } = await import("@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider");
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  h.deleted = [];
+  h.deleteFails = false;
+  h.errors = [];
+  h.successes = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+// The dialog renders through `<Portal id="modal-portal">`, i.e. outside the
+// test container — query it from the document.
+const dialog = () => document.querySelector('[role="alertdialog"]');
+
+const deleteButton = (teamName: string) =>
+  container.querySelector<HTMLElement>(`button[aria-label="rework.adminTeams.deleteTeam.action:${teamName}"]`);
+
+const dialogButton = (label: string) =>
+  Array.from(document.querySelectorAll<HTMLElement>('[role="alertdialog"] button')).find(
+    (b) => b.textContent?.trim() === label,
+  );
+
+function render() {
+  act(() =>
+    root.render(
+      <ConfirmationDialogProvider>
+        <AdminTeamsPage />
+      </ConfirmationDialogProvider>,
+    ),
+  );
+}
+
+describe("AdminTeamsPage — team deletion", () => {
+  it("never deletes on the bare click — the dialog intercepts it", () => {
+    render();
+    const button = deleteButton("Swiftpost");
+    expect(button, "each team row carries a delete action").toBeTruthy();
+
+    act(() => button!.click());
+
+    expect(h.deleted).toEqual([]);
+    expect(dialog()).not.toBeNull();
+  });
+
+  it("states the action is irreversible and names the team", () => {
+    render();
+    act(() => deleteButton("Swiftpost")!.click());
+
+    expect(dialog()!.textContent).toContain("rework.adminTeams.deleteTeam.dialogTitle:Swiftpost");
+    expect(dialog()!.textContent).toContain("rework.adminTeams.deleteTeam.dialogMessage:Swiftpost");
+  });
+
+  it("deletes only the confirmed team", async () => {
+    render();
+    act(() => deleteButton("Fredlab")!.click());
+    await act(async () => dialogButton("rework.adminTeams.deleteTeam.confirm")!.click());
+
+    expect(h.deleted).toEqual(["team-b"]);
+    expect(h.successes).toEqual(["rework.adminTeams.deleteTeam.successSummary"]);
+    expect(dialog()).toBeNull();
+  });
+
+  it("cancelling fires no request", async () => {
+    render();
+    act(() => deleteButton("Swiftpost")!.click());
+    await act(async () => dialogButton("rework.adminTeams.deleteTeam.cancel")!.click());
+
+    expect(h.deleted).toEqual([]);
+    expect(dialog()).toBeNull();
+  });
+
+  it("surfaces a failed deletion as an error toast", async () => {
+    h.deleteFails = true;
+    render();
+    act(() => deleteButton("Swiftpost")!.click());
+    await act(async () => dialogButton("rework.adminTeams.deleteTeam.confirm")!.click());
+
+    expect(h.deleted).toEqual(["team-a"]);
+    expect(h.successes).toEqual([]);
+    expect(h.errors).toEqual(["rework.adminTeams.deleteTeam.errors.summary"]);
+  });
+});

--- a/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.test.tsx
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Team deletion drops the registry row AND every ReBAC relation pointing at
-// it — there is no undo on the backend, so the guarantee under test is that
-// the request cannot leave the client without a confirmed dialog. The real
-// ConfirmationDialogProvider is mounted (not stubbed) so the assertions run
-// against the dialog users actually see.
+// Team deletion has no undo on the backend, so the guarantee under test is
+// that the request cannot leave the client unconfirmed. The real
+// ConfirmationDialogProvider is mounted rather than stubbed, so the
+// assertions run against the dialog users actually see.
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -53,14 +52,19 @@ vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => 
     ],
   }),
   useCreateTeamMutation: () => [vi.fn(), { isLoading: false }],
+  // The request leaves on the trigger call, not on `unwrap()`. Recording it
+  // there is what makes "no request without a confirm" a real assertion
+  // rather than an assertion about awaiting.
   useDeleteTeamMutation: () => [
-    (args: { teamId: string }) => ({
-      unwrap: async () => {
-        h.deleted.push(args.teamId);
-        if (h.deleteFails) throw new Error("boom");
-        return null;
-      },
-    }),
+    (args: { teamId: string }) => {
+      h.deleted.push(args.teamId);
+      return {
+        unwrap: async () => {
+          if (h.deleteFails) throw new Error("boom");
+          return null;
+        },
+      };
+    },
     { isLoading: false },
   ],
 }));
@@ -96,7 +100,7 @@ afterEach(() => {
 });
 
 // The dialog renders through `<Portal id="modal-portal">`, i.e. outside the
-// test container — query it from the document.
+// test container, so it is queried from the document.
 const dialog = () => document.querySelector('[role="alertdialog"]');
 
 const deleteButton = (teamName: string) =>
@@ -117,8 +121,8 @@ function render() {
   );
 }
 
-describe("AdminTeamsPage — team deletion", () => {
-  it("never deletes on the bare click — the dialog intercepts it", () => {
+describe("AdminTeamsPage team deletion", () => {
+  it("never deletes on the bare click - the dialog intercepts it", () => {
     render();
     const button = deleteButton("Swiftpost");
     expect(button, "each team row carries a delete action").toBeTruthy();
@@ -129,7 +133,7 @@ describe("AdminTeamsPage — team deletion", () => {
     expect(dialog()).not.toBeNull();
   });
 
-  it("states the action is irreversible and names the team", () => {
+  it("names the team in both the title and the consequences copy", () => {
     render();
     act(() => deleteButton("Swiftpost")!.click());
 

--- a/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Autocomplete from "@shared/molecules/Autocomplete/Autocomplete.tsx";
 import AvatarGroup from "@shared/molecules/AvatarGroup/AvatarGroup.tsx";
@@ -22,11 +22,13 @@ import IconButton from "@shared/atoms/IconButton/IconButton.tsx";
 import PageHeader from "@shared/molecules/PageHeader/PageHeader.tsx";
 import Separator from "@shared/atoms/Separator/Separator.tsx";
 import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
+import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider";
 import { useToast } from "@shared/molecules/Toast/ToastProvider";
 import { useApiErrorToast } from "@core/hooks/useApiErrorToast.ts";
 import { useMutationAction } from "@core/hooks/useMutationAction.ts";
 import {
   useCreateTeamMutation,
+  useDeleteTeamMutation,
   useListAllTeamsQuery,
   useListUsersQuery,
 } from "../../../../../slices/controlPlane/controlPlaneApiEnhancements";
@@ -35,14 +37,15 @@ import styles from "./AdminTeamsPage.module.css";
 
 // AUTHZ-05 (RFC §28): team creation is a one-shot, platform-admin-gated
 // bootstrap action — there is no other way to give a freshly created team its
-// first team_admin. The existing-teams list below is read-only (registry
-// governance view, item 9's `can_list_all_teams`) — this page still has no
-// edit/delete affordance for a team, only creation and registry visibility.
+// first team_admin. Deletion is the same kind of registry-level action
+// (`can_delete_team`): it drops the registry entry and every relation pointing
+// at the team, so it always goes through a critical-action confirmation.
 export default function AdminTeamsPage() {
   const { t } = useTranslation();
   const { showSuccess } = useToast();
   const { notifyApiError } = useApiErrorToast();
   const { runMutationAction } = useMutationAction();
+  const { showConfirmationDialog } = useConfirmationDialog();
 
   const [name, setName] = useState("");
   const [selectedAdmins, setSelectedAdmins] = useState<UserSummary[]>([]);
@@ -51,6 +54,31 @@ export default function AdminTeamsPage() {
   const { data: allUsers } = useListUsersQuery();
   const { data: allTeams } = useListAllTeamsQuery();
   const [createTeam, { isLoading: isCreating }] = useCreateTeamMutation();
+  const [deleteTeam] = useDeleteTeamMutation();
+
+  const handleDelete = useCallback(
+    (team: Team) => {
+      showConfirmationDialog({
+        criticalAction: true,
+        title: t("rework.adminTeams.deleteTeam.dialogTitle", { name: team.name }),
+        message: t("rework.adminTeams.deleteTeam.dialogMessage", { name: team.name }),
+        confirmButtonLabel: t("rework.adminTeams.deleteTeam.confirm"),
+        cancelButtonLabel: t("rework.adminTeams.deleteTeam.cancel"),
+        onConfirm: () =>
+          void runMutationAction({
+            action: () => deleteTeam({ teamId: team.id }).unwrap(),
+            onSuccess: () => showSuccess({ summary: t("rework.adminTeams.deleteTeam.successSummary") }),
+            onError: (error) =>
+              notifyApiError(error, {
+                summary: t("rework.adminTeams.deleteTeam.errors.summary"),
+                fallbackDetail: t("rework.adminTeams.deleteTeam.errors.fallbackDetail"),
+                forbiddenDetail: t("rework.adminTeams.deleteTeam.errors.forbiddenDetail"),
+              }),
+          }),
+      });
+    },
+    [showConfirmationDialog, runMutationAction, deleteTeam, showSuccess, notifyApiError, t],
+  );
 
   const teamColumns = useMemo(
     (): DataTableColumn<Team>[] => [
@@ -67,8 +95,23 @@ export default function AdminTeamsPage() {
           />
         ),
       },
+      {
+        // Fixed track, not "auto": the header is empty while the cell holds an
+        // icon button, and DataTable resolves header and body tracks separately.
+        label: "",
+        size: "3rem",
+        cellRenderer: (team) => (
+          <IconButton
+            variant="icon"
+            size="small"
+            icon={{ category: "outlined", type: "delete" }}
+            aria-label={t("rework.adminTeams.deleteTeam.action", { name: team.name })}
+            onClick={() => handleDelete(team)}
+          />
+        ),
+      },
     ],
-    [t],
+    [t, handleDelete],
   );
 
   const suggestions = useMemo(() => {

--- a/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/admin/AdminTeamsPage/AdminTeamsPage.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Autocomplete from "@shared/molecules/Autocomplete/Autocomplete.tsx";
 import AvatarGroup from "@shared/molecules/AvatarGroup/AvatarGroup.tsx";
@@ -54,31 +54,28 @@ export default function AdminTeamsPage() {
   const { data: allUsers } = useListUsersQuery();
   const { data: allTeams } = useListAllTeamsQuery();
   const [createTeam, { isLoading: isCreating }] = useCreateTeamMutation();
-  const [deleteTeam] = useDeleteTeamMutation();
+  const [deleteTeam, { isLoading: isDeleting }] = useDeleteTeamMutation();
 
-  const handleDelete = useCallback(
-    (team: Team) => {
-      showConfirmationDialog({
-        criticalAction: true,
-        title: t("rework.adminTeams.deleteTeam.dialogTitle", { name: team.name }),
-        message: t("rework.adminTeams.deleteTeam.dialogMessage", { name: team.name }),
-        confirmButtonLabel: t("rework.adminTeams.deleteTeam.confirm"),
-        cancelButtonLabel: t("rework.adminTeams.deleteTeam.cancel"),
-        onConfirm: () =>
-          void runMutationAction({
-            action: () => deleteTeam({ teamId: team.id }).unwrap(),
-            onSuccess: () => showSuccess({ summary: t("rework.adminTeams.deleteTeam.successSummary") }),
-            onError: (error) =>
-              notifyApiError(error, {
-                summary: t("rework.adminTeams.deleteTeam.errors.summary"),
-                fallbackDetail: t("rework.adminTeams.deleteTeam.errors.fallbackDetail"),
-                forbiddenDetail: t("rework.adminTeams.deleteTeam.errors.forbiddenDetail"),
-              }),
-          }),
-      });
-    },
-    [showConfirmationDialog, runMutationAction, deleteTeam, showSuccess, notifyApiError, t],
-  );
+  const handleDelete = (team: Team) => {
+    showConfirmationDialog({
+      criticalAction: true,
+      title: t("rework.adminTeams.deleteTeam.dialogTitle", { name: team.name }),
+      message: t("rework.adminTeams.deleteTeam.dialogMessage", { name: team.name }),
+      confirmButtonLabel: t("rework.adminTeams.deleteTeam.confirm"),
+      cancelButtonLabel: t("rework.adminTeams.deleteTeam.cancel"),
+      onConfirm: () =>
+        void runMutationAction({
+          action: () => deleteTeam({ teamId: team.id }).unwrap(),
+          onSuccess: () => showSuccess({ summary: t("rework.adminTeams.deleteTeam.successSummary") }),
+          onError: (error) =>
+            notifyApiError(error, {
+              summary: t("rework.adminTeams.deleteTeam.errors.summary"),
+              fallbackDetail: t("rework.adminTeams.deleteTeam.errors.fallbackDetail"),
+              forbiddenDetail: t("rework.adminTeams.deleteTeam.errors.forbiddenDetail"),
+            }),
+        }),
+    });
+  };
 
   const teamColumns = useMemo(
     (): DataTableColumn<Team>[] => [
@@ -96,22 +93,27 @@ export default function AdminTeamsPage() {
         ),
       },
       {
-        // Fixed track, not "auto": the header is empty while the cell holds an
-        // icon button, and DataTable resolves header and body tracks separately.
-        label: "",
-        size: "3rem",
+        // Fixed track, not "auto": header and body render as separate grids, so
+        // an auto track over icon-button cells drifts out of alignment.
+        label: t("rework.adminTeams.existingTeams.table.actions"),
+        size: "6rem",
         cellRenderer: (team) => (
           <IconButton
             variant="icon"
             size="small"
             icon={{ category: "outlined", type: "delete" }}
             aria-label={t("rework.adminTeams.deleteTeam.action", { name: team.name })}
+            // The dialog closes before the request settles, so the row survives
+            // the click - a second confirm would 404 on an already-deleted team.
+            disabled={isDeleting}
             onClick={() => handleDelete(team)}
           />
         ),
       },
     ],
-    [t, handleDelete],
+    // handleDelete is deliberately not a dep: it reads no component state, only
+    // hook callbacks and `t`, so a captured copy behaves like a fresh one.
+    [t, isDeleting],
   );
 
   const suggestions = useMemo(() => {
@@ -165,7 +167,7 @@ export default function AdminTeamsPage() {
       <section className={styles.existingTeamsSection}>
         <h2 className={styles.sectionTitle}>{t("rework.adminTeams.existingTeams.title")}</h2>
         {allTeams && allTeams.length > 0 ? (
-          <DataTable columns={teamColumns} data={allTeams} />
+          <DataTable columns={teamColumns} data={allTeams} rowKey={(team) => team.id} />
         ) : (
           <p className={styles.emptyTeamsMessage}>{t("rework.adminTeams.existingTeams.empty")}</p>
         )}

--- a/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
@@ -148,6 +148,12 @@ export const enhancedControlPlaneApi = api.enhanceEndpoints({
         { type: "ControlPlaneTeam", id: "LIST" },
       ],
     },
+    deleteTeamControlPlaneV1TeamsTeamIdDelete: {
+      invalidatesTags: (_, __, arg) => [
+        { type: "ControlPlaneTeam", id: arg.teamId },
+        { type: "ControlPlaneTeam", id: "LIST" },
+      ],
+    },
     // TEAM-09: self-service join — same tags as updateTeam so the marketplace
     // list (yourTeams/otherTeams split) and this team's own cache entry both
     // refresh with the caller now a member.
@@ -403,6 +409,7 @@ export const {
   useGetTeamControlPlaneV1TeamsTeamIdGetQuery: useGetTeamQuery,
   useCreateTeamControlPlaneV1TeamsPostMutation: useCreateTeamMutation,
   useUpdateTeamControlPlaneV1TeamsTeamIdPatchMutation: useUpdateTeamMutation,
+  useDeleteTeamControlPlaneV1TeamsTeamIdDeleteMutation: useDeleteTeamMutation,
   useJoinTeamControlPlaneV1TeamsTeamIdJoinPostMutation: useJoinTeamMutation,
   useUploadTeamAvatarControlPlaneV1TeamsTeamIdAvatarPostMutation: useUploadTeamAvatarMutation,
   useListTeamMembersControlPlaneV1TeamsTeamIdMembersGetQuery: useListTeamMembersQuery,

--- a/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneApiEnhancements.ts
@@ -148,10 +148,18 @@ export const enhancedControlPlaneApi = api.enhanceEndpoints({
         { type: "ControlPlaneTeam", id: "LIST" },
       ],
     },
+    // Wider than its sibling team mutations on purpose: an updated team keeps
+    // its members/sessions/agents/prompts, a deleted one does not. The store
+    // only refreshes through tags (no refetchOnMount), so every per-team list
+    // left untagged here would keep serving a dead team's rows from cache.
     deleteTeamControlPlaneV1TeamsTeamIdDelete: {
       invalidatesTags: (_, __, arg) => [
         { type: "ControlPlaneTeam", id: arg.teamId },
         { type: "ControlPlaneTeam", id: "LIST" },
+        { type: "ControlPlaneTeamMember", id: `LIST-${arg.teamId}` },
+        { type: "ControlPlaneSession", id: `LIST-${arg.teamId}` },
+        { type: "ControlPlaneAgentInstance", id: `LIST-${arg.teamId}` },
+        { type: "ControlPlanePrompt", id: `LIST-${arg.teamId}` },
       ],
     },
     // TEAM-09: self-service join — same tags as updateTeam so the marketplace

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1585,6 +1585,11 @@ delete prompt) now gets the inverted emphasis for free — the three call
 sites that used to pass the override triplet by hand had it removed since
 it's now redundant with the default.
 
+`AdminTeamsPage` joined that list (2026-09-03): each row of "Existing teams"
+carries a `delete` icon button, and its dialog names the team and spells out
+that the registry entry and every access relation attached to it go with it,
+with no undo. The page had been create-only until then.
+
 #### Open UX issues
 
 - Not yet design-reviewed. First functional pass only.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1586,9 +1586,13 @@ sites that used to pass the override triplet by hand had it removed since
 it's now redundant with the default.
 
 `AdminTeamsPage` joined that list (2026-09-03): each row of "Existing teams"
-carries a `delete` icon button, and its dialog names the team and spells out
-that the registry entry and every access relation attached to it go with it,
-with no undo. The page had been create-only until then.
+carries a `delete` icon button, and the page had been create-only until then.
+The copy states the full blast radius rather than just the registry row -
+`delete_all_relations_of_reference` drops every tuple where the team is the
+subject too, so the team's libraries, agents and prompts are left owner-less
+with their content still on disk. A dialog that said only "access relations"
+would read as an access-control cleanup, which is the understatement that
+makes a destructive action feel safe.
 
 #### Open UX issues
 


### PR DESCRIPTION
Closes #2506.

## What

The admin Teams table gains a per-row delete action. `DELETE /teams/{team_id}`
has existed and been `platform_admin`-gated since AUTHZ-05 with no UI, so the
only way to drop a stale team was a hand-rolled API call.

**Frontend only** - no backend change. The endpoint, its authorization and its
relation cleanup were already in place.

## How

- `AdminTeamsPage` gets a third, fixed-width column holding a `delete` icon
  button (fixed track, not `auto`: `DataTable` resolves header and body tracks
  as separate grids, and this header is empty).
- The click opens the shared `useConfirmationDialog` with `criticalAction: true`
  - the same inverted-emphasis formalism leave-team and delete-agent already
  use (filled/primary Cancel, text/error Confirm). No new dialog component.
- The message names the team and states that the registry entry and every
  access relation attached to it go with it, with no undo.
- `deleteTeamControlPlaneV1TeamsTeamIdDelete` gets a friendly alias in
  `controlPlaneApiEnhancements.ts` and the same `ControlPlaneTeam/{id}` +
  `ControlPlaneTeam/LIST` invalidation as its sibling team mutations, so the
  table refreshes on its own.

## Tests

New `AdminTeamsPage.test.tsx`, 5 cases, mounting the **real**
`ConfirmationDialogProvider` rather than stubbing it - the guarantee under test
is that the request cannot leave the client unconfirmed, so the dialog users
actually see is what gets driven:

- a bare click fires no request and opens the dialog;
- the dialog names the team and carries the irreversibility copy;
- confirming deletes only that team and toasts success;
- cancelling fires nothing;
- a failed deletion surfaces an error toast, not silence.

## Verification

- `vitest` — 5/5 pass
- `tsc --noEmit` — clean
- `eslint` + `prettier` on the touched files — clean

Root `make code-quality` not run here (cold worktree); the CI matrix covers it.

## Notes for review

- `list_all_teams` already filters personal spaces out of the registry view, so
  a personal space is not reachable from this table.
- Scope stops at the registry: the endpoint drops the row and the relations, not
  the team's documents/sessions/agent instances. Broadening that is a separate
  discussion, not this PR.
