### PR TITLE
style(chat): refine the prompt-selection panel

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -543,7 +543,8 @@
       "clearSearch": "Clear search",
       "allCategories": "All",
       "empty": "No prompts in this space.",
-      "emptyFilters": "No prompts match these filters."
+      "emptyFilters": "No prompts match these filters.",
+      "categoryLabel": "Category"
     }
   },
   "comingSoon": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -543,7 +543,8 @@
       "clearSearch": "Effacer la recherche",
       "allCategories": "Toutes",
       "empty": "Aucun prompt dans cet espace.",
-      "emptyFilters": "Aucun prompt ne correspond aux filtres."
+      "emptyFilters": "Aucun prompt ne correspond aux filtres.",
+      "categoryLabel": "Catégorie"
     }
   },
   "comingSoon": {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -177,9 +177,12 @@ export default function ManagedChatPage() {
   // The rail's attachments launcher. Offered when the agent still exposes
   // attaching OR the conversation already holds files: an older session whose
   // agent lost `attach_files` must not lose the way back to its own files.
-  const attachmentsLaunchers = useMemo(
-    () =>
-      allowChatAttachments || attachmentsCount > 0
+  // The conversation's own panels, above the capability viewers. The prompt
+  // library is reachable from the composer's add menu too — the rail is a
+  // second door to the same panel, not a different one.
+  const railLaunchers = useMemo(
+    () => [
+      ...(allowChatAttachments || attachmentsCount > 0
         ? [
             {
               key: "attachments",
@@ -190,8 +193,16 @@ export default function ManagedChatPage() {
               onOpen: () => setActivePushDrawer((v) => (v?.kind === "attachments" ? null : { kind: "attachments" })),
             },
           ]
-        : [],
-    [allowChatAttachments, attachmentsCount, attachmentsDrawerOpen, t],
+        : []),
+      {
+        key: "prompt-library",
+        label: t("chatbot.promptSelectionPanel.menuRow"),
+        icon: "edit_note" as const,
+        selected: activePushDrawer?.kind === "prompt-library",
+        onOpen: () => setActivePushDrawer((v) => (v?.kind === "prompt-library" ? null : { kind: "prompt-library" })),
+      },
+    ],
+    [allowChatAttachments, attachmentsCount, attachmentsDrawerOpen, activePushDrawer, t],
   );
   // The composer options menu always renders: even when an agent exposes no
   // search options, the prompt-library row is always available (personal +
@@ -594,7 +605,7 @@ export default function ManagedChatPage() {
           capabilityIds={chat.capabilityIds}
           activeKey={activePushDrawer?.kind === "capability" ? activePushDrawer.key : null}
           onActiveKeyChange={(key) => setActivePushDrawer(key ? { kind: "capability", key } : null)}
-          launchers={attachmentsLaunchers}
+          launchers={railLaunchers}
           footerLaunchers={debugLaunchers}
         />
 

--- a/apps/frontend/src/rework/components/shared/molecules/ChatSidePanel/ChatSidePanel.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ChatSidePanel/ChatSidePanel.module.css
@@ -3,7 +3,7 @@
 .body {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-m);
+  gap: var(--spacing-s);
   padding: 0 var(--spacing-m) var(--spacing-m);
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/InlineDrawer/InlineDrawer.module.css
@@ -117,16 +117,19 @@
   border-left-color: transparent;
 }
 
+/* Asymmetric on purpose: 12px against the page edges and the conversation, 8px
+   on the right where the launcher rail sits — a gap to a neighbouring control
+   wants to be tighter than a gap to the edge of the page. */
 .drawer[data-floating="true"][data-layout="push"] .panel {
   top: var(--spacing-s);
-  right: var(--spacing-s);
+  right: var(--spacing-xs);
   bottom: var(--spacing-s);
   left: auto;
   box-shadow: var(--shadow-s);
   border: 1px solid var(--outline-muted);
   border-radius: var(--radius-m);
   background: var(--drawer-background, var(--surface-container));
-  width: calc(var(--drawer-width) - 2 * var(--spacing-s));
+  width: calc(var(--drawer-width) - var(--spacing-s) - var(--spacing-xs));
   overflow: hidden;
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.module.css
@@ -1,3 +1,11 @@
+/* The two narrowing controls, closer to each other than to the blocks around
+   them — the panel body's own gap separates groups, not their contents. */
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
 /* The list is the only part that scrolls: the space picker, the search field
    and the category chips stay reachable however long the list gets. */
 .list {

--- a/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.module.css
@@ -25,7 +25,7 @@
   flex-direction: column;
   gap: var(--spacing-3xs);
   cursor: pointer;
-  border: 1px solid transparent;
+  border: 1px solid var(--outline-muted);
   border-radius: var(--radius-s);
   background: none;
   padding: var(--spacing-xs) var(--spacing-s);

--- a/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.test.tsx
@@ -84,6 +84,10 @@ function mount(props: Partial<React.ComponentProps<typeof PromptSelectionChatPan
   });
 }
 
+function categoryTrigger(): HTMLButtonElement | null {
+  return container.querySelector('button[aria-haspopup="listbox"]');
+}
+
 function buttonWithText(text: string): HTMLButtonElement | undefined {
   return Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes(text));
 }
@@ -140,6 +144,33 @@ describe("PromptSelectionChatPanel", () => {
     mount({ isPersonalChat: true });
 
     expect(container.textContent).not.toContain("chatbot.promptSelectionPanel.space.team");
+  });
+
+  it("defaults the category filter to every category", () => {
+    mount();
+
+    // toContain, not toBe: the trigger also renders its dropdown arrow glyph.
+    expect(categoryTrigger()?.textContent).toContain("chatbot.promptSelectionPanel.allCategories");
+    expect(container.textContent).toContain("Weekly report");
+    expect(container.textContent).toContain("Bug triage");
+  });
+
+  it("carries each category's count in its option label", async () => {
+    // A menu row has no second column for a count, so it rides in the label —
+    // and it is what makes an empty category obvious before clicking it.
+    mount();
+    await click(categoryTrigger());
+
+    const options = document.body.textContent ?? "";
+    expect(options).toContain("Reports (1)");
+    expect(options).toContain("rework.promptCategories.noCategory (1)");
+  });
+
+  it("hides the category filter when the space has none", () => {
+    h.categoriesByTeam[TEAM_ID] = [];
+    mount();
+
+    expect(categoryTrigger()).toBeNull();
   });
 
   it("filters the list as the user searches", async () => {

--- a/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx
@@ -19,9 +19,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ButtonGroup from "@shared/atoms/ButtonGroup/ButtonGroup.tsx";
-import FilterChips from "@shared/molecules/FilterChips/FilterChips.tsx";
 import ChatSidePanel from "@shared/molecules/ChatSidePanel/ChatSidePanel.tsx";
 import SearchInput from "@shared/molecules/SearchInput/SearchInput.tsx";
+import Select from "@shared/molecules/Select/Select.tsx";
+import type { OptionModel } from "@models/Option.model.ts";
 import { Spinner } from "@shared/atoms/Spinner/Spinner.tsx";
 import { filterPrompts, NO_CATEGORY_FILTER_ID } from "@shared/utils/promptFilter.ts";
 import {
@@ -31,8 +32,12 @@ import {
 } from "../../../../../slices/controlPlane/controlPlaneOpenApi";
 import styles from "./PromptSelectionChatPanel.module.css";
 
-/** Chips shown before the "+N" toggle — same budget as the team prompts page. */
-const FILTER_VISIBLE = 4;
+/**
+ * "Every category" as a select value. A sentinel rather than `null`: the menu
+ * derives each option's DOM id from its value, and `null` would stringify.
+ * Mapped back to `null` — no filter — before it reaches the predicate.
+ */
+const ALL_CATEGORIES = "__all__";
 
 type Space = "team" | "personal";
 const SPACES: Space[] = ["team", "personal"];
@@ -136,6 +141,25 @@ export default function PromptSelectionChatPanel({
     return { byId, noCategory };
   }, [prompts, knownCategoryIds]);
 
+  // Counts ride in the label: a menu row has no second column for them, and the
+  // number is what makes an empty category obvious before clicking it.
+  const categoryOptions: OptionModel<string>[] = useMemo(
+    () => [
+      { value: ALL_CATEGORIES, key: ALL_CATEGORIES, label: t("chatbot.promptSelectionPanel.allCategories") },
+      {
+        value: NO_CATEGORY_FILTER_ID,
+        key: NO_CATEGORY_FILTER_ID,
+        label: `${t("rework.promptCategories.noCategory")} (${categoryCounts.noCategory})`,
+      },
+      ...categories.map((cat) => ({
+        value: cat.id,
+        key: cat.id,
+        label: `${cat.name} (${categoryCounts.byId.get(cat.id) ?? 0})`,
+      })),
+    ],
+    [categories, categoryCounts, t],
+  );
+
   const visiblePrompts = useMemo(
     () => filterPrompts(prompts, { search, categoryId: category, knownCategoryIds }),
     [prompts, search, category, knownCategoryIds],
@@ -181,25 +205,13 @@ export default function PromptSelectionChatPanel({
       />
 
       {categories.length > 0 && (
-        <FilterChips
-          options={[
-            {
-              id: NO_CATEGORY_FILTER_ID,
-              label: t("rework.promptCategories.noCategory"),
-              count: categoryCounts.noCategory,
-            },
-            ...categories.map((cat) => ({
-              id: cat.id,
-              label: cat.name,
-              count: categoryCounts.byId.get(cat.id) ?? 0,
-            })),
-          ]}
-          value={category}
-          onChange={setCategory}
-          allLabel={t("chatbot.promptSelectionPanel.allCategories")}
-          maxVisible={FILTER_VISIBLE}
-          showMoreLabel={(count) => `+${count}`}
-          showLessLabel="−"
+        <Select<string>
+          size="small"
+          compact
+          options={categoryOptions}
+          value={category ?? ALL_CATEGORIES}
+          onChange={(value) => setCategory(value === ALL_CATEGORIES ? null : value)}
+          ariaLabel={t("chatbot.promptSelectionPanel.categoryLabel")}
         />
       )}
 

--- a/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx
@@ -196,24 +196,28 @@ export default function PromptSelectionChatPanel({
         />
       )}
 
-      <SearchInput
-        value={search}
-        onChange={setSearch}
-        placeholder={t("chatbot.promptSelectionPanel.searchPlaceholder")}
-        clearAriaLabel={t("chatbot.promptSelectionPanel.clearSearch")}
-        size="small"
-      />
-
-      {categories.length > 0 && (
-        <Select<string>
+      {/* Search and category are one group — both narrow the same list — so they
+          sit tighter than the panel body's own spacing between blocks. */}
+      <div className={styles.filters}>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t("chatbot.promptSelectionPanel.searchPlaceholder")}
+          clearAriaLabel={t("chatbot.promptSelectionPanel.clearSearch")}
           size="small"
-          compact
-          options={categoryOptions}
-          value={category ?? ALL_CATEGORIES}
-          onChange={(value) => setCategory(value === ALL_CATEGORIES ? null : value)}
-          ariaLabel={t("chatbot.promptSelectionPanel.categoryLabel")}
         />
-      )}
+
+        {categories.length > 0 && (
+          <Select<string>
+            size="small"
+            compact
+            options={categoryOptions}
+            value={category ?? ALL_CATEGORIES}
+            onChange={(value) => setCategory(value === ALL_CATEGORIES ? null : value)}
+            ariaLabel={t("chatbot.promptSelectionPanel.categoryLabel")}
+          />
+        )}
+      </div>
 
       {isLoading ? (
         <div className={styles.state}>

--- a/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx
@@ -181,11 +181,13 @@ export default function PromptSelectionChatPanel({
       onClose={onClose}
       title={t("chatbot.promptSelectionPanel.title")}
       persistKey="prompt-selection-panel"
+      width="340px"
       fill
     >
       {canPickSpace && (
         <ButtonGroup
-          size="small"
+          // 2xs, not xs: ButtonGroup's ladder skips that tier.
+          size="2xs"
           color="secondary"
           variant="radio"
           fullWidth
@@ -204,12 +206,12 @@ export default function PromptSelectionChatPanel({
           onChange={setSearch}
           placeholder={t("chatbot.promptSelectionPanel.searchPlaceholder")}
           clearAriaLabel={t("chatbot.promptSelectionPanel.clearSearch")}
-          size="small"
+          size="xs"
         />
 
         {categories.length > 0 && (
           <Select<string>
-            size="small"
+            size="xs"
             compact
             options={categoryOptions}
             value={category ?? ALL_CATEGORIES}

--- a/apps/frontend/src/rework/components/shared/molecules/Select/Select.module.scss
+++ b/apps/frontend/src/rework/components/shared/molecules/Select/Select.module.scss
@@ -44,6 +44,12 @@
 
 .select-container[data-size="xs"] {
   --select-height: 2rem;
+
+  /* Body Medium on this compact tier, matching TextInput at the same size —
+   * Body Large is sized for a 40px control and reads oversized in 32px. */
+  .value {
+    font: var(--font-body-medium);
+  }
 }
 
 .select-container[data-size="small"] {

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -857,7 +857,10 @@ session attachments, prompt library — had drifted into three slightly differen
 "insets minus the top one" body rule). The shell fixes the treatment once:
 
 `layout="push"` so it reflows the conversation instead of covering it,
-`floating` (12px inset card, `outline-muted` border, `--radius-m`, soft shadow),
+`floating` (inset card, `outline-muted` border, `--radius-m`, soft shadow;
+12px from the page edges and the conversation, 8px on the right where the
+launcher rail sits — a gap to a neighbouring control is tighter than a gap to
+the page edge),
 `background: --surface-container-high`, `compactHeader` (a 12px/8px title band
 rather than the drawer's roomier 16px/12px — these panels sit in a narrow column
 beside the conversation; the settings and admin drawers keep the default),

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -916,7 +916,7 @@ personal prompts from a team chat. `ContextPromptPicker` and the
 push-drawer slot so it never stacks with the attachments, capability or
 document-scope panels. The shell supplies the header (title + close), the
 surface and the insets. Body, top to bottom: a `ButtonGroup` picking the space,
-a `SearchInput`, category `FilterChips`, then the list. Only the list scrolls.
+a `SearchInput`, a category `Select`, then the list. Only the list scrolls.
 
 **Two spaces, two queries.** `GET /teams/{id}/prompts/context` returns personal
 **or** team prompts depending on the id passed, never both — deliberately (a
@@ -930,12 +930,26 @@ on session load.
 In a personal chat the space picker is hidden: the team side would have nothing
 to show, and the chat's own team id *is* the personal space.
 
-**Categories are team-owned** (migration `8ca7cafc292f`), so the chips are
-fetched per space and the active category resets when the space changes. Chip
-counts come from the whole space, not the searched subset, so a number does not
-shift as the user types. The chips row is hidden when a space has no category.
-The search + category predicate is `promptFilter.ts`, shared with the team
-prompts page and unit-tested on its own.
+**Categories are team-owned** (migration `8ca7cafc292f`), so they are fetched
+per space and the active category resets when the space changes. The counts come
+from the whole space, not the searched subset, so a number does not shift as the
+user types. The control is hidden when a space has no category. The search +
+category predicate is `promptFilter.ts`, shared with the team prompts page and
+unit-tested on its own.
+
+**A dropdown, not chips (2026-09-04).** The panel opened with the same
+`FilterChips` row the team prompts page uses. That row is right on a full-width
+page and wrong in a narrow column, where it wrapped and ate the height the
+prompt list needs. It is now one unlabelled `Select` defaulting to "every
+category", with each option's count folded into its label — a menu row has no
+second column for a count, and the number is what makes an empty category
+obvious before picking it. `FilterChips` is unchanged and still serves
+`PromptsPage`.
+
+Two consequences worth knowing: a dropdown has no toggle-off, so clearing the
+filter means picking "Toutes" rather than clicking the active chip again; and
+"every category" travels as a sentinel value, not `null`, because the menu
+derives each option's DOM id from its value.
 
 **Insert.** Picking a row fetches the full record (`GetTeamPrompt` — `text`
 lives there, not on `ContextPromptSummary`) and appends it to the draft,

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -921,7 +921,13 @@ document-scope panels. The shell supplies the header (title + close), the
 surface and the insets. Body, top to bottom: a `ButtonGroup` picking the space,
 a `SearchInput` and a category `Select` grouped together at 8px — both narrow
 the same list, so they sit tighter than the body's 16px between blocks — then
-the list. Only the list scrolls.
+the list of outlined tiles. Only the list scrolls.
+
+The three controls run one tier below the app default, the panel being a narrow
+column: `xs` for the search field and the select, `2xs` for the space picker —
+`ButtonGroup`'s ladder has no `xs`, and `2xs` keeps it the same 8px shorter than
+the fields that it already was. The drawer opens at 340px rather than the 480px
+default; that only seeds the first-ever width, a dragged one persists.
 
 **Two spaces, two queries.** `GET /teams/{id}/prompts/context` returns personal
 **or** team prompts depending on the id passed, never both — deliberately (a

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -866,7 +866,7 @@ rather than the drawer's roomier 16px/12px — these panels sit in a narrow colu
 beside the conversation; the settings and admin drawers keep the default),
 `flushBody` plus a body that carries
 the insets the drawer's own padding would double up (`0 16px 16px` — the header
-already leaves the top gap) and a `--spacing-m` column gap, and drag-to-resize
+already leaves the top gap) and a `--spacing-s` column gap, and drag-to-resize
 with a persisted width (`persistKey`, unique per panel; `width` seeds the
 first-ever value only).
 
@@ -920,7 +920,7 @@ push-drawer slot so it never stacks with the attachments, capability or
 document-scope panels. The shell supplies the header (title + close), the
 surface and the insets. Body, top to bottom: a `ButtonGroup` picking the space,
 a `SearchInput` and a category `Select` grouped together at 8px — both narrow
-the same list, so they sit tighter than the body's 16px between blocks — then
+the same list, so they sit tighter than the body's 12px between blocks — then
 the list of outlined tiles. Only the list scrolls.
 
 The three controls run one tier below the app default, the panel being a narrow

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -916,7 +916,9 @@ personal prompts from a team chat. `ContextPromptPicker` and the
 push-drawer slot so it never stacks with the attachments, capability or
 document-scope panels. The shell supplies the header (title + close), the
 surface and the insets. Body, top to bottom: a `ButtonGroup` picking the space,
-a `SearchInput`, a category `Select`, then the list. Only the list scrolls.
+a `SearchInput` and a category `Select` grouped together at 8px — both narrow
+the same list, so they sit tighter than the body's 16px between blocks — then
+the list. Only the list scrolls.
 
 **Two spaces, two queries.** `GET /teams/{id}/prompts/context` returns personal
 **or** team prompts depending on the id passed, never both — deliberately (a


### PR DESCRIPTION
Follow-up to #2558, refining the prompt-selection panel now that it is in use.

## What

| Commit | Change |
| --- | --- |
| `67200ced` | Category filter: `FilterChips` row → a single `Select` |
| `02123db6` | Search + category grouped at 8px |
| `3f727e26` | A rail launcher for the prompt library |
| `31880b88` | 8px between a side panel and the rail |
| `19e6c006` | Controls one tier down, outlined tiles, 340px default width |
| `2ba11518` | Body Medium in an `xs` Select trigger |
| `d5cc8447` | 12px column gap in a chat panel body |

## Worth a look

**The chips became a dropdown.** That row is right on the full-width team
prompts page and wrong in a narrow column, where it wrapped and ate the height
the list needs. Each option's count rides in its label (`Reports (3)`) — a menu
row has no second column for one, and the number is what makes an empty
category obvious before picking it. `FilterChips` is untouched and still serves
`PromptsPage`.

"Every category" travels as a sentinel value rather than `null`, because the
menu derives each option's DOM id from its value.

Two behaviour notes: a dropdown has no toggle-off, so clearing the filter means
picking "Toutes"; and the 340px width only *seeds* the first-ever value, so
anyone who already dragged the panel keeps their own.

**The prompt library gets a second door.** A rail launcher beside the
attachments one. The composer's add-menu row stays — same panel, two ways in.

**Sizes don't share one ladder.** "One tier down" resolves differently per
component: `TextInput` and `Select` have an `xs`, `ButtonGroup` does not
(`2xs / small / medium`). So the fields go to `xs` (40→32px) and the space
picker to `2xs` (32→24px), which leaves it the same 8px shorter than the fields
it already was. Passing `xs` to `ButtonGroup` would have done nothing at all.

## Two shared-component changes

Both narrow, both verified for blast radius:

- **`InlineDrawer`** — the floating card's right inset drops to 8px (the width
  calc following, so the left inset stays 12px against the conversation). Only
  `ChatSidePanel` and `CapabilitySidePanelHost` use `floating`, and both sit
  next to the rail. Deliberately asymmetric: a gap to a neighbouring control
  wants to be tighter than a gap to the page edge.
- **`Select`** — the trigger's value text was Body Large at every tier, sized
  for a 40px control and oversized in the 32px `xs` one. It now matches
  `TextInput` at the same size. The prompt panel is the only `xs` consumer today.

## Scope note

The 12px body gap lives in `ChatSidePanel`, so it moves all four chat panels
rather than the prompt panel alone — the shell's whole point. Flagged rather
than assumed; say the word and it can be scoped.

## Tests

3 added, covering the category filter through the UI — a gap the previous PR
left, since the predicate was unit-tested but its wiring was not: the default
"every category" value, the counts in the option labels, and the control hidden
when a space has none.

Whole suite: **1825 passed, 2 skipped, 183 files**. `tsc`, `eslint`, `prettier`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)