### PR TITLE
feat(rebac): add fail-closed SDK for first-party application backends

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/applications/catalog.py
+++ b/apps/control-plane-backend/control_plane_backend/applications/catalog.py
@@ -30,9 +30,11 @@ from dataclasses import dataclass
 from typing import Protocol
 from urllib.parse import urlsplit
 
+from fred_core.security.rebac.capability_authz import (
+    application_capability_id,
+)
 from fred_sdk.contracts.capability import CapabilityCatalogEntry
 from fred_sdk.contracts.capability.manifest import (
-    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
     CAPABILITY_ID_PATTERN,
     TeamScopePolicy,
 )
@@ -213,7 +215,7 @@ class ApplicationSourceConfig(BaseModel):
     def capability_id(self) -> str:
         """Derived, never authored: team admission filters on exactly this id."""
 
-        return f"{APPLICATION_CAPABILITY_NAMESPACE_PREFIX}{self.app_id}"
+        return application_capability_id(self.app_id)
 
     def capability_entry(self) -> CapabilityCatalogEntry:
         """Project the application into the shared admin entitlement catalog.

--- a/apps/control-plane-backend/control_plane_backend/capabilities/authz.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/authz.py
@@ -22,55 +22,27 @@ is the plain catalog server id now (#1988, supersedes the `mcp:<id>` bypass),
 so it is an ordinary `capability` object in the FGA type and is scoped here
 like any other.
 
-`_team_subject_and_context`/`usable_capability_ids` are re-exported from
-`fred_core.security.rebac.capability_authz` (2026-08-03, RSK-B follow-up to
-#2191) rather than defined here: fred-runtime's `model_routing/authz.py`
-needs the exact same team-subject query for its own `can_use` check and used
-to keep an independent, field-for-field-identical copy of both — moved into
-`fred-core` (both packages already depend on it) so there is exactly one
-copy. `can_use_capability` stays here — control-plane-only, no fred-runtime
-caller.
+Every team-subject `can_use` query lives in
+`fred_core.security.rebac.capability_authz` and is re-exported here: the
+control-plane, fred-runtime and first-party application backends all need the
+identical subject and contextual edges, and fred-core is the one package they
+all depend on. What stays in this module is the catalog-shaped filtering the
+control plane alone performs on the answer.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Iterable, Sequence
 
-from fred_core import CapabilityPermission
-from fred_core.common import TeamId
-from fred_core.security.models import Resource
 from fred_core.security.rebac.capability_authz import (
-    team_capability_subject_and_context as _team_subject_and_context,
+    can_team_use_capability as can_team_use_capability,
 )
 from fred_core.security.rebac.capability_authz import (
     usable_capability_ids as usable_capability_ids,
 )
-from fred_core.security.rebac.rebac_engine import RebacEngine, RebacReference
 from fred_sdk.contracts.capability import CapabilityCatalogEntry
 
-__all__ = ["usable_capability_ids"]
-
-logger = logging.getLogger(__name__)
-
-
-async def can_use_capability(
-    rebac: RebacEngine, team_id: TeamId, capability_id: str
-) -> bool:
-    """`Check(team:{id}, can_use, capability:{id})` (agent save / session prep).
-
-    Every capability — including MCP-backed ones (#1988) — is gated by this
-    check. The noop engine returns True, so ReBAC-disabled deployments allow
-    everything.
-    """
-
-    team_ref, context = _team_subject_and_context(str(team_id))
-    return await rebac.has_permission(
-        team_ref,
-        CapabilityPermission.CAN_USE,
-        RebacReference(type=Resource.CAPABILITY, id=capability_id),
-        contextual_relations=context,
-    )
+__all__ = ["can_team_use_capability", "usable_capability_ids"]
 
 
 def filter_entries_by_usable(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/catalog.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/catalog.py
@@ -25,9 +25,11 @@ from __future__ import annotations
 import logging
 import re
 
+from fred_core.security.rebac.capability_authz import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+)
 from fred_sdk.contracts.capability import CapabilityCatalogEntry
 from fred_sdk.contracts.capability.manifest import (
-    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
     CAPABILITY_ID_PATTERN,
     MODEL_CAPABILITY_NAMESPACE_PREFIX,
 )

--- a/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/enablement.py
@@ -36,7 +36,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping
 
-from fred_core.common import TeamId, ThreadSafeLRUCache, is_personal_team_id
+from fred_core.common import (
+    TeamId,
+    ThreadSafeLRUCache,
+    is_personal_team_id,
+    is_personal_team_ref,
+)
 from fred_core.kpi.base_kpi_writer import BaseKPIWriter
 from fred_core.security.models import Resource
 from fred_core.security.rebac.rebac_engine import (
@@ -274,7 +279,7 @@ def _is_personal_application_team(team_id: TeamId) -> bool:
     # The admin API accepts the same reserved alias as other team routes. It
     # cannot canonicalize it without the target user's identity, but it can
     # still fail closed before writing any application grant.
-    return str(team_id) == "personal" or is_personal_team_id(str(team_id))
+    return is_personal_team_ref(str(team_id))
 
 
 def _reject_personal_team_application_grant(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -29,6 +29,9 @@ from typing import Any, Mapping
 from fred_core import CapabilityPermission, KeycloakUser, RebacDisabledResult
 from fred_core.common import TeamId, is_personal_team_id
 from fred_core.security.models import Resource
+from fred_core.security.rebac.capability_authz import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+)
 from fred_core.security.rebac.rebac_engine import (
     ORGANIZATION_ID,
     RebacEngine,
@@ -37,7 +40,6 @@ from fred_core.security.rebac.rebac_engine import (
 )
 from fred_sdk.contracts.capability import CapabilityCatalogEntry
 from fred_sdk.contracts.capability.manifest import (
-    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
     MODEL_CAPABILITY_NAMESPACE_PREFIX,
     TeamScopePolicy,
 )

--- a/apps/control-plane-backend/control_plane_backend/product/service.py
+++ b/apps/control-plane-backend/control_plane_backend/product/service.py
@@ -25,6 +25,9 @@ from fred_core.common.team_id import is_personal_team_id
 from fred_core.kpi.kpi_writer import to_kpi_actor
 from fred_core.kpi.kpi_writer_structures import KPIActor
 from fred_core.security.models import Resource
+from fred_core.security.rebac.capability_authz import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+)
 from fred_core.security.rebac.rebac_engine import RebacReference, Relation, RelationType
 from fred_core.tasks import ErasureReason
 from fred_sdk.contracts.capability import (
@@ -35,9 +38,6 @@ from fred_sdk.contracts.capability import (
     ChatControlsRequestItem,
     ChatControlsResponse,
     StoredCapabilityConfig,
-)
-from fred_sdk.contracts.capability.manifest import (
-    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
 )
 from fred_sdk.contracts.models import TeamScopePolicy
 from pydantic import ValidationError
@@ -51,7 +51,7 @@ from control_plane_backend.agent_instances.suspension import (
     reconcile_instance_suspension,
 )
 from control_plane_backend.capabilities.authz import (
-    can_use_capability,
+    can_team_use_capability,
     filter_entries_by_usable,
     usable_capability_ids,
 )
@@ -1452,7 +1452,9 @@ async def _apply_capability_selection(
             denied = [
                 cap_id
                 for cap_id in selected_ids
-                if not await can_use_capability(rebac, team_id, cap_id)
+                if not await can_team_use_capability(
+                    rebac, team_id, capability_id=cap_id
+                )
             ]
             if denied:
                 raise EnrollmentError(
@@ -2664,10 +2666,11 @@ async def enroll_agent_instance(
     # exempt, same reasoning and same narrow allowlist as `list_agent_templates`
     # above (`capability_gate_exempt`) — never any `public=False` template,
     # which has its own, independent meaning.
-    if not capability_gate_exempt(source_agent_id) and not await can_use_capability(
+    gate_exempt = capability_gate_exempt(source_agent_id)
+    if not gate_exempt and not await can_team_use_capability(
         deps.team_dependencies.rebac,
         team_id,
-        template_capability_id(source_runtime_id, source_agent_id),
+        capability_id=template_capability_id(source_runtime_id, source_agent_id),
     ):
         raise EnrollmentError(
             f"Template {request.template_id!r} was not found on runtime source "
@@ -2805,10 +2808,12 @@ async def update_agent_instance(
     # `suspend_dependent_instances`/`set_capability_default_on` already
     # suspended for exactly that reason — unenroll (delete) is still always
     # allowed, only editing is blocked.
-    if not await can_use_capability(
+    if not await can_team_use_capability(
         deps.team_dependencies.rebac,
         team_id,
-        template_capability_id(record.source_runtime_id, record.source_agent_id),
+        capability_id=template_capability_id(
+            record.source_runtime_id, record.source_agent_id
+        ),
     ):
         raise EnrollmentError(
             "This agent's template access has been revoked for your team; it "

--- a/apps/control-plane-backend/control_plane_backend/routing_policy/service.py
+++ b/apps/control-plane-backend/control_plane_backend/routing_policy/service.py
@@ -36,7 +36,7 @@ from fred_sdk.contracts.capability.manifest import model_capability_id
 from fred_sdk.contracts.context import ModelBinding, resolve_effective_chat_profile
 
 from control_plane_backend.capabilities.authz import (
-    can_use_capability,
+    can_team_use_capability,
     usable_capability_ids,
 )
 from control_plane_backend.capabilities.catalog import (
@@ -211,7 +211,9 @@ async def _validate_write(
         if capability_id in checked_capability_ids:
             continue
         checked_capability_ids.add(capability_id)
-        if not await can_use_capability(rebac, team_id, capability_id):
+        if not await can_team_use_capability(
+            rebac, team_id, capability_id=capability_id
+        ):
             not_usable.append(profile_id)
     if not_usable:
         raise ProfileNotUsableError(team_id=team_id, profile_ids=sorted(not_usable))

--- a/apps/control-plane-backend/pyproject.toml
+++ b/apps/control-plane-backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "python-dotenv>=1.0.1,<2.0.0",
   "pydantic>=2.10.0,<3.0.0",
   "temporalio>=1.11.1,<2.0.0",
-  "fred-core>=3.8.3",
+  "fred-core>=3.9.0",
   "fred-sdk>=3.5.0",
   "alembic>=1.18.4",
   # SQLAlchemy async engine requires greenlet at runtime.

--- a/apps/control-plane-backend/tests/test_applications.py
+++ b/apps/control-plane-backend/tests/test_applications.py
@@ -60,6 +60,9 @@ from fred_core import (
 )
 from fred_core.common import TeamId, personal_team_id
 from fred_core.security.models import Resource
+from fred_core.security.rebac.capability_authz import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+)
 from fred_core.security.rebac.rebac_engine import (
     RebacDisabledResult,
     RebacReference,
@@ -70,7 +73,6 @@ from fred_core.security.rebac.rebac_engine import (
 from fred_core.teams.metadata_store import TeamMetadata
 from fred_sdk.contracts.capability import CapabilityCatalogEntry, CapabilityManifest
 from fred_sdk.contracts.capability.manifest import (
-    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
     TeamScopePolicy,
 )
 from httpx import ASGITransport, AsyncClient

--- a/apps/control-plane-backend/tests/test_capability_enablement_1980.py
+++ b/apps/control-plane-backend/tests/test_capability_enablement_1980.py
@@ -2517,13 +2517,15 @@ async def test_authz_injects_personal_team_edge_only_for_personal_teams() -> Non
     """A personal-space subject gets BOTH the `team` and `personal_team`
     contextual edges; a regular team gets only `team` (RFC §8.4)."""
 
-    from control_plane_backend.capabilities.authz import _team_subject_and_context
+    from fred_core.security.rebac.capability_authz import (
+        team_capability_subject_and_context,
+    )
 
-    _, personal_ctx = _team_subject_and_context("personal-u1")
+    _, personal_ctx = team_capability_subject_and_context("personal-u1")
     relations = {r.relation.value for r in personal_ctx}
     assert relations == {"team", "personal_team"}
 
-    _, regular_ctx = _team_subject_and_context("team-a")
+    _, regular_ctx = team_capability_subject_and_context("team-a")
     assert {r.relation.value for r in regular_ctx} == {"team"}
 
 
@@ -2627,16 +2629,20 @@ async def test_catalog_filter_disabled_rebac_keeps_everything() -> None:
 
 
 @pytest.mark.asyncio
-async def test_can_use_capability_check() -> None:
-    from control_plane_backend.capabilities.authz import can_use_capability
+async def test_can_team_use_capability_check() -> None:
+    from control_plane_backend.capabilities.authz import can_team_use_capability
 
     rebac = _FilterRebac({"team-a": {"doc_access", "bank_core"}})
-    assert await can_use_capability(rebac, "team-a", "doc_access") is True
-    assert await can_use_capability(rebac, "team-a", "corp_drive") is False
-    # #1988: MCP-backed capabilities are gated like any other id — a granted
-    # MCP capability passes, a non-granted one is rejected.
-    assert await can_use_capability(rebac, "team-a", "bank_core") is True
-    assert await can_use_capability(rebac, "team-a", "market_data") is False
+    assert await can_team_use_capability(rebac, "team-a", capability_id="doc_access")
+    assert not await can_team_use_capability(
+        rebac, "team-a", capability_id="corp_drive"
+    )
+    # MCP-backed capabilities are gated like any other id — a granted MCP
+    # capability passes, a non-granted one is rejected.
+    assert await can_team_use_capability(rebac, "team-a", capability_id="bank_core")
+    assert not await can_team_use_capability(
+        rebac, "team-a", capability_id="market_data"
+    )
 
 
 @pytest.mark.asyncio
@@ -2645,13 +2651,15 @@ async def test_can_use_is_scoped_to_the_team_context() -> None:
     # usable while operating in team-b, even when the SAME user belongs to
     # both teams (the check subject is the team, not the user).
     from control_plane_backend.capabilities.authz import (
-        can_use_capability,
+        can_team_use_capability,
         usable_capability_ids,
     )
 
     rebac = _FilterRebac({"team-a": {"doc_access"}})
-    assert await can_use_capability(rebac, "team-a", "doc_access") is True
-    assert await can_use_capability(rebac, "team-b", "doc_access") is False
+    assert await can_team_use_capability(rebac, "team-a", capability_id="doc_access")
+    assert not await can_team_use_capability(
+        rebac, "team-b", capability_id="doc_access"
+    )
     assert await usable_capability_ids(rebac, team_id="team-b") == set()
 
 

--- a/apps/control-plane-backend/tests/test_routing_policy.py
+++ b/apps/control-plane-backend/tests/test_routing_policy.py
@@ -302,7 +302,7 @@ def _stub_catalog(monkeypatch: pytest.MonkeyPatch):
 class _FakeRebacElevatedCheck:
     """Fake for `_require_elevated_team_role`'s `has_permissions` BatchCheck —
     a distinct interface from the `has_permission` (singular) fakes below,
-    which back `_validate_write`'s `can_use_capability` checks instead.
+    which back `_validate_write`'s `can_team_use_capability` checks instead.
     `allowed` is the fixed `[can_update_info, can_update_resources,
     can_run_evaluations]` result, in `_ELEVATED_TEAM_ROLE_PERMISSIONS` order.
     """

--- a/apps/control-plane-backend/uv.lock
+++ b/apps/control-plane-backend/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -674,7 +674,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../../libs/fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/apps/fred-agents/uv.lock
+++ b/apps/fred-agents/uv.lock
@@ -809,7 +809,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -970,7 +970,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../../libs/fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/apps/knowledge-flow-backend/uv.lock
+++ b/apps/knowledge-flow-backend/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../../libs/fred-core" }
 dependencies = [
     { name = "aiosqlite", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },

--- a/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
+++ b/docs/swift/design/CONTROL-PLANE-PRODUCT-CONTRACT.md
@@ -1402,7 +1402,8 @@ subset the V1 team-routing picker/write path consumes. Capability is never
 inferred from a profile-id prefix.
 
 **Runtime enforcement is fail-closed and differs by kind, deliberately.**
-`kind="tool"`/`kind="agent"` enforce at **write time** — `can_use_capability`
+`kind="tool"`/`kind="agent"` enforce at **write time** —
+`can_team_use_capability`
 gates tool selection and template enrollment, and both suspend/revive
 dependent agent instances on revocation/grant (`enablement.py`, `impact.py`).
 `kind="model"` has no equivalent write-time surface (model choice is a
@@ -3230,10 +3231,11 @@ one 401 retry, and rejects absolute, traversing, or protected-header inputs;
 the frame supplies only a relative path and an ordinary payload over
 `fred:request`. A 401 from an application service is that service's own
 entitlement decision and never ends the Fred session; only a token refresh that
-fails does, so one misconfigured application cannot log the user out.
-**No app receives Fred's store, Keycloak object, or raw token** — that remains
-true, and is now the property that makes moving the frame to a separate origin
-a configuration change rather than a redesign.
+fails does, so one misconfigured application cannot log the user out. **No
+application frame receives Fred's store, Keycloak object, or raw token**; the
+backend service receives the caller's bearer only on the proxied request leg.
+Keeping the credential out of frame code is the property that makes moving the
+frame to a separate origin a configuration change rather than a redesign.
 
 Two browser-facing prefixes exist, and only these:
 
@@ -3257,10 +3259,84 @@ on the service leg. Application services remain responsible for equal or
 smaller per-request limits, aggregate concurrency bounds, and authorization
 before consuming a request body.
 
-The gateway authorizes nothing; the control plane does. A gateway registration
-with no matching `application_sources` entry therefore proxies both prefixes
-for an application no team was granted, so the gateway list must stay a subset
-of the catalog.
+The gateway never authorizes. In the arm's-length tier the control plane is the
+entitlement authority; in the first-party tier the application backend checks
+entitlement locally through the narrow SDK described below. A gateway
+registration with no matching `application_sources` entry still proxies both
+prefixes, so the gateway list must stay a subset of the catalog.
+
+`app__<app_id>` is derived by `application_capability_id` (fred-core), which
+unlike `model_capability_id` does **not** normalize characters outside the id
+charset. A registered `app_id` is already constrained to a subset of
+`CAPABILITY_ID_PATTERN` at config load, so an id needing repair is one no
+catalog accepted; normalizing it on an authorization path could resolve it
+onto a neighbouring capability's id instead of failing closed.
+
+### Two application trust tiers (2026-09-04)
+
+An application backend authorizes each request in one of two ways, and the
+tier is a deployment decision, not something the application selects:
+
+| Boundary | Arm's-length | First-party |
+| --- | --- | --- |
+| Who | Independently deployed code, any language, with no Fred service or OpenFGA credential | A backend built and run inside the Fred perimeter; admission is an explicit devops act |
+| Entitlement | Forward the caller's bearer to `GET /teams/{team_id}/applications` and require its own id in the response | Ask the named checks on a process-lifetime `RebacSdk` created by `rebac_sdk_factory` |
+| Keycloak service identity | None required for entitlement | Its own enabled `security.m2m` client; this is for outbound service calls, not caller validation or OpenFGA |
+| OpenFGA identity | None | Its own secret named by `security.rebac.token_env_var`, provisioned and revocable independently; never shared with another backend |
+
+Both tiers verify the caller's bearer locally before entitlement. A first-party
+backend runs with `security.profile: c3`, so the incoming JWT must carry the
+exact audience in that backend's `security.user.client_id`. That resource-server
+client is distinct from both the backend's outbound `security.m2m` identity and
+its OpenFGA token.
+
+`await rebac_sdk_factory(security_config, *, kpi_writer)` is the supported
+first-party construction path. It fails startup unless the `c3` profile, user
+and M2M authentication, and OpenFGA ReBAC are enabled, and unless
+`create_store_if_needed` and `sync_schema_on_init` are both `false`, and the
+OpenFGA timeout is between 1 ms and 30 seconds. The control plane remains the
+store and authorization-model owner. The async factory also initializes
+fred-core's process-local user JWT verifier from `security.user`, requires the
+backend's process-level KPI writer, creates one private OpenFGA engine, and
+resolves the configured store before startup completes. A backend reuses that
+facade for requests and awaits `close()` during shutdown (or uses its async
+context manager); it never constructs a client per request.
+
+The facade exposes only `check_user_team_permission`,
+`check_team_capability`, and `check_application_access`. These are
+authorization gates: they return no data and raise on denial. The combined
+application check asks team membership first, then the team's grant on
+`app__<app_id>`. Every facade check rejects personal spaces before contacting
+OpenFGA, so composing the two component checks cannot bypass the collaborative-
+team-only application boundary or trigger personal-team self-healing writes.
+It exposes no engine, tuple writer, general query, or raw OpenFGA client.
+
+The SDK deliberately reads neither catalog state nor the application feature
+gate. `enableApplications: false` still withdraws the normal browser path for
+**both** tiers because the gateway returns 404 for `/apps` and
+`/app-services`. Parking one catalog entry (`enabled: false`) is narrower: the
+arm's-length endpoint stops returning it while the gateway route and team grant
+remain, so a directly reachable first-party backend would still accept the
+grant. Parking is catalog state, **not a security kill switch**. Revoke the
+`app__<app_id>` team grant to withdraw entitlement from both tiers; for an
+incident, also block or remove the gateway route. Remove both registration
+halves to retire the application.
+
+The planned first-party example intentionally carries no agent capability. It
+demonstrates one boundary only — browser to host to application service, local
+JWT verification, then the SDK check. Agent-pod writes are a separate delegated
+downstream-auth problem; adding them would either retain the existing shared-key
+side door or silently expand this work to solve that problem. Any future agent
+integration needs its own design and may reuse the runtime's pod-to-pod JWT and
+OpenFGA pattern.
+
+Finally, trust does not confer datastore ownership. A first-party application
+may own a dedicated store for its own data. Data owned by another Fred backend
+must still be reached through that backend's API, bearer-forwarded for
+user-scoped operations: the owning backend may enforce object-level ReBAC in
+addition to team entitlement, and its schema is an internal detail rather than
+a contract. `GET /teams/{team_id}/applications` remains unchanged; Fred's own
+catalog and navigation depend on it regardless of tier.
 
 `ui_prefix` is a path today and the frame is therefore same-origin with Fred.
 A same-origin iframe is a rendering and lifecycle boundary, not a security

--- a/docs/swift/platform/REBAC.md
+++ b/docs/swift/platform/REBAC.md
@@ -175,6 +175,28 @@ enablement. V1 applications are unavailable in personal teams even when a
 capability is default-on; application services still own any finer-grained
 object authorization.
 
+A first-party application backend — one deliberately admitted by devops and
+provisioned with its own OpenFGA credential — creates one process-lifetime
+`RebacSdk` with `rebac_sdk_factory`. The facade privately owns the engine and
+exposes only `check_user_team_permission`, `check_team_capability`, and
+`check_application_access`; callers receive no tuple writer, general query, or
+raw OpenFGA client. All three calls are authorization gates that return no data
+and raise on denial. An arm's-length backend instead keeps forwarding the
+caller's bearer to `GET /teams/{team_id}/applications` and requires its own id
+in the response. Every facade check rejects personal spaces locally before an
+OpenFGA call, including when a backend composes the two component checks.
+
+The SDK answers the two ReBAC questions above and does not read catalog or
+feature-gate state. `enableApplications: false` nevertheless withdraws the
+normal browser path for both tiers because the gateway returns 404 for
+`/apps` and `/app-services`. Parking one application (`enabled: false`) removes
+it from the arm's-length catalog while leaving its route and grant intact, so
+it does not change the SDK result and must not be treated as a security kill
+switch. Revoke the team's `app__<app_id>` grant to withdraw entitlement from
+both tiers; during an incident, also block or remove the gateway route. The
+trust-tier rationale and datastore boundary are recorded in
+[`CONTROL-PLANE-PRODUCT-CONTRACT.md` §46](../design/CONTROL-PLANE-PRODUCT-CONTRACT.md#46-contract-notes--team-applications-are-runtime-registered-frame-hosted-uis-2026-08-31).
+
 ### Personal teams — self-provisioned, never admin-writable (AUTHZ-08)
 
 A personal team (`personal-<uid>`, format decided by CTRLP-10) is a real ReBAC
@@ -341,6 +363,83 @@ security:
 And set `OPENFGA_API_TOKEN` in the environment.
 
 By default the backend will create the store (if missing) and push the Fred authorization model at startup. You can turn that off (with `create_store_if_needed` and `sync_schema_on_init`) if you manage OpenFGA yourself. In that case, we recommend you to pass a a static authorization model id with `authorization_model_id`.
+
+A first-party application backend has a stricter configuration than the
+general default:
+
+```yaml
+security:
+  profile: c3
+  user:
+    enabled: true
+    client_id: "my-application" # exact audience of incoming user JWTs
+    # realm_url: ...
+  m2m:
+    enabled: true
+    client_id: "my-application-service" # outbound service identity
+    # realm_url: ...
+    # secret_env_var: ...
+  rebac:
+    enabled: true
+    type: openfga
+    api_url: "http://openfga:8080"
+    store_name: "fred"
+    create_store_if_needed: false
+    sync_schema_on_init: false
+    authorization_model_id: null # or a deployment-pinned existing model
+    token_env_var: "MY_APPLICATION_OPENFGA_API_TOKEN"
+    timeout_millisec: 5000
+```
+
+These are three separate identities. `security.user.client_id` is the local
+resource-server audience: under `c3`, a caller token issued for another backend
+is rejected. `security.m2m` is this backend's Keycloak identity for outbound
+service calls; it neither validates the incoming bearer nor authenticates to
+OpenFGA. `security.rebac.token_env_var` names the backend's OpenFGA secret.
+Devops provisions a different secret for every admitted backend so one can be
+revoked without rotating every first-party service. No secret value belongs in
+YAML or application registration.
+
+Admission is an explicit operator sequence: generate a new key value, add it to
+OpenFGA's accepted pre-shared-key list, mount only that value into the admitted
+backend under its configured `token_env_var`, and remove that key from the
+accepted list when withdrawing the backend. A distinct environment-variable
+name alone does not prove that the underlying values differ. OpenFGA pre-shared
+keys are equivalent, unscoped API credentials; using one value per backend
+lets operators rotate or revoke one backend without changing every other
+backend. It does not provide per-key authorization or reduce what a stolen
+accepted key can access inside OpenFGA. The concrete deployment wiring belongs
+with the first backend admitted to this tier.
+
+The first-party factory fails startup unless `c3`, user authentication, M2M
+authentication, and OpenFGA are enabled, both store/schema ownership flags are
+`false`, a KPI writer is supplied, and `timeout_millisec` is between 1 and
+30,000. This prevents the SDK from silently falling back to the permissive
+no-op engine, prevents an application from creating a misspelled store or
+publishing Fred's authorization model, and bounds dependency stalls. It also
+initializes fred-core's process-local JWT verifier from `security.user`, so the
+C3 issuer and audience checks guard the user dependency that supplies `user`.
+The async factory resolves the configured store before startup completes;
+invalid credentials, an absent store, or an unavailable OpenFGA endpoint do
+not wait for the first request. Build the facade once with the process-level
+writer, reuse it across requests, and close it during shutdown:
+
+```python
+from fred_core.security.rebac.rebac_sdk import rebac_sdk_factory
+
+# Application startup: initialize once and retain on process state.
+sdk = await rebac_sdk_factory(configuration.security, kpi_writer=kpi_writer)
+
+# Request handling: reuse the retained facade.
+await sdk.check_application_access(user, team_id=team_id, app_id=app_id)
+
+# Application shutdown.
+await sdk.close()
+```
+
+An async context manager is equivalent. Do not build an SDK or OpenFGA client
+per request; that discards connection pooling and lifecycle ownership. The KPI
+writer records the existing OpenFGA call count, failure, and latency metrics.
 
 ### Full commented configuration
 

--- a/docs/swift/rfc/FRED-APPLICATION-HOSTING-RFC.md
+++ b/docs/swift/rfc/FRED-APPLICATION-HOSTING-RFC.md
@@ -225,46 +225,6 @@ Grants are held **team to capability**, never user to capability, so any
 correct check answers two questions: is this caller a member of the team, and
 does the team hold the application.
 
-### 5.1 Open question: where enforcement belongs
-
-The gateway is proposed as pure routing — it checks that an application id is
-registered and has an upstream, then forwards the caller's credentials
-untouched. Under that design **the application's own API is the only thing
-authorizing its data**, and an application that omits the check is readable by
-every authenticated principal.
-
-Two properties make this sharper than an ordinary reminder to check
-authorization. There is no safety net: the API is code its owners write, in
-their own container, and no misconfiguration exists for an operator to notice.
-And the failure is invisible from the inside — the author belongs to an entitled
-team, so every check they naturally perform passes, and nothing errors or logs.
-
-The alternative is for the gateway to verify entitlement before proxying. It
-would be mechanically small, reusing the existing team-subject capability query.
-Its costs are not:
-
-1. The gateway stops being pure routing and acquires an authorization
-   dependency, which is what allows it to be operationally simple.
-2. The control plane enters the hot path of every application API call —
-   latency per request, and control-plane unavailability becoming application
-   unavailability. A short-lived cache makes the call rare but introduces
-   revocation lag.
-3. It risks being a confused deputy. The gateway can only authorize the team
-   identifier it parses from the request path; it cannot know what the
-   application does with that path, or whether the response is scoped to that
-   team at all. It would appear to have authorized a response it never saw.
-
-A guarantee that looks stronger than it is may be worse than none, because
-application authors would reasonably stop writing their own check.
-
-**Options:** documentation and a mandatory negative test; gateway enforcement;
-a short-lived signed entitlement assertion the application verifies; or
-enforcement limited to Fred-owned routes, which does not cover the exposure.
-
-This RFC proposes starting with the documented requirement and treating gateway
-enforcement as a separate decision, because only the application knows what its
-response contains.
-
 ---
 
 ## 6. Lifecycle
@@ -327,32 +287,30 @@ belongs to several teams.
 
 ## 8. Open questions
 
-1. Where authorization for the application API belongs (§5.1). This is the
-   decision with the widest consequences and should be settled explicitly.
-2. The durable registration and removal lifecycle (§6), including the catalog
+1. The durable registration and removal lifecycle (§6), including the catalog
    and gateway asymmetry.
-3. ~~Whether to let an application hand a record to a conversation (§4.5).~~
+2. ~~Whether to let an application hand a record to a conversation (§4.5).~~
    Decided — granted as `fred:open-chat`, with the bound and its two runtime
    dependencies recorded in §4.5. Kept in this list only until §4.5 is folded
    into the contract doc and trimmed from here.
-4. Serving an application from its own origin. The contract is written to make
+3. Serving an application from its own origin. The contract is written to make
    this a configuration change; it needs verifying under an opaque origin before
    the isolation property can be claimed rather than intended.
-5. Typed, non-secret per-team application configuration beyond enablement.
-6. Where application health belongs relative to existing operational health
+4. Typed, non-secret per-team application configuration beyond enablement.
+5. Where application health belongs relative to existing operational health
    surfaces.
-7. Personal-space availability, and how it would interact with the existing
+6. Personal-space availability, and how it would interact with the existing
    personal capability class.
 
-Items 5 through 7 want evidence from more than one independently developed
+Items 4 through 6 want evidence from more than one independently developed
 application before being standardized.
 
 ---
 
 ## 9. Acceptance
 
-This RFC is complete when §5.1 and §4.5 each have a recorded decision and
-rationale, and §6 has either an owner or an explicit deferral. §4.5 in
-particular should be decided against a real application that wanted it, not in
-the abstract. Anything settled moves into the relevant contract or platform
-document and is removed from this RFC rather than amended in place.
+This RFC is complete when §4.5 has a recorded decision and rationale, and §6
+has either an owner or an explicit deferral. §4.5 in particular should be
+decided against a real application that wanted it, not in the abstract.
+Anything settled moves into the relevant contract or platform document and is
+removed from this RFC rather than amended in place.

--- a/libs/fred-capability-html-artifact/uv.lock
+++ b/libs/fred-capability-html-artifact/uv.lock
@@ -633,7 +633,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -789,7 +789,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/libs/fred-capability-platform-ops/uv.lock
+++ b/libs/fred-capability-platform-ops/uv.lock
@@ -631,7 +631,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -787,7 +787,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/libs/fred-capability-ppt-filler/uv.lock
+++ b/libs/fred-capability-ppt-filler/uv.lock
@@ -572,7 +572,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -667,7 +667,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/libs/fred-capability-writable-document/uv.lock
+++ b/libs/fred-capability-writable-document/uv.lock
@@ -621,7 +621,7 @@ dev = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -777,7 +777,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/libs/fred-core/fred_core/common/__init__.py
+++ b/libs/fred-core/fred_core/common/__init__.py
@@ -40,7 +40,12 @@ from .structures import (
     StoreConfig,
     TemporalSchedulerConfig,
 )
-from .team_id import TeamId, is_personal_team_id, personal_team_id
+from .team_id import (
+    TeamId,
+    is_personal_team_id,
+    is_personal_team_ref,
+    personal_team_id,
+)
 from .utils import raise_internal_error
 
 __all__ = [
@@ -61,6 +66,7 @@ __all__ = [
     "StoreConfig",
     "TeamId",
     "is_personal_team_id",
+    "is_personal_team_ref",
     "personal_team_id",
     "ResilientSinkStore",
     "TemporalSchedulerConfig",

--- a/libs/fred-core/fred_core/common/fastapi_handlers.py
+++ b/libs/fred-core/fred_core/common/fastapi_handlers.py
@@ -55,7 +55,33 @@ def register_exception_handlers(app: FastAPI) -> None:
         request: Request, exc: AuthorizationError
     ) -> JSONResponse:
         """Handle AuthorizationError by returning a 403 Forbidden response."""
-        logger.warning("Authorization denied for user %s: %s", exc.user_id, exc)
+        if (
+            exc.actor_uid is not None
+            and exc.subject_type not in (None, Resource.USER)
+            and exc.subject_id is not None
+        ):
+            logger.warning(
+                "Authorization denied for user %s (checked subject %s %s): %s",
+                exc.actor_uid,
+                exc.subject_type.value,
+                exc.subject_id,
+                exc,
+            )
+        elif exc.actor_uid is not None:
+            logger.warning("Authorization denied for user %s: %s", exc.actor_uid, exc)
+        elif (
+            exc.subject_type is not None
+            and exc.subject_type != Resource.USER
+            and exc.subject_id is not None
+        ):
+            logger.warning(
+                "Authorization denied for %s %s (no user actor): %s",
+                exc.subject_type.value,
+                exc.subject_id,
+                exc,
+            )
+        else:
+            logger.warning("Authorization denied for user %s: %s", exc.user_id, exc)
         return JSONResponse(
             status_code=403,
             content={"detail": _authorization_detail_for_client(exc)},

--- a/libs/fred-core/fred_core/common/team_id.py
+++ b/libs/fred-core/fred_core/common/team_id.py
@@ -26,3 +26,12 @@ def personal_team_id(user_uid: str) -> TeamId:
 def is_personal_team_id(team_id: str | None) -> bool:
     """Return True if team_id is a personal-space ID (i.e. 'personal-<uuid>')."""
     return bool(team_id and team_id.startswith("personal-"))
+
+
+def is_personal_team_ref(team_id: str | None) -> bool:
+    """Return True for a personal space or the reserved ``personal`` alias.
+
+    Routes accept the alias in place of the caller's own personal team id, so
+    anything refusing personal spaces must refuse both spellings.
+    """
+    return team_id == "personal" or is_personal_team_id(team_id)

--- a/libs/fred-core/fred_core/security/models.py
+++ b/libs/fred-core/fred_core/security/models.py
@@ -64,7 +64,7 @@ class Resource(str, Enum):
 
 
 class AuthorizationError(PermissionError):
-    """Raised when a user is not authorized to perform an action.
+    """Raised when a principal is not authorized to perform an action.
 
     Inherits from the builtin `PermissionError` (not bare `Exception`) so that
     every call site's `except PermissionError` — the standard ReBAC-denial ->
@@ -81,9 +81,22 @@ class AuthorizationError(PermissionError):
         action: str,
         resource: Resource,
         message: Optional[str] = None,
+        *,
+        actor_uid: Optional[str] = None,
+        subject_type: Optional[Resource] = None,
+        subject_id: Optional[str] = None,
     ):
+        """Describe the actor, and optionally the checked ReBAC subject.
+
+        ``user_id`` retains its historical string contract: it names the user
+        actor when known and otherwise the checked subject. ``actor_uid`` is
+        the authoritative optional actor for non-user-subject checks.
+        """
         self.user_id = user_id
         self.action = action
         self.resource = resource
+        self.actor_uid = actor_uid
+        self.subject_type = subject_type
+        self.subject_id = subject_id
         default_message = f"Not authorized to {action} {resource.value}"
         super().__init__(message or default_message)

--- a/libs/fred-core/fred_core/security/rebac/capability_authz.py
+++ b/libs/fred-core/fred_core/security/rebac/capability_authz.py
@@ -45,6 +45,22 @@ from fred_core.security.rebac.rebac_engine import (
     RelationType,
 )
 
+# Reserved id prefix for `kind="app"` catalog entries. Tools, templates,
+# models and applications share one flat `capability:<id>` namespace, so an
+# unprefixed app id can collide with any of them.
+APPLICATION_CAPABILITY_NAMESPACE_PREFIX = "app__"
+
+
+def application_capability_id(app_id: str) -> str:
+    """Capability id one registered application's team grants are written against.
+
+    Derived, never authored: team admission filters on exactly this id. The
+    input is not normalized -- an id needing repair is one no catalog
+    accepted, and failing closed beats resolving onto a neighbouring id.
+    """
+
+    return f"{APPLICATION_CAPABILITY_NAMESPACE_PREFIX}{app_id}"
+
 
 def team_capability_subject_and_context(
     team_id: str,
@@ -91,3 +107,21 @@ async def usable_capability_ids(rebac: RebacEngine, team_id: str) -> set[str] | 
     if isinstance(refs, RebacDisabledResult):
         return None
     return {ref.id for ref in refs}
+
+
+async def can_team_use_capability(
+    rebac: RebacEngine, team_id: str, *, capability_id: str
+) -> bool:
+    """One team, one capability: a single `Check` instead of a `ListObjects`.
+
+    Same subject and contextual edges as `usable_capability_ids`. With ReBAC
+    disabled the engine answers `True`, matching the unfiltered catalog.
+    """
+
+    team_ref, context = team_capability_subject_and_context(team_id)
+    return await rebac.has_permission(
+        team_ref,
+        CapabilityPermission.CAN_USE,
+        RebacReference(type=Resource.CAPABILITY, id=capability_id),
+        contextual_relations=context,
+    )

--- a/libs/fred-core/fred_core/security/rebac/rebac_engine.py
+++ b/libs/fred-core/fred_core/security/rebac/rebac_engine.py
@@ -1089,8 +1089,14 @@ class RebacEngine(ABC):
         *,
         contextual_relations: Iterable[Relation] | None = None,
         consistency_token: str | None = None,
+        actor_uid: str | None = None,
     ) -> None:
         """Raise `AuthorizationError` when access is denied.
+
+        `actor_uid` names the acting user in the error when the checked subject
+        is not a user (for example, a team-subject capability check). The
+        legacy `AuthorizationError.user_id` remains a string and falls back to
+        the checked subject id when no user actor is available.
 
         Example:
         - Raises if Bob tries to update a team where he is only a member.
@@ -1110,11 +1116,17 @@ class RebacEngine(ABC):
                 resource.type.value,
                 resource.id,
             )
+            denied_actor_uid = actor_uid
+            if denied_actor_uid is None and subject.type == Resource.USER:
+                denied_actor_uid = subject.id
             raise AuthorizationError(
-                subject.id,
+                denied_actor_uid if denied_actor_uid is not None else subject.id,
                 permission.value,
                 resource.type,
                 f"Not authorized to {permission.value} {resource.type.value} {resource.id}",
+                actor_uid=denied_actor_uid,
+                subject_type=subject.type,
+                subject_id=subject.id,
             )
 
     async def check_user_permission_or_raise(

--- a/libs/fred-core/fred_core/security/rebac/rebac_sdk.py
+++ b/libs/fred-core/fred_core/security/rebac/rebac_sdk.py
@@ -1,0 +1,258 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Named, fail-closed ReBAC checks for first-party application backends."""
+
+from types import TracebackType as _TracebackType
+from typing import Protocol as _Protocol
+from typing import cast as _cast
+
+from fred_core.common.team_id import is_personal_team_ref as _is_personal_team_ref
+from fred_core.kpi.base_kpi_writer import BaseKPIWriter as _BaseKPIWriter
+from fred_core.security.models import AuthorizationError as _AuthorizationError
+from fred_core.security.models import Resource as _Resource
+from fred_core.security.oidc import apply_security_profile as _apply_security_profile
+from fred_core.security.oidc import (
+    initialize_user_security as _initialize_user_security,
+)
+from fred_core.security.rebac.capability_authz import (
+    application_capability_id as _application_capability_id,
+)
+from fred_core.security.rebac.capability_authz import (
+    team_capability_subject_and_context as _team_capability_subject_and_context,
+)
+from fred_core.security.rebac.rebac_engine import (
+    CapabilityPermission as _CapabilityPermission,
+)
+from fred_core.security.rebac.rebac_engine import RebacEngine as _RebacEngine
+from fred_core.security.rebac.rebac_engine import RebacReference as _RebacReference
+from fred_core.security.rebac.rebac_engine import TeamPermission as _TeamPermission
+from fred_core.security.rebac.rebac_factory import rebac_factory as _rebac_factory
+from fred_core.security.structure import KeycloakUser as _KeycloakUser
+from fred_core.security.structure import OpenFgaRebacConfig as _OpenFgaRebacConfig
+from fred_core.security.structure import SecurityConfiguration as _SecurityConfiguration
+
+__all__ = ["RebacSdk", "rebac_sdk_factory"]
+
+
+class RebacSdk(_Protocol):
+    """The complete authorization surface exposed to a first-party backend."""
+
+    async def check_user_team_permission(
+        self,
+        user: _KeycloakUser,
+        permission: _TeamPermission,
+        team_id: str,
+    ) -> None:
+        """Raise unless ``user`` holds ``permission`` on a collaborative team."""
+        ...
+
+    async def check_team_capability(
+        self,
+        team_id: str,
+        capability_id: str,
+    ) -> None:
+        """Raise unless a collaborative ``team_id`` may use ``capability_id``."""
+        ...
+
+    async def check_application_access(
+        self,
+        user: _KeycloakUser,
+        *,
+        team_id: str,
+        app_id: str,
+    ) -> None:
+        """Raise unless ``user`` may use ``app_id`` in ``team_id``."""
+        ...
+
+    async def close(self) -> None:
+        """Release the process-scoped OpenFGA client."""
+        ...
+
+    async def __aenter__(self) -> "RebacSdk":
+        """Return this SDK for process-lifetime async context management."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: _TracebackType | None,
+    ) -> None:
+        """Release the process-scoped OpenFGA client."""
+        ...
+
+
+class _InitializableRebacEngine(_Protocol):
+    async def get_client(self) -> object:
+        """Resolve the configured store and cache the process client."""
+        ...
+
+
+class _RebacSdk:
+    """Private engine-backed implementation of the named SDK surface."""
+
+    __slots__ = ("__engine",)
+
+    def __init__(self, engine: _RebacEngine) -> None:
+        if not engine.enabled:
+            raise ValueError(
+                "The first-party ReBAC SDK requires an enabled OpenFGA engine"
+            )
+        self.__engine = engine
+
+    async def check_user_team_permission(
+        self,
+        user: _KeycloakUser,
+        permission: _TeamPermission,
+        team_id: str,
+    ) -> None:
+        if _is_personal_team_ref(team_id):
+            raise _AuthorizationError(
+                user.uid,
+                permission.value,
+                _Resource.TEAM,
+                f"Team {team_id!r} is a personal space and is outside the application trust tier",
+                actor_uid=user.uid,
+                subject_type=_Resource.USER,
+                subject_id=user.uid,
+            )
+        await self.__engine.check_user_team_permission_or_raise(
+            user, permission, team_id
+        )
+
+    async def check_team_capability(
+        self,
+        team_id: str,
+        capability_id: str,
+    ) -> None:
+        if _is_personal_team_ref(team_id):
+            raise _AuthorizationError(
+                team_id,
+                _CapabilityPermission.CAN_USE.value,
+                _Resource.CAPABILITY,
+                f"Team {team_id!r} is a personal space and is outside the application trust tier",
+                subject_type=_Resource.TEAM,
+                subject_id=team_id,
+            )
+        await self._check_team_capability(team_id, capability_id)
+
+    async def _check_team_capability(
+        self,
+        team_id: str,
+        capability_id: str,
+        *,
+        user: _KeycloakUser | None = None,
+    ) -> None:
+        team_ref, context = _team_capability_subject_and_context(team_id)
+        await self.__engine.check_permission_or_raise(
+            team_ref,
+            _CapabilityPermission.CAN_USE,
+            _RebacReference(type=_Resource.CAPABILITY, id=capability_id),
+            contextual_relations=context,
+            actor_uid=user.uid if user else None,
+        )
+
+    async def check_application_access(
+        self,
+        user: _KeycloakUser,
+        *,
+        team_id: str,
+        app_id: str,
+    ) -> None:
+        if _is_personal_team_ref(team_id):
+            raise _AuthorizationError(
+                user.uid,
+                _TeamPermission.CAN_USE_TEAM_APPLICATIONS.value,
+                _Resource.TEAM,
+                f"Team {team_id!r} is a personal space and holds no application grants",
+                actor_uid=user.uid,
+            )
+
+        await self.check_user_team_permission(
+            user, _TeamPermission.CAN_USE_TEAM_APPLICATIONS, team_id
+        )
+        await self._check_team_capability(
+            team_id,
+            _application_capability_id(app_id),
+            user=user,
+        )
+
+    async def close(self) -> None:
+        await self.__engine.close()
+
+    async def __aenter__(self) -> RebacSdk:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: _TracebackType | None,
+    ) -> None:
+        await self.close()
+
+
+async def rebac_sdk_factory(
+    security_config: _SecurityConfiguration,
+    *,
+    kpi_writer: _BaseKPIWriter,
+) -> RebacSdk:
+    """Build and initialize the process-scoped, fail-closed ReBAC SDK.
+
+    First-party application backends are ReBAC readers, never schema or store
+    owners. They must use the hardened C3 profile and supply their process KPI
+    writer so every OpenFGA call remains observable.
+    """
+
+    writer = _require_kpi_writer(kpi_writer)
+    if security_config.profile != "c3":
+        raise ValueError("The first-party ReBAC SDK requires security.profile='c3'")
+
+    _apply_security_profile(security_config)
+    rebac_config = security_config.rebac
+    if not isinstance(rebac_config, _OpenFgaRebacConfig):
+        raise ValueError("The first-party ReBAC SDK requires enabled OpenFGA")
+    if rebac_config.create_store_if_needed:
+        raise ValueError(
+            "First-party ReBAC backends must set create_store_if_needed=false"
+        )
+    if rebac_config.sync_schema_on_init:
+        raise ValueError(
+            "First-party ReBAC backends must set sync_schema_on_init=false"
+        )
+    timeout = rebac_config.timeout_millisec
+    if timeout is None or not 1 <= timeout <= 30_000:
+        raise ValueError(
+            "First-party ReBAC backends must set timeout_millisec between 1 and 30000"
+        )
+    if not security_config.user.client_id.strip():
+        raise ValueError(
+            "First-party ReBAC backends must set security.user.client_id to the exact "
+            "JWT audience; configure a Keycloak audience mapper instead of leaving it blank"
+        )
+
+    _initialize_user_security(security_config.user)
+    engine = _rebac_factory(security_config, kpi_writer=writer)
+    sdk = _RebacSdk(engine)
+    await _cast(_InitializableRebacEngine, engine).get_client()
+    return sdk
+
+
+def _require_kpi_writer(
+    kpi_writer: _BaseKPIWriter | None,
+) -> _BaseKPIWriter:
+    if kpi_writer is None:
+        raise ValueError("The first-party ReBAC SDK requires a process KPI writer")
+    return kpi_writer

--- a/libs/fred-core/fred_core/tests/common/test_fastapi_handlers.py
+++ b/libs/fred-core/fred_core/tests/common/test_fastapi_handlers.py
@@ -64,6 +64,57 @@ def test_authorization_error_handler_humanizes_generic_resource_action() -> None
     assert response.json() == {"detail": "You are not allowed to read global document."}
 
 
+def test_authorization_error_handler_does_not_label_a_team_subject_as_a_user(
+    caplog,
+) -> None:
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/capability")
+    async def denied() -> None:
+        raise AuthorizationError(
+            user_id="team-1",
+            action="can_use",
+            resource=Resource.CAPABILITY,
+            subject_type=Resource.TEAM,
+            subject_id="team-1",
+        )
+
+    with caplog.at_level(logging.WARNING):
+        response = TestClient(app, raise_server_exceptions=False).get("/capability")
+
+    assert response.status_code == 403
+    assert "Authorization denied for team team-1 (no user actor)" in caplog.text
+    assert "Authorization denied for user team-1" not in caplog.text
+
+
+def test_authorization_error_handler_distinguishes_actor_from_team_subject(
+    caplog,
+) -> None:
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/capability")
+    async def denied() -> None:
+        raise AuthorizationError(
+            user_id="alice",
+            action="can_use",
+            resource=Resource.CAPABILITY,
+            actor_uid="alice",
+            subject_type=Resource.TEAM,
+            subject_id="team-1",
+        )
+
+    with caplog.at_level(logging.WARNING):
+        response = TestClient(app, raise_server_exceptions=False).get("/capability")
+
+    assert response.status_code == 403
+    assert (
+        "Authorization denied for user alice (checked subject team team-1)"
+        in caplog.text
+    )
+
+
 def test_generic_exception_handler_returns_internal_server_error(caplog) -> None:
     app = FastAPI()
     register_exception_handlers(app)

--- a/libs/fred-core/fred_core/tests/security/rebac_fakes.py
+++ b/libs/fred-core/fred_core/tests/security/rebac_fakes.py
@@ -1,0 +1,135 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared `RebacEngine` stand-in for the capability authorization tests."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from fred_core.security.models import Resource
+from fred_core.security.rebac.rebac_engine import (
+    RebacDisabledResult,
+    RebacEngine,
+    RebacPermission,
+    RebacReference,
+    Relation,
+    RelationType,
+)
+
+
+class FakeRebacEngine(RebacEngine):
+    """Minimal `RebacEngine` stand-in for the capability authorization paths.
+
+    `lookup_resources` and `has_permission` record into separate slots so one
+    instance can serve both a `ListObjects` and a `Check` assertion, and
+    `checked_contextual_relations` grows in lockstep with `checked` so a
+    multi-check path can be asserted call by call. Pass `denied_permissions`
+    to answer some permissions differently from `permitted` — the only way to
+    express "a team member whose team holds no grant". `disabled` drives
+    `enabled`, so the engine's personal-team self-heal is skipped exactly as
+    it is for a real disabled engine. Every other abstract method is a stub.
+    """
+
+    def __init__(
+        self,
+        *,
+        resource_ids: list[str] | None = None,
+        disabled: bool = False,
+        permitted: bool = True,
+        denied_permissions: set[RebacPermission] | None = None,
+    ) -> None:
+        self._resource_ids = resource_ids or []
+        self._disabled = disabled
+        self._permitted = permitted
+        self._denied_permissions = denied_permissions or set()
+        self.received_subject: RebacReference | None = None
+        self.received_permission: RebacPermission | None = None
+        self.received_resource_type: Resource | None = None
+        self.received_contextual_relations: list[Relation] = []
+        self.checked: list[tuple[RebacReference, RebacPermission, RebacReference]] = []
+        self.checked_contextual_relations: list[list[Relation]] = []
+
+    @property
+    def enabled(self) -> bool:
+        return not self._disabled
+
+    async def _persist_relation(self, relation: Relation) -> str | None:
+        return None
+
+    async def delete_relation(self, relation: Relation) -> str | None:
+        return None
+
+    async def delete_all_relations_of_reference(
+        self, reference: RebacReference
+    ) -> str | None:
+        return None
+
+    async def delete_all_relations_of_type(self, resource_type: Resource) -> int:
+        return 0
+
+    async def list_relations(
+        self,
+        *,
+        resource_type: Resource,
+        relation: RelationType,
+        subject: RebacReference,
+        consistency_token: str | None = None,
+    ) -> list[Relation]:
+        return []
+
+    async def lookup_resources(
+        self,
+        subject: RebacReference,
+        permission: RebacPermission,
+        resource_type: Resource,
+        *,
+        contextual_relations: Iterable[Relation] | None = None,
+        consistency_token: str | None = None,
+    ) -> list[RebacReference] | RebacDisabledResult:
+        self.received_subject = subject
+        self.received_permission = permission
+        self.received_resource_type = resource_type
+        self.received_contextual_relations = list(contextual_relations or [])
+        if self._disabled:
+            return RebacDisabledResult()
+        return [
+            RebacReference(type=resource_type, id=rid) for rid in self._resource_ids
+        ]
+
+    async def lookup_subjects(
+        self,
+        resource: RebacReference,
+        relation: RelationType,
+        subject_type: Resource,
+        *,
+        contextual_relations: Iterable[Relation] | None = None,
+        consistency_token: str | None = None,
+    ) -> list[RebacReference]:
+        return []
+
+    async def has_permission(
+        self,
+        subject: RebacReference,
+        permission: RebacPermission,
+        resource: RebacReference,
+        *,
+        contextual_relations: Iterable[Relation] | None = None,
+        consistency_token: str | None = None,
+    ) -> bool:
+        self.checked.append((subject, permission, resource))
+        self.checked_contextual_relations.append(list(contextual_relations or []))
+        if permission in self._denied_permissions:
+            return False
+        return self._permitted

--- a/libs/fred-core/fred_core/tests/security/test_capability_authz.py
+++ b/libs/fred-core/fred_core/tests/security/test_capability_authz.py
@@ -22,113 +22,28 @@ field-for-field copy.
 
 from __future__ import annotations
 
-from typing import Iterable
-
 import pytest
 
 from fred_core.security.models import Resource
 from fred_core.security.rebac.capability_authz import (
+    can_team_use_capability,
     team_capability_subject_and_context,
     usable_capability_ids,
 )
+from fred_core.security.rebac.noop_engine import NoopRebacEngine
 from fred_core.security.rebac.rebac_engine import (
     ORGANIZATION_ID,
     CapabilityPermission,
-    RebacDisabledResult,
-    RebacEngine,
-    RebacPermission,
     RebacReference,
     Relation,
     RelationType,
 )
-
-
-class _FakeRebacEngine(RebacEngine):
-    """Minimal `RebacEngine` stand-in — only `lookup_resources` is exercised
-    by `usable_capability_ids`; every other abstract method is a stub."""
-
-    def __init__(
-        self,
-        *,
-        resource_ids: list[str] | None = None,
-        disabled: bool = False,
-    ) -> None:
-        self._resource_ids = resource_ids or []
-        self._disabled = disabled
-        self.received_subject: RebacReference | None = None
-        self.received_permission: RebacPermission | None = None
-        self.received_resource_type: Resource | None = None
-        self.received_contextual_relations: list[Relation] = []
-
-    async def _persist_relation(self, relation: Relation) -> str | None:
-        return None
-
-    async def delete_relation(self, relation: Relation) -> str | None:
-        return None
-
-    async def delete_all_relations_of_reference(
-        self, reference: RebacReference
-    ) -> str | None:
-        return None
-
-    async def delete_all_relations_of_type(self, resource_type: Resource) -> int:
-        return 0
-
-    async def list_relations(
-        self,
-        *,
-        resource_type: Resource,
-        relation: RelationType,
-        subject: RebacReference,
-        consistency_token: str | None = None,
-    ) -> list[Relation]:
-        return []
-
-    async def lookup_resources(
-        self,
-        subject: RebacReference,
-        permission: RebacPermission,
-        resource_type: Resource,
-        *,
-        contextual_relations: Iterable[Relation] | None = None,
-        consistency_token: str | None = None,
-    ) -> list[RebacReference] | RebacDisabledResult:
-        self.received_subject = subject
-        self.received_permission = permission
-        self.received_resource_type = resource_type
-        self.received_contextual_relations = list(contextual_relations or [])
-        if self._disabled:
-            return RebacDisabledResult()
-        return [
-            RebacReference(type=resource_type, id=rid) for rid in self._resource_ids
-        ]
-
-    async def lookup_subjects(
-        self,
-        resource: RebacReference,
-        relation: RelationType,
-        subject_type: Resource,
-        *,
-        contextual_relations: Iterable[Relation] | None = None,
-        consistency_token: str | None = None,
-    ) -> list[RebacReference]:
-        return []
-
-    async def has_permission(
-        self,
-        subject: RebacReference,
-        permission: RebacPermission,
-        resource: RebacReference,
-        *,
-        contextual_relations: Iterable[Relation] | None = None,
-        consistency_token: str | None = None,
-    ) -> bool:
-        return True
+from fred_core.tests.security.rebac_fakes import FakeRebacEngine
 
 
 @pytest.mark.asyncio
 async def test_usable_capability_ids_returns_ids_from_lookup() -> None:
-    rebac = _FakeRebacEngine(resource_ids=["model__openai__gpt-5", "mcp__search"])
+    rebac = FakeRebacEngine(resource_ids=["model__openai__gpt-5", "mcp__search"])
 
     result = await usable_capability_ids(rebac, "team-1")
 
@@ -147,7 +62,7 @@ async def test_usable_capability_ids_returns_ids_from_lookup() -> None:
 
 @pytest.mark.asyncio
 async def test_usable_capability_ids_returns_none_when_rebac_disabled() -> None:
-    rebac = _FakeRebacEngine(disabled=True)
+    rebac = FakeRebacEngine(disabled=True)
 
     result = await usable_capability_ids(rebac, "team-1")
 
@@ -169,3 +84,47 @@ def test_team_capability_subject_and_context_includes_personal_edge_for_personal
         RelationType.TEAM,
         RelationType.PERSONAL_TEAM,
     }
+
+
+@pytest.mark.asyncio
+async def test_can_team_use_capability_is_a_single_check_with_team_context() -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    assert (
+        await can_team_use_capability(
+            rebac, "team-1", capability_id="app__acme-forecast"
+        )
+        is True
+    )
+    assert rebac.checked == [
+        (
+            RebacReference(type=Resource.TEAM, id="team-1"),
+            CapabilityPermission.CAN_USE,
+            RebacReference(type=Resource.CAPABILITY, id="app__acme-forecast"),
+        )
+    ]
+    assert [
+        [c.relation for c in call] for call in rebac.checked_contextual_relations
+    ] == [[RelationType.TEAM]]
+
+
+@pytest.mark.asyncio
+async def test_can_team_use_capability_reports_denial() -> None:
+    rebac = FakeRebacEngine(permitted=False)
+
+    assert (
+        await can_team_use_capability(
+            rebac, "team-1", capability_id="app__acme-forecast"
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_team_use_capability_allows_when_rebac_is_disabled() -> None:
+    assert (
+        await can_team_use_capability(
+            NoopRebacEngine(), "team-1", capability_id="app__acme-forecast"
+        )
+        is True
+    )

--- a/libs/fred-core/fred_core/tests/security/test_rebac_sdk.py
+++ b/libs/fred-core/fred_core/tests/security/test_rebac_sdk.py
@@ -1,0 +1,583 @@
+# Copyright Thales 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the named, fail-closed first-party ReBAC SDK."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Literal
+
+import pytest
+from pydantic import AnyHttpUrl, AnyUrl
+
+from fred_core.kpi.base_kpi_writer import BaseKPIWriter
+from fred_core.kpi.noop_kpi_writer import NoOpKPIWriter
+from fred_core.security import oidc
+from fred_core.security.models import AuthorizationError, Resource
+from fred_core.security.rebac import rebac_sdk as rebac_sdk_module
+from fred_core.security.rebac.noop_engine import NoopRebacEngine
+from fred_core.security.rebac.rebac_engine import (
+    CapabilityPermission,
+    RebacEngine,
+    RebacReference,
+    TeamPermission,
+)
+from fred_core.security.rebac.rebac_sdk import RebacSdk, rebac_sdk_factory
+from fred_core.security.structure import (
+    KeycloakUser,
+    M2MSecurity,
+    OpenFgaRebacConfig,
+    SecurityConfiguration,
+    UserSecurity,
+)
+from fred_core.tests.security.rebac_fakes import FakeRebacEngine
+
+_USER = KeycloakUser(uid="alice", username="alice", roles=[])
+_ENGINE_LOGGER = "fred_core.security.rebac.rebac_engine"
+_REALM = AnyUrl("http://localhost:8080/realms/app")
+_OPENFGA_ENV = "FIRST_PARTY_OPENFGA_TOKEN"
+
+
+class _ClosingFakeRebacEngine(FakeRebacEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_calls = 0
+        self.get_client_calls = 0
+
+    async def get_client(self) -> object:
+        self.get_client_calls += 1
+        return object()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FailingInitializationFakeRebacEngine(_ClosingFakeRebacEngine):
+    async def get_client(self) -> object:
+        self.get_client_calls += 1
+        raise RuntimeError("OpenFGA unavailable")
+
+
+@pytest.fixture(autouse=True)
+def _restore_security_profile_globals() -> Iterator[None]:
+    oidc_before = (
+        oidc.STRICT_ISSUER,
+        oidc.STRICT_AUDIENCE,
+        oidc.KEYCLOAK_ENABLED,
+        oidc.KEYCLOAK_URL,
+        oidc.KEYCLOAK_JWKS_URL,
+        oidc.KEYCLOAK_CLIENT_ID,
+        oidc._JWKS_CLIENT,
+    )
+    yield
+    (
+        oidc.STRICT_ISSUER,
+        oidc.STRICT_AUDIENCE,
+        oidc.KEYCLOAK_ENABLED,
+        oidc.KEYCLOAK_URL,
+        oidc.KEYCLOAK_JWKS_URL,
+        oidc.KEYCLOAK_CLIENT_ID,
+        oidc._JWKS_CLIENT,
+    ) = oidc_before
+
+
+def _security(
+    *,
+    profile: Literal["c3"] | None = "c3",
+    user_enabled: bool = True,
+    user_client_id: str = "first-party-app",
+    m2m_enabled: bool = True,
+    rebac_enabled: bool = True,
+    with_rebac: bool = True,
+    create_store_if_needed: bool = False,
+    sync_schema_on_init: bool = False,
+    timeout_millisec: int | None = 5000,
+) -> SecurityConfiguration:
+    rebac = (
+        OpenFgaRebacConfig(
+            enabled=rebac_enabled,
+            api_url=AnyHttpUrl("http://openfga:8080"),
+            store_name="fred",
+            create_store_if_needed=create_store_if_needed,
+            sync_schema_on_init=sync_schema_on_init,
+            token_env_var=_OPENFGA_ENV,
+            timeout_millisec=timeout_millisec,
+        )
+        if with_rebac
+        else None
+    )
+    return SecurityConfiguration(
+        profile=profile,
+        user=UserSecurity(
+            enabled=user_enabled,
+            realm_url=_REALM,
+            client_id=user_client_id,
+        ),
+        m2m=M2MSecurity(
+            enabled=m2m_enabled,
+            realm_url=_REALM,
+            client_id="first-party-app",
+        ),
+        rebac=rebac,
+    )
+
+
+def _sdk(engine: RebacEngine) -> RebacSdk:
+    return rebac_sdk_module._RebacSdk(engine)
+
+
+def _team_check(
+    permission: TeamPermission, team_id: str
+) -> tuple[RebacReference, TeamPermission, RebacReference]:
+    return (
+        RebacReference(type=Resource.USER, id=_USER.uid),
+        permission,
+        RebacReference(type=Resource.TEAM, id=team_id),
+    )
+
+
+def test_module_exports_only_the_named_sdk_surface_and_factory() -> None:
+    assert rebac_sdk_module.__all__ == ["RebacSdk", "rebac_sdk_factory"]
+    assert {name for name in vars(rebac_sdk_module) if not name.startswith("_")} == {
+        "RebacSdk",
+        "rebac_sdk_factory",
+    }
+
+    sdk = _sdk(FakeRebacEngine())
+    assert {name for name in dir(sdk) if not name.startswith("_")} == {
+        "check_application_access",
+        "check_team_capability",
+        "check_user_team_permission",
+        "close",
+    }
+    assert not hasattr(sdk, "engine")
+    assert not hasattr(sdk, "get_client")
+    assert not hasattr(sdk, "rebac")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("security", "message"),
+    [
+        (_security(profile=None), "requires security.profile='c3'"),
+        (_security(user_enabled=False), "security.user.enabled must be true"),
+        (_security(m2m_enabled=False), "security.m2m.enabled must be true"),
+        (_security(rebac_enabled=False), "security.rebac.enabled must be true"),
+        (_security(with_rebac=False), "security.rebac.enabled must be true"),
+    ],
+)
+async def test_factory_rejects_permissive_security_profiles(
+    security: SecurityConfiguration, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        await rebac_sdk_factory(security, kpi_writer=NoOpKPIWriter())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("security", "message"),
+    [
+        (
+            _security(create_store_if_needed=True),
+            "create_store_if_needed=false",
+        ),
+        (
+            _security(sync_schema_on_init=True),
+            "sync_schema_on_init=false",
+        ),
+    ],
+)
+async def test_factory_rejects_openfga_owner_configuration(
+    security: SecurityConfiguration, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        await rebac_sdk_factory(security, kpi_writer=NoOpKPIWriter())
+
+
+@pytest.mark.asyncio
+async def test_factory_rejects_unbounded_or_invalid_timeouts() -> None:
+    for timeout in (None, -1, 0, 30_001):
+        with pytest.raises(ValueError, match="timeout_millisec between 1 and 30000"):
+            await rebac_sdk_factory(
+                _security(timeout_millisec=timeout),
+                kpi_writer=NoOpKPIWriter(),
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_id", ["", "   "])
+async def test_factory_rejects_empty_user_client_id_before_rebac_creation(
+    monkeypatch: pytest.MonkeyPatch,
+    client_id: str,
+) -> None:
+    factory_called = False
+
+    def _factory(
+        security: SecurityConfiguration,
+        *,
+        kpi_writer: BaseKPIWriter | None = None,
+    ) -> RebacEngine:
+        nonlocal factory_called
+        factory_called = True
+        return _ClosingFakeRebacEngine()
+
+    monkeypatch.setattr(rebac_sdk_module, "_rebac_factory", _factory)
+
+    with pytest.raises(
+        ValueError,
+        match=r"set security\.user\.client_id to the exact JWT audience",
+    ):
+        await rebac_sdk_factory(
+            _security(user_client_id=client_id),
+            kpi_writer=NoOpKPIWriter(),
+        )
+
+    assert factory_called is False
+
+
+@pytest.mark.asyncio
+async def test_factory_requires_a_process_kpi_writer() -> None:
+    with pytest.raises(ValueError, match="requires a process KPI writer"):
+        await rebac_sdk_factory(
+            _security(),
+            kpi_writer=None,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_factory_propagates_missing_openfga_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_OPENFGA_ENV, raising=False)
+
+    with pytest.raises(ValueError, match=_OPENFGA_ENV):
+        await rebac_sdk_factory(_security(), kpi_writer=NoOpKPIWriter())
+
+
+@pytest.mark.asyncio
+async def test_factory_passes_the_process_kpi_writer_to_rebac_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _ClosingFakeRebacEngine()
+    writer = NoOpKPIWriter()
+    received: list[tuple[SecurityConfiguration, BaseKPIWriter | None]] = []
+
+    def _factory(
+        security: SecurityConfiguration,
+        *,
+        kpi_writer: BaseKPIWriter | None = None,
+    ) -> RebacEngine:
+        received.append((security, kpi_writer))
+        return engine
+
+    monkeypatch.setattr(rebac_sdk_module, "_rebac_factory", _factory)
+    security = _security()
+
+    sdk = await rebac_sdk_factory(security, kpi_writer=writer)
+
+    assert received == [(security, writer)]
+    assert isinstance(sdk, rebac_sdk_module._RebacSdk)
+    assert engine.get_client_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_factory_propagates_openfga_initialization_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _FailingInitializationFakeRebacEngine()
+
+    def _factory(
+        security: SecurityConfiguration,
+        *,
+        kpi_writer: BaseKPIWriter | None = None,
+    ) -> RebacEngine:
+        return engine
+
+    monkeypatch.setattr(rebac_sdk_module, "_rebac_factory", _factory)
+
+    with pytest.raises(RuntimeError, match="OpenFGA unavailable"):
+        await rebac_sdk_factory(_security(), kpi_writer=NoOpKPIWriter())
+
+    assert engine.get_client_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_factory_initializes_the_process_jwt_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _factory(
+        security: SecurityConfiguration,
+        *,
+        kpi_writer: BaseKPIWriter | None = None,
+    ) -> RebacEngine:
+        return _ClosingFakeRebacEngine()
+
+    monkeypatch.setattr(rebac_sdk_module, "_rebac_factory", _factory)
+    monkeypatch.setattr(oidc, "KEYCLOAK_ENABLED", False)
+    monkeypatch.setattr(oidc, "KEYCLOAK_URL", "")
+    monkeypatch.setattr(oidc, "KEYCLOAK_JWKS_URL", "")
+    monkeypatch.setattr(oidc, "KEYCLOAK_CLIENT_ID", "")
+    monkeypatch.setattr(oidc, "_JWKS_CLIENT", object())
+
+    await rebac_sdk_factory(_security(), kpi_writer=NoOpKPIWriter())
+
+    assert oidc.KEYCLOAK_ENABLED is True
+    assert oidc.KEYCLOAK_URL == str(_REALM)
+    assert oidc.KEYCLOAK_JWKS_URL == f"{_REALM}/protocol/openid-connect/certs"
+    assert oidc.KEYCLOAK_CLIENT_ID == "first-party-app"
+    assert oidc._JWKS_CLIENT is None
+    assert oidc.STRICT_ISSUER is True
+    assert oidc.STRICT_AUDIENCE is True
+    assert bool(oidc.STRICT_AUDIENCE and oidc.KEYCLOAK_CLIENT_ID) is True
+
+
+@pytest.mark.asyncio
+async def test_factory_rejects_a_disabled_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _factory(
+        security: SecurityConfiguration,
+        *,
+        kpi_writer: BaseKPIWriter | None = None,
+    ) -> RebacEngine:
+        return NoopRebacEngine()
+
+    monkeypatch.setattr(rebac_sdk_module, "_rebac_factory", _factory)
+
+    with pytest.raises(ValueError, match="requires an enabled OpenFGA engine"):
+        await rebac_sdk_factory(_security(), kpi_writer=NoOpKPIWriter())
+
+
+def test_private_implementation_rejects_noop_engine() -> None:
+    with pytest.raises(ValueError, match="requires an enabled OpenFGA engine"):
+        _sdk(NoopRebacEngine())
+
+
+@pytest.mark.asyncio
+async def test_check_user_team_permission_passes_through_to_the_engine() -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    result = await _sdk(rebac).check_user_team_permission(
+        _USER, TeamPermission.CAN_USE_TEAM_APPLICATIONS, "team-1"
+    )
+
+    assert result is None
+    assert rebac.checked == [
+        _team_check(TeamPermission.CAN_USE_TEAM_APPLICATIONS, "team-1")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_user_team_permission_raises_on_denial() -> None:
+    rebac = FakeRebacEngine(permitted=False)
+
+    with pytest.raises(AuthorizationError) as denial:
+        await _sdk(rebac).check_user_team_permission(
+            _USER, TeamPermission.CAN_USE_TEAM_APPLICATIONS, "team-1"
+        )
+
+    assert denial.value.user_id == _USER.uid
+    assert denial.value.actor_uid == _USER.uid
+    assert denial.value.subject_type == Resource.USER
+    assert denial.value.subject_id == _USER.uid
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("team_id", ["personal", "personal-alice"])
+async def test_check_user_team_permission_refuses_personal_spaces(
+    team_id: str,
+) -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    with pytest.raises(AuthorizationError) as denial:
+        await _sdk(rebac).check_user_team_permission(
+            _USER, TeamPermission.CAN_USE_TEAM_APPLICATIONS, team_id
+        )
+
+    assert denial.value.user_id == _USER.uid
+    assert denial.value.actor_uid == _USER.uid
+    assert rebac.checked == []
+
+
+@pytest.mark.asyncio
+async def test_check_team_capability_is_one_check_on_the_capability() -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    await _sdk(rebac).check_team_capability("team-1", "app__acme-forecast")
+
+    assert rebac.checked == [
+        (
+            RebacReference(type=Resource.TEAM, id="team-1"),
+            CapabilityPermission.CAN_USE,
+            RebacReference(type=Resource.CAPABILITY, id="app__acme-forecast"),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_team_capability_raises_a_permission_error_on_denial() -> None:
+    rebac = FakeRebacEngine(permitted=False)
+
+    with pytest.raises(AuthorizationError) as denial:
+        await _sdk(rebac).check_team_capability("team-1", "app__acme-forecast")
+
+    assert isinstance(denial.value, PermissionError)
+    assert denial.value.user_id == "team-1"
+    assert denial.value.actor_uid is None
+    assert denial.value.subject_type == Resource.TEAM
+    assert denial.value.subject_id == "team-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("team_id", ["personal", "personal-alice"])
+async def test_check_team_capability_refuses_personal_spaces(team_id: str) -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    with pytest.raises(AuthorizationError) as denial:
+        await _sdk(rebac).check_team_capability(team_id, "app__acme-forecast")
+
+    assert denial.value.user_id == team_id
+    assert denial.value.actor_uid is None
+    assert denial.value.subject_type == Resource.TEAM
+    assert denial.value.subject_id == team_id
+    assert rebac.checked == []
+
+
+@pytest.mark.asyncio
+async def test_check_team_capability_denial_reaches_the_rebac_denial_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rebac = FakeRebacEngine(permitted=False)
+
+    with caplog.at_level(logging.WARNING, logger=_ENGINE_LOGGER):
+        caplog.clear()
+        with pytest.raises(AuthorizationError):
+            await _sdk(rebac).check_team_capability("team-1", "app__acme-forecast")
+
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == _ENGINE_LOGGER
+    ] == [
+        "ReBAC authorization denied: subject=team:team-1 permission=can_use "
+        "resource=capability:app__acme-forecast"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_application_access_asks_membership_then_the_app_grant() -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    await _sdk(rebac).check_application_access(
+        _USER, team_id="team-1", app_id="acme-forecast"
+    )
+
+    assert rebac.checked == [
+        _team_check(TeamPermission.CAN_USE_TEAM_APPLICATIONS, "team-1"),
+        (
+            RebacReference(type=Resource.TEAM, id="team-1"),
+            CapabilityPermission.CAN_USE,
+            RebacReference(type=Resource.CAPABILITY, id="app__acme-forecast"),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_check_application_access_sends_the_team_edge_with_the_grant_check() -> (
+    None
+):
+    rebac = FakeRebacEngine(permitted=True)
+
+    await _sdk(rebac).check_application_access(
+        _USER, team_id="team-1", app_id="acme-forecast"
+    )
+
+    membership_context, grant_context = rebac.checked_contextual_relations
+    assert membership_context == []
+    assert [relation.relation.value for relation in grant_context] == ["team"]
+
+
+@pytest.mark.asyncio
+async def test_check_application_access_stops_at_membership_for_a_non_member() -> None:
+    rebac = FakeRebacEngine(permitted=False)
+
+    with pytest.raises(AuthorizationError):
+        await _sdk(rebac).check_application_access(
+            _USER, team_id="team-1", app_id="acme-forecast"
+        )
+
+    assert len(rebac.checked) == 1
+
+
+@pytest.mark.parametrize("team_id", ["personal-alice", "personal"])
+@pytest.mark.asyncio
+async def test_check_application_access_refuses_personal_spaces(team_id: str) -> None:
+    rebac = FakeRebacEngine(permitted=True)
+
+    with pytest.raises(AuthorizationError) as denial:
+        await _sdk(rebac).check_application_access(
+            _USER, team_id=team_id, app_id="acme-forecast"
+        )
+
+    assert rebac.checked == []
+    assert denial.value.user_id == _USER.uid
+    assert denial.value.actor_uid == _USER.uid
+
+
+@pytest.mark.asyncio
+async def test_check_application_access_denies_a_member_whose_team_lacks_the_grant() -> (
+    None
+):
+    rebac = FakeRebacEngine(
+        permitted=True, denied_permissions={CapabilityPermission.CAN_USE}
+    )
+
+    with pytest.raises(AuthorizationError) as denial:
+        await _sdk(rebac).check_application_access(
+            _USER, team_id="team-1", app_id="acme-forecast"
+        )
+
+    assert [permission for _subject, permission, _resource in rebac.checked] == [
+        TeamPermission.CAN_USE_TEAM_APPLICATIONS,
+        CapabilityPermission.CAN_USE,
+    ]
+    assert denial.value.user_id == _USER.uid
+    assert denial.value.actor_uid == _USER.uid
+    assert denial.value.subject_type == Resource.TEAM
+    assert denial.value.subject_id == "team-1"
+
+
+@pytest.mark.asyncio
+async def test_close_delegates_to_the_owned_engine() -> None:
+    engine = _ClosingFakeRebacEngine()
+    sdk = _sdk(engine)
+
+    await sdk.close()
+
+    assert engine.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_reuses_and_closes_the_sdk() -> None:
+    engine = _ClosingFakeRebacEngine()
+    sdk = _sdk(engine)
+
+    async with sdk as entered:
+        assert entered is sdk
+        await entered.check_team_capability("team-1", "app__acme-forecast")
+
+    assert engine.close_calls == 1
+    assert len(engine.checked) == 1

--- a/libs/fred-core/pyproject.toml
+++ b/libs/fred-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 description = "Core shared utilities for Fred backends (config, storage, security, and runtime helpers)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/fred-core/uv.lock
+++ b/libs/fred-core/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/fred-runtime/uv.lock
+++ b/libs/fred-runtime/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -733,7 +733,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "../fred-sdk" }
 dependencies = [
     { name = "fred-core" },

--- a/libs/fred-sdk/fred_sdk/contracts/capability/manifest.py
+++ b/libs/fred-sdk/fred_sdk/contracts/capability/manifest.py
@@ -34,6 +34,9 @@ from __future__ import annotations
 import re
 from typing import Any, Literal, get_args, get_origin
 
+from fred_core.security.rebac.capability_authz import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX as _CORE_APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+)
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ..models import FieldSpec, TeamScopePolicy
@@ -52,20 +55,17 @@ CAPABILITY_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$"
 # entries are likewise a projection — no `CapabilityManifest` of kind
 # "model" is ever authored — but unlike "agent" they are advertised BY the
 # runtime pod (`GET /agents/models-catalog`), not synthesized from data
-# control-plane already has. Both the runtime (id generation,
-# `model_capability_id` below) and control-plane (the same
-# reserved-prefix collision guard `aggregate_capability_catalog` already
-# applies to `agent__`) need this exact prefix, so it lives here in
-# fred-sdk — the one package both already depend on — rather than being
-# duplicated by convention in two places.
+# control-plane already has. It lives in fred-sdk because both the runtime
+# (id generation, `model_capability_id` below) and control-plane read it.
+# The flat `capability:<id>` namespace has three reserved prefixes, each
+# beside the code deriving that kind's ids: `model__` here, `app__` in
+# fred-core (`security.rebac.capability_authz`), `agent__` in control-plane
+# (`product.service`). `aggregate_capability_catalog` guards all three.
 MODEL_CAPABILITY_NAMESPACE_PREFIX = "model__"
 
-# Reserved id prefix for control-plane-projected product applications
-# (CONTROL-PLANE-PRODUCT-CONTRACT.md, "team applications are
-# runtime-registered, frame-hosted UIs"). Applications reuse the capability
-# tuple model for coarse team admission but are not runtime capabilities, so
-# only the JSON-safe `CapabilityCatalogEntry` admits `kind="app"`.
-APPLICATION_CAPABILITY_NAMESPACE_PREFIX = "app__"
+# Compatibility import for consumers of the former fred-sdk-owned constant.
+# fred-core remains the single source of truth for application capability ids.
+APPLICATION_CAPABILITY_NAMESPACE_PREFIX = _CORE_APPLICATION_CAPABILITY_NAMESPACE_PREFIX
 
 
 def model_capability_id(provider: str, name: str) -> str:

--- a/libs/fred-sdk/pyproject.toml
+++ b/libs/fred-sdk/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 description = "Authoring SDK for Fred agents — graph, ReAct, and team agent primitives."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Thales", email = "noreply@thalesgroup.com" }]
 dependencies = [
-  "fred-core>=3.8.3",
+  "fred-core>=3.9.0",
   "pydantic>=2.7.0,<3.0.0",
   "langchain-core>=0.3.0",
   "langchain>=1.3.14",

--- a/libs/fred-sdk/tests/test_capability_contracts.py
+++ b/libs/fred-sdk/tests/test_capability_contracts.py
@@ -27,6 +27,9 @@ import asyncio
 from typing import Any, Literal
 
 import pytest
+from fred_core.security.rebac.capability_authz import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX as CORE_APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+)
 from fred_sdk.contracts.capability import (
     AgentCapability,
     AssetSlot,
@@ -45,6 +48,9 @@ from fred_sdk.contracts.capability import (
     ToolCarrierMiddleware,
     UploadedFile,
     chat_part_kind,
+)
+from fred_sdk.contracts.capability.manifest import (
+    APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
 )
 from fred_sdk.contracts.capability.manifest import (
     TeamScopePolicy as ManifestTeamScopePolicy,
@@ -497,6 +503,13 @@ def test_team_scope_policy_importable_from_both_paths() -> None:
     # importable from its original home (capability.manifest) and from the
     # capability package's public surface — both re-export the same enum.
     assert ManifestTeamScopePolicy is TeamScopePolicy
+
+
+def test_application_capability_prefix_preserves_compatibility_import() -> None:
+    assert (
+        APPLICATION_CAPABILITY_NAMESPACE_PREFIX
+        == CORE_APPLICATION_CAPABILITY_NAMESPACE_PREFIX
+    )
 
 
 def test_mcp_server_configuration_team_scope_defaults_to_admin_gated() -> None:

--- a/libs/fred-sdk/uv.lock
+++ b/libs/fred-sdk/uv.lock
@@ -501,7 +501,7 @@ wheels = [
 
 [[package]]
 name = "fred-core"
-version = "3.8.3"
+version = "3.9.0"
 source = { editable = "../fred-core" }
 dependencies = [
     { name = "aiosqlite" },
@@ -596,7 +596,7 @@ dev = [
 
 [[package]]
 name = "fred-sdk"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fred-core" },


### PR DESCRIPTION
## Summary

- `libs/fred-core`: add a process-scoped `RebacSdk` exposing only named
  user/team, team/capability, and combined application authorization checks.
- `libs/fred-core`: fail startup unless the backend uses the hardened security
  profile, enabled user and service authentication, enabled OpenFGA, bounded
  timeouts, read-only store/schema settings, KPI instrumentation, and a
  non-blank exact JWT audience.
- `libs/fred-core`: reject personal spaces before contacting OpenFGA and check
  application access by verifying user membership before the team's
  `app__<app_id>` capability grant.
- `libs/fred-core`: distinguish the acting user from non-user ReBAC subjects in
  authorization errors and logs.
- `libs/fred-core` and `apps/control-plane-backend`: centralize application
  capability identifiers and team-capability query construction so all
  consumers use the same subject and contextual relations.
- `libs/fred-sdk`: retain the previous application-prefix export as a
  compatibility alias while moving ownership of the identifier to fred-core.
- Documentation: define arm's-length and first-party application trust tiers,
  credential separation, startup and shutdown requirements, entitlement
  withdrawal, and the rule that data owned by another backend remains
  accessible only through that backend's API.
- Package metadata: release fred-core 3.9.0 and fred-sdk 3.6.0 and update
  dependent lockfiles.

## Review corrections applied

- Reject an empty or whitespace-only user JWT audience before creating the
  ReBAC engine. Tests prove that invalid configuration fails before any
  OpenFGA initialization.
- Remove an unrelated control-plane statistics helper refactor; this PR makes
  no statistics behavior change.
- Preserve the existing frame-to-conversation RFC decision and its references;
  only the obsolete application-authorization open question is removed.

## Backward compatibility

- Deployments with Applications disabled require no new configuration,
  environment variables, secrets, Helm values, database migrations, or
  OpenFGA model changes. Existing services do not construct the new SDK.
- Existing control-plane, knowledge, agent, runtime, catalog, and application
  grant behavior is unchanged. A normal upgrade only requires coherently built
  service images, as before.
- Official images embed matching local library sources. The SDK and
  control-plane dependency floors require fred-core 3.9.0, preventing normal
  dependency resolution from combining the new code with an older core.
- `AuthorizationError.user_id` retains its historical `str` contract and
  value. Additive keyword-only actor and subject metadata provides accurate
  diagnostics for non-user checks without requiring downstream code changes.
- The previous SDK application-prefix import path and its `app__` value remain
  available through a compatibility alias.
- No existing HTTP API, application catalog route, or capability grant route
  changes as part of this work.

## Proposed follow-up ticket

### Harden shared C3 configuration and ReBAC shutdown semantics

The two confirmed pre-existing platform concerns can be handled in one
follow-up ticket because both affect the shared ReBAC construction and
lifecycle boundary rather than this application-specific facade.

Proposed scope:

1. Enforce a non-blank JWT audience in the shared C3 security-profile path so
   every C3 caller receives the same protection, not only first-party
   application SDK consumers.
2. Give the shared ReBAC engine an explicit terminal shutdown state so a late
   or concurrent call cannot recreate its client after `close()`.
3. Define predictable behavior for repeated shutdown and calls attempted after
   shutdown.
4. Add coverage for blank audience configuration, initialization/shutdown
   races, shutdown before initialization, repeated shutdown, and attempted
   client access after shutdown.

These behaviors are deliberately not changed here because doing so would alter
the security and lifecycle contract for all existing ReBAC consumers.

## Test plan

- [x] `make code-quality` — fred-core, fred-sdk, and control-plane; all checks
      passed with zero type-checking errors.
- [x] `make import-order` — all three affected Python packages passed.
- [x] `make test` — fred-core: 570 passed, 25 deselected.
- [x] `make test` — fred-sdk: 343 passed, 3 skipped.
- [x] `make test` — control-plane: 1,037 passed.
- [x] Regression coverage verifies that blank and whitespace-only audiences
      fail before ReBAC engine creation.
- [x] Regression coverage verifies string-compatible authorization errors for
      actor-less team checks and distinct actor/subject diagnostics.
- [ ] Live OpenFGA and identity-provider verification — no consumer deployment
      or service wiring is introduced by this PR.

## Risk and rollback

The intentional operational risk is that a misconfigured first-party backend
will now fail startup instead of running with incomplete audience validation.
Authorization mistakes could otherwise deny legitimate team access or admit a
team without the required application grant.

Rollback is to revert this feature and restore the previous fred-core and
fred-sdk package versions. Existing application catalog and gateway behavior
are unchanged.
