### PR TITLE
feat(frontend): load application proxy config from local env (#2532)

### DIFF
--- a/apps/frontend/Makefile
+++ b/apps/frontend/Makefile
@@ -17,6 +17,24 @@ include ../../scripts/makefiles/config/INFO-frontend.mk
 
 NODE_VERSION=22.13.0
 
+# Local application gateway configuration follows the backend config/.env
+# convention. Values already supplied by the invoking environment are restored
+# after the include so they keep precedence; make command-line values already do.
+FRONTEND_ENV_FILE ?= $(CURDIR)/config/.env
+FRONTEND_ENABLE_APPLICATIONS_ENV_ORIGIN := $(origin FRONTEND_ENABLE_APPLICATIONS)
+FRONTEND_ENABLE_APPLICATIONS_ENV_VALUE := $(value FRONTEND_ENABLE_APPLICATIONS)
+FRONTEND_APPLICATIONS_JSON_ENV_ORIGIN := $(origin FRONTEND_APPLICATIONS_JSON)
+FRONTEND_APPLICATIONS_JSON_ENV_VALUE := $(value FRONTEND_APPLICATIONS_JSON)
+
+-include $(FRONTEND_ENV_FILE)
+
+ifeq ($(FRONTEND_ENABLE_APPLICATIONS_ENV_ORIGIN),environment)
+override FRONTEND_ENABLE_APPLICATIONS := $(FRONTEND_ENABLE_APPLICATIONS_ENV_VALUE)
+endif
+ifeq ($(FRONTEND_APPLICATIONS_JSON_ENV_ORIGIN),environment)
+override FRONTEND_APPLICATIONS_JSON := $(FRONTEND_APPLICATIONS_JSON_ENV_VALUE)
+endif
+
 ##@ Common workflows
 ##> The commands you actually use day to day:
 ##>   make run             start the local dev server on http://localhost:5173
@@ -89,7 +107,7 @@ run-docker: ## Run the built image in a container, proxying backend calls to ser
 		-e FRONTEND_KNOWLEDGE_FLOW_UPSTREAM=$(FRONTEND_KNOWLEDGE_FLOW_UPSTREAM) \
 		-e FRONTEND_CONTROL_PLANE_UPSTREAM=$(FRONTEND_CONTROL_PLANE_UPSTREAM) \
 		-e FRONTEND_ENABLE_APPLICATIONS=$(FRONTEND_ENABLE_APPLICATIONS) \
-		-e FRONTEND_APPLICATIONS_JSON='$(FRONTEND_APPLICATIONS_JSON)' \
+		-e FRONTEND_APPLICATIONS_JSON='$(FRONTEND_APPLICATIONS_JSON_VALUE)' \
 		-p $(FRONTEND_HOST_PORT):$(FRONTEND_CONTAINER_PORT) \
 		$(IMAGE_FULL)
 
@@ -101,7 +119,7 @@ docker-run: run-docker ## Alias for run-docker (kept for backward compatibility)
 .PHONY: run
 run: check-node node_modules ## Start the local Vite dev server on :5173 (HMR; proxies backend calls) — the everyday command
 	FRONTEND_ENABLE_APPLICATIONS=$(FRONTEND_ENABLE_APPLICATIONS) \
-		FRONTEND_APPLICATIONS_JSON='$(FRONTEND_APPLICATIONS_JSON)' \
+		FRONTEND_APPLICATIONS_JSON='$(FRONTEND_APPLICATIONS_JSON_VALUE)' \
 		VITE_DEV_USERNAME=$(shell whoami) npm run dev
 
 ##@ Code quality
@@ -266,3 +284,6 @@ FRONTEND_KNOWLEDGE_FLOW_UPSTREAM ?= http://host.docker.internal:8111
 FRONTEND_CONTROL_PLANE_UPSTREAM ?= http://host.docker.internal:8222
 FRONTEND_ENABLE_APPLICATIONS ?= false
 FRONTEND_APPLICATIONS_JSON ?= []
+# Shell-compatible .env files quote JSON to protect it while sourcing. GNU make
+# preserves those outer quotes, so remove them before recipes quote the raw JSON.
+FRONTEND_APPLICATIONS_JSON_VALUE = $(patsubst '%',%,$(strip $(FRONTEND_APPLICATIONS_JSON)))

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -53,10 +53,23 @@ and the nginx container resolve both the same way:
 | `/app-services/<app_id>/` | `service_upstream` | the app's own code            |
 
 ```bash
-FRONTEND_ENABLE_APPLICATIONS=true \
-FRONTEND_APPLICATIONS_JSON='[{"app_id":"acme-forecast","ui_upstream":"http://localhost:8300","service_upstream":"http://localhost:8301","service_required":true}]' \
+cp config/.env.template config/.env
+# Edit config/.env, then start Fred and the registered application upstreams.
 make run
 ```
+
+Frontend make commands load application gateway settings from `config/.env`
+when it exists. The file is local-only and ignored by Git. An explicit shell
+environment value or make command-line value takes precedence, so one-off
+overrides remain available:
+
+```bash
+FRONTEND_ENABLE_APPLICATIONS=false make run
+```
+
+The template's `localhost` upstreams are for native `make run`. For
+`make docker-run`, use addresses reachable from inside the container, such as
+`host.docker.internal` for services running on the host.
 
 The whole `/apps/<app_id>` prefix is forwarded upstream, so build the app's
 bundle with that base path — its own absolute asset URLs then resolve back

--- a/apps/frontend/config/.env.template
+++ b/apps/frontend/config/.env.template
@@ -1,0 +1,11 @@
+# Copy this file to .env and adapt it for the applications running locally.
+# The frontend Makefile loads config/.env automatically when it exists.
+#
+# FRONTEND_APPLICATIONS_JSON must be a valid JSON array kept on one line. Each
+# entry registers one independent UI and, optionally, its service upstream.
+# Multiple applications are supported by adding more objects to the array:
+# FRONTEND_APPLICATIONS_JSON='[{"app_id":"information-systems","ui_upstream":"http://localhost:5180","service_upstream":"http://localhost:8112","service_required":true},{"app_id":"another-app","ui_upstream":"http://localhost:5190","service_upstream":"http://localhost:8120","service_required":true}]'
+
+FRONTEND_ENABLE_APPLICATIONS=true
+
+FRONTEND_APPLICATIONS_JSON='[{"app_id":"information-systems","ui_upstream":"http://localhost:5180","service_upstream":"http://localhost:8112","service_required":true}]'


### PR DESCRIPTION
# Pull Request

## 1. What problem does this solve — and where is it tracked?

**Issue:** Closes #2532

**Problem in one sentence:** Local frontend application proxy registrations had to be supplied manually on every invocation because `apps/frontend/config/.env` was not loaded by the frontend Makefile.

**Backlog ref:** n/a — issue #2532 is the tracking unit for this change.

---

## 2. Before you wrote a single line of code

**RFC written?**

Not required — this is local configuration plumbing for the existing application gateway. It does not introduce a new API, schema, component, or routing contract.

**Plan presented to the team before implementation?**

Yes — the scope, precedence rules, documentation changes, and validation criteria were documented in #2532 before implementation.

**Confirmation received?**

Yes — explicit instruction was received to create the issue and proceed with the implementation.

---

## 3. What you built

The frontend Makefile now optionally loads application gateway settings from `apps/frontend/config/.env`, following the configuration convention already used by the backends.

Explicit shell environment values and make command-line arguments retain precedence over values from the file. Quoted JSON from the shell-compatible `.env` file is normalized before being passed to Vite or the frontend container.

A documented `.env.template` provides a working Information Systems example and shows how to register multiple applications.

This PR does not change the generic proxy implementation or the existing static agent route prefixes in `vite.config.ts`; generalizing those routes can be handled separately.

---

## 4. Proof of quality

**Tests added or updated:**

No automated test files were added. The change is Makefile configuration plumbing around the existing, already-tested application proxy parser.

The following focused Make dry-runs were performed:

| Test | File | What it covers |
| ---- | ---- | -------------- |
| Local `.env` values | `apps/frontend/Makefile` | Values are loaded from `config/.env` |
| Shell environment override | `apps/frontend/Makefile` | Explicit environment values retain precedence |
| Make command-line override | `apps/frontend/Makefile` | Command-line values retain precedence |
| Missing `.env` file | `apps/frontend/Makefile` | Existing defaults remain active |
| Quoted JSON normalization | `apps/frontend/Makefile` | Vite and Docker receive raw valid JSON without outer shell quotes |

**`make code-quality` output:**

```text
All frontend code quality checks completed
```

**Raw `basedpyright` output:**

```text
n/a — the touched package is the TypeScript frontend and does not use basedpyright.
```

**`make test` output:**

```text
Test Files  174 passed | 1 skipped (175)
Tests       1736 passed | 2 skipped (1738)
```

---

## 5. Docs updated

| What changed | File updated |
| ------------ | ------------ |
| Backlog `[ ]` item is now done | n/a — tracked directly by #2532 |
| New behaviour, API field, or contract change | `apps/frontend/README.md`, `apps/frontend/config/.env.template` |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a — no frozen contract changed |
| UX component implemented or visual status changed | n/a — local runtime configuration only |
| Phase progress row exists for this area | n/a |
| WORKPLAN sprint item finished | n/a |
| Code and a design doc now diverge | No — the operational documentation was updated with the implementation |

---

## 6. Close-out statement

```text
## Task close-out
- Code: frontend Makefile loads optional config/.env while preserving explicit environment and command-line precedence; quoted JSON is normalized before use.
- Tests: focused Make dry-runs passed; make code-quality passed; 1736 tests passed and 2 were skipped.
- Docs updated: apps/frontend/README.md and apps/frontend/config/.env.template.
- Backlog: n/a — closes #2532.
- Skipped steps: no RFC because this reuses the existing application gateway contract and changes only local configuration loading.
```

---

## 7. Risk and rollback

**What breaks if this is wrong?**

Local `make run` or `make docker-run` could receive malformed application registration JSON or use an unexpected value-precedence order. This could prevent application UI or service routes from being proxied correctly. The feature remains disabled by default when no local configuration is provided.

**How do we roll back?**

Revert this commit. The frontend will return to requiring `FRONTEND_ENABLE_APPLICATIONS` and `FRONTEND_APPLICATIONS_JSON` to be supplied explicitly for each invocation.
