### PR TITLE
feat(#2507): label the top-agents KPI series with the owning team

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/kpi/presets/team_names.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/presets/team_names.py
@@ -1,0 +1,55 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Team-id to display-name resolution, shared by the presets that label a team.
+
+Its own module rather than `kpi/utils.py`: that one is a stdlib-only leaf every
+preset imports for `resolve_interval`, and the container this needs drags in
+keycloak and sqlalchemy.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request
+from fred_core.common import TeamId
+
+from control_plane_backend.app.dependencies import get_application_container
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_team_names(request: Request, team_ids: list[str]) -> dict[str, str]:
+    """Return {team_id: display_name}, falling back to the id on any error.
+
+    A team's name lives in `team_metadata_store`, not in Keycloak (AUTHZ-05
+    review item 9).
+    """
+    if not team_ids:
+        return {}
+    try:
+        store = get_application_container(request).get_team_metadata_store()
+        metadata_by_id = await store.get_by_team_ids([TeamId(tid) for tid in team_ids])
+        return {
+            tid: metadata_by_id[TeamId(tid)].name
+            if TeamId(tid) in metadata_by_id
+            else tid
+            for tid in team_ids
+        }
+    except Exception:
+        # Logged, not silent: an unreachable store and a genuinely deleted team
+        # both render as raw ids, and only this line tells the two apart.
+        logger.warning("Falling back to raw team ids for KPI labels", exc_info=True)
+        return {tid: tid for tid in team_ids}

--- a/apps/control-plane-backend/control_plane_backend/kpi/presets/top_agents_by_conversations.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/presets/top_agents_by_conversations.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from fastapi import Request
 from fred_core import KeycloakUser
-from fred_core.common import TeamId
+from fred_core.common import TeamId, is_personal_team_id
 from fred_core.kpi.opensearch_kpi_store import OpenSearchKPIStore
 
 from control_plane_backend.kpi.presets.base import PresetDef
@@ -29,7 +29,8 @@ from control_plane_backend.kpi.presets.common import (
     MultiSeriesPoint,
     MultiSeriesTimeSeriesResponse,
 )
-from control_plane_backend.kpi.utils import resolve_interval, resolve_team_names
+from control_plane_backend.kpi.presets.team_names import resolve_team_names
+from control_plane_backend.kpi.utils import resolve_interval
 
 logger = logging.getLogger(__name__)
 
@@ -60,27 +61,20 @@ def _build_labels(
     id_to_name: dict[str, str],
     id_to_team_id: dict[str, str],
     team_names: dict[str, str],
-    *,
-    scoped: bool,
 ) -> dict[str, str]:
-    """agent_instance_id → the label its series is drawn under.
+    """agent_instance_id -> the label its series is drawn under.
 
     Instance names are not unique across teams, so a cross-team chart qualifies
-    each one with its owning team. A team-scoped chart does not: every series
-    would carry the same suffix, repeating the filter the caller already set.
+    each one with its owning team. Pass an empty `team_names` to keep bare
+    names, which is what a team-scoped request does.
     """
-    if scoped:
-        qualified = dict(id_to_name)
-    else:
-        qualified = {}
-        for instance_id, name in id_to_name.items():
-            team_name = team_names.get(id_to_team_id.get(instance_id, ""))
-            qualified[instance_id] = f"{name} - {team_name}" if team_name else name
+    qualified: dict[str, str] = {}
+    for instance_id, name in id_to_name.items():
+        team_name = team_names.get(id_to_team_id.get(instance_id, ""))
+        qualified[instance_id] = f"{name} - {team_name}" if team_name else name
 
-    # Two instances can still land on one label (same name inside one team, or
-    # an event with no team_id). The id stays the accumulation key throughout —
-    # only the display label needs breaking apart, or the two would be drawn as
-    # a single line summing both.
+    # Two instances can still land on one label. The id stays the accumulation
+    # key throughout, so only the display label needs breaking apart.
     label_counts = Counter(qualified.values())
     return {
         instance_id: f"{label} ({instance_id[:8]})"
@@ -110,8 +104,8 @@ async def query_top_agents_by_conversations(
 
     # Phase 1: top N agent instances by turn count.
     # A top_hits sub-agg reads the instance's name and owning team from its
-    # most-recent event — the deleted-instance safety net: both were persisted
-    # at emit time, so a since-deleted instance still labels its own line.
+    # most-recent event: both were persisted at emit time, so a since-deleted
+    # instance still labels its own line.
     top_body: dict[str, Any] = {
         "size": 0,
         "query": {"bool": {"filter": [time_filter, *_filters(team_id)]}},
@@ -164,17 +158,20 @@ async def query_top_agents_by_conversations(
         hits = bucket.get("latest_dims", {}).get("hits", {}).get("hits", [])
         dims = hits[0]["_source"].get("dims", {}) if hits else {}
         id_to_name[instance_id] = dims.get("agent_instance_name") or instance_id
-        if dims.get("team_id"):
-            id_to_team_id[instance_id] = str(dims["team_id"])
+        # A personal space has no registry row, so its id would resolve to
+        # itself - and that id embeds the owner's uid. Never label with it.
+        event_team_id = str(dims.get("team_id") or "")
+        if event_team_id and not is_personal_team_id(event_team_id):
+            id_to_team_id[instance_id] = event_team_id
 
+    # Empty when the caller already scoped to one team: every series would
+    # otherwise repeat the filter it set.
     team_names = (
         {}
         if team_id is not None
         else await resolve_team_names(request, sorted(set(id_to_team_id.values())))
     )
-    id_to_label = _build_labels(
-        id_to_name, id_to_team_id, team_names, scoped=team_id is not None
-    )
+    id_to_label = _build_labels(id_to_name, id_to_team_id, team_names)
 
     # Phase 2: time-series breakdown per instance.
     series_body: dict[str, Any] = {

--- a/apps/control-plane-backend/control_plane_backend/kpi/presets/top_agents_by_conversations.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/presets/top_agents_by_conversations.py
@@ -29,7 +29,7 @@ from control_plane_backend.kpi.presets.common import (
     MultiSeriesPoint,
     MultiSeriesTimeSeriesResponse,
 )
-from control_plane_backend.kpi.utils import resolve_interval
+from control_plane_backend.kpi.utils import resolve_interval, resolve_team_names
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,40 @@ def _filters(team_id: TeamId | None) -> list[dict[str, Any]]:
     return filters
 
 
+def _build_labels(
+    id_to_name: dict[str, str],
+    id_to_team_id: dict[str, str],
+    team_names: dict[str, str],
+    *,
+    scoped: bool,
+) -> dict[str, str]:
+    """agent_instance_id → the label its series is drawn under.
+
+    Instance names are not unique across teams, so a cross-team chart qualifies
+    each one with its owning team. A team-scoped chart does not: every series
+    would carry the same suffix, repeating the filter the caller already set.
+    """
+    if scoped:
+        qualified = dict(id_to_name)
+    else:
+        qualified = {}
+        for instance_id, name in id_to_name.items():
+            team_name = team_names.get(id_to_team_id.get(instance_id, ""))
+            qualified[instance_id] = f"{name} - {team_name}" if team_name else name
+
+    # Two instances can still land on one label (same name inside one team, or
+    # an event with no team_id). The id stays the accumulation key throughout —
+    # only the display label needs breaking apart, or the two would be drawn as
+    # a single line summing both.
+    label_counts = Counter(qualified.values())
+    return {
+        instance_id: f"{label} ({instance_id[:8]})"
+        if label_counts[label] > 1
+        else label
+        for instance_id, label in qualified.items()
+    }
+
+
 async def query_top_agents_by_conversations(
     store: OpenSearchKPIStore,
     *,
@@ -66,7 +100,7 @@ async def query_top_agents_by_conversations(
     team_id: TeamId | None = None,
 ) -> MultiSeriesTimeSeriesResponse:
     # Authorization already resolved by the router (kpi/api.py, KpiScope).
-    del user, request
+    del user
 
     interval, date_fmt = resolve_interval(since, until)
 
@@ -75,8 +109,9 @@ async def query_top_agents_by_conversations(
     }
 
     # Phase 1: top N agent instances by turn count.
-    # A top_hits sub-agg reads agent_instance_name from the most-recent event —
-    # this is the deleted-instance safety net: the name was persisted at emit time.
+    # A top_hits sub-agg reads the instance's name and owning team from its
+    # most-recent event — the deleted-instance safety net: both were persisted
+    # at emit time, so a since-deleted instance still labels its own line.
     top_body: dict[str, Any] = {
         "size": 0,
         "query": {"bool": {"filter": [time_filter, *_filters(team_id)]}},
@@ -88,11 +123,16 @@ async def query_top_agents_by_conversations(
                     "order": {"_count": "desc"},
                 },
                 "aggs": {
-                    "latest_name": {
+                    "latest_dims": {
                         "top_hits": {
                             "size": 1,
                             "sort": [{"@timestamp": {"order": "desc"}}],
-                            "_source": {"includes": ["dims.agent_instance_name"]},
+                            "_source": {
+                                "includes": [
+                                    "dims.agent_instance_name",
+                                    "dims.team_id",
+                                ]
+                            },
                         }
                     }
                 },
@@ -114,24 +154,27 @@ async def query_top_agents_by_conversations(
             interval=interval,
         )
 
-    # agent_instance_id → name (agent_instance_name if stored, else the id).
+    # agent_instance_id → name / owning team, both read from that instance's
+    # most recent event (the deleted-instance safety net: they were persisted
+    # at emit time).
     id_to_name: dict[str, str] = {}
+    id_to_team_id: dict[str, str] = {}
     for bucket in top_buckets:
         instance_id = str(bucket["key"])
-        hits = bucket.get("latest_name", {}).get("hits", {}).get("hits", [])
+        hits = bucket.get("latest_dims", {}).get("hits", {}).get("hits", [])
         dims = hits[0]["_source"].get("dims", {}) if hits else {}
         id_to_name[instance_id] = dims.get("agent_instance_name") or instance_id
+        if dims.get("team_id"):
+            id_to_team_id[instance_id] = str(dims["team_id"])
 
-    # Instance names are not unique — two live instances may share one. Keying
-    # the series by name would merge them into a single line whose counts are
-    # the sum of both, so the id stays the accumulation key throughout and the
-    # name is only ever a display label. Colliding names get a short id suffix
-    # so the chart still shows two distinguishable lines.
-    name_counts = Counter(id_to_name.values())
-    id_to_label: dict[str, str] = {
-        instance_id: f"{name} ({instance_id[:8]})" if name_counts[name] > 1 else name
-        for instance_id, name in id_to_name.items()
-    }
+    team_names = (
+        {}
+        if team_id is not None
+        else await resolve_team_names(request, sorted(set(id_to_team_id.values())))
+    )
+    id_to_label = _build_labels(
+        id_to_name, id_to_team_id, team_names, scoped=team_id is not None
+    )
 
     # Phase 2: time-series breakdown per instance.
     series_body: dict[str, Any] = {

--- a/apps/control-plane-backend/control_plane_backend/kpi/presets/top_teams_by_sessions.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/presets/top_teams_by_sessions.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from typing import Any
 
@@ -24,9 +23,7 @@ from fred_core.kpi.opensearch_kpi_store import OpenSearchKPIStore
 
 from control_plane_backend.kpi.presets.base import PresetDef
 from control_plane_backend.kpi.presets.common import LabelValuePoint, LabelValueResponse
-from control_plane_backend.kpi.utils import resolve_team_names
-
-logger = logging.getLogger(__name__)
+from control_plane_backend.kpi.presets.team_names import resolve_team_names
 
 TOP_N = 20
 

--- a/apps/control-plane-backend/control_plane_backend/kpi/presets/top_teams_by_sessions.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/presets/top_teams_by_sessions.py
@@ -20,37 +20,15 @@ from typing import Any
 
 from fastapi import Request
 from fred_core import KeycloakUser
-from fred_core.common import TeamId
 from fred_core.kpi.opensearch_kpi_store import OpenSearchKPIStore
 
 from control_plane_backend.kpi.presets.base import PresetDef
 from control_plane_backend.kpi.presets.common import LabelValuePoint, LabelValueResponse
-from control_plane_backend.teams.dependencies import get_team_service_dependencies
+from control_plane_backend.kpi.utils import resolve_team_names
 
 logger = logging.getLogger(__name__)
 
 TOP_N = 20
-
-
-async def _resolve_team_names(request: Request, team_ids: list[str]) -> dict[str, str]:
-    """Return {team_id: display_name} for each id. Falls back to the id on any error."""
-    if not team_ids:
-        return {}
-    try:
-        deps = get_team_service_dependencies(request)
-        # AUTHZ-05 review item 9: a team's name lives in team_metadata_store —
-        # no Keycloak group backs it anymore.
-        metadata_by_id = await deps.get_team_metadata_store().get_by_team_ids(
-            [TeamId(tid) for tid in team_ids]
-        )
-        return {
-            tid: metadata_by_id[TeamId(tid)].name
-            if TeamId(tid) in metadata_by_id
-            else tid
-            for tid in team_ids
-        }
-    except Exception:
-        return {tid: tid for tid in team_ids}
 
 
 async def query_top_teams_by_sessions(
@@ -98,7 +76,7 @@ async def query_top_teams_by_sessions(
     buckets = resp.get("aggregations", {}).get("by_team", {}).get("buckets", [])
 
     team_ids = [b["key"] for b in buckets]
-    names = await _resolve_team_names(request, team_ids)
+    names = await resolve_team_names(request, team_ids)
 
     rows = [
         LabelValuePoint(

--- a/apps/control-plane-backend/control_plane_backend/kpi/utils.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/utils.py
@@ -17,6 +17,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import NamedTuple
 
+from fastapi import Request
+from fred_core.common import TeamId
+
+from control_plane_backend.teams.dependencies import get_team_service_dependencies
+
 
 def resolve_interval(since: datetime, until: datetime) -> tuple[str, str]:
     """Return (opensearch_fixed_interval, strftime_format) for the given range.
@@ -92,3 +97,27 @@ def resolve_trend_interval(since: datetime, until: datetime) -> TrendInterval:
         window_buckets=TREND_WINDOW_BUCKETS,
         lookback=TREND_WINDOW_BUCKETS * bucket,
     )
+
+
+async def resolve_team_names(request: Request, team_ids: list[str]) -> dict[str, str]:
+    """Return {team_id: display_name} for each id. Falls back to the id on any error.
+
+    A team's name lives in `team_metadata_store` — no Keycloak group backs it
+    anymore (AUTHZ-05 review item 9). Shared by every preset that shows a team
+    to a human rather than just aggregating on its id.
+    """
+    if not team_ids:
+        return {}
+    try:
+        deps = get_team_service_dependencies(request)
+        metadata_by_id = await deps.get_team_metadata_store().get_by_team_ids(
+            [TeamId(tid) for tid in team_ids]
+        )
+        return {
+            tid: metadata_by_id[TeamId(tid)].name
+            if TeamId(tid) in metadata_by_id
+            else tid
+            for tid in team_ids
+        }
+    except Exception:
+        return {tid: tid for tid in team_ids}

--- a/apps/control-plane-backend/control_plane_backend/kpi/utils.py
+++ b/apps/control-plane-backend/control_plane_backend/kpi/utils.py
@@ -17,11 +17,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import NamedTuple
 
-from fastapi import Request
-from fred_core.common import TeamId
-
-from control_plane_backend.teams.dependencies import get_team_service_dependencies
-
 
 def resolve_interval(since: datetime, until: datetime) -> tuple[str, str]:
     """Return (opensearch_fixed_interval, strftime_format) for the given range.
@@ -97,27 +92,3 @@ def resolve_trend_interval(since: datetime, until: datetime) -> TrendInterval:
         window_buckets=TREND_WINDOW_BUCKETS,
         lookback=TREND_WINDOW_BUCKETS * bucket,
     )
-
-
-async def resolve_team_names(request: Request, team_ids: list[str]) -> dict[str, str]:
-    """Return {team_id: display_name} for each id. Falls back to the id on any error.
-
-    A team's name lives in `team_metadata_store` — no Keycloak group backs it
-    anymore (AUTHZ-05 review item 9). Shared by every preset that shows a team
-    to a human rather than just aggregating on its id.
-    """
-    if not team_ids:
-        return {}
-    try:
-        deps = get_team_service_dependencies(request)
-        metadata_by_id = await deps.get_team_metadata_store().get_by_team_ids(
-            [TeamId(tid) for tid in team_ids]
-        )
-        return {
-            tid: metadata_by_id[TeamId(tid)].name
-            if TeamId(tid) in metadata_by_id
-            else tid
-            for tid in team_ids
-        }
-    except Exception:
-        return {tid: tid for tid in team_ids}

--- a/apps/control-plane-backend/tests/test_kpi_team_names.py
+++ b/apps/control-plane-backend/tests/test_kpi_team_names.py
@@ -1,0 +1,91 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`resolve_team_names` fallbacks.
+
+Two KPI presets label a team with this, and both degrade to raw ids rather
+than failing the chart. That degradation is the contract worth pinning: it is
+invisible in the response, so a regression here ships looking healthy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from control_plane_backend.kpi.presets import team_names as module
+from control_plane_backend.kpi.presets.team_names import resolve_team_names
+
+
+class _FakeStore:
+    def __init__(self, rows: dict[str, str] | Exception) -> None:
+        self._rows = rows
+
+    async def get_by_team_ids(self, team_ids: list[Any]) -> dict[Any, Any]:
+        if isinstance(self._rows, Exception):
+            raise self._rows
+        return {
+            tid: type("Row", (), {"name": self._rows[str(tid)]})()
+            for tid in team_ids
+            if str(tid) in self._rows
+        }
+
+
+def _patch_store(monkeypatch: pytest.MonkeyPatch, store: _FakeStore) -> None:
+    container = type(
+        "Container", (), {"get_team_metadata_store": lambda _self: store}
+    )()
+    monkeypatch.setattr(module, "get_application_container", lambda _request: container)
+
+
+@pytest.mark.asyncio
+async def test_no_ids_short_circuits_before_touching_the_container() -> None:
+    # No _patch_store: reaching the container at all would raise here.
+    assert await resolve_team_names(None, []) == {}  # pyright: ignore[reportArgumentType]
+
+
+@pytest.mark.asyncio
+async def test_known_ids_resolve_to_their_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_store(monkeypatch, _FakeStore({"team-a": "Swiftpost"}))
+
+    result = await resolve_team_names(None, ["team-a"])  # pyright: ignore[reportArgumentType]
+
+    assert result == {"team-a": "Swiftpost"}
+
+
+@pytest.mark.asyncio
+async def test_a_team_with_no_registry_row_falls_back_to_its_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_store(monkeypatch, _FakeStore({"team-a": "Swiftpost"}))
+
+    result = await resolve_team_names(None, ["team-a", "team-gone"])  # pyright: ignore[reportArgumentType]
+
+    assert result == {"team-a": "Swiftpost", "team-gone": "team-gone"}
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_store_degrades_to_ids_and_says_so(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The silent version of this is indistinguishable from deleted teams."""
+    _patch_store(monkeypatch, _FakeStore(RuntimeError("postgres is down")))
+
+    with caplog.at_level("WARNING"):
+        result = await resolve_team_names(None, ["team-a", "team-b"])  # pyright: ignore[reportArgumentType]
+
+    assert result == {"team-a": "team-a", "team-b": "team-b"}
+    assert any("raw team ids" in record.message for record in caplog.records)

--- a/apps/control-plane-backend/tests/test_kpi_top_agents_by_conversations.py
+++ b/apps/control-plane-backend/tests/test_kpi_top_agents_by_conversations.py
@@ -34,6 +34,9 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
+from control_plane_backend.kpi.presets import (
+    top_agents_by_conversations as preset_module,
+)
 from control_plane_backend.kpi.presets.top_agents_by_conversations import (
     TOP_N,
     query_top_agents_by_conversations,
@@ -62,8 +65,16 @@ class _FakeStore:
         self.index = "kpi-test"
 
 
-def _top_response(agents: list[tuple[str, str, int]]) -> dict[str, Any]:
-    """Phase-1 shape: (instance_id, instance_name, doc_count) per bucket."""
+def _top_response(
+    agents: list[tuple[str, str, int]],
+    teams: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Phase-1 shape: (instance_id, instance_name, doc_count) per bucket.
+
+    `teams` maps instance_id → the team_id its latest event carried; an
+    instance left out of it stands in for an event emitted without one.
+    """
+    teams = teams or {}
     return {
         "aggregations": {
             "by_agent": {
@@ -71,10 +82,21 @@ def _top_response(agents: list[tuple[str, str, int]]) -> dict[str, Any]:
                     {
                         "key": instance_id,
                         "doc_count": count,
-                        "latest_name": {
+                        "latest_dims": {
                             "hits": {
                                 "hits": [
-                                    {"_source": {"dims": {"agent_instance_name": name}}}
+                                    {
+                                        "_source": {
+                                            "dims": {
+                                                "agent_instance_name": name,
+                                                **(
+                                                    {"team_id": teams[instance_id]}
+                                                    if instance_id in teams
+                                                    else {}
+                                                ),
+                                            }
+                                        }
+                                    }
                                 ]
                             }
                         },
@@ -108,14 +130,31 @@ def _series_response(buckets: list[tuple[str, dict[str, int]]]) -> dict[str, Any
     }
 
 
-async def _run(store: _FakeStore) -> Any:
+async def _run(store: _FakeStore, team_id: str | None = None) -> Any:
     return await query_top_agents_by_conversations(
         store,  # pyright: ignore[reportArgumentType]
         user=None,  # pyright: ignore[reportArgumentType]
         since=SINCE,
         until=UNTIL,
         request=None,  # pyright: ignore[reportArgumentType]
+        team_id=team_id,  # pyright: ignore[reportArgumentType]
     )
+
+
+@pytest.fixture(autouse=True)
+def _team_names(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Stand in for the team_metadata_store lookup the preset does for labels.
+
+    The real helper resolves through a FastAPI request; these tests fake the
+    OpenSearch client only, so the registry is faked here in the same spirit.
+    """
+    registry = {"team-swift": "Swiftpost", "team-lab": "Fredlab"}
+
+    async def _fake(_request: Any, team_ids: list[str]) -> dict[str, str]:
+        return {tid: registry.get(tid, tid) for tid in team_ids}
+
+    monkeypatch.setattr(preset_module, "resolve_team_names", _fake)
+    return registry
 
 
 @pytest.mark.asyncio
@@ -140,12 +179,13 @@ async def test_series_query_is_pinned_to_the_phase_one_winners() -> None:
 @pytest.mark.asyncio
 async def test_instances_sharing_a_name_stay_separate_series() -> None:
     """Keying by name merged two instances into one line summing both counts.
-    Keying by id keeps them apart; the colliding names get an id suffix so the
-    two lines remain distinguishable in the chart."""
+    Keying by id keeps them apart, and the owning team is what tells the two
+    lines apart in the chart."""
     store = _FakeStore(
         [
             _top_response(
-                [("id-aaaa1111", "Support", 7), ("id-bbbb2222", "Support", 4)]
+                [("id-aaaa1111", "Support", 7), ("id-bbbb2222", "Support", 4)],
+                teams={"id-aaaa1111": "team-swift", "id-bbbb2222": "team-lab"},
             ),
             _series_response(
                 [("2026-08-01T00:00:00.000Z", {"id-aaaa1111": 7, "id-bbbb2222": 4})]
@@ -155,26 +195,106 @@ async def test_instances_sharing_a_name_stay_separate_series() -> None:
 
     result = await _run(store)
 
-    assert result.series == ["Support (id-aaaa1)", "Support (id-bbbb2)"]
+    assert result.series == ["Support - Swiftpost", "Support - Fredlab"]
     assert result.rows[-1].values == {
-        "Support (id-aaaa1)": 7.0,
-        "Support (id-bbbb2)": 4.0,
+        "Support - Swiftpost": 7.0,
+        "Support - Fredlab": 4.0,
     }
 
 
 @pytest.mark.asyncio
-async def test_unique_names_are_not_suffixed() -> None:
-    """The id suffix is a collision escape hatch, not the normal display."""
+async def test_same_name_inside_one_team_keeps_the_id_suffix() -> None:
+    """The team cannot separate two same-named instances that share it, so the
+    id suffix survives as the residual escape hatch."""
     store = _FakeStore(
         [
-            _top_response([("id-a", "Alpha", 2), ("id-b", "Beta", 1)]),
+            _top_response(
+                [("id-aaaa1111", "Support", 7), ("id-bbbb2222", "Support", 4)],
+                teams={"id-aaaa1111": "team-swift", "id-bbbb2222": "team-swift"},
+            ),
+            _series_response(
+                [("2026-08-01T00:00:00.000Z", {"id-aaaa1111": 7, "id-bbbb2222": 4})]
+            ),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == [
+        "Support - Swiftpost (id-aaaa1)",
+        "Support - Swiftpost (id-bbbb2)",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unique_names_are_still_qualified_by_their_team() -> None:
+    """The team suffix is the normal display, not a collision escape hatch —
+    a cross-team ranking is unreadable without knowing whose agent is whose."""
+    store = _FakeStore(
+        [
+            _top_response(
+                [("id-a", "Alpha", 2), ("id-b", "Beta", 1)],
+                teams={"id-a": "team-swift", "id-b": "team-lab"},
+            ),
             _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 2, "id-b": 1})]),
         ]
     )
 
     result = await _run(store)
 
+    assert result.series == ["Alpha - Swiftpost", "Beta - Fredlab"]
+
+
+@pytest.mark.asyncio
+async def test_team_scoped_request_keeps_bare_names() -> None:
+    """Every series in a team-scoped chart belongs to that team, so the suffix
+    would just repeat the filter the caller already set."""
+    store = _FakeStore(
+        [
+            _top_response(
+                [("id-a", "Alpha", 2), ("id-b", "Beta", 1)],
+                teams={"id-a": "team-swift", "id-b": "team-swift"},
+            ),
+            _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 2, "id-b": 1})]),
+        ]
+    )
+
+    result = await _run(store, team_id="team-swift")
+
     assert result.series == ["Alpha", "Beta"]
+
+
+@pytest.mark.asyncio
+async def test_event_without_a_team_id_falls_back_to_the_bare_name() -> None:
+    store = _FakeStore(
+        [
+            _top_response(
+                [("id-a", "Alpha", 2), ("id-b", "Beta", 1)],
+                teams={"id-a": "team-swift"},
+            ),
+            _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 2, "id-b": 1})]),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == ["Alpha - Swiftpost", "Beta"]
+
+
+@pytest.mark.asyncio
+async def test_deleted_team_falls_back_to_its_id() -> None:
+    """A team whose registry row is gone still labels its agent — the id is a
+    worse label than a name, but better than dropping the line."""
+    store = _FakeStore(
+        [
+            _top_response([("id-a", "Alpha", 2)], teams={"id-a": "team-ghost"}),
+            _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 2})]),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == ["Alpha - team-ghost"]
 
 
 @pytest.mark.asyncio

--- a/apps/control-plane-backend/tests/test_kpi_top_agents_by_conversations.py
+++ b/apps/control-plane-backend/tests/test_kpi_top_agents_by_conversations.py
@@ -330,3 +330,47 @@ async def test_no_turns_returns_empty_without_a_second_query() -> None:
     assert result.rows == []
     assert result.series == []
     assert len(store.client.bodies) == 1
+
+
+@pytest.mark.asyncio
+async def test_personal_space_agents_are_never_labelled_with_their_scope_id() -> None:
+    """A personal team id embeds the owner's uid and has no registry row, so
+    resolving it would print a user identifier into an admin chart."""
+    store = _FakeStore(
+        [
+            _top_response(
+                [("id-a", "Alpha", 2), ("id-b", "Beta", 1)],
+                teams={"id-a": "personal-3f9c1ab2-4d5e", "id-b": "team-swift"},
+            ),
+            _series_response([("2026-08-01T00:00:00.000Z", {"id-a": 2, "id-b": 1})]),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == ["Alpha", "Beta - Swiftpost"]
+
+
+@pytest.mark.asyncio
+async def test_colliding_names_with_no_team_id_still_split() -> None:
+    """The shape of every event emitted before the team_id dim existed: two
+    instances share a name and neither carries a team, so the id suffix is the
+    only thing keeping them from collapsing into one summed line."""
+    store = _FakeStore(
+        [
+            _top_response(
+                [("id-aaaa1111", "Support", 7), ("id-bbbb2222", "Support", 4)]
+            ),
+            _series_response(
+                [("2026-08-01T00:00:00.000Z", {"id-aaaa1111": 7, "id-bbbb2222": 4})]
+            ),
+        ]
+    )
+
+    result = await _run(store)
+
+    assert result.series == ["Support (id-aaaa1)", "Support (id-bbbb2)"]
+    assert result.rows[-1].values == {
+        "Support (id-aaaa1)": 7.0,
+        "Support (id-bbbb2)": 4.0,
+    }

--- a/apps/frontend/src/rework/components/shared/molecules/MultiSeriesLineChart/MultiSeriesLineChart.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MultiSeriesLineChart/MultiSeriesLineChart.tsx
@@ -139,7 +139,10 @@ export default function MultiSeriesLineChart({
                 fontSize: 10,
                 fontFamily: css["--font-family-base"],
                 color: css["--on-surface-retreat"],
-                maxHeight: 44,
+                // A cap, not a height: charts with a couple of series render
+                // one row either way. Sized for the top-agents ranking, whose
+                // ten labels each carry a team name and no longer fit in 44px.
+                maxHeight: 88,
                 overflowY: "auto",
                 paddingTop: 4,
               }}

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -2556,9 +2556,13 @@ Agent instance names are not unique across teams, and the chart's previous
 tie-breaker was a truncated instance id - unreadable in a cross-team ranking.
 Each series label is now `"<agent name> - <team name>"`, resolved through the
 same `TeamMetadataStore` lookup `top_teams_by_sessions` uses (now shared as
-`kpi.utils.resolve_team_names`, falling back to the raw id for a team whose
-registry row is gone). A team-scoped request keeps bare names. Response model
-and route are unchanged - only the string values inside `series`/`rows`.
+`kpi.presets.team_names.resolve_team_names` - its own module, so `kpi/utils.py`
+stays the stdlib-only leaf ten presets import for `resolve_interval`). A team
+whose registry row is gone falls back to its raw id, logged so a store outage
+is not mistaken for a deleted team. Personal spaces are never qualified: their
+scope id embeds the owner's uid and has no registry row. A team-scoped request
+keeps bare names. Response model and route are unchanged - only the string
+values inside `series`/`rows`.
 
 ## 37. Contract Notes — TEAM-05, team routing policy (2026-07-30, issue #2118; simplified 2026-08, `llm-routing-simplify`)
 

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -2551,6 +2551,15 @@ client removed outright. The dedicated Activity surfaces (`/admin/tasks`,
 `/team/:teamId/settings/activity`) remain the canonical, ack-capable place
 for this data; no replacement preset was added.
 
+**`top_agents_by_conversations` series carry their owning team (2026-09-03).**
+Agent instance names are not unique across teams, and the chart's previous
+tie-breaker was a truncated instance id - unreadable in a cross-team ranking.
+Each series label is now `"<agent name> - <team name>"`, resolved through the
+same `TeamMetadataStore` lookup `top_teams_by_sessions` uses (now shared as
+`kpi.utils.resolve_team_names`, falling back to the raw id for a team whose
+registry row is gone). A team-scoped request keeps bare names. Response model
+and route are unchanged - only the string values inside `series`/`rows`.
+
 ## 37. Contract Notes — TEAM-05, team routing policy (2026-07-30, issue #2118; simplified 2026-08, `llm-routing-simplify`)
 
 **2026-08-16 — chat profile typing (#2365).** The pod catalog now projects


### PR DESCRIPTION
Closes #2507.

## What

The "Most talked-to agents" chart on the admin Analytics tab labelled each
series with the agent instance's display name alone. Instance names are
per-team and routinely collide - several teams run an "Assistant", an "Analyst"
or a "Support". The preset already knew this and disambiguated collisions with
a truncated instance id (`Analyst (3f9c1ab2)`), which keeps the lines apart but
answers the wrong question: in a cross-team ranking a platform admin wants the
owning team, and it was already in the data.

## How

- Phase 1's existing `top_hits` sub-agg (renamed `latest_name` -> `latest_dims`,
  since it now reads more than the name) adds `dims.team_id` to its
  `_source.includes`. No extra query, and the deleted-instance safety net is
  unchanged: both values were persisted at emit time, so a since-deleted
  instance still labels its own line.
- Labels become `"<agent name> - <team name>"`. The id suffix survives only as
  the residual escape hatch - two same-named instances *inside one team*, or an
  event that carried no `team_id`.
- A **team-scoped** request keeps bare names: every series would otherwise carry
  the same suffix, repeating the filter the caller already set.
- The instance id stays the accumulation key throughout; the label is
  display-only. That invariant is what stops two instances collapsing into one
  summed line, and this change does not touch it.

## Reuse, not duplication

`top_teams_by_sessions` already had a `_resolve_team_names` helper against
`TeamMetadataStore` with an id fallback. Rather than copy it into a second
preset, it moved to `kpi.utils.resolve_team_names` and both presets now import
it. Net: one implementation where there would have been two.

## Tests

`test_kpi_top_agents_by_conversations.py` grows from 5 to 9 cases. The
team-registry lookup is faked with an autouse fixture, in the same spirit as the
existing fake OpenSearch client:

- two same-named instances in different teams -> distinguished by team;
- two same-named instances in the *same* team -> id suffix still applied;
- unique names are still team-qualified (the suffix is the normal display);
- a team-scoped request keeps bare names;
- an event with no `team_id` falls back to the bare name;
- a deleted team falls back to its raw id rather than dropping the line.

The pre-existing pinning/accumulation/empty-result cases are unchanged.

## Verification

- `pytest -k kpi` — 112 pass
- `ruff format` + `ruff check` — clean

8 failures in `test_main.py` / `test_team_visibility.py` /
`test_get_team_by_id_projection_budget.py` were confirmed **pre-existing** by
re-running them against a stashed tree on the same base. Root `make
code-quality` not run here (cold worktree); the CI matrix covers it.

## Notes for review

- No API contract change: same route, same `MultiSeriesTimeSeriesResponse`. Only
  the string values inside `series`/`rows` change, so no client regeneration.
- No frontend change either - `MultiSeriesLineChart` renders whatever `series`
  the backend returns, and its legend is already a `maxHeight: 44` scroll area.
  Worth a glance at review time, since labels do get longer.
- Contract note added to `CONTROL-PLANE-PRODUCT-CONTRACT.md` §36.
