### PR TITLE
fix(#2591): Excel ingestion no longer fails on a chart openpyxl cannot read

### DIFF
--- a/apps/knowledge-flow-backend/knowledge_flow_backend/compat/openpyxl_patch.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/compat/openpyxl_patch.py
@@ -1,0 +1,44 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Workaround for openpyxl's chart reader (3.1.5): `read_chart` indexes
+`plotArea._charts[0]` unguarded, so a chart whose plotArea carries no plot type
+openpyxl knows makes `load_workbook` raise IndexError and the whole workbook
+unreadable. Charts are irrelevant to Excel extraction (cells only), so such a
+chart is read as an empty placeholder instead. Applied once at import,
+from `excel_processor.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import openpyxl.reader.drawings as _drawings
+from openpyxl.chart import BarChart
+from openpyxl.chart.chartspace import ChartSpace
+from openpyxl.chart.reader import read_chart as original_read_chart
+
+
+def tolerant_read_chart(chartspace: ChartSpace) -> Any:
+    # `_charts` is an openpyxl descriptor, invisible to the type checker.
+    plot = cast(Any, chartspace.chart.plotArea)
+    if not plot._charts:
+        plot._charts = [BarChart()]
+    return original_read_chart(chartspace)
+
+
+# `find_images` resolves `read_chart` from its own module globals, so this is
+# the one binding that matters.
+cast(Any, _drawings).read_chart = tolerant_read_chart

--- a/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/excel_processor/excel_processor.py
+++ b/apps/knowledge-flow-backend/knowledge_flow_backend/core/processors/input/excel_processor/excel_processor.py
@@ -47,6 +47,7 @@ import pandas as pd
 from openpyxl import load_workbook
 from tabulate import tabulate
 
+from knowledge_flow_backend.compat import openpyxl_patch  # noqa: F401
 from knowledge_flow_backend.core.processors.input.common.base_input_processor import (
     BaseMarkdownProcessor,
     InputConversionError,

--- a/apps/knowledge-flow-backend/tests/compat/__init__.py
+++ b/apps/knowledge-flow-backend/tests/compat/__init__.py
@@ -1,0 +1,14 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/knowledge-flow-backend/tests/compat/test_openpyxl_patch.py
+++ b/apps/knowledge-flow-backend/tests/compat/test_openpyxl_patch.py
@@ -1,0 +1,89 @@
+# Copyright Thales 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests of the openpyxl chart-reader workaround.
+
+`empty_plotarea_workbook` builds a real workbook whose only chart had its
+`<barChart>` element stripped: the plotArea keeps its layout and axes but no
+plot type, which is what a chart written by a tool openpyxl does not
+understand looks like.
+"""
+
+from __future__ import annotations
+
+import re
+import zipfile
+
+import pytest
+from openpyxl import Workbook, load_workbook
+from openpyxl.chart import BarChart, LineChart, Reference
+from openpyxl.chart.chartspace import ChartContainer, ChartSpace
+from openpyxl.chart.plotarea import PlotArea
+
+from knowledge_flow_backend.compat import openpyxl_patch
+
+
+def _add_chart(ws, chart, anchor):
+    chart.add_data(Reference(ws, min_col=2, min_row=1, max_row=4))
+    ws.add_chart(chart, anchor)
+
+
+@pytest.fixture
+def empty_plotarea_workbook(tmp_path):
+    """Sheet with values, one chart openpyxl cannot read (chart1) and one valid line chart (chart2)."""
+    wb = Workbook()
+    ws = wb.active
+    for r in range(1, 5):
+        ws.append([r, r * 2])
+    _add_chart(ws, BarChart(), "D2")
+    _add_chart(ws, LineChart(), "D20")
+    src = tmp_path / "src.xlsx"
+    wb.save(src)
+
+    dst = tmp_path / "empty_plotarea.xlsx"
+    with zipfile.ZipFile(src) as zin, zipfile.ZipFile(dst, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if item.filename == "xl/charts/chart1.xml":
+                data, n = re.subn(rb"<barChart>.*?</barChart>", b"", data, flags=re.S)
+                assert n == 1
+            zout.writestr(item, data)
+    return dst
+
+
+def test_original_read_chart_still_fails_on_empty_plotarea():
+    # Canary: exercises openpyxl itself, not the workaround. If this test fails,
+    # openpyxl fixed the bug upstream — delete openpyxl_patch.py, its import in
+    # excel_processor.py and this test file.
+    chartspace = ChartSpace(chart=ChartContainer(plotArea=PlotArea()))
+    with pytest.raises(IndexError):
+        openpyxl_patch.original_read_chart(chartspace)
+
+
+def test_workbook_with_unreadable_chart_loads_and_keeps_valid_chart(empty_plotarea_workbook):
+    wb = load_workbook(empty_plotarea_workbook)
+    ws = wb.active
+    assert [c.value for c in ws["A"]] == [1, 2, 3, 4]
+    assert [c.value for c in ws["B"]] == [2, 4, 6, 8]
+    assert [type(c).__name__ for c in ws._charts] == ["BarChart", "LineChart"]
+    placeholder, kept = ws._charts
+    assert placeholder.series == []
+    assert len(kept.series) == 1
+
+
+def test_patch_is_installed_where_find_images_looks():
+    import openpyxl.reader.drawings as drawings
+
+    assert drawings.read_chart is openpyxl_patch.tolerant_read_chart

--- a/docs/swift/design/DESIGN.md
+++ b/docs/swift/design/DESIGN.md
@@ -176,6 +176,13 @@ never happens.
   opt-in for `.xlsx`/`.xlsm` and **mandatory** for legacy `.xls` (openpyxl
   cannot read binary BIFF) — this is how `.xls` support actually shipped,
   not via `xlrd`.
+- **Charts never block extraction.** openpyxl 3.1.5 aborts `load_workbook`
+  with an `IndexError` on a chart whose `plotArea` holds no plot type it
+  knows (a chart written by another tool). `compat/openpyxl_patch.py` patches the
+  chart reader at import so such a chart loads as an empty placeholder;
+  valid charts are untouched, and cells are all the extractor reads anyway.
+  A canary test asserts the upstream bug is still present — when it fails,
+  drop the module, its import and the test.
 - **Display-fidelity masking** — values hidden by Excel number format, zeros
   hidden by `showZeros=False`, and error cells are all treated as empty, so
   extraction matches what a human sees on screen.
@@ -199,7 +206,8 @@ never happens.
 
 **Code map:** `core/processors/input/excel_processor/excel_extractor.py`
 (`ExcelExtractor`, phases), `excel_processor.py` (`ExcelProcessor`, I/O +
-LibreOffice recalc), `core/processors/output/excel_processor/
+LibreOffice recalc), `compat/openpyxl_patch.py` (chart-reader workaround),
+`core/processors/output/excel_processor/
 excel_table_registration_processor.py` (output stage).
 
 **Tabular value locator (`search_tabular_values`):** a read-only


### PR DESCRIPTION
Closes #2591

## Summary
- A real `.xlsx` failed ingestion on every Temporal retry: openpyxl 3.1.5 indexes `plotArea._charts[0]` unguarded in `read_chart`, so one chart whose `plotArea` holds no plot type openpyxl knows makes `load_workbook` raise `IndexError` and the whole workbook uningestable. The pre-check passes because it opens in `read_only` mode, which skips drawings; only the full load in `_build_extractor` parses charts.
- `compat/openpyxl_patch.py` patches `openpyxl.reader.drawings.read_chart` at import, the one binding `find_images` resolves: such a chart loads as an empty placeholder `BarChart`, valid charts are untouched. Charts are irrelevant to Excel extraction (cells only). Same side-effect-import pattern as `compat/fastapi_mcp_patch.py`, imported from `excel_processor.py`.
- Not caused by LibreOffice: 24.2.7 round-trips all 16 OOXML chart types plus of-pie, combo, data-table, chartsheet and series-less charts, and openpyxl reads every result. No existing upstream issue on the openpyxl tracker (closest is #1250, same function, empty series, fixed in 2019); an upstream ticket with a self-contained reproduction is being filed separately.
- `docs/swift/design/DESIGN.md` §1: one bullet and a code-map entry.

## Test plan
- [x] `tests/compat/test_openpyxl_patch.py`: canary calling the original `read_chart` on an empty `plotArea` (asserts `IndexError`; when it fails, openpyxl fixed the bug upstream and the patch, its import and the test are to be deleted), behaviour test on a synthetic workbook with one unreadable and one valid chart (values extracted, both charts present), and a check that the patch sits on the binding `find_images` uses.
- [x] `pytest tests/compat tests/processors/input/excel_processor`: 165 passed
- [x] `make code-quality` on `apps/knowledge-flow-backend`: green (ruff, basedpyright 0 errors). The monorepo-root run stops earlier on a pre-existing detect-secrets false positive in `libs/fred-runtime/tests/test_react_tool_resolution.py:58` from #2575, unrelated.
- [ ] Re-upload the workbook that triggered #2591 on a worker running this branch