### PR TITLE
fix: repair swift's frontend unit suite after the ATTACH-TAB-01 merge

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.batch.test.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.batch.test.tsx
@@ -45,6 +45,9 @@ function mockMutationResult<T>(promise: Promise<T>): Promise<T> & { unwrap: () =
 // One deferred per fast-ingest call, settled by hand so the test controls
 // which file finishes first.
 const pendingIngests: Array<{ name: string; resolve: (value: unknown) => void }> = [];
+// Calls made through the mocked delete-fast-artifacts mutation, so a test can
+// assert Knowledge Flow cleanup fired (or didn't) without a real store.
+const deleteFastArtifactsCalls: Array<{ documentUid: string; sessionId?: string | null }> = [];
 vi.mock("../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
   useFastIngestKnowledgeFlowV1FastIngestPostMutation: () => [
     (args: { bodyFastIngestKnowledgeFlowV1FastIngestPost: FormData }) => {
@@ -55,14 +58,24 @@ vi.mock("../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
       return mockMutationResult(promise);
     },
   ],
+  useDeleteFastArtifactsKnowledgeFlowV1FastDeleteDocumentUidDeleteMutation: () => [
+    (args: { documentUid: string; sessionId?: string | null }) => {
+      deleteFastArtifactsCalls.push(args);
+      return mockMutationResult(Promise.resolve({}));
+    },
+  ],
 }));
+const persistAttachmentBehavior = { rejectNext: false };
 vi.mock("../../../../slices/controlPlane/controlPlaneOpenApi", () => ({
   useGetTeamSessionAttachmentsControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsGetQuery: () => ({
     data: [],
     isFetching: false,
   }),
   usePostTeamSessionAttachmentControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsPostMutation: () => [
-    () => mockMutationResult(Promise.resolve({})),
+    () =>
+      persistAttachmentBehavior.rejectNext
+        ? mockMutationResult(Promise.reject(new Error("simulated control-plane persist failure")))
+        : mockMutationResult(Promise.resolve({})),
   ],
   useDeleteTeamSessionAttachmentControlPlaneV1TeamsTeamIdSessionsSessionIdAttachmentsAttachmentIdDeleteMutation: () => [
     () => mockMutationResult(Promise.resolve({})),
@@ -89,6 +102,8 @@ describe("useChatAttachments.addFiles — multi-file batch", () => {
 
   beforeEach(() => {
     pendingIngests.length = 0;
+    deleteFastArtifactsCalls.length = 0;
+    persistAttachmentBehavior.rejectNext = false;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -138,5 +153,20 @@ describe("useChatAttachments.addFiles — multi-file batch", () => {
     ]);
     expect(latest.attachments.map((attachment) => attachment.documentUid)).toEqual(["doc-a", "doc-b"]);
     expect(latest.hasUploadingAttachments).toBe(false);
+  });
+
+  it("cleans up the Knowledge Flow artifact when the control-plane persist fails", async () => {
+    persistAttachmentBehavior.rejectNext = true;
+
+    await act(async () => {
+      void latest.addFiles([pdf("a.pdf")], "paste", "session-1");
+    });
+
+    await act(async () => {
+      pendingIngests[0].resolve({ document_uid: "doc-a", summary_md: "a" });
+    });
+
+    expect(statuses()).toEqual([["a.pdf", "error"]]);
+    expect(deleteFastArtifactsCalls).toEqual([{ documentUid: "doc-a", sessionId: "session-1" }]);
   });
 });

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/useChatAttachments.ts
@@ -349,7 +349,7 @@ export function useChatAttachments({ teamId, sessionId }: UseChatAttachmentsPara
       // concurrently — one at a time hid file N behind file N-1's ingestion.
       await Promise.all(files.filter((file) => file.size > 0).map(ingestFile));
     },
-    [dispatch, fastIngestAttachment, persistAttachmentMutation, sessionId, t, teamId],
+    [deleteFastArtifactsMutation, dispatch, fastIngestAttachment, persistAttachmentMutation, sessionId, t, teamId],
   );
 
   const removeAttachment = useCallback(


### PR DESCRIPTION
## Summary
- PR #2420 added `useDeleteFastArtifactsKnowledgeFlowV1FastDeleteDocumentUidDeleteMutation` inside `useChatAttachments`'s upload flow (cleans up an orphaned Knowledge Flow attachment when the control-plane persist call after fast-ingest fails). Two things were missed: `useChatAttachments.batch.test.tsx` never returned a mock for the new hook (crashing on render), and `deleteFastArtifactsMutation` was missing from the `addFiles` `useCallback` dependency array.
- No runtime behavior changed — the merged code builds and works as shipped. This only fixes test coverage; `swift`'s frontend unit suite has been red since the #2420 merge because the PR workflow only builds/starts the frontend, it doesn't run the unit suite (separate follow-up worth considering).

## Test plan
- [x] `useChatAttachments.batch.test.tsx` passes locally (3/3, including a new test asserting a failed control-plane persist triggers the Knowledge Flow cleanup call with the right `document_uid`/`session_id`)
- [x] Full frontend suite: 181 files / 1792 tests pass
- [x] `make code-quality` (tsc, prettier, eslint) clean