### PR TITLE
feat(#2538): search and sort the team agents list

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2454,7 +2454,10 @@
           "aria": "Filter by pod"
         },
         "title": "Team agents",
-        "titlePersonal": "Your personal agents"
+        "titlePersonal": "Your personal agents",
+        "searchPlaceholder": "Search {{agentsNicknamePlural}}...",
+        "clearSearch": "Clear search",
+        "emptySearch": "No results for this search."
       },
       "formAgent": {
         "advancedSettings": "Advanced settings",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2457,7 +2457,13 @@
         "titlePersonal": "Your personal agents",
         "searchPlaceholder": "Search {{agentsNicknamePlural}}...",
         "clearSearch": "Clear search",
-        "emptySearch": "No results for this search."
+        "emptySearch": "No results for this search.",
+        "sortLabel": "Sort",
+        "sort": {
+          "name": "Alphabetical",
+          "created": "Recently created",
+          "updated": "Recently updated"
+        }
       },
       "formAgent": {
         "advancedSettings": "Advanced settings",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2462,7 +2462,8 @@
           "name": "Alphabetical",
           "created": "Recently created",
           "updated": "Recently updated"
-        }
+        },
+        "sortLabel": "Sort"
       },
       "formAgent": {
         "advancedSettings": "Advanced settings",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -2458,7 +2458,6 @@
         "searchPlaceholder": "Search {{agentsNicknamePlural}}...",
         "clearSearch": "Clear search",
         "emptySearch": "No results for this search.",
-        "sortLabel": "Sort",
         "sort": {
           "name": "Alphabetical",
           "created": "Recently created",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2457,7 +2457,13 @@
         "titlePersonal": "Vos agents personnels",
         "searchPlaceholder": "Rechercher des {{agentsNicknamePlural}}...",
         "clearSearch": "Effacer la recherche",
-        "emptySearch": "Aucun résultat pour cette recherche."
+        "emptySearch": "Aucun résultat pour cette recherche.",
+        "sortLabel": "Trier",
+        "sort": {
+          "name": "Alphabétique",
+          "created": "Derniers créés",
+          "updated": "Derniers modifiés"
+        }
       },
       "formAgent": {
         "advancedSettings": "Paramètres avancés",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2454,7 +2454,10 @@
           "aria": "Filtrer par pod"
         },
         "title": "Agents de l'équipe",
-        "titlePersonal": "Vos agents personnels"
+        "titlePersonal": "Vos agents personnels",
+        "searchPlaceholder": "Rechercher des {{agentsNicknamePlural}}...",
+        "clearSearch": "Effacer la recherche",
+        "emptySearch": "Aucun résultat pour cette recherche."
       },
       "formAgent": {
         "advancedSettings": "Paramètres avancés",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2458,7 +2458,6 @@
         "searchPlaceholder": "Rechercher des {{agentsNicknamePlural}}...",
         "clearSearch": "Effacer la recherche",
         "emptySearch": "Aucun résultat pour cette recherche.",
-        "sortLabel": "Trier",
         "sort": {
           "name": "Alphabétique",
           "created": "Derniers créés",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -2462,7 +2462,8 @@
           "name": "Alphabétique",
           "created": "Derniers créés",
           "updated": "Derniers modifiés"
-        }
+        },
+        "sortLabel": "Trier"
       },
       "formAgent": {
         "advancedSettings": "Paramètres avancés",

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -8,7 +8,7 @@
 .title {
   display: flex;
   align-items: center;
-  gap: var(--spacing-m);
+  gap: var(--spacing-s);
   padding: var(--spacing-l) var(--spacing-l) var(--spacing-m);
   color: var(--on-surface);
   font: var(--font-title-large);

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -30,7 +30,7 @@
 /* Fixed width so the control does not resize as the selected option changes
    length — a toolbar that reflows on every pick is hard to aim at. */
 .sortSelect {
-  min-width: 300px;
+  min-width: 200px;
 }
 
 /* Shown in place of the list when a query matches nothing — distinct from

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -6,11 +6,8 @@
 }
 
 .title {
-  /* Bottom-aligned, not centered: the sort Select stacks its label above its
-     trigger, so centering would sit the trigger lower than the search field
-     and the create button (same reason as the evaluations toolbar). */
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: var(--spacing-m);
   padding: var(--spacing-l) var(--spacing-l) var(--spacing-m);
   color: var(--on-surface);
@@ -28,6 +25,12 @@
 .searchBar {
   width: 100%;
   max-width: 250px;
+}
+
+/* Fixed width so the control does not resize as the selected option changes
+   length — a toolbar that reflows on every pick is hard to aim at. */
+.sortSelect {
+  min-width: 300px;
 }
 
 /* Shown in place of the list when a query matches nothing — distinct from

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -20,6 +20,23 @@
   margin-right: auto;
 }
 
+/* Caps the field so it stays a compact search box in a wide toolbar rather
+   than stretching across the freed space (matches the team prompts page). */
+.searchBar {
+  width: 100%;
+  max-width: 320px;
+}
+
+/* Shown in place of the list when a query matches nothing — distinct from
+   TeamAgentEmptyState, which means the team has no agents at all. */
+.emptySearch {
+  display: flex;
+  justify-content: center;
+  padding: var(--spacing-l);
+  color: var(--on-surface-retreat);
+  font: var(--font-body-medium);
+}
+
 .bannerNotice {
   margin: 0 auto var(--spacing-l);
   border-radius: var(--radius-s);

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.module.css
@@ -6,8 +6,11 @@
 }
 
 .title {
+  /* Bottom-aligned, not centered: the sort Select stacks its label above its
+     trigger, so centering would sit the trigger lower than the search field
+     and the create button (same reason as the evaluations toolbar). */
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: var(--spacing-m);
   padding: var(--spacing-l) var(--spacing-l) var(--spacing-m);
   color: var(--on-surface);
@@ -24,7 +27,7 @@
    than stretching across the freed space (matches the team prompts page). */
 .searchBar {
   width: 100%;
-  max-width: 320px;
+  max-width: 250px;
 }
 
 /* Shown in place of the list when a query matches nothing — distinct from

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -456,7 +456,14 @@ export default function TeamAgentsPage() {
             />
           </div>
           <div className={styles.sortSelect}>
-            <Select<AgentSortValue> size="small" compact options={sortOptions} value={sort} onChange={setSort} />
+            <Select<AgentSortValue>
+              size="small"
+              compact
+              options={sortOptions}
+              value={sort}
+              onChange={setSort}
+              ariaLabel={t("rework.teams.agents.sortLabel")}
+            />
           </div>
         </div>
       )}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -455,14 +455,9 @@ export default function TeamAgentsPage() {
               size="small"
             />
           </div>
-          <Select<AgentSortValue>
-            size="small"
-            compact
-            options={sortOptions}
-            value={sort}
-            onChange={setSort}
-            label={t("rework.teams.agents.sortLabel")}
-          />
+          <div className={styles.sortSelect}>
+            <Select<AgentSortValue> size="small" compact options={sortOptions} value={sort} onChange={setSort} />
+          </div>
         </div>
       )}
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -15,7 +15,8 @@
 import Button from "@shared/atoms/Button/Button.tsx";
 import { Spinner } from "@shared/atoms/Spinner/Spinner.tsx";
 import AgentCard from "@shared/organisms/AgentCard/AgentCard.tsx";
-import { useState } from "react";
+import SearchInput from "@shared/molecules/SearchInput/SearchInput.tsx";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { useConfirmationDialog } from "@shared/molecules/ConfirmationDialog/ConfirmationDialogProvider";
@@ -32,6 +33,7 @@ import {
 } from "./AgentFormModal/AgentFormModal.tsx";
 import DuplicateAgentDialog from "./DuplicateAgentDialog/DuplicateAgentDialog.tsx";
 import TeamAgentEmptyState from "./TeamAgentEmptyState/TeamAgentEmptyState.tsx";
+import { filterAgents } from "./agentFilter.ts";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice.tsx";
 import { useUsersByIdsQuery } from "../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import {
@@ -118,6 +120,7 @@ export default function TeamAgentsPage() {
   const [isEnrollOpen, setIsEnrollOpen] = useState(false);
   const [editingInstance, setEditingInstance] = useState<ManagedAgentInstanceSummary | null>(null);
   const [duplicatingInstance, setDuplicatingInstance] = useState<ManagedAgentInstanceSummary | null>(null);
+  const [search, setSearch] = useState("");
 
   const { data: fetchedTeam } = useGetTeamQuery({ teamId: teamId || "" }, { skip: !teamId || isPersonalTeam });
   const team = isPersonalTeam ? activeTeam : fetchedTeam;
@@ -140,6 +143,20 @@ export default function TeamAgentsPage() {
   } = useGetTeamAgentTemplatesControlPlaneV1TeamsTeamIdAgentTemplatesGetQuery(
     { teamId: teamId || "" },
     { skip: !teamId || !canManageAgents },
+  );
+
+  // Must stay above the early returns below - a hook after them renders a
+  // different hook count when a query errors, which React refuses.
+  // A suspended agent stays hidden from chat-only members (they cannot fix it
+  // and must not see a broken agent); editors/owners keep seeing it with a
+  // warning and a locked enable toggle. The search narrows what is left.
+  const searchedInstances = useMemo(
+    () =>
+      filterAgents(
+        managedInstances.filter((instance) => canManageAgents || !instance.suspension_reason),
+        search,
+      ),
+    [managedInstances, canManageAgents, search],
   );
 
   // Batched once for the whole list (not one query per card, #2096) — the
@@ -393,6 +410,9 @@ export default function TeamAgentsPage() {
     canManageAgents && !isLoadingTemplates && !isTemplatesError && availableTemplates.length === 0;
   const showEmptyState = !isLoadingInstances && managedInstances.length === 0;
   const hasAgents = managedInstances.length > 0;
+  // Only a non-empty query earns the no-match message: an empty list under an
+  // empty query means something else entirely, and is left as it was.
+  const showNoSearchMatch = Boolean(search.trim()) && searchedInstances.length === 0;
 
   return (
     <div className={styles.teamAgentContainer}>
@@ -412,6 +432,17 @@ export default function TeamAgentsPage() {
               {t("rework.teams.agents.create", { agentsNicknameSingular })}
             </Button>
           )}
+          <div className={styles.searchBar}>
+            <SearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder={t("rework.teams.agents.searchPlaceholder", {
+                agentsNicknamePlural: agentsNicknamePlural.toLowerCase(),
+              })}
+              clearAriaLabel={t("rework.teams.agents.clearSearch")}
+              size="small"
+            />
+          </div>
         </div>
       )}
 
@@ -433,33 +464,29 @@ export default function TeamAgentsPage() {
           templatesUnavailable={false}
           onCreateAgent={() => setIsEnrollOpen(true)}
         />
+      ) : showNoSearchMatch ? (
+        <div className={styles.emptySearch}>{t("rework.teams.agents.emptySearch")}</div>
       ) : (
         <div className={styles.agentList}>
-          {managedInstances
-            // #1975 (RFC §3.9): a suspended agent is hidden from chat-only
-            // members (they cannot fix it and must not see a broken agent);
-            // editors/owners (`can_update_agents`) keep seeing it with a warning
-            // and a locked enable toggle so they can open the edit form and fix.
-            .filter((instance) => canManageAgents || !instance.suspension_reason)
-            .map((instance) => {
-              const template = availableTemplates.find((tpl) => tpl.template_id === instance.template_id);
-              return (
-                <AgentCard
-                  key={instance.agent_instance_id}
-                  instance={instance}
-                  templateDisplayName={template?.display_name || instance.template_id}
-                  runtimeId={template?.source_runtime_id}
-                  teamId={teamId}
-                  canManageAgents={canManageAgents}
-                  offline={templatesUnavailable}
-                  auditUserById={auditUserById}
-                  onEdit={() => setEditingInstance(instance)}
-                  onToggleEnabled={() => handleToggleEnabled(instance)}
-                  onDuplicate={() => setDuplicatingInstance(instance)}
-                  onDelete={() => handleDelete(instance)}
-                />
-              );
-            })}
+          {searchedInstances.map((instance) => {
+            const template = availableTemplates.find((tpl) => tpl.template_id === instance.template_id);
+            return (
+              <AgentCard
+                key={instance.agent_instance_id}
+                instance={instance}
+                templateDisplayName={template?.display_name || instance.template_id}
+                runtimeId={template?.source_runtime_id}
+                teamId={teamId}
+                canManageAgents={canManageAgents}
+                offline={templatesUnavailable}
+                auditUserById={auditUserById}
+                onEdit={() => setEditingInstance(instance)}
+                onToggleEnabled={() => handleToggleEnabled(instance)}
+                onDuplicate={() => setDuplicatingInstance(instance)}
+                onDelete={() => handleDelete(instance)}
+              />
+            );
+          })}
         </div>
       )}
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/TeamAgentsPage.tsx
@@ -16,6 +16,8 @@ import Button from "@shared/atoms/Button/Button.tsx";
 import { Spinner } from "@shared/atoms/Spinner/Spinner.tsx";
 import AgentCard from "@shared/organisms/AgentCard/AgentCard.tsx";
 import SearchInput from "@shared/molecules/SearchInput/SearchInput.tsx";
+import Select from "@shared/molecules/Select/Select.tsx";
+import type { OptionModel } from "@models/Option.model.ts";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -34,6 +36,7 @@ import {
 import DuplicateAgentDialog from "./DuplicateAgentDialog/DuplicateAgentDialog.tsx";
 import TeamAgentEmptyState from "./TeamAgentEmptyState/TeamAgentEmptyState.tsx";
 import { filterAgents } from "./agentFilter.ts";
+import { DEFAULT_AGENT_SORT, sortAgents, type AgentSortValue } from "./agentSort.ts";
 import ServiceNotice from "@shared/molecules/ServiceNotice/ServiceNotice.tsx";
 import { useUsersByIdsQuery } from "../../../../slices/controlPlane/controlPlaneApiEnhancements";
 import {
@@ -121,6 +124,7 @@ export default function TeamAgentsPage() {
   const [editingInstance, setEditingInstance] = useState<ManagedAgentInstanceSummary | null>(null);
   const [duplicatingInstance, setDuplicatingInstance] = useState<ManagedAgentInstanceSummary | null>(null);
   const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<AgentSortValue>(DEFAULT_AGENT_SORT);
 
   const { data: fetchedTeam } = useGetTeamQuery({ teamId: teamId || "" }, { skip: !teamId || isPersonalTeam });
   const team = isPersonalTeam ? activeTeam : fetchedTeam;
@@ -152,11 +156,14 @@ export default function TeamAgentsPage() {
   // warning and a locked enable toggle. The search narrows what is left.
   const searchedInstances = useMemo(
     () =>
-      filterAgents(
-        managedInstances.filter((instance) => canManageAgents || !instance.suspension_reason),
-        search,
+      sortAgents(
+        filterAgents(
+          managedInstances.filter((instance) => canManageAgents || !instance.suspension_reason),
+          search,
+        ),
+        sort,
       ),
-    [managedInstances, canManageAgents, search],
+    [managedInstances, canManageAgents, search, sort],
   );
 
   // Batched once for the whole list (not one query per card, #2096) — the
@@ -410,6 +417,11 @@ export default function TeamAgentsPage() {
     canManageAgents && !isLoadingTemplates && !isTemplatesError && availableTemplates.length === 0;
   const showEmptyState = !isLoadingInstances && managedInstances.length === 0;
   const hasAgents = managedInstances.length > 0;
+  const sortOptions: OptionModel<AgentSortValue>[] = [
+    { value: "name", key: "name", label: t("rework.teams.agents.sort.name") },
+    { value: "created_at:desc", key: "created", label: t("rework.teams.agents.sort.created") },
+    { value: "updated_at:desc", key: "updated", label: t("rework.teams.agents.sort.updated") },
+  ];
   // Only a non-empty query earns the no-match message: an empty list under an
   // empty query means something else entirely, and is left as it was.
   const showNoSearchMatch = Boolean(search.trim()) && searchedInstances.length === 0;
@@ -443,6 +455,14 @@ export default function TeamAgentsPage() {
               size="small"
             />
           </div>
+          <Select<AgentSortValue>
+            size="small"
+            compact
+            options={sortOptions}
+            value={sort}
+            onChange={setSort}
+            label={t("rework.teams.agents.sortLabel")}
+          />
         </div>
       )}
 

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentFilter.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentFilter.test.ts
@@ -1,0 +1,98 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import type { ManagedAgentInstanceSummary } from "../../../../slices/controlPlane/controlPlaneOpenApi";
+import { filterAgents } from "./agentFilter";
+
+// --- helpers ---------------------------------------------------------------
+
+function agent(overrides: Partial<ManagedAgentInstanceSummary>): ManagedAgentInstanceSummary {
+  return {
+    agent_instance_id: "a-1",
+    template_id: "tpl-1",
+    display_name: "Support Assistant",
+    role: "Customer support",
+    description: "Answers customer questions",
+    ...overrides,
+  } as ManagedAgentInstanceSummary;
+}
+
+const SUPPORT = agent({ agent_instance_id: "a-1" });
+const INVOICES = agent({
+  agent_instance_id: "a-2",
+  display_name: "Invoice Reader",
+  description: "Extracts totals from PDFs",
+});
+
+function ids(instances: ManagedAgentInstanceSummary[]): string[] {
+  return instances.map((i) => i.agent_instance_id);
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe("filterAgents", () => {
+  it("returns everything for an empty or whitespace-only query", () => {
+    // The page passes the raw input value, so a user who typed only spaces
+    // must not be shown an empty list.
+    expect(ids(filterAgents([SUPPORT, INVOICES], ""))).toEqual(["a-1", "a-2"]);
+    expect(ids(filterAgents([SUPPORT, INVOICES], "   "))).toEqual(["a-1", "a-2"]);
+  });
+
+  it("matches the display name, case-insensitively", () => {
+    expect(ids(filterAgents([SUPPORT, INVOICES], "INVOICE"))).toEqual(["a-2"]);
+  });
+
+  it("matches the role, which the card renders under the name", () => {
+    const payroll = agent({ agent_instance_id: "a-5", role: "Answers payroll questions" });
+    expect(ids(filterAgents([SUPPORT, payroll], "payroll"))).toEqual(["a-5"]);
+  });
+
+  it("matches the description too", () => {
+    expect(ids(filterAgents([SUPPORT, INVOICES], "totals"))).toEqual(["a-2"]);
+  });
+
+  it("matches on a substring, not just a prefix", () => {
+    expect(ids(filterAgents([SUPPORT, INVOICES], "sist"))).toEqual(["a-1"]);
+  });
+
+  it("ignores surrounding whitespace in the query", () => {
+    expect(ids(filterAgents([SUPPORT, INVOICES], "  invoice  "))).toEqual(["a-2"]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    // Drives the page's dedicated no-match state rather than the
+    // "create your first agent" empty state.
+    expect(filterAgents([SUPPORT, INVOICES], "zzz")).toEqual([]);
+  });
+
+  it("preserves the incoming order", () => {
+    expect(ids(filterAgents([INVOICES, SUPPORT], "e"))).toEqual(["a-2", "a-1"]);
+  });
+
+  it("tolerates a missing description", () => {
+    // `description` is optional on the payload; a null must not throw or
+    // stringify into something matchable.
+    const bare = agent({ agent_instance_id: "a-3", display_name: "Bare", description: null });
+    expect(ids(filterAgents([bare], "bare"))).toEqual(["a-3"]);
+    expect(filterAgents([bare], "null")).toEqual([]);
+  });
+
+  it("does not let a query span the name/description boundary", () => {
+    // Name and description are joined to build the haystack; the join must not
+    // create matches that exist in neither field.
+    const a = agent({ agent_instance_id: "a-4", display_name: "alpha", description: "beta" });
+    expect(filterAgents([a], "alphabeta")).toEqual([]);
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentFilter.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentFilter.ts
@@ -1,0 +1,35 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Search predicate for the team agents list. Kept out of the page so it can be
+// tested without mounting a container full of RTK Query hooks.
+
+import type { ManagedAgentInstanceSummary } from "../../../../slices/controlPlane/controlPlaneOpenApi";
+
+/** Fields the card shows, so the fields a search is expected to reach:
+ * the name, the role rendered under it, and the description. */
+function haystack(instance: ManagedAgentInstanceSummary): string {
+  return [instance.display_name, instance.role, instance.description].filter(Boolean).join("\n").toLowerCase();
+}
+
+/**
+ * Case-insensitive substring match over name + description. An empty or
+ * whitespace-only query matches everything, so the caller can pass the raw
+ * input value straight through.
+ */
+export function filterAgents(instances: ManagedAgentInstanceSummary[], query: string): ManagedAgentInstanceSummary[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return instances;
+  return instances.filter((instance) => haystack(instance).includes(q));
+}

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentSort.test.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentSort.test.ts
@@ -1,0 +1,119 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import type { ManagedAgentInstanceSummary } from "../../../../slices/controlPlane/controlPlaneOpenApi";
+import { sortAgents } from "./agentSort";
+
+// --- helpers ---------------------------------------------------------------
+
+function agent(overrides: Partial<ManagedAgentInstanceSummary>): ManagedAgentInstanceSummary {
+  return {
+    agent_instance_id: "a-1",
+    template_id: "tpl-1",
+    display_name: "Agent",
+    role: "Role",
+    description: "",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as ManagedAgentInstanceSummary;
+}
+
+function ids(instances: ManagedAgentInstanceSummary[]): string[] {
+  return instances.map((i) => i.agent_instance_id);
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe("sortAgents", () => {
+  it("never mutates the caller's array", () => {
+    // The list is RTK Query state, frozen by immer in dev — an in-place sort
+    // would throw at runtime rather than fail a type check.
+    const input = Object.freeze([
+      agent({ agent_instance_id: "b", display_name: "Beta" }),
+      agent({ agent_instance_id: "a", display_name: "Alpha" }),
+    ]) as ManagedAgentInstanceSummary[];
+
+    expect(ids(sortAgents(input, "name"))).toEqual(["a", "b"]);
+    expect(ids(input)).toEqual(["b", "a"]);
+  });
+
+  describe("name", () => {
+    it("orders alphabetically, ignoring case", () => {
+      const list = [
+        agent({ agent_instance_id: "c", display_name: "charlie" }),
+        agent({ agent_instance_id: "a", display_name: "Alpha" }),
+        agent({ agent_instance_id: "b", display_name: "Bravo" }),
+      ];
+      expect(ids(sortAgents(list, "name"))).toEqual(["a", "b", "c"]);
+    });
+
+    it("files an accented name next to its unaccented form", () => {
+      // Base sensitivity: "Élan" belongs beside "Elan", not after "Zulu".
+      const list = [
+        agent({ agent_instance_id: "z", display_name: "Zulu" }),
+        agent({ agent_instance_id: "e", display_name: "Élan" }),
+        agent({ agent_instance_id: "f", display_name: "Fox" }),
+      ];
+      expect(ids(sortAgents(list, "name"))).toEqual(["e", "f", "z"]);
+    });
+  });
+
+  describe("created_at:desc", () => {
+    it("puts the most recently created first", () => {
+      const list = [
+        agent({ agent_instance_id: "old", created_at: "2026-01-01T00:00:00Z" }),
+        agent({ agent_instance_id: "new", created_at: "2026-06-01T00:00:00Z" }),
+      ];
+      expect(ids(sortAgents(list, "created_at:desc"))).toEqual(["new", "old"]);
+    });
+
+    it("pushes an undated agent to the end", () => {
+      // `created_at` is nullable on the payload.
+      const list = [
+        agent({ agent_instance_id: "none", created_at: null }),
+        agent({ agent_instance_id: "dated", created_at: "2026-01-01T00:00:00Z" }),
+      ];
+      expect(ids(sortAgents(list, "created_at:desc"))).toEqual(["dated", "none"]);
+    });
+
+    it("pushes an unparseable date to the end rather than to the front", () => {
+      const list = [
+        agent({ agent_instance_id: "junk", created_at: "not-a-date" }),
+        agent({ agent_instance_id: "dated", created_at: "2026-01-01T00:00:00Z" }),
+      ];
+      expect(ids(sortAgents(list, "created_at:desc"))).toEqual(["dated", "junk"]);
+    });
+
+    it("leaves two undated agents in their incoming order", () => {
+      const list = [
+        agent({ agent_instance_id: "first", created_at: null }),
+        agent({ agent_instance_id: "second", created_at: null }),
+      ];
+      expect(ids(sortAgents(list, "created_at:desc"))).toEqual(["first", "second"]);
+    });
+  });
+
+  describe("updated_at:desc", () => {
+    it("sorts on updated_at, not created_at", () => {
+      // An old agent edited yesterday must outrank a new one never touched.
+      const list = [
+        agent({ agent_instance_id: "fresh", created_at: "2026-06-01T00:00:00Z", updated_at: "2026-06-01T00:00:00Z" }),
+        agent({ agent_instance_id: "revised", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-08-01T00:00:00Z" }),
+      ];
+      expect(ids(sortAgents(list, "updated_at:desc"))).toEqual(["revised", "fresh"]);
+    });
+  });
+});

--- a/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentSort.ts
+++ b/apps/frontend/src/rework/components/pages/TeamAgentsPage/agentSort.ts
@@ -1,0 +1,64 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Sort orders for the team agents list. Kept out of the page for the same
+// reason as the search predicate: testable without mounting the container.
+
+import type { ManagedAgentInstanceSummary } from "../../../../slices/controlPlane/controlPlaneOpenApi";
+
+export type AgentSortValue = "name" | "created_at:desc" | "updated_at:desc";
+
+export const DEFAULT_AGENT_SORT: AgentSortValue = "name";
+
+/** Epoch millis, or null when the field is absent or unparseable. */
+function timestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** Most recent first, with anything undated last whichever way the pair falls. */
+function byRecency(a: string | null | undefined, b: string | null | undefined): number {
+  const left = timestamp(a);
+  const right = timestamp(b);
+  if (left === right) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return right - left;
+}
+
+/**
+ * Returns a new array — the caller's list is RTK Query state, frozen in dev,
+ * so sorting it in place would throw.
+ *
+ * Alphabetical uses `localeCompare` with base sensitivity so accents and case
+ * fall where a reader expects ("Élan" next to "Elan", not after "Zulu").
+ */
+export function sortAgents(
+  instances: ManagedAgentInstanceSummary[],
+  sort: AgentSortValue,
+): ManagedAgentInstanceSummary[] {
+  const sorted = [...instances];
+  switch (sort) {
+    case "created_at:desc":
+      return sorted.sort((a, b) => byRecency(a.created_at, b.created_at));
+    case "updated_at:desc":
+      return sorted.sort((a, b) => byRecency(a.updated_at, b.updated_at));
+    case "name":
+    default:
+      return sorted.sort((a, b) =>
+        (a.display_name ?? "").localeCompare(b.display_name ?? "", undefined, { sensitivity: "base" }),
+      );
+  }
+}

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.module.scss
@@ -4,7 +4,7 @@
 
 .select-container {
   --select-outline: transparent;
-  --border-color: var(--outline-muted);
+  --border-color: var(--outline-retreat);
   --bg-color: var(--surface-container-lowest);
   display: flex;
   position: relative;

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.test.tsx
@@ -68,6 +68,29 @@ function activeDescendantLabel(options: OptionModel<string>[]): string | undefin
   return options.find((o) => String(o.value) === value)?.label;
 }
 
+describe("Select accessible name", () => {
+  const OPTS: OptionModel<string>[] = [
+    { value: "a", key: "a", label: "Alphabetical" },
+    { value: "b", key: "b", label: "Recently created" },
+  ];
+
+  it("names the trigger from ariaLabel when no visible label is rendered", () => {
+    // Without it the button falls back to its own content, so a screen reader
+    // announces the current value with no hint of what the control does.
+    render(<Select<string> size="small" options={OPTS} value="a" onChange={() => {}} ariaLabel="Sort" />);
+
+    expect(container.querySelector("label")).toBeNull();
+    expect(trigger().getAttribute("aria-label")).toBe("Sort");
+  });
+
+  it("sets no aria-label when the prop is omitted, leaving a visible label to name it", () => {
+    render(<Select<string> size="small" options={OPTS} value="a" onChange={() => {}} label="Sort" />);
+
+    expect(trigger().hasAttribute("aria-label")).toBe(false);
+    expect(container.querySelector("label")?.getAttribute("for")).toBe(trigger().id);
+  });
+});
+
 describe("Select keyboard navigation — disabled options", () => {
   it("Home selects the first enabled option when the literal first option is disabled", () => {
     const options: OptionModel<string>[] = [

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.tsx
@@ -42,6 +42,10 @@ interface SelectProps<T> {
   size: ComponentSize;
   placeholder?: string;
   label?: string;
+  /** Accessible name for the trigger when no visible `label` is rendered —
+   * without either, a screen reader announces only the current value. Takes
+   * precedence over `label`, so pass one or the other. */
+  ariaLabel?: string;
   disabled?: boolean;
   error?: string;
   compact?: boolean;
@@ -52,6 +56,7 @@ export default function Select<T>({
   value,
   placeholder,
   label,
+  ariaLabel,
   disabled = false,
   error,
   onChange,
@@ -237,6 +242,7 @@ export default function Select<T>({
         className={styles["trigger"]}
         onClick={toggleMenu}
         onKeyDown={handleTriggerKeyDown}
+        aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         aria-controls={options.length > 0 ? `${baseId}-listbox` : undefined}

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1325,7 +1325,7 @@ Composition and states:
 Wording is deployment-configurable: the placeholder interpolates
 `agentsNicknamePlural`, since a deployment renames agents (e.g. "Lumis").
 
-**Sort.** A `Select` (`size="small"`, `compact`, no label, `min-width: 300px`
+**Sort.** A `Select` (`size="small"`, `compact`, no label, `min-width: 200px`
 so the control does not resize as the picked option changes length) sits after
 the search field, offering Alphabetical (default), Recently created and Recently updated —
 `display_name`, `created_at`, `updated_at`, the three orderings available

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1287,6 +1287,46 @@ row and making the list unreadable. Two changes:
 
 ---
 
+### `TeamAgentsPage` list search
+
+**Location:** `src/rework/components/pages/TeamAgentsPage/`
+**Status:** `Functional`
+
+A `SearchInput` (`size="small"`, capped at 320px) sits at the right of the page
+toolbar, after the create button — the same placement and component as the team
+prompts page, so the two team list pages read alike. It filters the already
+loaded list client-side: local `useState`, no debounce, no request. The list is
+fetched whole, so no query parameter and no control-plane change is involved.
+
+The predicate lives in `agentFilter.ts` rather than in the page: a
+case-insensitive substring match against the three fields `AgentCard` actually
+renders — `display_name`, `role`, `description` — joined per instance so a query
+cannot match across a field boundary. An empty or whitespace-only query returns
+everything, so the raw input value can be passed straight through. It is a pure
+function with its own unit test, matching how `toolPackLogic` is tested in this
+directory; `TeamAgentsPage.tsx` is an RTK Query container with no test of its
+own.
+
+Composition and states:
+
+- The search narrows what is left **after** the suspension filter (a suspended
+  agent stays hidden from members without `can_update_agents`).
+- A query matching nothing shows a dedicated message, never
+  `TeamAgentEmptyState` — that state means "this team has no agents yet" and is
+  driven by the unfiltered list. Guarding the message on a non-empty query keeps
+  the no-query behaviour untouched.
+- The toolbar (and so the field) is driven by the unfiltered list, so a search
+  that empties the grid never removes the field the user needs to correct it.
+- The memo sits above the page's early returns: a hook placed after them renders
+  a different hook count when a query errors. Note `eslint.config.mjs` registers
+  `eslint-plugin-react-hooks` but enables none of its rules, so lint will not
+  catch a regression here.
+
+Wording is deployment-configurable: the placeholder interpolates
+`agentsNicknamePlural`, since a deployment renames agents (e.g. "Lumis").
+
+---
+
 ### `AgentCard`
 
 **Location:** `src/rework/components/shared/organisms/AgentCard/AgentCard.tsx`

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1287,7 +1287,7 @@ row and making the list unreadable. Two changes:
 
 ---
 
-### `TeamAgentsPage` list search
+### `TeamAgentsPage` list search + sort
 
 **Location:** `src/rework/components/pages/TeamAgentsPage/`
 **Status:** `Functional`
@@ -1324,6 +1324,25 @@ Composition and states:
 
 Wording is deployment-configurable: the placeholder interpolates
 `agentsNicknamePlural`, since a deployment renames agents (e.g. "Lumis").
+
+**Sort.** A labelled `Select` (`size="small"`, `compact`) sits after the search
+field, offering Alphabetical (default), Recently created and Recently updated —
+`display_name`, `created_at`, `updated_at`, the three orderings available
+without touching the API. `sortAgents` (`agentSort.ts`, unit-tested like the
+filter) applies after the search so the visible list is always sorted, and:
+
+- copies before sorting — the list is RTK Query state, frozen by immer in dev,
+  so an in-place sort throws at runtime;
+- puts an agent with a null or unparseable date last in either date order,
+  rather than letting `NaN` scatter it;
+- compares names with `localeCompare` at base sensitivity, so an accented name
+  files next to its unaccented form instead of after `Z`;
+- returns 0 for ties, leaving `Array.sort`'s stability to preserve the incoming
+  order.
+
+The toolbar is `align-items: flex-end`, not centered: the `Select` stacks its
+label above its trigger, so centering would sit the trigger lower than the
+search field and the create button. Same reason as the evaluations toolbar.
 
 ---
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -94,6 +94,12 @@ theme (both resolve to `cold-grey-80`) but dimmer in the dark one
 dark-theme users. `--outline-muted` remains correct for containers and
 dividers; form controls take `--outline-retreat`.
 
+**Naming the trigger.** A visible `label` names it through `htmlFor`. Where a
+toolbar has no room for one, pass `ariaLabel` instead — without either, the
+button falls back to its own content and a screen reader announces the current
+value ("Alphabetical") with no hint of what the control does. `ariaLabel` wins
+over `label`, so pass one or the other.
+
 #### Open UX issues
 
 _(none)_
@@ -1363,10 +1369,9 @@ filter) applies after the search so the visible list is always sorted, and:
 - returns 0 for ties, leaving `Array.sort`'s stability to preserve the incoming
   order.
 
-Dropping the label costs the trigger its explicit accessible name: `Select`
-exposes no `ariaLabel` prop, so the button falls back to its own content and a
-screen reader announces the current value ("Alphabetical") without saying it is
-the sort control.
+The control carries no visible label, so it is named with `Select`'s
+`ariaLabel` prop — otherwise a screen reader announces the current value with
+no hint that it is the sort control.
 
 ---
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -78,6 +78,28 @@ _(none)_
 
 ---
 
+### `Select`
+
+**Location:** `src/rework/components/shared/molecules/Select/Select.tsx`
+**Status:** `Functional`
+
+Portaled listbox with virtual focus (DOM focus stays on the trigger,
+`aria-activedescendant` tracks the highlighted option).
+
+**Border token (2026-09-04).** The trigger borders with `--outline-retreat`,
+the same token `TextInput` uses, so a `Select` and a text field placed in one
+toolbar match. It previously used `--outline-muted`: identical in the light
+theme (both resolve to `cold-grey-80`) but dimmer in the dark one
+(`cold-grey-20` against `cold-grey-30`), so the two controls disagreed only for
+dark-theme users. `--outline-muted` remains correct for containers and
+dividers; form controls take `--outline-retreat`.
+
+#### Open UX issues
+
+_(none)_
+
+---
+
 ### `SearchInput`
 
 **Location:** `src/rework/components/shared/molecules/SearchInput/SearchInput.tsx`
@@ -1344,8 +1366,7 @@ filter) applies after the search so the visible list is always sorted, and:
 Dropping the label costs the trigger its explicit accessible name: `Select`
 exposes no `ariaLabel` prop, so the button falls back to its own content and a
 screen reader announces the current value ("Alphabetical") without saying it is
-the sort control. Adding an `ariaLabel` prop to the shared `Select` would close
-this for every consumer.
+the sort control.
 
 ---
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -1325,8 +1325,9 @@ Composition and states:
 Wording is deployment-configurable: the placeholder interpolates
 `agentsNicknamePlural`, since a deployment renames agents (e.g. "Lumis").
 
-**Sort.** A labelled `Select` (`size="small"`, `compact`) sits after the search
-field, offering Alphabetical (default), Recently created and Recently updated —
+**Sort.** A `Select` (`size="small"`, `compact`, no label, `min-width: 300px`
+so the control does not resize as the picked option changes length) sits after
+the search field, offering Alphabetical (default), Recently created and Recently updated —
 `display_name`, `created_at`, `updated_at`, the three orderings available
 without touching the API. `sortAgents` (`agentSort.ts`, unit-tested like the
 filter) applies after the search so the visible list is always sorted, and:
@@ -1340,9 +1341,11 @@ filter) applies after the search so the visible list is always sorted, and:
 - returns 0 for ties, leaving `Array.sort`'s stability to preserve the incoming
   order.
 
-The toolbar is `align-items: flex-end`, not centered: the `Select` stacks its
-label above its trigger, so centering would sit the trigger lower than the
-search field and the create button. Same reason as the evaluations toolbar.
+Dropping the label costs the trigger its explicit accessible name: `Select`
+exposes no `ariaLabel` prop, so the button falls back to its own content and a
+screen reader announces the current value ("Alphabetical") without saying it is
+the sort control. Adding an `ariaLabel` prop to the shared `Select` would close
+this for every consumer.
 
 ---
 


### PR DESCRIPTION
Closes #2538.

## What

The team agents page (`/team/:teamId/agents`) rendered every instance as a flat,
unordered list in whatever order the control-plane returned. It now has an
instant search field and a sort dropdown, both client-side over the
already-loaded list — no control-plane or OpenAPI change, no query parameter.

Two design-system commits ride along, because the shared `Select` this page
needed had to be fixed first.

| Commit | Change |
| --- | --- |
| `d3e3207b` | Search filter — `SearchInput`, matching name / role / description |
| `9a8531b1` | Sort dropdown — alphabetical (default), recently created, recently updated |
| `1bfa1526` | Drop the dropdown's stacked label, fix its width |
| `1e91f480` | Dropdown min-width 200px |
| `482edfc6` | **design-system**: `Select` borders like a `TextInput` |
| `a670bee1` | **design-system**: `ariaLabel` prop for a `Select` with no visible label |
| `8db95bf2` | Header gap 16px → 12px |

## Design decisions worth a look

**The search mirrors the team prompts page** — same `SearchInput`, same
placement, same instant client-side filter — so the two team list pages behave
alike rather than each inventing a search.

**Both predicates are pure modules with their own tests** (`agentFilter.ts`,
`agentSort.ts`) rather than page code. `TeamAgentsPage.tsx` is a ~500-line RTK
Query container with no test of its own, while its subtree already tests
extracted logic that way (`toolPackLogic`). Testing the predicates needs no
mounting and no RTK Query mocking.

**Sorting copies before it sorts.** The list is RTK Query state, frozen by immer
in dev — an in-place `.sort()` throws at runtime and no type check catches it.
Undated agents sort last rather than scattering on `NaN`, and names compare with
`localeCompare` at base sensitivity so "Élan" files next to "Elan" instead of
after "Zulu".

**The no-match state is distinct from the empty state.** `TeamAgentEmptyState`
means "this team has no agents yet, create one" and is driven by the unfiltered
list; a search matching nothing gets its own message. The message is guarded on
a non-empty query, so behaviour with no search is untouched.

**Wording is deployment-configurable.** The placeholder interpolates
`agentsNicknamePlural` — this deployment calls agents "Lumis".

## The two design-system commits

`482edfc6` — the `Select` trigger bordered with `--outline-muted` while
`TextInput` uses `--outline-retreat`. The tokens resolve to the same colour in
the light theme, so a `Select` and a search field in one toolbar disagreed
**only for dark-theme users**, where muted is a step dimmer. `--outline-muted`
stays right for containers and dividers; form controls take
`--outline-retreat`.

`a670bee1` — a `Select` with no `label` had no accessible name: the trigger fell
back to its own content, so a screen reader announced the current value
("Alphabetical") with no hint of what the control does. The new `ariaLabel` prop
closes that, and the sort dropdown uses it.

`Select` has 13 consumers (agent form, evaluations, routing, document upload,
pagination, self-test…), so the **full frontend suite** was run rather than the
touched folders: 1795 passed, 2 skipped, 182 files. A test pins that a `Select`
given a visible `label` still gets no `aria-label`, so the other consumers'
`htmlFor` naming is unchanged.

## Tests

18 new unit tests across `agentFilter.test.ts` (10), `agentSort.test.ts` (8),
plus 2 on `Select.test.tsx`. `tsc`, `eslint` and `prettier` clean.

## Not done here

Two items deliberately left out, both pre-existing:

- `showEmptyState` keys off the unfiltered list, so a member without
  `can_update_agents` whose agents are all suspended sees a header, a search box
  and a blank grid with no message. Untouched — a fix belongs in its own change.
- `RichInputField` (the chat composer) is the other form control still on
  `--outline-muted`. Left alone; same call as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)