### PR TITLE
feat(#2516): a team_admin can rename their own team

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/teams/schemas.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/schemas.py
@@ -229,6 +229,16 @@ class CreateTeamRequest(BaseModel):
     name: str = Field(min_length=1, max_length=180)
     initial_team_admin_ids: list[str] = Field(min_length=1)
 
+    @field_validator("name")
+    @classmethod
+    def _trim_name(cls, value: str) -> str:
+        """Stored trimmed, exactly like a rename: `"Ops "` and `"Ops"` are the
+        same name to a reader, and the unique index would let both through."""
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("Team name cannot be empty.")
+        return trimmed
+
 
 class RescueTeamAdminRequest(BaseModel):
     """AUTHZ-05 review item 9 (RFC §32): `POST /teams/{team_id}/rescue-admin`.
@@ -254,6 +264,9 @@ class GrantTeamMemberRoleRequest(BaseModel):
 
 
 class UpdateTeamRequest(BaseModel):
+    # A team_admin may rename their own team through this surface (the route is
+    # gated on `can_update_info`, which is exactly `team_admin` in schema.fga).
+    name: str | None = Field(default=None, min_length=1, max_length=180)
     description: str | None = Field(default=None, max_length=180)
     joining_mode: JoiningMode | None = None
     visibility: TeamVisibility | None = None
@@ -265,6 +278,16 @@ class UpdateTeamRequest(BaseModel):
     # is enforced server-side in `update_team` (422 via `RetentionUpdateError`).
     team_delete_grace: str | None = Field(default=None, min_length=1)
     max_idle: str | None = Field(default=None, min_length=1)
+
+    @field_validator("name")
+    @classmethod
+    def _reject_blank_name(cls, value: str | None) -> str:
+        """Unlike the other fields here, an explicit ``null`` is not "clear the
+        value" - a team always has a name. Only ever reached for a
+        client-supplied value: pydantic skips validators on unset defaults."""
+        if value is None or not value.strip():
+            raise ValueError("Team name cannot be empty.")
+        return value.strip()
 
     @field_validator("team_delete_grace", "max_idle")
     @classmethod

--- a/apps/control-plane-backend/control_plane_backend/teams/service.py
+++ b/apps/control-plane-backend/control_plane_backend/teams/service.py
@@ -734,8 +734,9 @@ async def update_team(
 
     Why this function exists:
     - collaborative teams need a single business path for editable metadata,
-      including `joining_mode` (TEAM-09) and `visibility` (TEAM-10) —
-      marketplace discoverability is gated by `visibility` alone (see
+      including `name` (a team_admin rename), `joining_mode` (TEAM-09) and
+      `visibility` (TEAM-10) — marketplace discoverability is gated by
+      `visibility` alone (see
       `ensure_team_public_relations`/`revoke_team_public_relations`)
 
     How to use it:
@@ -758,6 +759,17 @@ async def update_team(
     # PATCH with no fields is a no-op.
     if request.model_fields_set:
         patch_data = request.model_dump(exclude_unset=True)
+        store = deps.get_team_metadata_store()
+        renamed_from: str | None = None
+        # Renaming to the current name is a no-op, not a conflict. Any other
+        # name must be free: `teammetadata.name` is globally unique, so this
+        # pre-check turns the common collision into a 409 instead of a 500.
+        if patch_data.get("name") == metadata.name:
+            patch_data.pop("name")
+        elif "name" in patch_data:
+            if await store.get_by_name(patch_data["name"]):
+                raise TeamAlreadyExistsError(patch_data["name"])
+            renamed_from = metadata.name
         # The public API exposes the team image as `avatar_image_url`, but the
         # storage layer (fred_core `TeamMetadataPatch`) still speaks `banner_*`
         # (#2300 Option A: the DB column keeps its legacy name, no migration).
@@ -784,7 +796,26 @@ async def update_team(
         ):
             patch_data["joining_mode"] = JoiningMode.INVITE_ONLY
         patch = TeamMetadataPatch.model_validate(patch_data)
-        updated = await deps.get_team_metadata_store().upsert(team_id, patch)
+        try:
+            updated = await store.upsert(team_id, patch)
+        except IntegrityError as exc:
+            # `name` is the only unique-constrained column, and the pre-check
+            # above is a fast path only - this is what closes the race between
+            # two concurrent renames onto the same name.
+            if "name" not in patch_data:
+                raise
+            raise TeamAlreadyExistsError(patch_data["name"]) from exc
+        if renamed_from is not None:
+            # Nothing else records a rename: there is no team audit table, and
+            # the bundle importer reconciles teams by name, so a duplicate team
+            # appearing on a later import is only explainable from this line.
+            logger.info(
+                "Team %s renamed from '%s' to '%s' by %s",
+                team_id,
+                renamed_from,
+                patch_data["name"],
+                user.uid,
+            )
         if updated is not None:
             metadata = updated
         if "visibility" in patch_data:

--- a/apps/control-plane-backend/tests/test_team_registry_governance.py
+++ b/apps/control-plane-backend/tests/test_team_registry_governance.py
@@ -37,12 +37,15 @@ from control_plane_backend.teams.schemas import (
     TeamAlreadyExistsError,
     TeamNotFoundError,
     TeamRescueNotOrphanedError,
+    TeamWithPermissions,
+    UpdateTeamRequest,
 )
 from control_plane_backend.teams.service import (
     create_team,
     delete_team,
     list_all_teams_for_registry,
     rescue_team_admin,
+    update_team,
 )
 from fred_core import (
     KeycloakUser,
@@ -56,6 +59,7 @@ from fred_core import (
 from fred_core.common import TeamId
 from fred_core.teams.metadata_store import TeamMetadata
 from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 
 
@@ -116,12 +120,14 @@ class _FakeMetadataStore:
         teams: dict[str, TeamMetadata] | None = None,
         *,
         create_raises: Exception | None = None,
+        upsert_raises: Exception | None = None,
     ) -> None:
         self.teams = dict(teams or {})
         self.deleted_ids: list[str] = []
         self.created: list[tuple[str, str]] = []
         self.advisory_lock_keys: list[str] = []
         self._create_raises = create_raises
+        self._upsert_raises = upsert_raises
 
     async def get_by_team_id(self, team_id, session=None):
         return self.teams.get(str(team_id))
@@ -136,6 +142,20 @@ class _FakeMetadataStore:
         metadata = TeamMetadata(id=TeamId(str(team_id)), name=name)
         self.teams[str(team_id)] = metadata
         return metadata
+
+    async def upsert(self, team_id, patch, session=None) -> TeamMetadata | None:
+        """Mirrors the real store's partial semantics via `to_store_values`, so a
+        patch that leaves a field unset really does keep the stored value."""
+        if self._upsert_raises is not None:
+            raise self._upsert_raises
+        existing = self.teams.get(str(team_id))
+        if existing is None:
+            return None
+        record = existing.model_dump()
+        record.update(patch.to_store_values())
+        updated = TeamMetadata(**record)
+        self.teams[str(team_id)] = updated
+        return updated
 
     async def delete(self, team_id, session=None) -> None:
         self.deleted_ids.append(str(team_id))
@@ -345,6 +365,177 @@ async def test_seed_starter_kit_failure_is_swallowed() -> None:
         TeamId("swiftpost-team-id"),
         _deps(rebac, store, prompt_category_store=failing_category_store),
     )
+
+
+# --------------------------- update_team (team_admin rename) ----------------
+
+
+def _stub_team_projection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace `update_team`'s response tail with a bare projection.
+
+    `_build_team_with_permissions` is a ReBAC read/BatchCheck fan-out with its
+    own tests; these cover the rename rules, not the projection.
+    """
+
+    async def _build(_user, metadata, _deps, _token) -> TeamWithPermissions:
+        return TeamWithPermissions(id=metadata.id, name=metadata.name)
+
+    monkeypatch.setattr(
+        "control_plane_backend.teams.service._build_team_with_permissions",
+        _build,
+    )
+
+
+def _team_store(**names: str) -> _FakeMetadataStore:
+    return _FakeMetadataStore(
+        {tid: TeamMetadata(id=TeamId(tid), name=name) for tid, name in names.items()}
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_team_renames_the_team_under_can_update_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rename rides the existing team PATCH surface, so it is gated on
+    `can_update_info` — exactly `team_admin` in schema.fga — and needs no
+    platform-admin governance capability of its own. The stored name is the
+    trimmed one: surrounding whitespace would make two visually identical
+    names collide-free at the DB level."""
+    rebac = _FakeRebac()
+    store = _team_store(t1="Northbridge")
+    _stub_team_projection(monkeypatch)
+
+    team = await update_team(
+        _user(),
+        TeamId("t1"),
+        UpdateTeamRequest(name="  Southbridge  "),
+        _deps(rebac, store),
+    )
+
+    assert team.name == "Southbridge"
+    assert store.teams["t1"].name == "Southbridge"
+    assert rebac.team_permission_checks == [
+        ("t1", (TeamPermission.CAN_UPDATE_INFO,)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_team_refuses_a_name_another_team_already_holds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`teammetadata.name` is globally unique, so a rename can collide exactly
+    like a create. It must surface as the same 409 and leave the team's own
+    name untouched."""
+    store = _team_store(t1="Northbridge", t2="Southbridge")
+    _stub_team_projection(monkeypatch)
+
+    with pytest.raises(TeamAlreadyExistsError):
+        await update_team(
+            _user(),
+            TeamId("t1"),
+            UpdateTeamRequest(name="Southbridge"),
+            _deps(_FakeRebac(), store),
+        )
+
+    assert store.teams["t1"].name == "Northbridge"
+
+
+@pytest.mark.asyncio
+async def test_update_team_accepts_the_name_the_team_already_has(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The form posts every field it renders, so an unchanged name reaches the
+    service on any edit. Matching the team's *own* registry row is a no-op, not
+    a conflict — the rest of the patch must still apply."""
+    store = _team_store(t1="Northbridge")
+    _stub_team_projection(monkeypatch)
+
+    team = await update_team(
+        _user(),
+        TeamId("t1"),
+        UpdateTeamRequest(name="Northbridge", description="Storage team"),
+        _deps(_FakeRebac(), store),
+    )
+
+    assert team.name == "Northbridge"
+    assert store.teams["t1"].description == "Storage team"
+
+
+@pytest.mark.asyncio
+async def test_update_team_translates_a_rename_integrity_error_to_already_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same race as `create_team`'s: the `get_by_name` pre-check is a fast path
+    only, and cannot close the window between two concurrent renames onto the
+    same name. The unique constraint catches it, and the caller must still see
+    a 409 rather than a raw 500."""
+    store = _FakeMetadataStore(
+        {"t1": TeamMetadata(id=TeamId("t1"), name="Northbridge")},
+        upsert_raises=IntegrityError("UPDATE", {}, Exception("duplicate key")),
+    )
+    _stub_team_projection(monkeypatch)
+
+    with pytest.raises(TeamAlreadyExistsError):
+        await update_team(
+            _user(),
+            TeamId("t1"),
+            UpdateTeamRequest(name="Southbridge"),
+            _deps(_FakeRebac(), store),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_team_does_not_mask_an_integrity_error_without_a_rename(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only `name` is unique-constrained. A patch that renames nothing has no
+    business turning a database failure into "that team name is taken"."""
+    store = _FakeMetadataStore(
+        {"t1": TeamMetadata(id=TeamId("t1"), name="Northbridge")},
+        upsert_raises=IntegrityError("UPDATE", {}, Exception("boom")),
+    )
+    _stub_team_projection(monkeypatch)
+
+    with pytest.raises(IntegrityError):
+        await update_team(
+            _user(),
+            TeamId("t1"),
+            UpdateTeamRequest(description="Storage team"),
+            _deps(_FakeRebac(), store),
+        )
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_update_team_request_refuses_a_blank_name(value: str | None) -> None:
+    """Every other field on this request treats `null` as "clear the value" —
+    a team always has a name, so for this one it is a client error, not an
+    erasure. A whitespace-only name is the same mistake in disguise."""
+    with pytest.raises(ValidationError):
+        UpdateTeamRequest.model_validate({"name": value})
+
+
+def test_create_and_rename_agree_on_trimming() -> None:
+    """Both write paths must trim, or the uniqueness they share is only skin
+    deep: a team created as `"Ops "` and a rename to `"Ops"` would each pass
+    the pre-check and the unique index, leaving two teams a reader cannot tell
+    apart."""
+    created = CreateTeamRequest(name="  Ops  ", initial_team_admin_ids=["alice"])
+    renamed = UpdateTeamRequest(name="  Ops  ")
+
+    assert created.name == "Ops"
+    assert renamed.name == "Ops"
+
+    with pytest.raises(ValidationError):
+        CreateTeamRequest.model_validate(
+            {"name": "   ", "initial_team_admin_ids": ["alice"]}
+        )
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_update_team_request_keeps_clearing_other_fields(value: str | None) -> None:
+    """Guard against the name rule leaking onto its neighbours: `description`
+    still accepts `null` (clear it) and any string."""
+    assert UpdateTeamRequest.model_validate({"description": value}).description == value
 
 
 # --------------------------- can_rescue_team_admin ---------------------------

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2380,6 +2380,13 @@
       },
       "parameters": {
         "title": "Settings",
+        "name": {
+          "label": "Team name",
+          "support": "This name identifies your team everywhere on the platform. It must be unique.",
+          "save": "Rename team",
+          "alreadyTaken": "Another team already uses this name.",
+          "saveError": "Could not rename the team."
+        },
         "description": {
           "label": "Team description",
           "placeholder": "Help other users understand your team's role."

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2380,6 +2380,13 @@
       },
       "parameters": {
         "title": "Paramètres",
+        "name": {
+          "label": "Nom de l'équipe",
+          "support": "Ce nom identifie votre équipe partout dans la plateforme. Il doit être unique.",
+          "save": "Renommer l'équipe",
+          "alreadyTaken": "Ce nom est déjà utilisé par une autre équipe.",
+          "saveError": "Impossible de renommer l'équipe."
+        },
         "description": {
           "label": "Description de l'équipe",
           "placeholder": "Aidez les autres utilisateurs à comprendre le rôle de votre équipe."

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.module.scss
@@ -110,3 +110,17 @@
   flex-shrink: 0;
   white-space: nowrap;
 }
+
+/* The save button sits on its own row under the field rather than beside it:
+ * the input grows a validation message when a rename is refused, and a
+ * side-by-side button would jump with it. */
+.team-name-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.team-name-actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.test.tsx
@@ -33,7 +33,8 @@ declare global {
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const h = vi.hoisted(() => ({
-  updateTeam: vi.fn(),
+  // The rename path awaits `.unwrap()`; every other PATCH here fires and forgets.
+  updateTeam: vi.fn(() => ({ unwrap: () => Promise.resolve() })),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -227,5 +228,126 @@ describe("TeamSettingsParameters avatar preview", () => {
     const img = container.querySelector("img");
     expect(img?.getAttribute("src")).toBe("https://example.com/banner.png");
     expect(container.textContent).not.toContain("rework.teamSettings.parameters.teamAvatar.noAvatar");
+  });
+});
+
+describe("TeamSettingsParameters rename", () => {
+  function nameInput(): HTMLInputElement {
+    return container.querySelector('input[name="name"]') as HTMLInputElement;
+  }
+
+  function renameButton(): HTMLButtonElement {
+    return Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("rework.teamSettings.parameters.name.save"),
+    ) as HTMLButtonElement;
+  }
+
+  // The input is React-controlled, so the value has to go through the native
+  // setter for React to pick the change up.
+  function type(value: string) {
+    const input = nameInput();
+    const setValue = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setValue.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  it("shows the current name with the rename button disabled", () => {
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    expect(nameInput().value).toBe("Team One");
+    expect(renameButton().disabled).toBe(true);
+  });
+
+  it("PATCHes the trimmed name once it differs from the team's own", async () => {
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("  Team Two  ");
+    expect(renameButton().disabled).toBe(false);
+
+    await act(async () => {
+      renameButton().click();
+    });
+
+    expect(h.updateTeam).toHaveBeenCalledWith({
+      teamId: "team-1",
+      updateTeamRequest: { name: "Team Two" },
+    });
+  });
+
+  it("keeps the button disabled for a blank name or the name the team already has", () => {
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("   ");
+    expect(renameButton().disabled).toBe(true);
+
+    type("Team One");
+    expect(renameButton().disabled).toBe(true);
+  });
+
+  it("surfaces a taken name without discarding what the user typed", async () => {
+    h.updateTeam.mockReturnValueOnce({ unwrap: () => Promise.reject({ status: 409 }) });
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("Team Two");
+    await act(async () => {
+      renameButton().click();
+    });
+
+    expect(container.textContent).toContain("rework.teamSettings.parameters.name.alreadyTaken");
+    expect(nameInput().value).toBe("Team Two");
+  });
+
+  it("falls back to a generic message on any other failure", async () => {
+    h.updateTeam.mockReturnValueOnce({ unwrap: () => Promise.reject({ status: 500 }) });
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("Team Two");
+    await act(async () => {
+      renameButton().click();
+    });
+
+    expect(container.textContent).toContain("rework.teamSettings.parameters.name.saveError");
+    expect(container.textContent).not.toContain("rework.teamSettings.parameters.name.alreadyTaken");
+  });
+
+  it("keeps a typed-but-unsaved name when the team refetches with a new description", () => {
+    // Saving the description invalidates the team, so the component re-renders
+    // with a new `team` object while the rename is still only typed.
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("Team Two");
+    act(() => {
+      root.render(<TeamSettingsParameters team={{ ...baseTeam("invite_only"), description: "Edited" }} />);
+    });
+
+    expect(nameInput().value).toBe("Team Two");
+    expect(renameButton().disabled).toBe(false);
+  });
+
+  it("adopts the new name once the rename itself lands", () => {
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("Team Two");
+    act(() => {
+      root.render(<TeamSettingsParameters team={{ ...baseTeam("invite_only"), name: "Team Two" }} />);
+    });
+
+    expect(nameInput().value).toBe("Team Two");
+    expect(renameButton().disabled).toBe(true);
+  });
+
+  it("clears the error as soon as the name is edited again", async () => {
+    h.updateTeam.mockReturnValueOnce({ unwrap: () => Promise.reject({ status: 409 }) });
+    render(<TeamSettingsParameters team={baseTeam("invite_only")} />);
+
+    type("Team Two");
+    await act(async () => {
+      renameButton().click();
+    });
+    type("Team Three");
+
+    expect(container.textContent).not.toContain("rework.teamSettings.parameters.name.alreadyTaken");
   });
 });

--- a/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamSettingsPanel/TeamSettingsParameters/TeamSettingsParameters.tsx
@@ -15,6 +15,7 @@
 import styles from "./TeamSettingsParameters.module.scss";
 import PageHeader from "@shared/molecules/PageHeader/PageHeader.tsx";
 import TextArea from "@shared/atoms/TextArea/TextArea.tsx";
+import TextInput from "@shared/atoms/TextInput/TextInput.tsx";
 import { useTranslation } from "react-i18next";
 import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup.tsx";
 import Button from "@shared/atoms/Button/Button.tsx";
@@ -38,8 +39,13 @@ interface TeamSettingsParametersProps {
 }
 
 interface TeamSettingsParametersForm {
+  name: string;
   description: string;
 }
+
+// Mirrors `UpdateTeamRequest.name` server-side, so the field cannot submit a
+// value the backend would reject on length alone.
+const MAX_TEAM_NAME_LENGTH = 180;
 
 const MAX_AVATAR_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -60,15 +66,28 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
   // The image the user just picked, pending crop. Non-null opens the editor.
   const [cropFile, setCropFile] = useState<File | null>(null);
 
-  const { register, getValues, watch, reset } = useForm<TeamSettingsParametersForm>({
+  // Set by a failed rename only; the field's own value is form state.
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [isRenaming, setIsRenaming] = useState(false);
+
+  const { register, getValues, watch, setValue } = useForm<TeamSettingsParametersForm>({
     defaultValues: {
+      name: team.name,
       description: team.description || "",
     },
   });
 
+  // Each field re-syncs on its own value, never through a shared `reset`:
+  // saving the description refetches the whole team, and a reset would wipe a
+  // rename the user had typed but not submitted yet.
   useEffect(() => {
-    reset({ description: team.description || "" });
-  }, [team.description, reset]);
+    setValue("description", team.description || "");
+  }, [team.description, setValue]);
+
+  useEffect(() => {
+    setValue("name", team.name);
+    setRenameError(null);
+  }, [team.name, setValue]);
 
   const handleSaveDescription = () => {
     const newDescription = getValues().description;
@@ -81,6 +100,39 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
     });
   };
   const descriptionValue = watch("description");
+
+  // A rename is committed by an explicit button rather than on blur like the
+  // description: it renames the team everywhere, and it can be refused (team
+  // names are globally unique), so it needs a deliberate action and somewhere
+  // to put the refusal.
+  const nameValue = watch("name");
+  const trimmedName = nameValue.trim();
+  const canRename = trimmedName.length > 0 && trimmedName !== team.name;
+
+  const handleSaveName = async () => {
+    // The in-flight guard is not just double-click hygiene: a second PATCH
+    // would let a late 409 pin "name already taken" onto a name the user has
+    // since changed.
+    if (!canRename || isRenaming) return;
+    setRenameError(null);
+    setIsRenaming(true);
+    try {
+      await updateTeam({
+        teamId: team.id,
+        updateTeamRequest: { name: trimmedName },
+      }).unwrap();
+    } catch (error) {
+      // 409 is the one failure the user can act on: another team holds the name.
+      const status = (error as { status?: number } | undefined)?.status;
+      setRenameError(
+        status === 409
+          ? t("rework.teamSettings.parameters.name.alreadyTaken")
+          : t("rework.teamSettings.parameters.name.saveError"),
+      );
+    } finally {
+      setIsRenaming(false);
+    }
+  };
   const defaultAvatarUrl = defaultTeamAvatarFile ? `/images/${defaultTeamAvatarFile}` : undefined;
   const avatarImageUrl = team.avatar_image_url ?? defaultAvatarUrl;
 
@@ -157,6 +209,27 @@ export default function TeamSettingsParameters({ team }: TeamSettingsParametersP
   return (
     <div className={styles["team-settings-parameters-container"]}>
       <PageHeader title={t("rework.teamSettings.parameters.title")} />
+      <div className={`${styles["form-section"]} ${styles["team-name-section"]}`}>
+        <TextInput
+          label={t("rework.teamSettings.parameters.name.label")}
+          explanation={t("rework.teamSettings.parameters.name.support")}
+          maxLength={MAX_TEAM_NAME_LENGTH}
+          value={nameValue}
+          error={renameError ?? undefined}
+          {...register("name", { onChange: () => setRenameError(null) })}
+        />
+        <div className={styles["team-name-actions"]}>
+          <Button
+            color="primary"
+            variant="filled"
+            size="small"
+            disabled={!canRename || isRenaming}
+            onClick={handleSaveName}
+          >
+            {t("rework.teamSettings.parameters.name.save")}
+          </Button>
+        </div>
+      </div>
       <div className={`${styles["form-section"]} ${styles["team-images-section"]}`}>
         <div className={styles["team-avatar"]}>
           <span className={styles["team-avatar-title"]}>{t("rework.teamSettings.parameters.teamAvatar.title")}</span>

--- a/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
+++ b/apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
@@ -2213,6 +2213,7 @@ export type CreateTeamRequest = {
   initial_team_admin_ids: string[];
 };
 export type UpdateTeamRequest = {
+  name?: string | null;
   description?: string | null;
   joining_mode?: JoiningMode | null;
   visibility?: TeamVisibility | null;

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -3259,3 +3259,43 @@ else changes. Anything that would only work same-origin is a defect against
 this contract. Durable installed/tombstoned registration, admin-visible
 stale-grant cleanup after removal, and `pending_reactivation` on id
 reappearance remain deferred lifecycle requirements.
+
+---
+
+## 47. Contract Notes — a team_admin may rename their own team (2026-09-03, issue #2516)
+
+**`UpdateTeamRequest.name` (`PATCH /teams/{team_id}`), 1-180 chars.** A team's
+name was set once by `POST /teams` (platform-admin only) and immutable
+afterwards; a team_admin who mistyped it, or whose team was renamed in the real
+world, had no way to fix it. It now rides the existing team PATCH surface, which
+is gated on `can_update_info` — defined as exactly `team_admin` in `schema.fga`.
+No new endpoint, no new permission, no governance capability: renaming is team
+self-service, unlike creating or deleting a team. Deleting a team from the team
+settings stays out of scope.
+
+**`null` is a client error for this field, not "clear the value".** Every other
+field on `UpdateTeamRequest` uses `exclude_unset` partial semantics where an
+explicit `null` clears the stored value. A team always has a name, so `null` and
+a whitespace-only string are both 422; the accepted value is stored trimmed.
+`CreateTeamRequest.name` now trims the same way — uniqueness only means
+something if both write paths agree, otherwise a team created as `"Ops "` and a
+rename to `"Ops"` each clear the pre-check and the unique index and leave two
+teams a reader cannot tell apart.
+
+**A rename can 409.** `teammetadata.name` is globally unique (migration
+`a8b9c0d1e2f3`), so `update_team` reuses `TeamAlreadyExistsError` exactly like
+`create_team`: a `get_by_name` pre-check for the common case, and an
+`IntegrityError` catch around the upsert for the concurrent-rename race the
+pre-check cannot close. An `IntegrityError` on a patch that renames nothing is
+re-raised untouched — `name` is the only unique-constrained column, and a
+database failure must not be reported as a taken name. Renaming a team to the
+name it already holds is a no-op, not a conflict.
+
+**Personal spaces are not renameable, and need no guard to stay that way.** They
+have no `teammetadata` row, so `update_team` already 404s for them through its
+normal existence check.
+
+**Consequence for bundle import.** `importer.py` reconciles teams by name, not
+id. A bundle exported before a rename no longer matches the renamed team and
+creates a new one on import. Accepted for now; the import surface is unchanged
+by this issue.

--- a/libs/fred-core/fred_core/teams/metadata_store.py
+++ b/libs/fred-core/fred_core/teams/metadata_store.py
@@ -64,6 +64,10 @@ class TeamVisibility(str, Enum):
 
 
 class TeamMetadataPatch(BaseModel):
+    # A rename rides the same patch as every other mutable field. The unique
+    # constraint on `teammetadata.name` is what actually rejects a collision -
+    # callers map the resulting IntegrityError to their own 409.
+    name: str | None = Field(default=None, min_length=1, max_length=180)
     description: str | None = Field(default=None, max_length=180)
     joining_mode: JoiningMode | None = None
     visibility: TeamVisibility | None = None
@@ -79,6 +83,8 @@ class TeamMetadataPatch(BaseModel):
     def to_store_values(self) -> dict[str, str | bool | None]:
         values: dict[str, str | bool | None] = {}
         payload = self.model_dump(exclude_unset=True, mode="json")
+        if "name" in payload:
+            values["name"] = payload["name"]
         if "description" in payload:
             values["description"] = payload["description"]
         if "joining_mode" in payload:
@@ -98,9 +104,9 @@ class TeamMetadataPatch(BaseModel):
 
 class TeamMetadata(BaseModel):
     id: TeamId
-    # AUTHZ-05 review item 9: the team's name, set once at creation
-    # (`TeamMetadataStore.create`) and immutable afterwards — no Keycloak
-    # group backs it anymore.
+    # The team's identity lives here - no Keycloak group backs it anymore.
+    # Set at creation and renameable afterwards by a team_admin through the
+    # team PATCH surface; globally unique either way.
     name: str
     description: str | None = None
     joining_mode: JoiningMode = JoiningMode.INVITE_ONLY
@@ -197,9 +203,9 @@ class TeamMetadataStore:
     ) -> TeamMetadata:
         """Create one team's metadata row (AUTHZ-05 review item 9).
 
-        `name` is set once, here, and never patched afterwards — `upsert`
-        only touches the mutable fields (description, privacy, banner,
-        retention). Callers must ensure `team_id` does not already exist
+        `name` can be changed afterwards through `upsert` (a team_admin
+        rename); it stays globally unique either way, enforced by the column's
+        own constraint. Callers must ensure `team_id` does not already exist
         (`create_team`'s own name-uniqueness check does this); a duplicate
         id raises the underlying integrity error rather than silently
         overwriting an existing team.


### PR DESCRIPTION
Closes #2516.

A team's name was set once by `POST /teams` (platform-admin only) and immutable
afterwards - `TeamMetadataPatch` did not carry it, and the store documented the
field as "set once, here, and never patched afterwards". A team_admin who
mistyped the name had no recourse short of a platform admin deleting and
recreating the team.

Renaming now rides the existing `PATCH /teams/{team_id}`, already gated on
`can_update_info` - defined as exactly `team_admin` in `schema.fga`. No new
endpoint, no new permission, no governance capability: this is team
self-service. **Team deletion is deliberately out of scope** (libraries,
sessions and ReBAC tuples make it a much larger change).

## Backend

- `fred-core`: `TeamMetadataPatch.name` (1-180), propagated through
  `to_store_values`.
- `control-plane`: `UpdateTeamRequest.name`. Unlike every other field on that
  request, an explicit `null` is a 422 rather than "clear the value" - a team
  always has a name. Whitespace-only is the same mistake in disguise.
- `teammetadata.name` is globally unique, so a rename can collide exactly like a
  create: `get_by_name` pre-check for the common case, `IntegrityError` catch
  around the upsert for the concurrent-rename race the pre-check cannot close,
  both mapped to the existing `TeamAlreadyExistsError` (409). An
  `IntegrityError` on a patch that renames *nothing* is re-raised untouched -
  `name` is the only unique-constrained column, and a database failure must not
  be reported as a taken name.
- Renaming to the name the team already has is a no-op, not a conflict.
- `CreateTeamRequest.name` now trims like the rename does. Uniqueness is only
  skin deep if the two write paths disagree: a team created as `"Ops "` and a
  rename to `"Ops"` would each clear the pre-check and the unique index.
- Personal spaces have no `teammetadata` row, so `update_team` already 404s for
  them - no extra guard needed. They also lack `can_update_info`, so the
  settings section is unreachable for them in the first place.
- A successful rename logs old name, new name and actor. There is no team audit
  table, and see the import consequence below.

## Frontend

- A "team name" input in the team settings parameters tab (a section already
  gated on `canUpdateInfo`), with an explicit **Rename team** button rather than
  the on-blur save the description uses: a rename is more impactful and it can
  be refused, so it needs a deliberate action and somewhere to put the refusal.
- 409 renders inline on the field ("another team already uses this name")
  without discarding what was typed; anything else gets a generic message.
- In-flight guard on the button. Not just double-click hygiene: a second PATCH
  would let a late 409 pin "name already taken" onto a name the user has since
  changed.
- Each form field now re-syncs on its own value instead of through a shared
  `reset` - saving the description refetches the whole team, and the shared
  reset would have wiped a rename typed but not yet submitted.
- Regenerated `controlPlaneOpenApi.ts` (one line: `name?: string | null`).

## Known consequence, unchanged by this PR

`import_export/importer.py` reconciles teams **by name**, not id. A bundle
exported before a rename no longer matches the renamed team and creates a new
one on import. Documented in the contract note rather than fixed here.

## Left for a follow-up decision

`teamColor(team.name)` hashes the name into the avatar palette - an assumption
that only held while the name was immutable, so a rename now changes the team's
color everywhere. Hashing `team.id` would fix it but recolors every existing
team at once, which is a product call rather than part of this change.

## Verification

- `make test` control-plane: 1016 passed. fred-core: 530 passed.
- `npx vitest run` frontend: 1744 passed.
- `make code-quality` green on control-plane, fred-core and frontend.
- `/code-review` at high effort; four of its five findings are fixed above, the
  fifth is the `teamColor` item left for a decision.

## Docs

`CONTROL-PLANE-PRODUCT-CONTRACT.md` §47 (dated) - the frozen contract gains a
request field.