### PR TITLE
feat(#2510): the turn document scope reaches read_document, summarize, extract and the tree

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1551,6 +1551,7 @@
     "collapse": "Collapse",
     "create": "Create",
     "delete": "Delete",
+    "documentIncludedByFolder": "Included by the folder selection",
     "documents": "documents",
     "expand": "Expand",
     "gcu": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1551,6 +1551,7 @@
     "collapse": "Réduire",
     "create": "Créer",
     "delete": "Supprimer",
+    "documentIncludedByFolder": "Inclus par la sélection du dossier",
     "documents": "documents",
     "expand": "Développer",
     "gcu": {

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
@@ -144,16 +144,6 @@
   min-width: 0;
 }
 
-/* Covered by the folder pick above: ticked, but the tick belongs to the folder.
-   Softened rather than greyed out, so it still reads as selected. */
-.documentToggle:has(.checkbox:disabled) {
-  cursor: default;
-}
-
-.checkbox:disabled {
-  opacity: 0.65;
-}
-
 .stateText,
 .loadingText {
   margin: 0;

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.module.css
@@ -144,6 +144,16 @@
   min-width: 0;
 }
 
+/* Covered by the folder pick above: ticked, but the tick belongs to the folder.
+   Softened rather than greyed out, so it still reads as selected. */
+.documentToggle:has(.checkbox:disabled) {
+  cursor: default;
+}
+
+.checkbox:disabled {
+  opacity: 0.65;
+}
+
 .stateText,
 .loadingText {
   margin: 0;

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A scope is libraries + documents, unioned - there is no "everything here
+// except this" to send. These cases pin how the picker still lets a user say
+// it: a folder shows its documents ticked, and unticking one expands the folder
+// into its own documents minus that one.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const TAG = {
+  id: "tag-1",
+  name: "logs",
+  path: "",
+  type: "document",
+  item_ids: ["doc-1", "doc-2", "doc-3"],
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("../../../../../hooks/useFrontendBootstrap", () => ({
+  useFrontendBootstrap: () => ({ activeTeam: { id: "team-1" } }),
+}));
+vi.mock("../../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
+  TagType: { document: "document" },
+  useListAllTagsKnowledgeFlowV1TagsGetQuery: () => ({ data: [TAG], isLoading: false }),
+  useBrowseDocumentsByTagKnowledgeFlowV1DocumentsMetadataBrowsePostMutation: () => [
+    () => ({
+      unwrap: async () => ({
+        documents: TAG.item_ids.map((uid) => ({
+          identity: { document_uid: uid, document_name: `${uid}.txt` },
+          file: { file_type: "txt" },
+        })),
+      }),
+    }),
+  ],
+}));
+
+import { DocumentLibraryScopePicker } from "./DocumentLibraryScopePicker";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** Render, then expand the single folder so its documents are listed. */
+async function renderExpanded(props: Parameters<typeof DocumentLibraryScopePicker>[0]) {
+  await act(async () => {
+    root.render(<DocumentLibraryScopePicker {...props} />);
+  });
+  const expand = container.querySelector("button");
+  await act(async () => {
+    expand?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+/** Document checkboxes, in render order — the folder's own checkbox comes first. */
+function checkboxes(): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll<HTMLInputElement>("input[type=checkbox]"));
+}
+
+describe("DocumentLibraryScopePicker folder selection", () => {
+  it("shows a picked folder's documents as selected", async () => {
+    await renderExpanded({
+      selectedTagIds: ["tag-1"],
+      onChange: () => {},
+      selectedDocumentUids: [],
+      onDocumentsChange: () => {},
+    });
+
+    const [folder, ...docs] = checkboxes();
+    expect(folder.checked).toBe(true);
+    expect(docs).toHaveLength(3);
+    expect(docs.every((box) => box.checked)).toBe(true);
+  });
+
+  it("expands the folder into its other documents when one is unticked", async () => {
+    const onChange = vi.fn();
+    const onDocumentsChange = vi.fn();
+    await renderExpanded({
+      selectedTagIds: ["tag-1"],
+      onChange,
+      selectedDocumentUids: [],
+      onDocumentsChange,
+    });
+
+    const [, firstDoc] = checkboxes();
+    await act(async () => {
+      firstDoc.click();
+    });
+
+    // The folder can no longer speak for the selection, so it steps aside.
+    expect(onChange).toHaveBeenCalledWith([]);
+    expect(onDocumentsChange).toHaveBeenCalledWith(["doc-2", "doc-3"]);
+  });
+
+  it("drops the per-document entries a folder pick makes redundant", async () => {
+    const onDocumentsChange = vi.fn();
+    await renderExpanded({
+      selectedTagIds: [],
+      onChange: () => {},
+      selectedDocumentUids: ["doc-2", "other-doc"],
+      onDocumentsChange,
+    });
+
+    const [folder] = checkboxes();
+    await act(async () => {
+      folder.click();
+    });
+
+    expect(onDocumentsChange).toHaveBeenCalledWith(["other-doc"]);
+  });
+
+  it("keeps a pinned library scope untouchable from a document row", async () => {
+    const onChange = vi.fn();
+    await renderExpanded({
+      selectedTagIds: ["tag-1"],
+      onChange,
+      selectedDocumentUids: [],
+      onDocumentsChange: () => {},
+      disableLibrarySelection: true,
+    });
+
+    const [, firstDoc] = checkboxes();
+    expect(firstDoc.disabled).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
@@ -235,7 +235,13 @@ export function DocumentLibraryScopePicker({
                   <ul className={styles.documentList}>
                     {docs.map((doc) => {
                       const documentUid = doc.identity.document_uid;
-                      const checked = selectedDocumentUids?.includes(documentUid) ?? false;
+                      // Picking the folder already puts every document it holds
+                      // in scope (library and document picks union server-side),
+                      // so show them checked rather than leaving the user to tick
+                      // each one - and read-only, since unticking one cannot
+                      // carve an exception out of a folder-level pick.
+                      const includedByFolder = tagId !== null && selectedTagIds.includes(tagId);
+                      const checked = includedByFolder || (selectedDocumentUids?.includes(documentUid) ?? false);
                       // Same file-type icon/color as the Resources table (shared
                       // fileIconSpec), so a given extension reads identically here.
                       const docSpec = fileIconSpec(doc.file?.file_type);
@@ -247,11 +253,15 @@ export function DocumentLibraryScopePicker({
                       return (
                         <li key={documentUid} className={styles.documentItem}>
                           {documentSelectionEnabled ? (
-                            <label className={styles.documentToggle}>
+                            <label
+                              className={styles.documentToggle}
+                              title={includedByFolder ? t("rework.documentIncludedByFolder") : undefined}
+                            >
                               <input
                                 type="checkbox"
                                 className={styles.checkbox}
                                 checked={checked}
+                                disabled={includedByFolder}
                                 onChange={(event) => toggleDocumentSelection(documentUid, event.target.checked)}
                               />
                               {docIcon}

--- a/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/DocumentLibraryScopePicker/DocumentLibraryScopePicker.tsx
@@ -145,17 +145,45 @@ export function DocumentLibraryScopePicker({
     if (disableLibrarySelection) return;
     const tagIds = collectTagIds(node);
     const allSelected = tagIds.every((id) => selectedTagIds.includes(id));
-    if (allSelected) {
-      onChange(selectedTagIds.filter((id) => !tagIds.includes(id)));
-      return;
+    onChange(
+      allSelected
+        ? selectedTagIds.filter((id) => !tagIds.includes(id))
+        : Array.from(new Set([...selectedTagIds, ...tagIds])),
+    );
+    // Either way the folder now speaks for its own documents: drop the
+    // per-document entries it just made redundant (on select) or no longer
+    // covers (on clear), so the two selectors never describe the same folder
+    // twice.
+    if (documentSelectionEnabled && selectedDocumentUids && onDocumentsChange) {
+      const covered = new Set(collectDocumentIds(node));
+      const remaining = selectedDocumentUids.filter((uid) => !covered.has(uid));
+      if (remaining.length !== selectedDocumentUids.length) onDocumentsChange(remaining);
     }
-    onChange(Array.from(new Set([...selectedTagIds, ...tagIds])));
   };
 
-  const toggleDocumentSelection = (documentUid: string, checked: boolean) => {
+  /** Untick one document, including one its folder covers.
+   *
+   *  A scope is a set of libraries plus a set of documents, unioned - it has no
+   *  "everything here except this" to send. So excluding a document from a
+   *  picked folder expands that folder into its own documents (`item_ids`, the
+   *  complete list, not the page of 20 shown) minus this one, and drops the
+   *  folder itself. The folder then reads as partially selected, which is what
+   *  it now is. */
+  const toggleDocumentSelection = (documentUid: string, checked: boolean, node: TagNode) => {
     if (!documentSelectionEnabled || !selectedDocumentUids || !onDocumentsChange) return;
     if (checked) {
       onDocumentsChange(Array.from(new Set([...selectedDocumentUids, documentUid])));
+      return;
+    }
+    const tagId = findPrimaryTagId(node);
+    if (tagId && selectedTagIds.includes(tagId)) {
+      // A pinned library scope is not the user's to carve up - the folder
+      // checkbox is read-only for the same reason, and dropping its tag here
+      // would walk around that.
+      if (disableLibrarySelection) return;
+      const siblings = (node.tagsHere?.[0]?.item_ids ?? []).filter((uid) => uid !== documentUid);
+      onChange(selectedTagIds.filter((id) => id !== tagId));
+      onDocumentsChange(Array.from(new Set([...selectedDocumentUids, ...siblings])));
       return;
     }
     onDocumentsChange(selectedDocumentUids.filter((uid) => uid !== documentUid));
@@ -238,8 +266,7 @@ export function DocumentLibraryScopePicker({
                       // Picking the folder already puts every document it holds
                       // in scope (library and document picks union server-side),
                       // so show them checked rather than leaving the user to tick
-                      // each one - and read-only, since unticking one cannot
-                      // carve an exception out of a folder-level pick.
+                      // each one. Still untickable: see toggleDocumentSelection.
                       const includedByFolder = tagId !== null && selectedTagIds.includes(tagId);
                       const checked = includedByFolder || (selectedDocumentUids?.includes(documentUid) ?? false);
                       // Same file-type icon/color as the Resources table (shared
@@ -261,8 +288,8 @@ export function DocumentLibraryScopePicker({
                                 type="checkbox"
                                 className={styles.checkbox}
                                 checked={checked}
-                                disabled={includedByFolder}
-                                onChange={(event) => toggleDocumentSelection(documentUid, event.target.checked)}
+                                disabled={includedByFolder && disableLibrarySelection}
+                                onChange={(event) => toggleDocumentSelection(documentUid, event.target.checked, child)}
                               />
                               {docIcon}
                               <span className={styles.documentName}>{doc.identity.document_name}</span>

--- a/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
+++ b/apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
@@ -2212,6 +2212,8 @@ export type DocumentTreeRequest = {
   working_directory?: string | null;
   /** Restrict the listing to these folder tag ids (and their descendants), when set. */
   tag_ids?: string[] | null;
+  /** Restrict the listing to these documents, dropping the folders left empty, when set. */
+  document_uids?: string[] | null;
   /** Render budget for the returned tree text. Oversized trees are pruned, deepest branches first. */
   max_chars?: number;
   /** Filter by ownership: 'personal' for user-owned folders, 'team' for team-owned folders. */

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_tree/service.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_tree/service.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Tuple
 from fred_core import KeycloakUser
 
 from knowledge_flow_backend.features.corpus_tree.structure import DocumentTreeRequest, DocumentTreeResponse
-from knowledge_flow_backend.features.corpus_tree.tree_builder import build_tree, render_tree
+from knowledge_flow_backend.features.corpus_tree.tree_builder import build_tree, prune_empty_folders, render_tree
 from knowledge_flow_backend.features.metadata.service import MetadataService
 from knowledge_flow_backend.features.tag.structure import TagType
 from knowledge_flow_backend.features.tag.tag_service import TagService
@@ -82,17 +82,38 @@ class CorpusTreeService:
             team_id=request.team_id,
         )
 
+        scoped = tags
         if request.tag_ids:
             allowed_ids = set(request.tag_ids)
             allowed_paths = {t.full_path for t in tags if t.id in allowed_ids}
-            tags = [t for t in tags if t.id in allowed_ids or any(t.full_path == p or t.full_path.startswith(p + "/") for p in allowed_paths)]
+            scoped = [t for t in tags if t.id in allowed_ids or any(t.full_path == p or t.full_path.startswith(p + "/") for p in allowed_paths)]
 
-        folders: List[Tuple[str, List[str], str]] = [(t.full_path, t.item_ids, t.id) for t in tags]
+        # A library scope and a document scope UNION, they do not intersect -- the
+        # same semantics vector search applies (`vector_search_service`: library
+        # hits and document hits are merged). Ticking a library and one document
+        # elsewhere means "that library, plus that document", never "the document
+        # only if it happens to sit in that library".
+        selected_uids = set(request.document_uids or ())
+        in_scope_uids: Optional[set] = None
+        if selected_uids:
+            scoped_ids = {t.id for t in scoped}
+            in_scope_uids = selected_uids
+            if request.tag_ids:
+                in_scope_uids = in_scope_uids | {uid for t in scoped for uid in t.item_ids}
+            scoped = [t for t in tags if t.id in scoped_ids or (selected_uids & set(t.item_ids))]
+
+        folders: List[Tuple[str, List[str], str]] = [(t.full_path, t.item_ids, t.id) for t in scoped]
 
         all_uids = sorted({uid for _, item_ids, _ in folders for uid in item_ids})
+        if in_scope_uids is not None:
+            # Narrowing the resolved leaves narrows the tree on its own:
+            # `build_tree` skips any uid it cannot resolve to a name.
+            all_uids = [uid for uid in all_uids if uid in in_scope_uids]
         leaves_by_uid = await self._resolve_leaves(user, all_uids)
 
         root = build_tree(folders=folders, leaves_by_uid=leaves_by_uid)
+        if in_scope_uids is not None:
+            prune_empty_folders(root)
         text, truncated = render_tree(root, max_chars=request.max_chars)
         return DocumentTreeResponse(tree=text, truncated=truncated)
 

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_tree/structure.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_tree/structure.py
@@ -27,6 +27,10 @@ class DocumentTreeRequest(BaseModel):
         default=None,
         description="Restrict the listing to these folder tag ids (and their descendants), when set.",
     )
+    document_uids: Optional[List[str]] = Field(
+        default=None,
+        description="Restrict the listing to these documents, dropping the folders left empty, when set.",
+    )
     max_chars: int = Field(
         default=6000,
         ge=500,

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_tree/tree_builder.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/features/corpus_tree/tree_builder.py
@@ -120,6 +120,20 @@ def build_tree(
     return root
 
 
+def prune_empty_folders(node: TreeNode) -> bool:
+    """Drop every branch holding no document, and report whether `node` keeps one.
+
+    Only used when the caller narrowed the listing to specific documents: an
+    empty folder is meaningful information in a full listing ("this folder
+    exists and holds nothing"), but under a document scope it is just the
+    unselected corpus rendered as a skeleton.
+    """
+    for name, child in list(node.children.items()):
+        if not prune_empty_folders(child):
+            del node.children[name]
+    return bool(node.docs or node.children)
+
+
 def _format_leaf(doc: DocLeaf) -> str:
     when = doc.created.date().isoformat() if doc.created else "unknown date"
     return f"{doc.document_name} [{doc.document_uid}] (uploaded {when})"

--- a/apps/knowledge-flow-backend/tests/features/test_corpus_tree_service.py
+++ b/apps/knowledge-flow-backend/tests/features/test_corpus_tree_service.py
@@ -117,3 +117,51 @@ async def test_empty_scope_returns_canonical_empty_tree():
 
     assert response.tree == "(empty)"
     assert response.truncated is False
+
+
+@pytest.mark.asyncio
+async def test_document_uids_narrows_the_listing_to_the_selected_leaves():
+    sales = _tag(tag_id="tag-1", full_path="Sales", item_ids=["doc-1", "doc-2"])
+    hr = _tag(tag_id="tag-2", full_path="HR", item_ids=["doc-3"])
+    docs = [
+        _document(uid="doc-1", name="Architecture.docx"),
+        _document(uid="doc-2", name="Budget.xlsx"),
+        _document(uid="doc-3", name="Onboarding.docx"),
+    ]
+    service = _tree_service(tags=[sales, hr], docs=docs)
+
+    response = await service.get_tree(_user(), DocumentTreeRequest(document_uids=["doc-2"]))
+
+    assert "Budget.xlsx [doc-2]" in response.tree
+    assert "Architecture.docx" not in response.tree
+    # The folder holding nothing selected is pruned, not rendered empty.
+    assert "HR" not in response.tree
+
+
+@pytest.mark.asyncio
+async def test_library_scope_and_document_scope_union_rather_than_intersect():
+    sales = _tag(tag_id="tag-1", full_path="Sales", item_ids=["doc-1"])
+    hr = _tag(tag_id="tag-2", full_path="HR", item_ids=["doc-2", "doc-3"])
+    docs = [
+        _document(uid="doc-1", name="Architecture.docx"),
+        _document(uid="doc-2", name="Onboarding.docx"),
+        _document(uid="doc-3", name="Payroll.xlsx"),
+    ]
+    service = _tree_service(tags=[sales, hr], docs=docs)
+
+    response = await service.get_tree(_user(), DocumentTreeRequest(tag_ids=["tag-1"], document_uids=["doc-2"]))
+
+    # The whole selected library, plus the separately named document.
+    assert "Architecture.docx [doc-1]" in response.tree
+    assert "Onboarding.docx [doc-2]" in response.tree
+    assert "Payroll.xlsx" not in response.tree
+
+
+@pytest.mark.asyncio
+async def test_a_folder_with_no_document_still_renders_without_a_document_scope():
+    empty = _tag(tag_id="tag-1", full_path="Archive", item_ids=[])
+    service = _tree_service(tags=[empty], docs=[])
+
+    response = await service.get_tree(_user(), DocumentTreeRequest())
+
+    assert "Archive [folder:tag-1]/" in response.tree

--- a/apps/knowledge-flow-backend/tests/features/test_corpus_tree_service.py
+++ b/apps/knowledge-flow-backend/tests/features/test_corpus_tree_service.py
@@ -165,3 +165,22 @@ async def test_a_folder_with_no_document_still_renders_without_a_document_scope(
     response = await service.get_tree(_user(), DocumentTreeRequest())
 
     assert "Archive [folder:tag-1]/" in response.tree
+
+
+@pytest.mark.asyncio
+async def test_selecting_a_folder_and_its_documents_lists_each_one_once():
+    """Ticking a folder and the files inside it is redundant, not duplicating:
+    the union collapses to the same set and every leaf renders once."""
+
+    sales = _tag(tag_id="tag-1", full_path="Sales", item_ids=["doc-1", "doc-2"])
+    docs = [
+        _document(uid="doc-1", name="Architecture.docx"),
+        _document(uid="doc-2", name="Budget.xlsx"),
+    ]
+    service = _tree_service(tags=[sales], docs=docs)
+
+    response = await service.get_tree(_user(), DocumentTreeRequest(tag_ids=["tag-1"], document_uids=["doc-1", "doc-2"]))
+
+    assert response.tree.count("Architecture.docx [doc-1]") == 1
+    assert response.tree.count("Budget.xlsx [doc-2]") == 1
+    assert response.tree.count("Sales [folder:tag-1]/") == 1

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -4598,14 +4598,24 @@ already merges library hits with document hits, so ticking a library plus one
 file elsewhere means "that library, plus that file". The tree now follows the
 same rule rather than inventing an intersection nobody asked for.
 
-**One residual, deliberate.** The read gate enforces the document level only: a
-library-level selection cannot be checked pod-side, since resolving a library to
-its documents needs the tag store fred-agents does not have. Search and the tree
-still narrow by library, so only a uid carried over from an earlier, wider turn
-gets past it; closing that means moving the scope onto Knowledge Flow's read
-endpoints.
+**The gate refuses only what it can prove.** A false refusal is worse than a
+missed one here: the model reports a document the user picked as unreachable.
+So two cases pass through, both by design — a selection that includes a library
+(its documents cannot be enumerated pod-side, and refusing them would refuse the
+user's own pick), and a uid among the conversation's attached files
+(`get_attachment_uids`, read from the same `attachments_markdown` the model is
+told to quote from — the picker lists the corpus, so an attachment is never in
+the selection). What remains enforced is the case that produced the bug: a
+documents-only selection, with a stale uid from a wider earlier turn.
 
-**Attachments follow the selection, as they already did.** A non-empty selection
-also bounds the conversation's attached files — Knowledge Flow restricts the
-session branch of a search to the same uids, so the reading tools now behave the
-way search always has rather than inventing an exception.
+**Two known gaps, tracked rather than papered over.**
+
+- With `bind_libraries=True`, the pinned library is always sent as the tree's
+  library scope and Knowledge Flow unions it with the document scope, so ticking
+  one file still lists the whole bound library. Separating "the user picked this
+  library" from "the agent is pinned to it" needs a second wire field, not a
+  behaviour change here.
+- `narrow_scope_ids` reads an empty intersection (`config.document_uids`
+  disjoint from the turn's pick) as "no bound at this level" and re-widens to the
+  session selection. Pre-existing on the search path, now shared by the tree;
+  `DocumentSimilarityAdapter` is the one caller that handles it explicitly.

--- a/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
+++ b/docs/swift/design/RUNTIME-EXECUTION-CONTRACT.md
@@ -4558,3 +4558,54 @@ tuple — §8.60), `list_document_tree`, `list_documents_by_label` (labels are a
 metadata-store notion), the tabular tools (#2418) and `ppt_filler`'s raw-bytes
 fetch (an attachment keeps no blob).
 
+
+---
+
+### 8.65 ✅ The turn's document scope reaches the read tools and the tree — issue #2510 (2026-09-03)
+
+**The composer's selection used to narrow retrieval only.** The document-scope
+picker sends the user's pick twice — as `turn_options["document_access"]
+.document_uids` and as `RuntimeContext.selected_document_uids` — and two of the
+six document tools read it: `search_documents_using_vectorization` and
+`find_similar_passages`. `list_document_tree` narrowed by library and ignored
+documents; `read_document`, `summarize_document` and `extract_from_document`
+narrowed by nothing at all. Ticking one file therefore produced a listing of the
+whole corpus, a model asking which document was meant, and a reading tool that
+would accept any uid it had ever seen.
+
+**Three seams, one selection.**
+
+- `DocumentTreePort.tree` takes `document_uids`; `DocumentTreeAdapter`
+  intersects it with the binding, `KfDocumentClient` puts it on the wire, and
+  `DocumentTreeRequest` / `CorpusTreeService` narrow the resolved leaves and
+  drop the folders left empty (`prune_empty_folders`). Without a document scope
+  the listing is byte-for-byte what it was, empty folders included.
+- `DocumentMarkdownAdapter`, `DocumentSummarizeAdapter` and
+  `DocumentExtractionAdapter` bound the model-supplied uid by the same selection
+  (`_ensure_uid_in_turn_scope`) and raise `DocumentScopeRefusedError` — the
+  seam `DocumentSimilarityAdapter` already had, for uids of exactly the same
+  provenance. The capabilities render it through `document_scope_refusal`, never
+  as a Knowledge Flow failure: a scope decision told as a transport error gets
+  retried, and told as an empty result gets reported as an empty document.
+- `build_document_scope_suffix` names the selection in the per-turn system
+  prompt, beside the attachment suffix. Without a referent for "this document"
+  the model listed the tree and asked which file was meant while exactly one was
+  ticked. Uids, not display names: `RuntimeContext` carries the selection as
+  uids, and they are what the tools take.
+
+**Library and document scope UNION, they do not intersect.** Vector search
+already merges library hits with document hits, so ticking a library plus one
+file elsewhere means "that library, plus that file". The tree now follows the
+same rule rather than inventing an intersection nobody asked for.
+
+**One residual, deliberate.** The read gate enforces the document level only: a
+library-level selection cannot be checked pod-side, since resolving a library to
+its documents needs the tag store fred-agents does not have. Search and the tree
+still narrow by library, so only a uid carried over from an earlier, wider turn
+gets past it; closing that means moving the scope onto Knowledge Flow's read
+endpoints.
+
+**Attachments follow the selection, as they already did.** A non-empty selection
+also bounds the conversation's attached files — Knowledge Flow restricts the
+session branch of a search to the same uids, so the reading tools now behave the
+way search always has rather than inventing an exception.

--- a/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
@@ -56,9 +56,10 @@ Doctrine (RFC §3.5, §3.8, §10):
 Scoping precedence (`turn_option ⊆ capability_config ⊆ session_binding`):
 - HERE both tools narrow their stored-config scope (`config.library_tag_ids` /
   `config.document_uids`) by the per-turn `document_scope` selection
-  (`turn_options`), enforcing `turn_option ⊆ capability_config`; a library
-  selection and a document selection each narrow on their own, and together
-  intersect;
+  (`turn_options`), enforcing `turn_option ⊆ capability_config`; a library pick
+  and a document pick each narrow on their own, and UNION when both are made -
+  "that library, plus that file", the rule Knowledge Flow already applies to
+  search hits;
 - the runtime adapter then bounds the result by the session binding's own scope,
   enforcing `⊆ session_binding` (see `DocumentSearchAdapter`).
 

--- a/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_access/capability.py
@@ -54,9 +54,11 @@ Doctrine (RFC §3.5, §3.8, §10):
   identity reach the tool through the middleware closure, never the tool schema
 
 Scoping precedence (`turn_option ⊆ capability_config ⊆ session_binding`):
-- HERE the tool narrows its stored-config scope (`config.library_tag_ids` /
+- HERE both tools narrow their stored-config scope (`config.library_tag_ids` /
   `config.document_uids`) by the per-turn `document_scope` selection
-  (`turn_options`), enforcing `turn_option ⊆ capability_config`;
+  (`turn_options`), enforcing `turn_option ⊆ capability_config`; a library
+  selection and a document selection each narrow on their own, and together
+  intersect;
 - the runtime adapter then bounds the result by the session binding's own scope,
   enforcing `⊆ session_binding` (see `DocumentSearchAdapter`).
 
@@ -742,6 +744,7 @@ class DocumentAccessCapability(
                 result: DocumentTreeResult = await port.tree(
                     working_directory=working_directory,
                     library_tag_ids=scoped_library_tag_ids,
+                    document_uids=scoped_document_uids,
                     max_chars=effective_max_chars,
                 )
             except Exception as exc:

--- a/libs/fred-runtime/fred_runtime/capabilities/document_extract/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_extract/capability.py
@@ -48,10 +48,14 @@ from fred_sdk.contracts.context import (
     ToolInvocationResult,
 )
 from fred_sdk.contracts.models import FieldSpec, UIHints
+from fred_sdk.contracts.runtime import DocumentScopeRefusedError
 from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel
 
-from fred_runtime.capabilities.document_read_common import document_tool_failure
+from fred_runtime.capabilities.document_read_common import (
+    document_scope_refusal,
+    document_tool_failure,
+)
 
 
 class DocumentExtractConfig(BaseModel):
@@ -141,6 +145,12 @@ class DocumentExtractCapability(
             started = time.monotonic()
             try:
                 result = await port.extract(document_uid, instruction=what_to_extract)
+            except DocumentScopeRefusedError as exc:
+                return document_scope_refusal(
+                    tool_ref="extract_from_document",
+                    action="extract from the document",
+                    exc=exc,
+                )
             except Exception as exc:
                 message, artifact = document_tool_failure(
                     tool_ref="extract_from_document",

--- a/libs/fred-runtime/fred_runtime/capabilities/document_read_common.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_read_common.py
@@ -46,7 +46,10 @@ from fred_sdk.contracts.context import (
     ToolContentKind,
     ToolInvocationResult,
 )
-from fred_sdk.contracts.runtime import DocumentMarkdownResult
+from fred_sdk.contracts.runtime import (
+    DocumentMarkdownResult,
+    DocumentScopeRefusedError,
+)
 from pydantic import BaseModel, Field
 
 _KF_SERVICE = "Knowledge Flow"
@@ -143,6 +146,35 @@ def document_tool_failure(
     )
 
 
+def document_scope_refusal(
+    *,
+    tool_ref: str,
+    action: str,
+    exc: DocumentScopeRefusedError,
+) -> tuple[str, ToolInvocationResult]:
+    """Shape a turn-scope refusal for the model — never as a service failure.
+
+    Nothing failed downstream: the user narrowed this turn to a selection the
+    named document is not in. Told as a transport error the model retries;
+    told as an empty result it reports the document as empty.
+    """
+
+    uids = ", ".join(exc.requested_uids) or "that document"
+    message = (
+        f"Cannot {action} ({uids}): the user has restricted this conversation to "
+        "a specific set of documents, and this one is not in it. Nothing was "
+        "read - this is NOT an empty or unreadable document. Work from a "
+        "document that is in scope (search and the document tree return exactly "
+        "those), or tell the user the document they mean is outside the current "
+        "selection. Never repeat the identifier to the user."
+    )
+    return message, ToolInvocationResult(
+        tool_ref=tool_ref,
+        is_error=True,
+        blocks=(ToolContentBlock(kind=ToolContentKind.TEXT, text=message),),
+    )
+
+
 def _pagination_footer(result: DocumentMarkdownResult, *, exhaustive: bool) -> str:
     """Machine-readable page/continuation banner appended to the tool content.
 
@@ -201,12 +233,14 @@ async def read_document_page(
         )
 
     started = time.monotonic()
+    action = "extract from the document" if exhaustive else "read the document"
     try:
         result = await port.fetch_markdown(
             document_uid, offset=offset, max_chars=max_chars
         )
+    except DocumentScopeRefusedError as exc:
+        return document_scope_refusal(tool_ref=tool_ref, action=action, exc=exc)
     except Exception as exc:
-        action = "extract from the document" if exhaustive else "read the document"
         return document_tool_failure(
             tool_ref=tool_ref,
             action=action,

--- a/libs/fred-runtime/fred_runtime/capabilities/document_summarize/capability.py
+++ b/libs/fred-runtime/fred_runtime/capabilities/document_summarize/capability.py
@@ -69,9 +69,14 @@ from fred_sdk.contracts.context import (
     ToolInvocationResult,
 )
 from fred_sdk.contracts.models import FieldSpec, UIHints
-from fred_sdk.contracts.runtime import DocumentSummaryResult
+from fred_sdk.contracts.runtime import (
+    DocumentScopeRefusedError,
+    DocumentSummaryResult,
+)
 from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel, Field
+
+from fred_runtime.capabilities.document_read_common import document_scope_refusal
 
 _KF_SERVICE = "Knowledge Flow"
 
@@ -277,6 +282,12 @@ class DocumentSummarizeCapability(
                     document_uid,
                     instruction=instruction,
                     max_chars=effective_max_chars,
+                )
+            except DocumentScopeRefusedError as exc:
+                return document_scope_refusal(
+                    tool_ref="summarize_document",
+                    action="summarize the document",
+                    exc=exc,
                 )
             except Exception as exc:
                 message, artifact = _document_tool_failure(

--- a/libs/fred-runtime/fred_runtime/common/kf_document_client.py
+++ b/libs/fred-runtime/fred_runtime/common/kf_document_client.py
@@ -192,6 +192,7 @@ class KfDocumentClient(KfBaseClient):
         *,
         working_directory: Optional[str] = None,
         tag_ids: Optional[Sequence[str]] = None,
+        document_uids: Optional[Sequence[str]] = None,
         max_chars: int = 6000,
         owner_filter: Optional[OwnerFilter] = None,
         team_id: Optional[str] = None,
@@ -202,6 +203,7 @@ class KfDocumentClient(KfBaseClient):
           {
             "working_directory": str?,
             "tag_ids": [str]?,
+            "document_uids": [str]?,
             "max_chars": int,
             "owner_filter": str?,
             "team_id": str?
@@ -212,6 +214,8 @@ class KfDocumentClient(KfBaseClient):
             payload["working_directory"] = working_directory
         if tag_ids:
             payload["tag_ids"] = list(tag_ids)
+        if document_uids:
+            payload["document_uids"] = list(document_uids)
         if owner_filter:
             payload["owner_filter"] = owner_filter.value
         if team_id:

--- a/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
+++ b/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
@@ -1280,6 +1280,33 @@ def _narrow_scope_ids(
     return [value for value in inner if value in allowed]
 
 
+def _ensure_uid_in_turn_scope(
+    runtime_context: RuntimeContext | None, document_uid: str
+) -> None:
+    """Refuse a model-named uid that the turn's document selection excludes.
+
+    The uid comes from the MODEL - a search hit, the tree, or a turn taken
+    before the user narrowed the scope - so this seam is the only thing keeping
+    a document the user took out of the conversation out of the answer.
+    An empty selection bounds nothing. A non-empty one bounds attachments too,
+    exactly as it already does on the search path (Knowledge Flow restricts the
+    session branch to the same uids).
+
+    Documents only: a library-level selection is NOT enforced here, because
+    resolving a library to its documents needs the tag store this pod does not
+    have. Search and the tree still narrow to the selected libraries, so a
+    stale uid from an earlier turn is the only way past it - closing that means
+    moving the scope onto Knowledge Flow's read endpoints.
+    """
+
+    selected = get_document_uids(runtime_context)
+    if selected and document_uid not in selected:
+        raise DocumentScopeRefusedError(
+            "the requested document is not part of this conversation's scope",
+            requested_uids=[document_uid],
+        )
+
+
 class DocumentSearchAdapter(DocumentSearchPort):
     """
     Runtime adapter behind `RuntimeServices.document_search` (CAPAB-01 #1906).
@@ -1633,9 +1660,9 @@ class DocumentTreeAdapter(DocumentTreePort):
     Same shape as `DocumentSearchAdapter`: the per-turn binding is captured
     PRIVATELY (through `_VectorSearchAgentShim` + `KfDocumentClient`, which own
     the access token and its refresh) and only the capability-safe `tree(...)`
-    surface is exposed. The caller-supplied `library_tag_ids` are the
-    capability's already-narrowed scope; this adapter intersects them with the
-    session binding's own library scope and stamps the owner_filter/team_id
+    surface is exposed. The caller-supplied `library_tag_ids` / `document_uids`
+    are the capability's already-narrowed scope; this adapter intersects them
+    with the session binding's own scope and stamps the owner_filter/team_id
     seam, so the Knowledge Flow listing can never leak folders across team
     boundaries.
     """
@@ -1657,11 +1684,15 @@ class DocumentTreeAdapter(DocumentTreePort):
         *,
         working_directory: str | None = None,
         library_tag_ids: Sequence[str] | None = None,
+        document_uids: Sequence[str] | None = None,
         max_chars: int = 6000,
     ) -> DocumentTreeResult:
         runtime_context = self._binding.runtime_context
         effective_libs = _narrow_scope_ids(
             get_document_library_tags_ids(runtime_context), library_tag_ids
+        )
+        effective_uids = _narrow_scope_ids(
+            get_document_uids(runtime_context), document_uids
         )
         team_id = self._settings.team_id
         scoped_team = bool(team_id) and not is_personal_team_id(team_id)
@@ -1669,6 +1700,7 @@ class DocumentTreeAdapter(DocumentTreePort):
             result = await self._client.tree(
                 working_directory=working_directory,
                 tag_ids=effective_libs,
+                document_uids=effective_uids,
                 max_chars=max_chars,
                 owner_filter=OwnerFilter.TEAM if scoped_team else OwnerFilter.PERSONAL,
                 team_id=team_id if scoped_team else None,
@@ -1710,11 +1742,11 @@ class DocumentSummarizeAdapter(DocumentSummarizePort):
     """
     Runtime adapter behind `RuntimeServices.document_summarize`.
 
-    No scope narrowing here: the caller already holds a concrete
-    `document_uid` (from a search hit, tree listing, or the conversation's
-    attached-files context), and Knowledge Flow's own per-document ReBAC is
-    the real authorization gate. The binding/token stay private;
-    `KfDocumentClient` applies the extended summarize read timeout.
+    The uid is model-supplied, so `_ensure_uid_in_turn_scope` bounds it by the
+    turn's document selection before anything is fetched; Knowledge Flow's own
+    per-document ReBAC remains the authorization gate underneath. The
+    binding/token stay private; `KfDocumentClient` applies the extended
+    summarize read timeout.
     """
 
     def __init__(
@@ -1736,6 +1768,7 @@ class DocumentSummarizeAdapter(DocumentSummarizePort):
         instruction: str | None = None,
         max_chars: int = 2000,
     ) -> DocumentSummaryResult:
+        _ensure_uid_in_turn_scope(self._binding.runtime_context, document_uid)
         try:
             result = await self._client.summarize(
                 document_uid=document_uid,
@@ -1791,11 +1824,11 @@ class DocumentMarkdownAdapter(DocumentMarkdownPort):
 
     Fetches a document's FULL text by uid (corpus markdown or a session
     attachment, resolved Knowledge Flow-side) and returns it one bounded page
-    at a time. Same doctrine as `DocumentSummarizeAdapter`: no
-    scope narrowing (the caller already holds a concrete uid and KF is the
-    gate - per-document ReBAC for corpus, chunk-level session ownership for an
-    attachment), the per-turn binding/token stay private (through
-    `_VectorSearchAgentShim` + `KfDocumentClient`).
+    at a time. Same doctrine as `DocumentSummarizeAdapter`: the model-supplied
+    uid is bounded by the turn's document selection here, and KF is the
+    authorization gate underneath - per-document ReBAC for corpus, chunk-level
+    session ownership for an attachment. The per-turn binding/token stay
+    private (through `_VectorSearchAgentShim` + `KfDocumentClient`).
 
     Pagination is done adapter-side because Knowledge Flow's markdown endpoint
     has no page parameter today (the KF client stays wire-format only). To avoid
@@ -1824,6 +1857,7 @@ class DocumentMarkdownAdapter(DocumentMarkdownPort):
         offset: int = 0,
         max_chars: int = DEFAULT_MARKDOWN_PAGE_CHARS,
     ) -> DocumentMarkdownResult:
+        _ensure_uid_in_turn_scope(self._binding.runtime_context, document_uid)
         full = self._cache.get(document_uid)
         if full is None:
             try:
@@ -1844,7 +1878,8 @@ class DocumentExtractionAdapter(DocumentExtractionPort):
     Runtime adapter behind `RuntimeServices.document_extraction` (DOCREAD-01
     Phase 2). Delegates the whole exhaustive map-reduce to Knowledge Flow in one
     call (`KfDocumentClient.extract`, extended read timeout). Same doctrine as
-    `DocumentSummarizeAdapter`: no scope narrowing, binding/token stay private.
+    `DocumentSummarizeAdapter`: the model-supplied uid is bounded by the turn's
+    document selection, binding/token stay private.
     """
 
     def __init__(
@@ -1862,6 +1897,7 @@ class DocumentExtractionAdapter(DocumentExtractionPort):
     async def extract(
         self, document_uid: str, *, instruction: str
     ) -> DocumentExtractionResult:
+        _ensure_uid_in_turn_scope(self._binding.runtime_context, document_uid)
         try:
             result = await self._client.extract(
                 document_uid=document_uid, instruction=instruction

--- a/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
+++ b/libs/fred-runtime/fred_runtime/integrations/v2_runtime/adapters.py
@@ -115,6 +115,7 @@ from fred_runtime.common.structures import AgentSettingsLike
 from fred_runtime.common.table_hits import repair_table_hits
 from fred_runtime.runtime_context import get_runtime_context
 from fred_runtime.runtime_support import (
+    get_attachment_uids,
     get_document_library_tags_ids,
     get_document_uids,
     get_rag_knowledge_scope,
@@ -1288,23 +1289,34 @@ def _ensure_uid_in_turn_scope(
     The uid comes from the MODEL - a search hit, the tree, or a turn taken
     before the user narrowed the scope - so this seam is the only thing keeping
     a document the user took out of the conversation out of the answer.
-    An empty selection bounds nothing. A non-empty one bounds attachments too,
-    exactly as it already does on the search path (Knowledge Flow restricts the
-    session branch to the same uids).
 
-    Documents only: a library-level selection is NOT enforced here, because
-    resolving a library to its documents needs the tag store this pod does not
-    have. Search and the tree still narrow to the selected libraries, so a
-    stale uid from an earlier turn is the only way past it - closing that means
-    moving the scope onto Knowledge Flow's read endpoints.
+    It refuses only what it can prove is out of scope, because a false refusal
+    is worse here than a missed one: the model reports a document the user
+    picked as unreachable. Two cases it cannot prove, and therefore lets
+    through:
+
+    - a library is part of the selection. Library and document picks UNION (the
+      rule search and the tree apply), and resolving a library to its documents
+      needs a tag store this pod has none of - so every document of that
+      library would be refused;
+    - the uid is one of the conversation's attached files. The picker lists the
+      corpus, so an attachment is never part of the selection, while the
+      attachment prompt tells the model to read those files by uid.
     """
 
     selected = get_document_uids(runtime_context)
-    if selected and document_uid not in selected:
-        raise DocumentScopeRefusedError(
-            "the requested document is not part of this conversation's scope",
-            requested_uids=[document_uid],
-        )
+    if not selected:
+        return
+    if get_document_library_tags_ids(runtime_context):
+        return
+    if document_uid in selected:
+        return
+    if document_uid in get_attachment_uids(runtime_context):
+        return
+    raise DocumentScopeRefusedError(
+        "the requested document is not part of this conversation's scope",
+        requested_uids=[document_uid],
+    )
 
 
 class DocumentSearchAdapter(DocumentSearchPort):

--- a/libs/fred-runtime/fred_runtime/react/react_prompting.py
+++ b/libs/fred-runtime/fred_runtime/react/react_prompting.py
@@ -267,6 +267,37 @@ def build_attachment_context_suffix(binding: BoundRuntimeContext) -> str:
     )
 
 
+def build_document_scope_suffix(binding: BoundRuntimeContext) -> str:
+    """
+    Tell the model that the user narrowed this turn to specific documents.
+
+    Without it the selection is invisible to the model: it has no referent for
+    "read this document", falls back to listing the tree, and asks the user
+    which file they mean while exactly one is selected. Derived per turn like
+    the attachment suffix, so deselecting removes the notice instead of leaving
+    a checkpointed system message behind.
+
+    Uids, not display names: `RuntimeContext` carries the selection as uids
+    only, and they are what the document tools take. The model is told never to
+    repeat them, as everywhere else.
+    """
+
+    uids = binding.runtime_context.selected_document_uids
+    if not uids:
+        return ""
+    listed = "\n".join(f"- {uid}" for uid in uids)
+    return (
+        "\n\nThe user has restricted this turn to the document(s) listed below, "
+        "and the document tools reach nothing else: search, the document tree "
+        "and the reading tools all return or accept only these. When the user "
+        'says "this document" or "the document", they mean one of them - read '
+        "it rather than asking which file is meant. Pass a listed value as "
+        "`document_uid`; these are internal working ids, so NEVER repeat one in "
+        "your answer - refer to a document by its display name.\n\n"
+        f"{listed}"
+    )
+
+
 def build_context_prompt_suffix(binding: BoundRuntimeContext, *, agent_id: str) -> str:
     """
     Render the session's attached chat-context prompts as a system-prompt suffix.
@@ -331,9 +362,10 @@ def compose_system_prompt(
     - guardrails, then the global base output contract, then the tool-failure
       recovery notice — hard invariants
     - ``runtime_suffixes`` — runtime-specific system notices (e.g. Deep filesystem)
-    - selected chat-context prompts, then conversation attachments — per-turn user
-      context, placed last so it is freshest while the envelope in
-      ``build_context_prompt_suffix`` still subordinates it to the guardrails above.
+    - selected chat-context prompts, then the turn's document scope, then
+      conversation attachments — per-turn user context, placed last so it is
+      freshest while the envelope in ``build_context_prompt_suffix`` still
+      subordinates it to the guardrails above.
 
     How to use:
     - render the agent template first, then pass it here with the runtime's tool
@@ -349,6 +381,7 @@ def compose_system_prompt(
             build_tool_failure_recovery_suffix(),
             *runtime_suffixes,
             build_context_prompt_suffix(binding, agent_id=agent_id),
+            build_document_scope_suffix(binding),
             build_attachment_context_suffix(binding),
         ]
     )

--- a/libs/fred-runtime/fred_runtime/react/react_prompting.py
+++ b/libs/fred-runtime/fred_runtime/react/react_prompting.py
@@ -287,13 +287,13 @@ def build_document_scope_suffix(binding: BoundRuntimeContext) -> str:
         return ""
     listed = "\n".join(f"- {uid}" for uid in uids)
     return (
-        "\n\nThe user has restricted this turn to the document(s) listed below, "
-        "and the document tools reach nothing else: search, the document tree "
-        "and the reading tools all return or accept only these. When the user "
-        'says "this document" or "the document", they mean one of them - read '
-        "it rather than asking which file is meant. Pass a listed value as "
-        "`document_uid`; these are internal working ids, so NEVER repeat one in "
-        "your answer - refer to a document by its display name.\n\n"
+        "\n\nThe user has picked the document(s) listed below for this turn. "
+        'When they say "this document" or "the document", they mean one of '
+        "them - read it rather than asking which file they mean. Pass a listed "
+        "value as `document_uid`; these are internal working ids, so NEVER "
+        "repeat one in your answer - refer to a document by its display name. "
+        "The user may also have selected whole libraries, whose documents are "
+        "in scope too and reachable through search and the document tree.\n\n"
         f"{listed}"
     )
 

--- a/libs/fred-runtime/fred_runtime/runtime_support/__init__.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/__init__.py
@@ -18,6 +18,7 @@ Runtime support utilities for Fred v2 agents.
 from .request_context_helpers import (
     RuntimeContextProvider,
     get_access_token,
+    get_attachment_uids,
     get_chat_context_libraries_ids,
     get_deep_search_enabled,
     get_document_library_tags_ids,
@@ -45,6 +46,7 @@ __all__ = [
     "set_attachments_markdown",
     "get_document_library_tags_ids",
     "get_search_policy",
+    "get_attachment_uids",
     "get_document_uids",
     "get_rag_knowledge_scope",
     "get_vector_search_scopes",

--- a/libs/fred-runtime/fred_runtime/runtime_support/request_context_helpers.py
+++ b/libs/fred-runtime/fred_runtime/runtime_support/request_context_helpers.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Callable, Optional
 
 from fred_sdk.contracts.context import RuntimeContext
@@ -75,6 +76,31 @@ def get_document_uids(context: RuntimeContext | None) -> list[str] | None:
     if not context:
         return None
     return context.selected_document_uids
+
+
+# The frontend renders one attached file per line as
+# `- <name> [<document_uid>]: conversation document`, and the model is told to
+# pass that bracketed value to the document tools - so the runtime reads its own
+# scope decisions from the same source rather than a second, divergent one. The
+# greedy prefix keeps the LAST bracket before the colon, so a file name with
+# brackets of its own does not shadow the uid.
+_ATTACHMENT_UID_RE = re.compile(r"^\s*-\s.*\[([^\[\]]+)\]\s*:", re.MULTILINE)
+
+
+def get_attachment_uids(context: RuntimeContext | None) -> set[str]:
+    """Return the uids of the files attached to the current conversation.
+
+    Why: a corpus-level document selection must not make the conversation's own
+    files unreadable - the picker lists the corpus, so an attachment uid is
+    never part of that selection.
+    Example:
+        >>> sorted(get_attachment_uids(RuntimeContext(
+        ...     attachments_markdown="- notes.pdf [u-1]: conversation document")))
+        ['u-1']
+    """
+    if not context or not context.attachments_markdown:
+        return set()
+    return set(_ATTACHMENT_UID_RE.findall(context.attachments_markdown))
 
 
 def get_rag_knowledge_scope(context: RuntimeContext | None) -> str:

--- a/libs/fred-runtime/tests/test_capability_document_access_1906.py
+++ b/libs/fred-runtime/tests/test_capability_document_access_1906.py
@@ -187,12 +187,14 @@ class _FakeTreePort(DocumentTreePort):
         *,
         working_directory: str | None = None,
         library_tag_ids=None,
+        document_uids=None,
         max_chars: int = 6000,
     ) -> DocumentTreeResult:
         self.calls.append(
             {
                 "working_directory": working_directory,
                 "library_tag_ids": library_tag_ids,
+                "document_uids": document_uids,
                 "max_chars": max_chars,
             }
         )
@@ -769,6 +771,27 @@ def test_attachments_only_drops_the_tree_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tree_tool_carries_the_turn_document_selection() -> None:
+    """A document-level pick must prune the listing too - not only the search.
+    Selecting one file and being handed the whole corpus is what sent the model
+    back to asking which document was meant."""
+
+    tree_port = _FakeTreePort()
+    cap = DocumentAccessCapability()
+    ctx = build_capability_context(
+        cap,
+        identity=_identity(),
+        services=_full_services(tree=tree_port),
+        config={},
+        turn_options={"document_uids": ["u1"]},
+    )
+
+    await _invoke_named_tool(cap, ctx, "list_document_tree", {})
+
+    assert tree_port.calls[0]["document_uids"] == ["u1"]
+
+
+@pytest.mark.asyncio
 async def test_tree_tool_scopes_by_bound_libraries_and_clamps_budget() -> None:
     tree_port = _FakeTreePort()
     cap = DocumentAccessCapability()
@@ -790,6 +813,8 @@ async def test_tree_tool_scopes_by_bound_libraries_and_clamps_budget() -> None:
     assert call["working_directory"] == "Sales"
     # Hard binding flows to the port as the capability-side scope.
     assert call["library_tag_ids"] == ["A", "B"]
+    # No document narrowing configured or ticked: the tree stays library-scoped.
+    assert call["document_uids"] is None
     # 50 is under the endpoint's floor — clamped, not 422ed.
     assert call["max_chars"] == 500
     assert message.content == "Sales/\n  doc-a [u1]"

--- a/libs/fred-runtime/tests/test_capability_document_reading.py
+++ b/libs/fred-runtime/tests/test_capability_document_reading.py
@@ -54,6 +54,7 @@ from fred_sdk.contracts.runtime import (
     DocumentMarkdownPort,
     DocumentMarkdownResult,
     DocumentPortCallError,
+    DocumentScopeRefusedError,
     RuntimeServices,
 )
 
@@ -416,6 +417,47 @@ async def test_403_failure_teaches_uid_recovery() -> None:
     assert "document_uid=cahier.pdf" in msg.content
     # The recovery hint must also land in the artifact blocks (Graph agent path).
     assert msg.artifact.blocks[0].text == msg.content
+
+
+@pytest.mark.asyncio
+async def test_scope_refusal_is_not_told_as_a_service_failure() -> None:
+    """A refused uid must not read as a broken service, or the model retries it
+    (and, worse, may report the document as empty)."""
+
+    port = _FakeMarkdownPort(
+        error=DocumentScopeRefusedError("out of scope", requested_uids=["u-42"])
+    )
+    cap = DocumentVerbatimCapability()
+    ctx = build_capability_context(
+        cap, identity=_identity(), services=_services(port), config={}
+    )
+
+    msg = await _invoke(cap, ctx, "read_document", {"document_uid": "u-42"})
+    assert msg.artifact.is_error is True
+    assert "restricted this conversation" in msg.content
+    assert "Knowledge Flow" not in msg.content
+    assert msg.artifact.blocks[0].text == msg.content
+
+
+@pytest.mark.asyncio
+async def test_extract_scope_refusal_is_not_told_as_a_service_failure() -> None:
+    port = _FakeExtractionPort(
+        error=DocumentScopeRefusedError("out of scope", requested_uids=["u-42"])
+    )
+    cap = DocumentExtractCapability()
+    ctx = build_capability_context(
+        cap, identity=_identity(), services=_extract_services(port), config={}
+    )
+
+    msg = await _invoke(
+        cap,
+        ctx,
+        "extract_from_document",
+        {"document_uid": "u-42", "what_to_extract": "every risk"},
+    )
+    assert msg.artifact.is_error is True
+    assert "restricted this conversation" in msg.content
+    assert "Knowledge Flow" not in msg.content
 
 
 @pytest.mark.asyncio

--- a/libs/fred-runtime/tests/test_document_read_scope.py
+++ b/libs/fred-runtime/tests/test_document_read_scope.py
@@ -149,6 +149,45 @@ async def test_no_selection_bounds_nothing() -> None:
     assert page.text == "the whole document"
 
 
+async def test_a_library_pick_disarms_the_gate() -> None:
+    """Library and document picks UNION, and a library cannot be resolved to its
+    documents pod-side - so enforcing the document list alone would refuse a
+    document the user selected through its library."""
+
+    adapter = adapters_module.DocumentMarkdownAdapter(
+        binding=_binding(
+            selected_document_uids=["in-scope"],
+            selected_document_libraries_ids=["lib-a"],
+        ),
+        settings=_FakeSettings(),
+    )
+
+    page = await adapter.fetch_markdown("a-document-of-lib-a")
+
+    assert page.text == "the whole document"
+
+
+async def test_an_attached_file_stays_readable_under_a_corpus_selection() -> None:
+    """The picker lists the corpus, so an attachment uid is never in the
+    selection - refusing it would make the conversation's own files unreadable
+    while the attachment prompt tells the model to read them by uid."""
+
+    adapter = adapters_module.DocumentMarkdownAdapter(
+        binding=_binding(
+            selected_document_uids=["in-scope"],
+            attachments_markdown=(
+                "## Attached files for this conversation\n"
+                "- notes.pdf [attached-1]: conversation document"
+            ),
+        ),
+        settings=_FakeSettings(),
+    )
+
+    page = await adapter.fetch_markdown("attached-1")
+
+    assert page.text == "the whole document"
+
+
 async def test_summarize_refuses_a_uid_outside_the_selection() -> None:
     adapter = adapters_module.DocumentSummarizeAdapter(
         binding=_binding(selected_document_uids=["in-scope"]),

--- a/libs/fred-runtime/tests/test_document_read_scope.py
+++ b/libs/fred-runtime/tests/test_document_read_scope.py
@@ -1,0 +1,197 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The turn's document selection, enforced on the tools that take a uid.
+
+`read_document`, `summarize_document` and `extract_from_document` take a uid the
+MODEL produced - from a search hit, the tree, or a turn taken before the user
+narrowed the scope. The adapter seam is what keeps a document the user removed
+from the conversation out of the answer; the tree carries the same selection
+down the wire instead of listing the whole corpus.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import fred_runtime.integrations.v2_runtime.adapters as adapters_module
+import pytest
+from fred_sdk.contracts.context import (
+    BoundRuntimeContext,
+    PortableContext,
+    PortableEnvironment,
+    RuntimeContext,
+)
+from fred_sdk.contracts.models import AgentTuning, MCPServerRef
+from fred_sdk.contracts.runtime import DocumentScopeRefusedError
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeSettings:
+    id: str = "agent-1"
+    team_id: str | None = "team-1"
+    tuning: AgentTuning | None = None
+    active_mcp_servers: Sequence[MCPServerRef] = ()
+
+
+class _RecordingKfClient:
+    """Stand-in for KfDocumentClient, recording what reached Knowledge Flow."""
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __init__(self, agent: object) -> None:
+        self._agent = agent
+
+    async def fetch_markdown(self, **kwargs: Any) -> str:
+        type(self).calls.append(("fetch_markdown", kwargs))
+        return "the whole document"
+
+    async def summarize(self, **kwargs: Any):
+        type(self).calls.append(("summarize", kwargs))
+        return _Summary()
+
+    async def extract(self, **kwargs: Any):
+        type(self).calls.append(("extract", kwargs))
+        return _Extraction()
+
+    async def tree(self, **kwargs: Any):
+        type(self).calls.append(("tree", kwargs))
+        return _Tree()
+
+
+class _Summary:
+    document_uid = "in-scope"
+    summary = "a summary"
+    shrunk_for_budget = False
+    keywords: list[str] = []
+
+
+class _Extraction:
+    document_uid = "in-scope"
+    extraction = "- one item"
+    item_count = 1
+    chunks_processed = 1
+    truncated = False
+
+
+class _Tree:
+    tree = "Sales/"
+    truncated = False
+
+
+def _binding(**runtime_kwargs: Any) -> BoundRuntimeContext:
+    return BoundRuntimeContext(
+        runtime_context=RuntimeContext(
+            session_id="s-1", team_id="team-1", **runtime_kwargs
+        ),
+        portable_context=PortableContext(
+            request_id="request-1",
+            correlation_id="correlation-1",
+            actor="u-1",
+            tenant="team-1",
+            environment=PortableEnvironment.DEV,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapters_module, "KfDocumentClient", _RecordingKfClient)
+    _RecordingKfClient.calls = []
+
+
+async def test_markdown_read_refuses_a_uid_outside_the_selection() -> None:
+    adapter = adapters_module.DocumentMarkdownAdapter(
+        binding=_binding(selected_document_uids=["in-scope"]),
+        settings=_FakeSettings(),
+    )
+
+    with pytest.raises(DocumentScopeRefusedError) as raised:
+        await adapter.fetch_markdown("other-document")
+
+    assert raised.value.requested_uids == ("other-document",)
+    # Refused locally: Knowledge Flow was never asked for the document.
+    assert _RecordingKfClient.calls == []
+
+
+async def test_markdown_read_allows_a_selected_uid() -> None:
+    adapter = adapters_module.DocumentMarkdownAdapter(
+        binding=_binding(selected_document_uids=["in-scope"]),
+        settings=_FakeSettings(),
+    )
+
+    page = await adapter.fetch_markdown("in-scope")
+
+    assert page.text == "the whole document"
+    assert _RecordingKfClient.calls[0][0] == "fetch_markdown"
+
+
+async def test_no_selection_bounds_nothing() -> None:
+    adapter = adapters_module.DocumentMarkdownAdapter(
+        binding=_binding(), settings=_FakeSettings()
+    )
+
+    page = await adapter.fetch_markdown("any-document")
+
+    assert page.text == "the whole document"
+
+
+async def test_summarize_refuses_a_uid_outside_the_selection() -> None:
+    adapter = adapters_module.DocumentSummarizeAdapter(
+        binding=_binding(selected_document_uids=["in-scope"]),
+        settings=_FakeSettings(),
+    )
+
+    with pytest.raises(DocumentScopeRefusedError):
+        await adapter.summarize("other-document")
+
+    assert _RecordingKfClient.calls == []
+
+
+async def test_extract_refuses_a_uid_outside_the_selection() -> None:
+    adapter = adapters_module.DocumentExtractionAdapter(
+        binding=_binding(selected_document_uids=["in-scope"]),
+        settings=_FakeSettings(),
+    )
+
+    with pytest.raises(DocumentScopeRefusedError):
+        await adapter.extract("other-document", instruction="list every risk")
+
+    assert _RecordingKfClient.calls == []
+
+
+async def test_tree_carries_the_selection_down_the_wire() -> None:
+    adapter = adapters_module.DocumentTreeAdapter(
+        binding=_binding(selected_document_uids=["a", "b"]),
+        settings=_FakeSettings(),
+    )
+
+    await adapter.tree(document_uids=["b", "c"])
+
+    name, kwargs = _RecordingKfClient.calls[0]
+    assert name == "tree"
+    # `params ⊆ session_binding`: "c" was never in the conversation's selection.
+    assert kwargs["document_uids"] == ["b"]
+
+
+async def test_tree_without_a_selection_sends_no_document_filter() -> None:
+    adapter = adapters_module.DocumentTreeAdapter(
+        binding=_binding(), settings=_FakeSettings()
+    )
+
+    await adapter.tree()
+
+    assert _RecordingKfClient.calls[0][1]["document_uids"] is None

--- a/libs/fred-runtime/tests/test_react_prompting.py
+++ b/libs/fred-runtime/tests/test_react_prompting.py
@@ -18,6 +18,7 @@ from typing import cast
 from fred_runtime.react.react_prompting import (
     build_attachment_context_suffix,
     build_context_prompt_suffix,
+    build_document_scope_suffix,
     build_global_base_prompt_suffix,
     build_tool_failure_recovery_suffix,
     compose_system_prompt,
@@ -45,12 +46,14 @@ def _binding(
     *,
     context_prompt_text: str | None = None,
     language: str | None = None,
+    selected_document_uids: list[str] | None = None,
 ) -> BoundRuntimeContext:
     return BoundRuntimeContext(
         runtime_context=RuntimeContext(
             attachments_markdown=attachments_markdown,
             context_prompt_text=context_prompt_text,
             language=language,
+            selected_document_uids=selected_document_uids,
         ),
         portable_context=PortableContext(
             request_id="request-1",
@@ -194,6 +197,21 @@ def test_attachment_context_suffix_instructs_model_to_search_images() -> None:
     assert "documents AND images" in suffix
     assert "MUST first call the search tool" in suffix
     assert "do not claim you cannot see or analyze an attachment" in suffix
+
+
+def test_document_scope_suffix_names_the_selection() -> None:
+    suffix = build_document_scope_suffix(_binding(selected_document_uids=["u-1"]))
+
+    assert "restricted this turn" in suffix
+    # Without a referent the model asks which file is meant while one is ticked.
+    assert "this document" in suffix
+    assert "- u-1" in suffix
+    assert "NEVER repeat" in suffix
+
+
+def test_document_scope_suffix_is_absent_without_a_selection() -> None:
+    assert build_document_scope_suffix(_binding()) == ""
+    assert build_document_scope_suffix(_binding(selected_document_uids=[])) == ""
 
 
 def test_context_prompt_suffix_injects_selected_prompt_text() -> None:

--- a/libs/fred-runtime/tests/test_react_prompting.py
+++ b/libs/fred-runtime/tests/test_react_prompting.py
@@ -202,11 +202,14 @@ def test_attachment_context_suffix_instructs_model_to_search_images() -> None:
 def test_document_scope_suffix_names_the_selection() -> None:
     suffix = build_document_scope_suffix(_binding(selected_document_uids=["u-1"]))
 
-    assert "restricted this turn" in suffix
+    assert "picked the document(s) listed below" in suffix
     # Without a referent the model asks which file is meant while one is ticked.
     assert "this document" in suffix
     assert "- u-1" in suffix
     assert "NEVER repeat" in suffix
+    # A library pick unions with the document pick, so the suffix must not
+    # claim the listed documents are all the tools can reach.
+    assert "whole libraries" in suffix
 
 
 def test_document_scope_suffix_is_absent_without_a_selection() -> None:

--- a/libs/fred-sdk/fred_sdk/contracts/runtime.py
+++ b/libs/fred-sdk/fred_sdk/contracts/runtime.py
@@ -936,15 +936,18 @@ class DocumentTreePort(ABC):
         *,
         working_directory: str | None = None,
         library_tag_ids: Sequence[str] | None = None,
+        document_uids: Sequence[str] | None = None,
         max_chars: int = 6000,
     ) -> DocumentTreeResult:
         """
         Return the caller's authorized folder/document tree as rendered text.
 
-        `library_tag_ids` is the capability's already-narrowed library scope
-        (None = "no capability-side narrowing"); the adapter further bounds it
-        by the session binding before calling Knowledge Flow, completing
-        `turn_option ⊆ capability_config ⊆ session_binding`. Raises
+        `library_tag_ids` / `document_uids` are the capability's already-narrowed
+        scope (None = "no capability-side narrowing at that level"); the adapter
+        further bounds them by the session binding before calling Knowledge Flow,
+        completing `turn_option ⊆ capability_config ⊆ session_binding`. A
+        document scope prunes the listing to those leaves and drops the folders
+        left empty, so a one-document selection renders one document. Raises
         `DocumentPortCallError` on transport failure.
 
         No business-label filtering here, deliberately: a folder tree renders


### PR DESCRIPTION
Closes #2510.

## What was broken

The composer's document picker sends the user's selection twice - as a
`document_access` turn-options slice and on `RuntimeContext` - and only two of
the six document tools read it (`search_documents_using_vectorization`,
`find_similar_passages`). Ticking a single file produced a listing of the whole
corpus, a model asking which document was meant, and reading tools that would
accept any uid they had ever seen.

## What changed

Three seams now share one selection:

- **the tree.** `DocumentTreePort.tree` takes `document_uids`; the adapter
  intersects it with the binding, `KfDocumentClient` puts it on the wire, and
  `CorpusTreeService` narrows the resolved leaves and drops the folders left
  empty. Without a document scope the listing is byte-for-byte what it was,
  empty folders included.
- **the reading tools.** The markdown, summarize and extraction adapters bound
  the model-supplied uid by the same selection and raise
  `DocumentScopeRefusedError` - the seam `DocumentSimilarityAdapter` already had
  for uids of the same provenance. The capabilities render it through
  `document_scope_refusal`, never as a Knowledge Flow failure: a scope decision
  told as a transport error gets retried, told as an empty result gets reported
  as an empty document.
- **the prompt.** `build_document_scope_suffix` names the selection in the
  per-turn system prompt, so "read this document" has a referent instead of a
  tree walk.

**Library and document picks UNION**, matching what Knowledge Flow already does
with search hits: ticking a library plus a file elsewhere means "that library,
plus that file".

**The gate refuses only what it can prove** (second commit, after review). A
false refusal is worse than a missed one - the model tells the user a document
they picked is unreachable. So a selection that includes a library disarms it
(its documents cannot be enumerated pod-side), and an attached file stays
readable under a corpus selection (the picker lists the corpus, so an attachment
uid is never in the selection). What stays enforced is the case that produced
the bug: a documents-only selection with a stale uid from a wider earlier turn.

## Known gaps, stated rather than papered over

- with `bind_libraries=True` the pinned library is always sent as the tree's
  library scope and unions with the document scope, so ticking one file still
  lists the whole bound library. Separating "the user picked this library" from
  "the agent is pinned to it" needs a second wire field.
- `narrow_scope_ids` reads an empty intersection (stored `document_uids`
  disjoint from the turn's pick) as "no bound" and re-widens to the session
  selection. Pre-existing on the search path, now shared by the tree.

## Tests

`libs/fred-runtime`: new `test_document_read_scope.py` (9 cases: refusal on each
of the three read adapters, library pick disarming the gate, attachment still
readable, tree carrying the narrowed selection), plus the refusal rendering in
`test_capability_document_reading.py`, the tree wiring in
`test_capability_document_access_1906.py` and the suffix in
`test_react_prompting.py`. `knowledge-flow`: document scope, the library/document
union, and the untouched no-scope listing in `test_corpus_tree_service.py`.

1123 fred-runtime + 1009 knowledge-flow + 342 fred-sdk pass; `make code-quality`
clean on all three. `knowledgeFlowOpenApi.ts` regenerated for the new request
field. Contract entry: `RUNTIME-EXECUTION-CONTRACT.md` §8.65.

Follow-up on the same tool, split out so this can merge on its own: #2514
(page 1 answered as the whole document).