### PR TITLE
fix(#2522): keep the attachment delete button out of the row button

### DIFF
--- a/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.module.css
@@ -14,19 +14,33 @@
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-xs);
-  cursor: pointer;
   border: 1px solid var(--outline-retreat);
   border-radius: var(--radius-s);
   background: var(--surface-container-low);
   padding: var(--spacing-xs);
-  width: 100%;
   color: var(--on-surface);
-  text-align: left;
 }
 
 .row:hover {
   border-color: var(--outline-muted);
   background: var(--surface-container-high);
+}
+
+/* Opens the preview: fills the row up to the action buttons so the whole line
+ * stays clickable, minus the controls that must not live inside a button. */
+.rowPreview {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 0;
+  min-width: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 }
 
 .rowIcon {

--- a/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage: each attachment row used to be one <button> wrapping the
+// delete IconButton - invalid HTML that React flags as a hydration error. The
+// preview target and the delete control must stay siblings.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionAttachment } from "@rework/types/attachments";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Only the attachment list is under test: the drawer chrome and the warning
+// banner are reduced to their children, the preview modal to its open flag.
+vi.mock("../InlineDrawer/InlineDrawer", () => ({
+  InlineDrawer: ({ children }: { children: React.ReactNode }) => <aside>{children}</aside>,
+}));
+vi.mock("../MarkdownPreviewModal/MarkdownPreviewModal", () => ({
+  MarkdownPreviewModal: ({ open }: { open: boolean }) => <div data-preview-open={open} />,
+}));
+vi.mock("@shared/molecules/UploadWarningBanner/UploadWarningBanner", () => ({
+  default: () => null,
+}));
+
+import { SessionAttachmentsDrawer } from "./SessionAttachmentsDrawer";
+
+const attachment: SessionAttachment = {
+  attachmentId: "att-1",
+  name: "diff_main_swift.md",
+  mime: "text/markdown",
+  sizeBytes: 1024,
+  summaryMd: "# summary",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function renderDrawer(onDelete = vi.fn()) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(<SessionAttachmentsDrawer open onClose={() => {}} attachments={[attachment]} onDelete={onDelete} />);
+  });
+  return onDelete;
+}
+
+function click(element: Element | null) {
+  act(() => {
+    element?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function previewOpen(): string | null | undefined {
+  return container.querySelector("[data-preview-open]")?.getAttribute("data-preview-open");
+}
+
+describe("SessionAttachmentsDrawer - attachment row markup", () => {
+  it("never nests the delete button inside the preview button", () => {
+    renderDrawer();
+
+    expect(container.querySelectorAll("button")).toHaveLength(2);
+    expect(container.querySelector("button button")).toBeNull();
+  });
+
+  it("opens the preview when the attachment itself is clicked", () => {
+    renderDrawer();
+
+    click(container.querySelector("button"));
+
+    expect(previewOpen()).toBe("true");
+  });
+
+  it("deletes without opening the preview when the delete button is clicked", () => {
+    const onDelete = renderDrawer();
+
+    click(container.querySelector('button[aria-label="chatbot.sessionAttachments.deleteAria"]'));
+
+    expect(onDelete).toHaveBeenCalledWith("att-1");
+    expect(previewOpen()).toBe("false");
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/SessionAttachmentsDrawer/SessionAttachmentsDrawer.tsx
@@ -85,35 +85,35 @@ export function SessionAttachmentsDrawer({
               const sizeLabel = formatBytes(attachment.sizeBytes);
               const timestampLabel = formatTimestamp(attachment.createdAt);
               const metaLabel = [attachment.mime, sizeLabel, timestampLabel].filter(Boolean).join(" · ");
+              // A <button> cannot nest another, so the delete control sits beside
+              // the preview target instead of inside it.
               return (
-                <button
-                  key={attachment.attachmentId}
-                  type="button"
-                  className={styles.row}
-                  onClick={() => setPreviewAttachmentId(attachment.attachmentId)}
-                >
-                  <span className={styles.rowIcon} aria-hidden>
-                    <Icon category="outlined" type="attach_file" />
-                  </span>
-                  <span className={styles.rowBody}>
-                    <span className={styles.rowName} title={attachment.name}>
-                      {attachment.name}
+                <div key={attachment.attachmentId} className={styles.row}>
+                  <button
+                    type="button"
+                    className={styles.rowPreview}
+                    onClick={() => setPreviewAttachmentId(attachment.attachmentId)}
+                  >
+                    <span className={styles.rowIcon} aria-hidden>
+                      <Icon category="outlined" type="attach_file" />
                     </span>
-                    <span className={styles.rowMeta}>{metaLabel}</span>
-                  </span>
+                    <span className={styles.rowBody}>
+                      <span className={styles.rowName} title={attachment.name}>
+                        {attachment.name}
+                      </span>
+                      <span className={styles.rowMeta}>{metaLabel}</span>
+                    </span>
+                  </button>
                   <span className={styles.rowButtons}>
                     <IconButton
                       variant="icon"
                       size="2xs"
                       icon={{ category: "outlined", type: "delete" }}
                       aria-label={t("chatbot.sessionAttachments.deleteAria", { name: attachment.name })}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(attachment.attachmentId);
-                      }}
+                      onClick={() => onDelete(attachment.attachmentId)}
                     />
                   </span>
-                </button>
+                </div>
               );
             })
           )}


### PR DESCRIPTION
Closes #2522

## What

Each row of the session attachments drawer was a `<button>` (opens the markdown preview) wrapping the delete `IconButton`, itself a `<button>`. React flags the nested button as invalid HTML and a hydration error.

## How

Same shape as `DocRow`: the row becomes a `<div>`, the preview target becomes its own `<button>` that fills the row up to the action buttons, and the delete control sits beside it as a sibling. The delete handler no longer needs `stopPropagation`.

Visually unchanged: the row keeps its border, background, hover state and layout; the whole line minus the delete button remains the preview target.

## Tests

`SessionAttachmentsDrawer.test.tsx` (happy-dom): no `button button` in the rendered drawer, clicking the row opens the preview, clicking delete calls `onDelete` without opening the preview. The first test is red on the previous markup.

Pre-existing bug, surfaced while validating #2515 in the browser. Independent of that branch.