### PR TITLE
refactor(marketplace): drop the TeamCard invite-only mailto button

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2278,10 +2278,6 @@
     "teamCard": {
       "join": "Join",
       "inviteOnly": "Invite only",
-      "invitationMail": {
-        "subject": "[{{site}}] Request to join the {{team}} team",
-        "body": "Hello,\n\nI would like to join the {{team}} team on {{site}}.\n\nUser details: {{user}}\n\nGo to the {{team}} team page: {{agentsUrl}}\nManage the {{team}} team members: {{membersUrl}}"
-      },
       "memberCount": "{{count}} members"
     },
     "teamRoles": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2278,10 +2278,6 @@
     "teamCard": {
       "join": "Rejoindre",
       "inviteOnly": "Sur invitation",
-      "invitationMail": {
-        "subject": "[{{site}}] Demande pour rejoindre l'équipe {{team}}",
-        "body": "Bonjour,\n\nJe souhaite rejoindre l'équipe {{team}} sur {{site}}.\n\nInformations utilisateur : {{user}}\n\nAller à la page de l'équipe {{team}} : {{agentsUrl}}\nGérer les membres de l'équipe {{team}} : {{membersUrl}}"
-      },
       "memberCount": "{{count}} membres"
     },
     "teamRoles": {

--- a/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/AvatarGroup/AvatarGroup.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: row-reverse;
   justify-content: flex-end;
-  gap: var(--spacing-2xs);
 
   > * {
     /* A fixed-size circle: shrinking it as a flex item renders an ellipse

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -110,6 +110,6 @@
    * the same footer slot must stay flush with the card's padding edge, so
    * it can't be solved with footer padding/gap. */
   margin-right: var(--spacing-xs);
-  color: var(--on-surface-retreat);
-  font: var(--font-body-medium);
+  color: var(--on-surface-muted);
+  font: var(--font-body-small);
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.module.scss
@@ -5,11 +5,12 @@
   border-radius: var(--radius-m);
   background-color: var(--surface-container);
   width: 290px;
-  /* Fills whatever height the row gives it (flex `align-items: stretch` on
-   * the parent list, and — when wrapped for navigation — the flex Link
-   * wrapper), so cards in the same row line up on their footer regardless of
-   * description length. */
-  height: 100%;
+  /* No explicit height: as a flex item the card stretches to the row's tallest
+   * (the list sets `align-items: stretch`, and the navigable-card Link wrapper
+   * is itself a stretching flex box), so cards in a row share a height and
+   * their footers line up regardless of description length. An explicit
+   * `height: 100%` would opt out of that stretch and fall back to content
+   * height — the cause of the uneven rows it was meant to prevent. */
   /* No overflow: hidden here — an admin-avatar tooltip in the footer must be
    * able to escape the card bounds. */
 }

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.test.tsx
@@ -13,17 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TEAM-09 (narrowed to 2 states 2026-07-26): the marketplace card's join
-// affordance is driven entirely by `joining_mode` (+ `is_member`) — the join
-// button for OPEN, an "invite only" label otherwise, plus the self-service
-// join mutation actually firing for OPEN.
-//
-// One branch on top: a public INVITE_ONLY team whose admins have a
-// reachable address gets a prefilled mailto button instead of that label.
+// The marketplace card's join affordance is driven entirely by `joining_mode`
+// (+ `is_member`): a direct self-service join button for OPEN, an "invite only"
+// label for every INVITE_ONLY case, plus the join mutation firing for OPEN.
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Team } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 
 declare global {
@@ -37,17 +33,8 @@ const h = vi.hoisted(() => ({
   isJoining: false,
 }));
 
-const k = vi.hoisted(() => ({
-  fullName: "Test User" as string | null,
-  username: "test.user" as string | null,
-}));
-
 vi.mock("react-i18next", () => ({
-  // Interpolation values are appended to the key so the mailto assertions can
-  // see what the card fed into the subject/body templates.
-  useTranslation: () => ({
-    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key}:${Object.values(opts).join("|")}` : key),
-  }),
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 vi.mock("../../../../../slices/controlPlane/controlPlaneApiEnhancements", () => ({
@@ -62,54 +49,21 @@ vi.mock("src/hooks/useFrontendProperties", () => ({
   useFrontendProperties: () => ({
     defaultTeamAvatarFile: undefined,
     defaultPersonalAvatarFile: undefined,
-    siteTitle: "Fred",
-    siteSubtitle: "Platform",
   }),
 }));
 
 vi.mock("../../../../../security/KeycloakService.ts", () => ({
-  KeyCloakService: { GetUserFullName: () => k.fullName, GetUserName: () => k.username },
-}));
-
-// A subpath deployment: the mailed link must carry the basename.
-vi.mock("src/common/config", () => ({
-  getConfig: () => ({ frontend_basename: "/fred/" }),
+  KeyCloakService: { GetUserFullName: () => "Test User", GetUserName: () => "test.user" },
 }));
 
 import TeamCard from "./TeamCard.tsx";
 
-// Record the mailto instead of letting happy-dom act on it. The href setter
-// doubles as the assertion that this tab is never navigated away. location is
-// restored in afterAll - the stub only carries what this file needs.
-const openSpy = vi.fn();
-const hrefSetter = vi.fn();
-const realLocation = Object.getOwnPropertyDescriptor(window, "location");
-Object.defineProperty(window, "location", {
-  configurable: true,
-  value: {
-    origin: "http://localhost:3000",
-    set href(value: string) {
-      hrefSetter(value);
-    },
-  },
-});
-
-afterAll(() => {
-  if (realLocation) Object.defineProperty(window, "location", realLocation);
-});
-
 const admin = { id: "u-1", first_name: "Ay", last_name: "One", email: "ay@example.com" };
-
-function lastMailto(): string {
-  const calls = openSpy.mock.calls;
-  return calls[calls.length - 1]?.[0] ?? "";
-}
 
 let container: HTMLDivElement;
 let root: Root;
 
 function render(ui: React.ReactElement) {
-  vi.stubGlobal("open", openSpy);
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -124,12 +78,7 @@ afterEach(() => {
   });
   container.remove();
   h.joinTeam.mockClear();
-  hrefSetter.mockClear();
-  openSpy.mockClear();
-  vi.unstubAllGlobals();
   h.isJoining = false;
-  k.fullName = "Test User";
-  k.username = "test.user";
 });
 
 function baseTeam(overrides: Partial<Team>): Team {
@@ -159,9 +108,14 @@ describe("TeamCard joining_mode rendering", () => {
     expect(h.joinTeam).toHaveBeenCalledWith({ teamId: "team-1" });
   });
 
-  it("INVITE_ONLY with no visibility on the payload: fails closed to the label", () => {
-    // A version-skew backend can omit `visibility` (#2433).
-    render(<TeamCard team={baseTeam({ joining_mode: "invite_only", admins: [admin] })} withDescription={false} />);
+  it("INVITE_ONLY + public with reachable admins: no button, shows the invite-only label", () => {
+    // Formerly a prefilled mailto button; the marketplace no longer offers one.
+    render(
+      <TeamCard
+        team={baseTeam({ joining_mode: "invite_only", visibility: "public", admins: [admin] })}
+        withDescription={false}
+      />,
+    );
 
     expect(container.querySelector("button")).toBeNull();
     expect(container.textContent).toContain("rework.teamCard.inviteOnly");
@@ -179,91 +133,10 @@ describe("TeamCard joining_mode rendering", () => {
     expect(container.textContent).toContain("rework.teamCard.inviteOnly");
   });
 
-  it("INVITE_ONLY + public without a reachable admin address: falls back to the label", () => {
-    render(
-      <TeamCard
-        team={baseTeam({ joining_mode: "invite_only", visibility: "public", admins: [{ ...admin, email: null }] })}
-        withDescription={false}
-      />,
-    );
-
-    expect(container.querySelector("button")).toBeNull();
-    expect(container.textContent).toContain("rework.teamCard.inviteOnly");
-  });
-
   it("already a member: no join button or label regardless of joining_mode", () => {
     render(<TeamCard team={baseTeam({ joining_mode: "open", is_member: true })} withDescription={false} />);
 
     expect(container.querySelector("button")).toBeNull();
     expect(container.textContent).not.toContain("rework.teamCard.join");
-  });
-});
-
-describe("TeamCard invitation request", () => {
-  it("PUBLIC + INVITE_ONLY: opens a prefilled mailto addressed to every admin", () => {
-    render(
-      <TeamCard
-        team={baseTeam({
-          joining_mode: "invite_only",
-          visibility: "public",
-          admins: [admin, { id: "u-2", first_name: "Bee", last_name: "Two", email: "bee@example.com" }],
-        })}
-        withDescription={false}
-      />,
-    );
-
-    const button = container.querySelector("button");
-    expect(button?.textContent).toContain("rework.teamCard.join");
-    expect(container.textContent).not.toContain("rework.teamCard.inviteOnly");
-
-    act(() => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    });
-
-    // A new tab, and this one left alone.
-    expect(openSpy).toHaveBeenCalledWith(expect.any(String), "_blank", "noopener,noreferrer");
-    expect(hrefSetter).not.toHaveBeenCalled();
-
-    // Recipients are comma-separated per RFC 6068 and percent-encoded.
-    const raw = lastMailto();
-    expect(raw.startsWith("mailto:ay%40example.com,bee%40example.com?")).toBe(true);
-    // Spaces survive as %20, never the "+" URLSearchParams emits.
-    expect(raw).not.toContain("+");
-
-    const href = decodeURIComponent(raw);
-    expect(href).toContain("rework.teamCard.invitationMail.subject:Fred Platform|Team One");
-    // The team page and the members page, both under the configured basename.
-    expect(href).toContain(
-      "rework.teamCard.invitationMail.body:Fred Platform|Team One|Test User (test.user)|" +
-        "http://localhost:3000/fred/team/team-1/agents|http://localhost:3000/fred/team/team-1/settings/members",
-    );
-  });
-
-  it("falls back to whichever identity claim Keycloak returned", () => {
-    k.fullName = null;
-    render(
-      <TeamCard
-        team={baseTeam({ joining_mode: "invite_only", visibility: "public", admins: [admin] })}
-        withDescription={false}
-      />,
-    );
-
-    act(() => {
-      container.querySelector("button")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    });
-
-    // "(test.user)" alone, never a stray "  ()" the admin cannot act on.
-    expect(decodeURIComponent(lastMailto())).toContain("|(test.user)|");
-  });
-
-  it("PUBLIC + INVITE_ONLY but already a member: no mail button", () => {
-    render(
-      <TeamCard
-        team={baseTeam({ joining_mode: "invite_only", visibility: "public", is_member: true, admins: [admin] })}
-        withDescription={false}
-      />,
-    );
-
-    expect(container.querySelector("button")).toBeNull();
   });
 });

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -25,8 +25,6 @@ import { useFrontendBootstrap } from "src/hooks/useFrontendBootstrap";
 import Button from "@shared/atoms/Button/Button.tsx";
 import React from "react";
 import { KeyCloakService } from "../../../../../security/KeycloakService.ts";
-import { getConfig } from "src/common/config";
-import { normalizeBasename } from "../../../../utils/documentViewerUtils";
 
 export interface TeamCardProps {
   team: Team;
@@ -38,12 +36,11 @@ export interface TeamCardProps {
 }
 
 export default function TeamCard({ team, withDescription, onJoined }: TeamCardProps) {
-  const { defaultTeamAvatarFile, defaultPersonalAvatarFile, siteTitle, siteSubtitle } = useFrontendProperties();
+  const { defaultTeamAvatarFile, defaultPersonalAvatarFile } = useFrontendProperties();
   const { activeTeam } = useFrontendBootstrap();
   const { t } = useTranslation();
   const [joinTeam, { isLoading: isJoining }] = useJoinTeamMutation();
   const userFullName = KeyCloakService.GetUserFullName();
-  const username = KeyCloakService.GetUserName();
 
   // A configured default avatar replaces initials; without one, the card keeps
   // the name-derived coloured initials. The personal space renders round, teams
@@ -64,45 +61,10 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
     }
   };
 
-  // A public invite-only team gets a prefilled mail to its admins
-  // instead of a dead-end label. Public only (never hand a non-member a
-  // private team's addresses), and only when one resolved - nobody to write
-  // to otherwise. Full rationale: COMPONENT-UX.md `TeamCard`.
+  // Non-members see one join affordance: a direct self-service join for OPEN
+  // teams, an "invite only" label for every other case.
   const canJoinDirectly = !team.is_member && team.joining_mode === "open";
   const isInviteOnlyOutsider = !team.is_member && team.joining_mode === "invite_only";
-  const adminEmails = (team.admins ?? [])
-    .map((admin) => admin.email)
-    .filter((email): email is string => Boolean(email));
-  const canRequestInvitation = isInviteOnlyOutsider && team.visibility === "public" && adminEmails.length > 0;
-
-  const handleRequestInvitation = (e: React.MouseEvent<HTMLButtonElement>): void => {
-    e.preventDefault();
-    const site = [siteTitle, siteSubtitle].filter(Boolean).join(" ");
-    // Keycloak omits `name` / `preferred_username` on some accounts.
-    const user = [userFullName, username && `(${username})`].filter(Boolean).join(" ");
-    // Two links: the team page for context, and the members page where the
-    // recipients - its admins - actually add the sender. A mailed link
-    // inherits no router basename.
-    const teamPath = `${window.location.origin}${normalizeBasename(getConfig().frontend_basename)}/team/${team.id}`;
-    // Comma-separated and encoded per RFC 6068 - the addresses come from a
-    // directory sync, so nothing guarantees they are URL-safe.
-    const recipients = adminEmails.map(encodeURIComponent).join(",");
-    const params = new URLSearchParams({
-      subject: t("rework.teamCard.invitationMail.subject", { site, team: team.name }),
-      body: t("rework.teamCard.invitationMail.body", {
-        site,
-        team: team.name,
-        user,
-        agentsUrl: `${teamPath}/agents`,
-        membersUrl: `${teamPath}/settings/members`,
-      }),
-    });
-    // `+` back to %20 or mail clients render it literally in the subject.
-    const href = `mailto:${recipients}?${params.toString().replace(/\+/g, "%20")}`;
-    // A new tab: a webmail registered for mailto: would otherwise replace the
-    // app. `noopener` makes window.open return null, so no fallback to test.
-    window.open(href, "_blank", "noopener,noreferrer");
-  };
 
   return (
     <div className={styles.teamCardContainer}>
@@ -148,7 +110,7 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
           <div className={styles.teamCardAdmins}>
             <AvatarGroup
               avatars={(team.admins ?? []).map((o) => ({ name: o.first_name + " " + o.last_name }))}
-              max={canJoinDirectly || canRequestInvitation ? 2 : 4}
+              max={canJoinDirectly ? 2 : 4}
             />
           </div>
           {canJoinDirectly && (
@@ -164,21 +126,7 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
               {t("rework.teamCard.join")}
             </Button>
           )}
-          {canRequestInvitation && (
-            <Button
-              className={styles.teamCardJoinAction}
-              color={"primary"}
-              variant={"outlined"}
-              size={"medium"}
-              icon={{ category: "outlined", type: "mail" }}
-              onClick={handleRequestInvitation}
-            >
-              {t("rework.teamCard.join")}
-            </Button>
-          )}
-          {isInviteOnlyOutsider && !canRequestInvitation && (
-            <span className={styles.teamJoiningLabel}>{t("rework.teamCard.inviteOnly")}</span>
-          )}
+          {isInviteOnlyOutsider && <span className={styles.teamJoiningLabel}>{t("rework.teamCard.inviteOnly")}</span>}
         </div>
       </div>
     </div>

--- a/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/TeamCard/TeamCard.tsx
@@ -118,7 +118,7 @@ export default function TeamCard({ team, withDescription, onJoined }: TeamCardPr
               className={styles.teamCardJoinAction}
               color={"primary"}
               variant={"outlined"}
-              size={"medium"}
+              size={"small"}
               icon={{ category: "outlined", type: "person_add" }}
               disabled={isJoining}
               onClick={handleJoinTeam}

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1328,7 +1328,7 @@ the team's `joining_mode`, gated on `!team.is_member`:
 
 | `joining_mode` | Footer content |
 | --- | --- |
-| `open` | "Join" button (`person_add` icon) — calls `useJoinTeamMutation` directly (instant self-service, no confirmation step); on success calls the `onJoined` prop so the page can refresh anything outside this card's own cache (bootstrap's team navbar) |
+| `open` | "Join" button (`small`, `outlined`, `person_add` icon) — calls `useJoinTeamMutation` directly (instant self-service, no confirmation step); on success calls the `onJoined` prop so the page can refresh anything outside this card's own cache (bootstrap's team navbar) |
 | `invite_only` | No button; muted label (`body-small`, `on-surface-muted`) — the team is discoverable but not self-joinable |
 | already a member | Nothing renders in the footer's join slot |
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1329,8 +1329,7 @@ the team's `joining_mode`, gated on `!team.is_member`:
 | `joining_mode` | Footer content |
 | --- | --- |
 | `open` | "Join" button (`person_add` icon) — calls `useJoinTeamMutation` directly (instant self-service, no confirmation step); on success calls the `onJoined` prop so the page can refresh anything outside this card's own cache (bootstrap's team navbar) |
-| `invite_only`, team is `public`, at least one admin has an email | "Join" button (`mail` icon) - opens the user's mail client on a `mailto:` prefilled for the team admins (#2453, see below) |
-| `invite_only`, any other case | No button; muted label (`on-surface-retreat`) |
+| `invite_only` | No button; muted label (`on-surface-retreat`) — the team is discoverable but not self-joinable |
 | already a member | Nothing renders in the footer's join slot |
 
 The former lock icon next to the team name (driven by the retired
@@ -1343,52 +1342,10 @@ system to route requests to team admins was never built) and `closed` (a
 second muted label, indistinguishable in practice from `invite_only`) were
 dropped from the enum entirely; see `CONTROL-PLANE-PRODUCT-CONTRACT.md` §29.
 
-**Ask for an invitation (#2453, 2026-08-27).** A public invite-only team is
-discoverable but not joinable, and the muted label alone left the visitor with
-no next step. The card restores the pre-TEAM-09 escape hatch: a `mailto:`
-addressed to every team admin whose `UserSummary.email` resolved, prefilled
-with the subject, the caller's identity, and two links: the team's agents page
-for context (what `main` sent) plus a deep link to its members page, where the
-recipients - the admins - actually add the sender by hand. The wording is the
-pre-TEAM-09 one (`rework.teamCard.invitationMail.*`) plus that second line, and
-now lives in the locale files instead of hardcoded French as it did then.
-
-The button reuses the `join` label - it is the same intent, and a second,
-longer label wrapped the card's footer onto two lines; the `mail` icon and the
-draft that opens are what distinguish it from the instant `open` join.
-
-Two guards decide whether the button replaces the label:
-
-- **public only.** A private team keeps the label: the UI does not offer a
-  non-member a private team's admin addresses. This is a product rule about
-  what the card *proposes*, not a disclosure guarantee - `GET /teams` puts
-  `admins` (email included) in the payload for every team it returns, and
-  `MarketplaceTeams` records that private teams reach the client at all when
-  authorization is disabled. Withholding them from the wire is a server-side
-  question, still open. `TeamCard` checks `visibility` itself rather than
-  trusting `MarketplaceTeams`' filter: it is a shared component, and the check
-  is `=== "public"` so a payload with no `visibility` fails closed (#2433).
-- **a reachable address.** `admins` falls back to a bare `UserSummary(id=...)`
-  when the Keycloak lookup returns nothing, so an admin list can render with no
-  email at all. With no recipient there is nothing to open, so the label stays
-  rather than producing an empty `mailto:`.
-
-Mechanics worth keeping: the draft opens with `window.open(..., "_blank",
-"noopener,noreferrer")` rather than a `location.href` assignment, so a webmail
-registered as the `mailto:` handler opens beside the app instead of replacing
-it (a native client takes over the throwaway tab and the browser drops it);
-`noopener` makes `window.open` return `null` by spec, so there is nothing to
-test for a fallback - the click is the user gesture popup blockers key off.
-Recipients are comma-separated (RFC 6068) and
-percent-encoded, since the addresses come from a directory sync and nothing
-guarantees they are URL-safe; `URLSearchParams`' `+` is rewritten to `%20` or
-mail clients render it literally in the subject; the team link prepends the
-router basename (`normalizeBasename`, shared with `buildDocumentViewerPath`)
-because a mailed URL inherits nothing from the router; and the identity line
-degrades to whichever of `name` / `preferred_username` Keycloak returned.
-
-No server-side request flow is involved: this is a client-side mail draft, the
-same as before TEAM-09. Nothing routes an invitation request through the API.
+An invite-only team offers no in-app join path: the card shows only the muted
+label. A `mailto:`-to-admins escape hatch existed briefly (#2453) and was
+removed — a non-member could not be given a team's admin addresses, and no
+server-side request flow was ever built to replace it.
 
 **Footer layout.** The card is a fixed 290px, so the admin avatars and the join
 button compete for one line: a team with five admins pushed the button past the

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1329,7 +1329,7 @@ the team's `joining_mode`, gated on `!team.is_member`:
 | `joining_mode` | Footer content |
 | --- | --- |
 | `open` | "Join" button (`person_add` icon) — calls `useJoinTeamMutation` directly (instant self-service, no confirmation step); on success calls the `onJoined` prop so the page can refresh anything outside this card's own cache (bootstrap's team navbar) |
-| `invite_only` | No button; muted label (`on-surface-retreat`) — the team is discoverable but not self-joinable |
+| `invite_only` | No button; muted label (`body-small`, `on-surface-muted`) — the team is discoverable but not self-joinable |
 | already a member | Nothing renders in the footer's join slot |
 
 The former lock icon next to the team name (driven by the retired


### PR DESCRIPTION
## What

An invite-only team card in the teams marketplace no longer offers a `mailto:`
escape hatch to the team's admins. The card now shows a single muted label,
and the surrounding footer was tidied up in the same area.

Four commits, each its own concern:

| Commit | Change |
| --- | --- |
| `94f7831a` | Remove the prefilled mailto-to-admins button, its handler, the `visibility`/reachable-address guards, dead imports and the `invitationMail.*` locale keys |
| `5a9e522f` | Equal-height team cards across a row, gapless admin avatars |
| `e16a1ea4` | Invite-only label drops to `body-small` / `on-surface-muted` |
| `15203c05` | Join button drops to `size="small"` |

## Why

The UI handed a non-member a public team's admin email addresses, and no
server-side request flow was ever built to replace the draft it opened — the
button was a client-side mail draft and nothing more. Removing it leaves the
invite-only state reading as a state rather than a dead-end action, which the
two styling commits then follow through on.

## Footer states after this PR

| `joining_mode` | Footer content |
| --- | --- |
| `open` | "Join" button (`small`, `outlined`, `person_add`) — calls `useJoinTeamMutation` directly |
| `invite_only` | No button; muted label (`body-small`, `on-surface-muted`) |
| already a member | Nothing in the join slot |

## Tests

`TeamCard.test.tsx` loses the whole `TeamCard invitation request` suite and its
`window.location` / `window.open` stubbing along with the code it covered. The
two surviving `invite_only` cases now assert the label for both the public and
the private team, so the branch that used to render a button is still pinned —
it just pins the label instead.

4/4 pass. `tsc --noEmit`, `eslint` and `prettier --check` clean.

## Docs

`docs/swift/ux/COMPONENT-UX.md` — the `TeamCard` joining-mode table and the
rationale block behind it. The ~50 lines documenting the mailto mechanics
(RFC 6068 encoding, `noopener` popup behaviour, basename handling) are replaced
by a short note recording that the escape hatch existed and why it went.

## Note for the reviewer

Two things I left alone, both pre-existing and outside this PR's scope:

- `AvatarGroup max={2}` in the footer was calibrated for a `medium` button in a
  fixed 290px card. With the button now `small` there is room to spare, so
  `max={3}` would likely fit — but that is a behaviour change, not a restyle.
- `COMPONENT-UX.md` carries two consecutive **Footer layout.** paragraphs that
  largely duplicate each other. Worth deleting one, in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)