### PR TITLE
ci(#2554): cancel superseded runs and make the code-quality matrix honour its change filter

### DIFF
--- a/.github/workflows/Check-config-schema.yml
+++ b/.github/workflows/Check-config-schema.yml
@@ -10,10 +10,11 @@ on:
       - main
       - swift
 
-# A new push supersedes the run it interrupts, for pull requests only: on a base
-# branch each commit keeps its own verdict.
+# A pull request only needs its newest commit checked, so a push supersedes the
+# run it interrupts. A base-branch commit groups by sha instead: it keeps its own
+# run and its own verdict, and never waits behind the commit before it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/Check-config-schema.yml
+++ b/.github/workflows/Check-config-schema.yml
@@ -10,6 +10,12 @@ on:
       - main
       - swift
 
+# A new push supersedes the run it interrupts, for pull requests only: on a base
+# branch each commit keeps its own verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/Check-docker-images.yml
+++ b/.github/workflows/Check-docker-images.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# A new push supersedes the run it interrupts: keep only the latest commit of a
+# branch under check, so a work-in-progress series does not queue several full
+# job sets against the same runner pool.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/Check-docker-images.yml
+++ b/.github/workflows/Check-docker-images.yml
@@ -8,12 +8,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# A new push supersedes the run it interrupts: keep only the latest commit of a
-# branch under check, so a work-in-progress series does not queue several full
-# job sets against the same runner pool.
+# A pull request only needs its newest commit checked, so a push supersedes the
+# run it interrupts. A base-branch commit groups by sha instead: it keeps its own
+# run and its own verdict, and never waits behind the commit before it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/Check-migrations.yml
+++ b/.github/workflows/Check-migrations.yml
@@ -12,10 +12,11 @@ on:
       - swift
       - develop
 
-# A new push supersedes the run it interrupts, for pull requests only: on a base
-# branch each commit keeps its own verdict.
+# A pull request only needs its newest commit checked, so a push supersedes the
+# run it interrupts. A base-branch commit groups by sha instead: it keeps its own
+# run and its own verdict, and never waits behind the commit before it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Least-privilege GITHUB_TOKEN: these jobs only check out the repo and run

--- a/.github/workflows/Check-migrations.yml
+++ b/.github/workflows/Check-migrations.yml
@@ -12,6 +12,12 @@ on:
       - swift
       - develop
 
+# A new push supersedes the run it interrupts, for pull requests only: on a base
+# branch each commit keeps its own verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Least-privilege GITHUB_TOKEN: these jobs only check out the repo and run
 # migration checks — no write access is required (CodeQL actions/missing-workflow-permissions).
 permissions:

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# A new push supersedes the run it interrupts: keep only the latest commit of a
+# branch under check, so a work-in-progress series does not queue several full
+# job sets against the same runner pool.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -30,6 +30,7 @@ jobs:
       fred-runtime: ${{ steps.changes.outputs.fred-runtime }}
       fred-agents: ${{ steps.changes.outputs.fred-agents }}
       platform-ops: ${{ steps.changes.outputs.platform-ops }}
+      html-artifact: ${{ steps.changes.outputs.html-artifact }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,47 +81,51 @@ jobs:
           - sast
           # - detect-secret # todo: baseline not working, fix it and re enable this check
           - type-check
+        # Wrapped in ${{ }} so the expression is evaluated at matrix-expansion
+        # time and `should-run` holds a real true/false. An unwrapped condition
+        # is a non-empty string, which every `if:` reads as true - that is how
+        # all 40 combinations ran on every pull request.
         include:
           # Knowledge flow backend runs when knowledge-flow or fred-core changes
           - directory: apps/knowledge-flow-backend
-            condition: needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true'
+            should-run: ${{ needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           # Fred core runs when fred-core changes
           - directory: libs/fred-core
-            condition: needs.detect-changes.outputs.fred-core == 'true'
+            should-run: ${{ needs.detect-changes.outputs.fred-core == 'true' }}
           # Control plane backend runs when control-plane or fred-core changes
           - directory: apps/control-plane-backend
-            condition: needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true'
+            should-run: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           # Fred SDK runs when fred-sdk changes
           - directory: libs/fred-sdk
-            condition: needs.detect-changes.outputs.fred-sdk == 'true'
+            should-run: ${{ needs.detect-changes.outputs.fred-sdk == 'true' }}
           # Fred Runtime runs when fred-runtime or fred-sdk changes
           - directory: libs/fred-runtime
-            condition: needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true'
+            should-run: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
           # Fred Agents runs when fred-agents, fred-runtime, or fred-sdk changes
           - directory: apps/fred-agents
-            condition: needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true'
+            should-run: ${{ needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
           # Platform-ops capability runs when it, fred-runtime, or fred-sdk changes
           - directory: libs/fred-capability-platform-ops
-            condition: needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true'
+            should-run: ${{ needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
           # HTML-artifact capability runs when it, fred-runtime, or fred-sdk changes
           - directory: libs/fred-capability-html-artifact
-            condition: needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true'
+            should-run: ${{ needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
     name: Code Quality - ${{ matrix.directory }} - ${{ matrix.check }}
 
     steps:
       - uses: actions/checkout@v4
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Python environment
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         uses: ./.github/actions/setup-python-env
         with:
           working-directory: ${{ matrix.directory }}
 
       - name: Run ${{ matrix.check }}
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         run: |
           cd ${{ matrix.directory }}/
           make ${{ matrix.check }}

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -437,44 +437,44 @@ jobs:
             backend-directory: libs/fred-runtime
             make-target: update-runtime-api
             slice-path: apps/frontend/src/slices/runtime/runtimeOpenApi.ts
-            condition: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.frontend == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.frontend == 'true' }}
           - name: knowledge-flow
             backend-directory: apps/knowledge-flow-backend
             make-target: update-knowledge-flow-api
             slice-path: apps/frontend/src/slices/knowledgeFlow/knowledgeFlowOpenApi.ts
-            condition: ${{ needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.frontend == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.frontend == 'true' }}
           - name: control-plane
             backend-directory: apps/control-plane-backend
             make-target: update-control-plane-api
             slice-path: apps/frontend/src/slices/controlPlane/controlPlaneOpenApi.ts
-            condition: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.frontend == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.frontend == 'true' }}
     name: OpenAPI Drift - ${{ matrix.name }}
 
     steps:
       - name: Checkout code
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         uses: actions/setup-node@v4
         with:
           node-version: "22.13.0"
 
       - name: Setup backend dependencies
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         uses: ./.github/actions/setup-python-env
         with:
           working-directory: ${{ matrix.backend-directory }}
 
       - name: Backup current slice
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         run: cp -f ${{ matrix.slice-path }} /tmp/openapi-backup.ts 2>/dev/null || true
 
       - name: Regenerate OpenAPI slice
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         run: |
           cd apps/frontend/
           make ${{ matrix.make-target }}
@@ -482,7 +482,7 @@ jobs:
           UV: uv
 
       - name: Check for drift
-        if: ${{ matrix.condition }}
+        if: ${{ matrix.should-run }}
         run: |
           if ! diff -q /tmp/openapi-backup.ts ${{ matrix.slice-path }} > /dev/null 2>&1; then
             echo "--- diff (committed vs freshly generated) ---"

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -81,35 +81,26 @@ jobs:
           - sast
           # - detect-secret # todo: baseline not working, fix it and re enable this check
           - type-check
-        # Wrapped in ${{ }} so the expression is evaluated at matrix-expansion
-        # time and `should-run` holds a real true/false. An unwrapped condition
-        # is a non-empty string, which every `if:` reads as true - that is how
-        # all 40 combinations ran on every pull request.
+        # The ${{ }} wrapper is what makes should-run a real boolean: an
+        # unwrapped expression stays a string, and every non-empty string is
+        # true to `if:`. Conditions mirror each module's path dependencies.
         include:
-          # Knowledge flow backend runs when knowledge-flow or fred-core changes
           - directory: apps/knowledge-flow-backend
             should-run: ${{ needs.detect-changes.outputs.knowledge-flow == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
-          # Fred core runs when fred-core changes
           - directory: libs/fred-core
             should-run: ${{ needs.detect-changes.outputs.fred-core == 'true' }}
-          # Control plane backend runs when control-plane or fred-core changes
           - directory: apps/control-plane-backend
-            should-run: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
-          # Fred SDK runs when fred-sdk changes
+            should-run: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
           - directory: libs/fred-sdk
-            should-run: ${{ needs.detect-changes.outputs.fred-sdk == 'true' }}
-          # Fred Runtime runs when fred-runtime or fred-sdk changes
+            should-run: ${{ needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - directory: libs/fred-runtime
-            should-run: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
-          # Fred Agents runs when fred-agents, fred-runtime, or fred-sdk changes
+            should-run: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - directory: apps/fred-agents
-            should-run: ${{ needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
-          # Platform-ops capability runs when it, fred-runtime, or fred-sdk changes
+            should-run: ${{ needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - directory: libs/fred-capability-platform-ops
-            should-run: ${{ needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
-          # HTML-artifact capability runs when it, fred-runtime, or fred-sdk changes
+            should-run: ${{ needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - directory: libs/fred-capability-html-artifact
-            should-run: ${{ needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
     name: Code Quality - ${{ matrix.directory }} - ${{ matrix.check }}
 
     steps:
@@ -154,32 +145,32 @@ jobs:
             directory: apps/control-plane-backend
             unit-target: test
             needs-pandoc: false
-            should-run: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.control-plane == 'true' || needs.detect-changes.outputs.fred-core == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
           - name: fred-sdk
             directory: libs/fred-sdk
             unit-target: test
             needs-pandoc: false
-            should-run: ${{ needs.detect-changes.outputs.fred-sdk == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - name: fred-runtime
             directory: libs/fred-runtime
             unit-target: test
             needs-pandoc: false
-            should-run: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - name: fred-agents
             directory: apps/fred-agents
             unit-target: test
             needs-pandoc: false
-            should-run: ${{ needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.fred-agents == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - name: fred-capability-platform-ops
             directory: libs/fred-capability-platform-ops
             unit-target: test
             needs-pandoc: false
-            should-run: ${{ needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.platform-ops == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
           - name: fred-capability-html-artifact
             directory: libs/fred-capability-html-artifact
             unit-target: test
             needs-pandoc: false
-            should-run: ${{ needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' }}
+            should-run: ${{ needs.detect-changes.outputs.html-artifact == 'true' || needs.detect-changes.outputs.fred-runtime == 'true' || needs.detect-changes.outputs.fred-sdk == 'true' || needs.detect-changes.outputs.fred-core == 'true' }}
     name: Backend Tests - ${{ matrix.name }}
 
     steps:

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -224,7 +224,6 @@ jobs:
           # - check: knip
           #   continue-on-error: true
     name: Code Quality - frontend - ${{ matrix.check }}
-    continue-on-error: ${{ matrix.continue-on-error == true }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# A new push supersedes the run it interrupts: keep only the latest commit of a
-# branch under check, so a work-in-progress series does not queue several full
-# job sets against the same runner pool.
+# A pull request only needs its newest commit checked, so a push supersedes the
+# run it interrupts. A base-branch commit groups by sha instead: it keeps its own
+# run and its own verdict, and never waits behind the commit before it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/Check-pending-requests.yml
+++ b/.github/workflows/Check-pending-requests.yml
@@ -224,6 +224,7 @@ jobs:
           # - check: knip
           #   continue-on-error: true
     name: Code Quality - frontend - ${{ matrix.check }}
+    continue-on-error: ${{ matrix.continue-on-error == true }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #2554 (findings 1 to 3).

## What changes

**A new push supersedes the run it interrupts.** No workflow declared a
`concurrency` group, so every push started a full job set while the previous
one kept burning runners. Measured on PR #2420: two complete sets, ~144 jobs,
in flight at the same second for one pull request, jobs waiting **702 s on
average** before a runner picked them up (127 s when a single set was running),
and the same workflow taking **15 min 34 s** contended vs **5 min 58 s** alone.

Base-branch runs group by commit sha instead of by ref, so each commit merged
to `swift` keeps its own run and its own verdict. Grouping them by ref would
have done the opposite of what it promises: GitHub cancels a *pending* run when
a third one enters the group, so the middle commit of three quick merges would
lose its verdict, and runs that go in parallel today would serialize.

**The code-quality matrix now honours the change filter it already declares.**
The per-directory conditions were unwrapped strings, so `if: ${{ matrix.condition }}`
always received a non-empty - therefore truthy - value and all 40 combinations
ran on every pull request. A/B proof inside one run on PR #2420 (which touches
neither `libs/fred-sdk`, nor `libs/fred-core`, nor `apps/control-plane-backend`):
`Backend Tests - fred-sdk` took 3 s with its steps skipped, while
`Code Quality - libs/fred-sdk - lint` took 19 s with `Run lint` green.

**Both matrices now gate on the real dependency graph.** Every module below
`fred-core` resolves it from local source (`path = "../fred-core", editable = true`),
and `control-plane` path-depends on `fred-sdk`, but neither edge was expressed.
`backend-tests` gates correctly, so those holes are live today: a `fred-core`-only
pull request does not run `fred-sdk`'s tests. Turning the code-quality gate on
without this would have inherited them all.

**`html-artifact` is exported from `detect-changes`.** The filter was declared
but missing from the job outputs, so `outputs.html-artifact == 'true'` compared
an empty string.

## Effect

What a pull request now makes the 40 code-quality jobs actually do:

| touched | jobs doing work |
| --- | --- |
| frontend only | 0 / 40 |
| knowledge-flow | 5 / 40 |
| fred-runtime | 20 / 40 |
| fred-sdk | 30 / 40 |
| fred-core | 40 / 40 (it is the root of the graph) |

The 40 jobs are still created - the gate is at step level, so a skipped leg
spins up a runner to report success in ~3 s. Making unaffected directories
never become jobs at all needs the `fromJSON` matrix shape `Docker-images.yml`
already uses, which is option 4 on #2554. Job names are unchanged either way,
so branch protection is unaffected.

## Verification

- **Cancellation, exercised on this PR:** pushing `07736a2` while `06b810a` was
  still running turned all three of its in-flight runs (`Check docker images`
  included, one minute in) to `cancelled`.
- `actionlint` (docker) reports nothing new on the four touched files. Its two
  findings there - `dorny/paths-filter@v2` being too old for current runners,
  and the frontend job's `continue-on-error` reference - predate this branch.
  The second one was deleted mid-branch and put back: the commented-out `knip`
  leg it belongs to would come back hard-failing instead of tolerated.
- The gating itself cannot be exercised here: a `.github`-only PR skips
  `code-quality` at job level either way. The table above is computed from the
  workflow's own matrix; the first backend PR merged after this one is the real
  check.

## Follow-ups, left on #2554

- `libs/fred-capability-ppt-filler` and `libs/fred-capability-writable-document`
  match no filter at all, so a PR touching only them runs no backend CI - and
  never triggers `fred-agents`, which path-depends on both.
- The `agentic` output and its filter are consumed by nothing.
- `Build-and-push-docker` has no concurrency group, so two merges to `swift` can
  publish the mutable `swift-dev` tag out of order.
- Options 4 and 5 of #2554 (matrix-level gating, draft-state filtering) remain
  decisions rather than fixes.
