### PR TITLE
feat(chat): outline rail for navigating a long conversation

### DIFF
--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ConversationThread/ConversationThread.tsx
@@ -74,7 +74,12 @@ export const ConversationThread = memo(function ConversationThread({
           // docstring) — so translate it here; an unrecognized id falls back
           // to showing the raw text rather than nothing.
           const key = msg.role === "hitl_response" ? hitlResponseKey(msg.text) : null;
-          return <UserTurn key={msg.id} text={key ? t(key) : msg.text} />;
+          // Only a real user turn anchors the outline rail — a hitl_response
+          // renders through UserTurn but is a reply to the agent, not a turn
+          // anyone navigates back to.
+          return (
+            <UserTurn key={msg.id} turnId={msg.role === "user" ? msg.id : undefined} text={key ? t(key) : msg.text} />
+          );
         }
         if (msg.role === "hitl_request") {
           const frozenEvent: RuntimeAwaitingHumanEvent = {

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.module.css
@@ -196,6 +196,18 @@
   user-select: none;
 }
 
+/* ── Conversation stage — positioning context for the outline rail ───────
+   Wraps the scroll container alone, not the composer below it: the rail
+   centres itself on this box, and anchoring it on .mainColumn would push that
+   centre down by half the composer's height. */
+.conversationStage {
+  display: flex;
+  position: relative;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
 /* ── Single scroll container — flexes to fill the space between the in-flow
    top bar and composer. A soft mask fades content near both edges so it
    dissolves into the bars instead of cutting off with a hard line, which is

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { DragEvent, useEffect, useMemo, useRef, useState } from "react";
+import { DragEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { ConversationThread } from "./ConversationThread/ConversationThread";
+import { ConversationOutlineRail } from "@shared/molecules/ConversationOutlineRail/ConversationOutlineRail";
+import { sameOutline, toOutlineItems, toOutlinePreview } from "@shared/molecules/ConversationOutlineRail/outlineItems";
+import type { OutlineItem } from "@shared/molecules/ConversationOutlineRail/outlineItems";
 import { RichInputField } from "@shared/molecules/RichInputField/RichInputField";
 import { SessionTitleEditor } from "@shared/molecules/SessionTitleEditor/SessionTitleEditor";
 import { DebugRawDrawer } from "@shared/molecules/DebugRawDrawer/DebugRawDrawer";
@@ -36,6 +39,8 @@ import { selectSidePanelOpenRequest } from "../../../features/capabilities/sideP
 import PromptSelectionChatPanel from "@shared/molecules/PromptSelectionChatPanel/PromptSelectionChatPanel.tsx";
 import { conversationTokenTotals } from "./toThreadMessages";
 import { useChatAutoScroll } from "../../../core/hooks/useChatAutoScroll";
+import { useConversationJump } from "../../../core/hooks/useConversationJump";
+import { useOutlineScrollSpy } from "../../../core/hooks/useOutlineScrollSpy";
 import { useManagedChat } from "./useManagedChat";
 import { useUploadWarningAcknowledgement } from "../../../core/hooks/useUploadWarningAcknowledgement";
 import { usePastedFiles } from "./usePastedFiles";
@@ -190,6 +195,35 @@ export default function ManagedChatPage() {
     traceCount: lastTurn?.traceMessages.length ?? 0,
     isAwaitingHuman: chat.pendingHitl != null,
   });
+  // ── Outline rail ────────────────────────────────────────────────────────
+  // Frozen while a turn runs: the rail then takes no input, so it can never
+  // write the conversation's scroll position while useChatAutoScroll owns it.
+  const outlineFrozen = chat.waitResponse || chat.pendingHitl != null;
+  // Derived from the messages themselves, then handed back by identity when it
+  // describes the same rail. The message list is replaced on every streamed
+  // token, so a plain memo would re-render every mark tens of times a second;
+  // a coarser key (session + turn count) avoids that but goes stale instead,
+  // since `sessionId` changes a render before the messages do — switching
+  // between two cached conversations of equal length would leave the previous
+  // one's marks on screen. The fold itself is a linear scan over small objects.
+  const outlineItemsRef = useRef<OutlineItem[]>([]);
+  const outlineItems = useMemo(() => {
+    const next = toOutlineItems(chat.threadMessages);
+    if (sameOutline(outlineItemsRef.current, next)) return outlineItemsRef.current;
+    outlineItemsRef.current = next;
+    return next;
+  }, [chat.threadMessages]);
+  const activeTurnId = useOutlineScrollSpy(scrollContainerRef, chat.sessionId, outlineItems.length);
+  const jumpToTurn = useConversationJump(scrollContainerRef, outlineFrozen);
+  // Reads the message list only when a mark is actually hovered — see
+  // ConversationOutlineRail's PreviewTile. Through a ref, so this callback keeps
+  // one identity for the life of the page: keyed on `threadMessages` it would
+  // change on every streamed token and defeat the rail's own `memo`, which is
+  // the whole thing that keeps streaming off the rail's back.
+  const threadMessagesRef = useRef(chat.threadMessages);
+  threadMessagesRef.current = chat.threadMessages;
+  const outlinePreview = useCallback((turnId: string) => toOutlinePreview(threadMessagesRef.current, turnId), []);
+
   // CAPAB-01 #1976: attachments are allowed when the resolved chat controls
   // (ExecutionPreparation.chat_controls) include an `attach_files` descriptor —
   // supersedes the retired `EffectiveChatOptions.attach_files`.
@@ -522,29 +556,43 @@ export default function ManagedChatPage() {
                   </div>
                 )}
 
-                <div
-                  className={`${styles.chatArea} ${isInitialState ? styles.chatAreaInitial : ""}`}
-                  ref={scrollContainerRef}
-                >
-                  {isInitialState ? (
-                    <div className={styles.initialStage}>
-                      <ManagedChatWelcome />
-                      <div className={styles.initialComposer}>
-                        {composer}
-                        <div className={styles.aiDisclaimer}>{t("chatbot.aiDisclaimer")}</div>
+                {/* Positioning context for the outline rail, scoped to the
+                    conversation alone — anchoring it on mainColumn would centre
+                    the rail across the composer too. */}
+                <div className={styles.conversationStage}>
+                  <div
+                    className={`${styles.chatArea} ${isInitialState ? styles.chatAreaInitial : ""}`}
+                    ref={scrollContainerRef}
+                  >
+                    {isInitialState ? (
+                      <div className={styles.initialStage}>
+                        <ManagedChatWelcome />
+                        <div className={styles.initialComposer}>
+                          {composer}
+                          <div className={styles.aiDisclaimer}>{t("chatbot.aiDisclaimer")}</div>
+                        </div>
                       </div>
-                    </div>
-                  ) : (
-                    <ConversationThread
-                      messages={chat.threadMessages}
-                      pendingHitl={chat.pendingHitl}
-                      isLoading={chat.isLoadingHistory}
-                      isStreaming={chat.waitResponse}
-                      scrollContainerRef={scrollContainerRef}
-                      onHitlAnswer={chat.handleHitlAnswer}
-                      maxChatInputChars={chat.maxChatInputChars}
-                      hitlFreeText={chat.hitlFreeText}
-                      onHitlFreeTextChange={chat.setHitlFreeText}
+                    ) : (
+                      <ConversationThread
+                        messages={chat.threadMessages}
+                        pendingHitl={chat.pendingHitl}
+                        isLoading={chat.isLoadingHistory}
+                        isStreaming={chat.waitResponse}
+                        scrollContainerRef={scrollContainerRef}
+                        onHitlAnswer={chat.handleHitlAnswer}
+                        maxChatInputChars={chat.maxChatInputChars}
+                        hitlFreeText={chat.hitlFreeText}
+                        onHitlFreeTextChange={chat.setHitlFreeText}
+                      />
+                    )}
+                  </div>
+                  {!isInitialState && (
+                    <ConversationOutlineRail
+                      items={outlineItems}
+                      activeId={activeTurnId}
+                      frozen={outlineFrozen}
+                      onJump={jumpToTurn}
+                      getPreview={outlinePreview}
                     />
                   )}
                 </div>

--- a/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
+++ b/apps/frontend/src/rework/components/pages/ManagedChatPage/ManagedChatPage.tsx
@@ -18,8 +18,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { ConversationThread } from "./ConversationThread/ConversationThread";
 import { ConversationOutlineRail } from "@shared/molecules/ConversationOutlineRail/ConversationOutlineRail";
-import { sameOutline, toOutlineItems, toOutlinePreview } from "@shared/molecules/ConversationOutlineRail/outlineItems";
-import type { OutlineItem } from "@shared/molecules/ConversationOutlineRail/outlineItems";
+import { sameTurnIds, toOutlinePreview, toTurnIds } from "@shared/molecules/ConversationOutlineRail/outlineItems";
 import { RichInputField } from "@shared/molecules/RichInputField/RichInputField";
 import { SessionTitleEditor } from "@shared/molecules/SessionTitleEditor/SessionTitleEditor";
 import { DebugRawDrawer } from "@shared/molecules/DebugRawDrawer/DebugRawDrawer";
@@ -206,14 +205,14 @@ export default function ManagedChatPage() {
   // since `sessionId` changes a render before the messages do — switching
   // between two cached conversations of equal length would leave the previous
   // one's marks on screen. The fold itself is a linear scan over small objects.
-  const outlineItemsRef = useRef<OutlineItem[]>([]);
-  const outlineItems = useMemo(() => {
-    const next = toOutlineItems(chat.threadMessages);
-    if (sameOutline(outlineItemsRef.current, next)) return outlineItemsRef.current;
-    outlineItemsRef.current = next;
+  const outlineTurnIdsRef = useRef<string[]>([]);
+  const outlineTurnIds = useMemo(() => {
+    const next = toTurnIds(chat.threadMessages);
+    if (sameTurnIds(outlineTurnIdsRef.current, next)) return outlineTurnIdsRef.current;
+    outlineTurnIdsRef.current = next;
     return next;
   }, [chat.threadMessages]);
-  const activeTurnId = useOutlineScrollSpy(scrollContainerRef, chat.sessionId, outlineItems.length);
+  const activeTurnId = useOutlineScrollSpy(scrollContainerRef, outlineTurnIds, outlineFrozen);
   const jumpToTurn = useConversationJump(scrollContainerRef, outlineFrozen);
   // Reads the message list only when a mark is actually hovered — see
   // ConversationOutlineRail's PreviewTile. Through a ref, so this callback keeps
@@ -588,7 +587,7 @@ export default function ManagedChatPage() {
                   </div>
                   {!isInitialState && (
                     <ConversationOutlineRail
-                      items={outlineItems}
+                      turnIds={outlineTurnIds}
                       activeId={activeTurnId}
                       frozen={outlineFrozen}
                       onJump={jumpToTurn}

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.test.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.test.tsx
@@ -344,4 +344,64 @@ describe("Tooltip", () => {
     expect(top).toBeGreaterThanOrEqual(4);
     expect(top + 380).toBeLessThanOrEqual(400 - 4);
   });
+
+  // `gapPx` exists for a panel that reads as its own card rather than a hint
+  // stuck to its trigger — the conversation outline rail's preview tile.
+  it("honours a custom gap on both axes of a left-placed panel", () => {
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1000, configurable: true });
+
+    act(() => {
+      root.render(
+        <Tooltip content={<div>Detail</div>} placement="left" gapPx={12}>
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    wrapper.getBoundingClientRect = () =>
+      ({ top: 190, bottom: 210, left: 400, right: 420, width: 20, height: 20 }) as DOMRect;
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    const panel = document.querySelector('[role="tooltip"]') as HTMLElement;
+    panel.getBoundingClientRect = () => ({ width: 200, height: 100 }) as DOMRect;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    // 400 (trigger left) - 12 (gap) - 200 (panel width).
+    expect(parseFloat(panel.style.left)).toBe(188);
+    // Still vertically centred on the trigger: 200 (centre) - 50 (half height).
+    expect(parseFloat(panel.style.top)).toBe(150);
+  });
+
+  it("keeps its default gap when none is given", () => {
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1000, configurable: true });
+
+    act(() => {
+      root.render(
+        <Tooltip content={<div>Detail</div>} placement="left">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    wrapper.getBoundingClientRect = () =>
+      ({ top: 190, bottom: 210, left: 400, right: 420, width: 20, height: 20 }) as DOMRect;
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    const panel = document.querySelector('[role="tooltip"]') as HTMLElement;
+    panel.getBoundingClientRect = () => ({ width: 200, height: 100 }) as DOMRect;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    // 400 - 4 - 200: the 4px default every other tooltip in the app relies on.
+    expect(parseFloat(panel.style.left)).toBe(196);
+  });
 });

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.test.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.test.tsx
@@ -345,6 +345,96 @@ describe("Tooltip", () => {
     expect(top + 380).toBeLessThanOrEqual(400 - 4);
   });
 
+  it("places a right-placed panel beside the trigger, vertically centred", () => {
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1000, configurable: true });
+
+    act(() => {
+      root.render(
+        <Tooltip content={<div>Detail</div>} placement="right" gapPx={12}>
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    // A trigger against the left edge — the outline rail's case.
+    wrapper.getBoundingClientRect = () =>
+      ({ top: 190, bottom: 210, left: 12, right: 44, width: 32, height: 20 }) as DOMRect;
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    const panel = document.querySelector('[role="tooltip"]') as HTMLElement;
+    panel.getBoundingClientRect = () => ({ width: 200, height: 100 }) as DOMRect;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    // 12 (trigger left) + 32 (trigger width) + 12 (gap).
+    expect(parseFloat(panel.style.left)).toBe(56);
+    // 200 (trigger centre) - 50 (half the panel).
+    expect(parseFloat(panel.style.top)).toBe(150);
+  });
+
+  it("flips a right-placed panel to the left when there is no room", () => {
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1000, configurable: true });
+
+    act(() => {
+      root.render(
+        <Tooltip content={<div>Detail</div>} placement="right" gapPx={12}>
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    wrapper.getBoundingClientRect = () =>
+      ({ top: 190, bottom: 210, left: 900, right: 932, width: 32, height: 20 }) as DOMRect;
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    const panel = document.querySelector('[role="tooltip"]') as HTMLElement;
+    panel.getBoundingClientRect = () => ({ width: 200, height: 100 }) as DOMRect;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    // 900 - 12 - 200: to the left, since 944 + 200 overflows a 1000px viewport.
+    expect(parseFloat(panel.style.left)).toBe(688);
+  });
+
+  // Leaving the window produces no mouseleave, so a tooltip hovered at the
+  // moment of an alt-tab stayed open on return — and, its own leave event
+  // having been lost, stayed open next to the next one hovered.
+  it("closes when the window loses focus", () => {
+    const trigger = renderTooltip();
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    expect(document.querySelector('[role="tooltip"]')).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it("closes when the page is hidden", () => {
+    const trigger = renderTooltip();
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    expect(document.querySelector('[role="tooltip"]')).not.toBeNull();
+
+    const hidden = vi.spyOn(document, "hidden", "get").mockReturnValue(true);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+    hidden.mockRestore();
+  });
+
   // `gapPx` exists for a panel that reads as its own card rather than a hint
   // stuck to its trigger — the conversation outline rail's preview tile.
   it("honours a custom gap on both axes of a left-placed panel", () => {

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
@@ -52,8 +52,11 @@ interface TooltipProps {
    * - `"left"`: to the left of the trigger, vertically centred on it, flipping
    *   right when there's no room. Suited to a trigger hugging the viewport's
    *   right edge (e.g. a right-rail icon button).
+   * - `"right"`: the mirror image — to the right, vertically centred, flipping
+   *   left when there's no room. For a trigger against the left edge (e.g. the
+   *   conversation outline rail).
    */
-  placement?: "top" | "left";
+  placement?: "top" | "left" | "right";
   /** Distance between trigger and panel. Defaults to `TOOLTIP_GAP_PX`; raise it
    *  for a panel that reads as its own card rather than a hint attached to the
    *  trigger. */
@@ -170,6 +173,28 @@ export const Tooltip = ({
     }
   }, [visible, updateTriggerRect]);
 
+  // Leaving the window does not produce a mouseleave: alt-tab away while
+  // hovering a trigger and the pointer is simply gone, with `isHovering` stuck
+  // true. The tooltip is then still open on return, and — since its own leave
+  // event will never arrive — stays open alongside the next one hovered. Common
+  // enough on a rail of many triggers that two panels sit on screen at once.
+  useEffect(() => {
+    if (!visible) return;
+    const close = () => {
+      window.clearTimeout(hideTimer.current);
+      setIsHovering(false);
+    };
+    const onVisibilityChange = () => {
+      if (document.hidden) close();
+    };
+    window.addEventListener("blur", close);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("blur", close);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [visible]);
+
   // A visible tooltip tracks the trigger's position through scroll/resize —
   // without this, scrolling the table while hovering leaves it stranded.
   useEffect(() => {
@@ -218,13 +243,19 @@ export const Tooltip = ({
     // bottom edge cannot escape however wrong the measurement was.
     let top: number;
     let left: number;
-    if (placement === "left") {
-      // To the left of the trigger, flipping right only when it wouldn't fit
-      // (trigger hugging the viewport's left edge).
-      const fitsLeftSide = triggerRect.left - width - gapPx >= VIEWPORT_MARGIN_PX;
-      const desiredLeft = fitsLeftSide
-        ? triggerRect.left - gapPx - width
-        : triggerRect.left + triggerRect.width + gapPx;
+    if (placement === "left" || placement === "right") {
+      // Beside the trigger on the preferred side, flipping to the other only
+      // when it wouldn't fit (a trigger hugging that edge of the viewport).
+      const beforeTrigger = triggerRect.left - gapPx - width;
+      const afterTrigger = triggerRect.left + triggerRect.width + gapPx;
+      const desiredLeft =
+        placement === "left"
+          ? triggerRect.left - width - gapPx >= VIEWPORT_MARGIN_PX
+            ? beforeTrigger
+            : afterTrigger
+          : afterTrigger + width <= viewportWidth() - VIEWPORT_MARGIN_PX
+            ? afterTrigger
+            : beforeTrigger;
       left = Math.max(VIEWPORT_MARGIN_PX, Math.min(desiredLeft, viewportWidth() - VIEWPORT_MARGIN_PX - width));
       // Vertically centred on the trigger.
       const center = (triggerRect.top + triggerRect.bottom) / 2;

--- a/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
+++ b/apps/frontend/src/rework/components/shared/atoms/Tooltip/Tooltip.tsx
@@ -54,6 +54,10 @@ interface TooltipProps {
    *   right edge (e.g. a right-rail icon button).
    */
   placement?: "top" | "left";
+  /** Distance between trigger and panel. Defaults to `TOOLTIP_GAP_PX`; raise it
+   *  for a panel that reads as its own card rather than a hint attached to the
+   *  trigger. */
+  gapPx?: number;
   children: ReactNode;
 }
 
@@ -92,7 +96,14 @@ function trackFocusModality() {
 
 if (typeof document !== "undefined") trackFocusModality();
 
-export const Tooltip = ({ text, content, children, interactive = false, placement = "top" }: TooltipProps) => {
+export const Tooltip = ({
+  text,
+  content,
+  children,
+  interactive = false,
+  placement = "top",
+  gapPx = TOOLTIP_GAP_PX,
+}: TooltipProps) => {
   const tooltipId = useId();
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
@@ -210,18 +221,18 @@ export const Tooltip = ({ text, content, children, interactive = false, placemen
     if (placement === "left") {
       // To the left of the trigger, flipping right only when it wouldn't fit
       // (trigger hugging the viewport's left edge).
-      const fitsLeftSide = triggerRect.left - width - TOOLTIP_GAP_PX >= VIEWPORT_MARGIN_PX;
+      const fitsLeftSide = triggerRect.left - width - gapPx >= VIEWPORT_MARGIN_PX;
       const desiredLeft = fitsLeftSide
-        ? triggerRect.left - TOOLTIP_GAP_PX - width
-        : triggerRect.left + triggerRect.width + TOOLTIP_GAP_PX;
+        ? triggerRect.left - gapPx - width
+        : triggerRect.left + triggerRect.width + gapPx;
       left = Math.max(VIEWPORT_MARGIN_PX, Math.min(desiredLeft, viewportWidth() - VIEWPORT_MARGIN_PX - width));
       // Vertically centred on the trigger.
       const center = (triggerRect.top + triggerRect.bottom) / 2;
       const desiredTop = center - height / 2;
       top = Math.max(VIEWPORT_MARGIN_PX, Math.min(desiredTop, viewportHeight() - VIEWPORT_MARGIN_PX - height));
     } else {
-      const fitsAbove = triggerRect.top - height - TOOLTIP_GAP_PX >= VIEWPORT_MARGIN_PX;
-      const desiredTop = fitsAbove ? triggerRect.top - TOOLTIP_GAP_PX - height : triggerRect.bottom + TOOLTIP_GAP_PX;
+      const fitsAbove = triggerRect.top - height - gapPx >= VIEWPORT_MARGIN_PX;
+      const desiredTop = fitsAbove ? triggerRect.top - gapPx - height : triggerRect.bottom + gapPx;
       top = Math.max(VIEWPORT_MARGIN_PX, Math.min(desiredTop, viewportHeight() - VIEWPORT_MARGIN_PX - height));
 
       // Aligned on the trigger's own left edge (no centring transform): centring
@@ -239,7 +250,7 @@ export const Tooltip = ({ text, content, children, interactive = false, placemen
       maxWidth: availableWidth,
       overflow: "auto",
     });
-  }, [triggerRect, placement]);
+  }, [triggerRect, placement, gapPx]);
 
   const child = isValidElement(children)
     ? cloneElement(children as ReactElement<{ "aria-describedby"?: string }>, { "aria-describedby": tooltipId })

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
@@ -3,7 +3,6 @@
 /* Against the page's left edge, not the conversation's. The rail is chrome for
    the whole page, and tying it to the lane made it drift inward with the
    reading column instead of staying where the reader's eye learns to find it.
-   The inset matches the top bar's, which is what sets the page's edge.
 
    The cost is known and accepted: on a column barely wider than the lane — one
    with a side panel open — the rail sits over the first characters of each
@@ -24,7 +23,7 @@
   display: flex;
   position: absolute;
   top: 50%;
-  left: var(--spacing-s);
+  left: var(--spacing-xs);
   flex-direction: column;
   transform: translateY(-50%);
   /* Widest a magnified mark gets, so magnifying never reflows anything. */

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
@@ -1,0 +1,157 @@
+/* Outline rail — one mark per turn, along the conversation's left edge.
+   Marks are outside the squircle scope, so they take a plain radius token. */
+
+/* Sized to its marks and centred, never a full-height overlay. The rail is a
+   SIBLING of the scroll container, so a wheel gesture over it has no scrollable
+   ancestor to chain to and the conversation would simply not move — the dead
+   left gutter reported before. Hugging the marks keeps that surface to the few
+   pixels the reader is deliberately pointing at, where scrolling the rail is
+   the sensible reading of the gesture anyway.
+
+   Capped at the available height, at which point it scrolls itself: newest
+   turns stay reachable at the bottom and older ones leave through the top, the
+   same reading model as the conversation. Landing there is the reveal effect's
+   job (ConversationOutlineRail.tsx), which follows the active mark. */
+.rail {
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: var(--spacing-m);
+  flex-direction: column;
+  transform: translateY(-50%);
+  /* Widest a magnified mark gets, so magnifying never reflows anything. */
+  width: 32px;
+  max-height: 100%;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.rail::-webkit-scrollbar {
+  display: none;
+}
+
+.marks {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+/* Each mark is wrapped — by Tooltip when interactive, by .markSlot when frozen.
+   The magnification rules below key off these wrappers, so they must stay a
+   uniform, styling-free row. */
+.marks > * {
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  width: 100%;
+}
+
+.markSlot {
+  display: flex;
+  justify-content: center;
+}
+
+.mark {
+  flex-shrink: 0;
+  transition:
+    width var(--duration-short-3) var(--easing-emphasized),
+    height var(--duration-short-3) var(--easing-emphasized),
+    background-color var(--duration-short-3) var(--easing-standard);
+  cursor: pointer;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--outline-variant);
+  padding: 0;
+  width: var(--mark-w, 14px);
+  height: calc(var(--mark-h) + var(--mark-grow, 0px));
+}
+
+/* Height buckets — driven by the agent answer's length (outlineItems.ts). */
+.short {
+  --mark-h: 3px;
+}
+
+.medium {
+  --mark-h: 6px;
+}
+
+.tall {
+  --mark-h: 10px;
+}
+
+/* ── Magnification ──────────────────────────────────────────────────────────
+   Discrete falloff over the hovered mark and two neighbours each side, so the
+   rail deforms as one surface instead of a single mark popping alone. Sizing
+   only — colour is handled below, and mixing the two here would make the
+   active mark's colour depend on where the pointer happens to be.
+
+   Forward neighbours use sibling combinators; backward ones need `:has()`,
+   CSS having no previous-sibling combinator. Both are already used elsewhere
+   in this codebase. */
+.marks > *:hover .mark {
+  --mark-w: 32px;
+  --mark-grow: 3px;
+}
+
+.marks > *:hover + * .mark,
+.marks > *:has(+ *:hover) .mark {
+  --mark-w: 24px;
+  --mark-grow: 2px;
+}
+
+.marks > *:hover + * + * .mark,
+.marks > *:has(+ * + *:hover) .mark {
+  --mark-w: 18px;
+  --mark-grow: 1px;
+}
+
+/* ── Colour ─────────────────────────────────────────────────────────────────
+   Equal specificity to the hover rule, declared after it, so the turn being
+   read keeps its indicator colour even under the pointer. */
+.mark:hover {
+  background: var(--on-surface);
+}
+
+.mark.markActive {
+  background: var(--primary);
+}
+
+/* A turn is running: the rail stays legible as a position indicator but takes
+   no input, which is what keeps it from ever writing the conversation's scroll
+   position while useChatAutoScroll owns it. 38% is M3's disabled-content
+   opacity. */
+.railFrozen {
+  opacity: 0.38;
+  pointer-events: none;
+}
+
+/* ── Hover tile ─────────────────────────────────────────────────────────── */
+/* Tooltip's rich-content mode drops its own padding: the tile owns its
+   spacing. Width is capped so a long first sentence wraps into the line budget
+   below rather than stretching towards the reading column. */
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xs);
+  padding: var(--spacing-xs) var(--spacing-s);
+  max-width: 320px;
+}
+
+.tileRequest {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  color: var(--on-surface);
+  font: var(--font-label-large);
+}
+
+.tileAnswer {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+  color: var(--on-surface-retreat);
+  font: var(--font-body-medium);
+}

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
@@ -1,12 +1,19 @@
-/* Outline rail — one mark per turn, along the conversation's left edge.
-   Marks are outside the squircle scope, so they take a plain radius token. */
+/* Outline rail — one mark per turn, along the conversation's left edge. */
 
-/* Sized to its marks and centred, never a full-height overlay. The rail is a
+/* Anchored to the message lane's left edge, not the column's. The lane is
+   centred and capped at --composer-max-width, so this keeps the rail in the
+   gutter beside the text instead of on top of it: positioned from the column
+   edge, a column barely wider than the lane — one with a side panel open — put
+   the rail over the first characters of every line, swallowing clicks and text
+   selection there. Where the gutter is narrower than the rail, the rail is
+   clipped by the column rather than covering the conversation. Narrow viewports
+   deserve a real answer; that is deferred, and this is the safe default.
+
+   Sized to its marks and centred, never a full-height overlay: the rail is a
    SIBLING of the scroll container, so a wheel gesture over it has no scrollable
-   ancestor to chain to and the conversation would simply not move — the dead
-   left gutter reported before. Hugging the marks keeps that surface to the few
-   pixels the reader is deliberately pointing at, where scrolling the rail is
-   the sensible reading of the gesture anyway.
+   ancestor to chain to and the conversation would simply not move. Hugging the
+   marks keeps that surface to the few pixels the reader is deliberately
+   pointing at, where scrolling the rail is the sensible reading of the gesture.
 
    Capped at the available height, at which point it scrolls itself: newest
    turns stay reachable at the bottom and older ones leave through the top, the
@@ -16,7 +23,7 @@
   display: flex;
   position: absolute;
   top: 50%;
-  left: var(--spacing-m);
+  right: calc(50% + var(--composer-max-width) / 2 + var(--spacing-xs));
   flex-direction: column;
   transform: translateY(-50%);
   /* Widest a magnified mark gets, so magnifying never reflows anything. */
@@ -34,12 +41,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--spacing-xs);
 }
 
-/* Each mark is wrapped — by Tooltip when interactive, by .markSlot when frozen.
-   The magnification rules below key off these wrappers, so they must stay a
-   uniform, styling-free row. */
+/* Each mark is wrapped by its Tooltip. The magnification rules below key off
+   these wrappers, so they must stay a uniform, styling-free row. */
 .marks > * {
   display: flex;
   flex-shrink: 0;
@@ -47,37 +52,36 @@
   width: 100%;
 }
 
-.markSlot {
+/* The row IS the target. There is no gap between marks and no padding around
+   the list: anywhere the pointer lands on the rail, it is on exactly one mark.
+   A gap between rows would leave slivers where the tile closes and the
+   magnification collapses as the pointer travels down the rail. */
+.mark {
   display: flex;
+  flex-shrink: 0;
   justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 0;
+  width: 100%;
+  height: 16px;
 }
 
-.mark {
-  flex-shrink: 0;
+/* The visible bar, drawn inside the much larger target above. Marks are outside
+   the squircle scope, so a plain radius token. */
+.mark::before {
+  display: block;
   transition:
     width var(--duration-short-3) var(--easing-emphasized),
     height var(--duration-short-3) var(--easing-emphasized),
     background-color var(--duration-short-3) var(--easing-standard);
-  cursor: pointer;
-  border: none;
   border-radius: var(--radius-full);
   background: var(--outline-variant);
-  padding: 0;
   width: var(--mark-w, 14px);
-  height: calc(var(--mark-h) + var(--mark-grow, 0px));
-}
-
-/* Height buckets — driven by the agent answer's length (outlineItems.ts). */
-.short {
-  --mark-h: 3px;
-}
-
-.medium {
-  --mark-h: 6px;
-}
-
-.tall {
-  --mark-h: 10px;
+  height: var(--mark-h, 4px);
+  content: "";
 }
 
 /* ── Magnification ──────────────────────────────────────────────────────────
@@ -89,31 +93,31 @@
    Forward neighbours use sibling combinators; backward ones need `:has()`,
    CSS having no previous-sibling combinator. Both are already used elsewhere
    in this codebase. */
-.marks > *:hover .mark {
+.marks > *:hover .mark::before {
   --mark-w: 32px;
-  --mark-grow: 3px;
+  --mark-h: 7px;
 }
 
-.marks > *:hover + * .mark,
-.marks > *:has(+ *:hover) .mark {
+.marks > *:hover + * .mark::before,
+.marks > *:has(+ *:hover) .mark::before {
   --mark-w: 24px;
-  --mark-grow: 2px;
+  --mark-h: 6px;
 }
 
-.marks > *:hover + * + * .mark,
-.marks > *:has(+ * + *:hover) .mark {
+.marks > *:hover + * + * .mark::before,
+.marks > *:has(+ * + *:hover) .mark::before {
   --mark-w: 18px;
-  --mark-grow: 1px;
+  --mark-h: 5px;
 }
 
 /* ── Colour ─────────────────────────────────────────────────────────────────
    Equal specificity to the hover rule, declared after it, so the turn being
    read keeps its indicator colour even under the pointer. */
-.mark:hover {
+.mark:hover::before {
   background: var(--on-surface);
 }
 
-.mark.markActive {
+.mark.markActive::before {
   background: var(--primary);
 }
 

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.module.css
@@ -1,13 +1,14 @@
 /* Outline rail — one mark per turn, along the conversation's left edge. */
 
-/* Anchored to the message lane's left edge, not the column's. The lane is
-   centred and capped at --composer-max-width, so this keeps the rail in the
-   gutter beside the text instead of on top of it: positioned from the column
-   edge, a column barely wider than the lane — one with a side panel open — put
-   the rail over the first characters of every line, swallowing clicks and text
-   selection there. Where the gutter is narrower than the rail, the rail is
-   clipped by the column rather than covering the conversation. Narrow viewports
-   deserve a real answer; that is deferred, and this is the safe default.
+/* Against the page's left edge, not the conversation's. The rail is chrome for
+   the whole page, and tying it to the lane made it drift inward with the
+   reading column instead of staying where the reader's eye learns to find it.
+   The inset matches the top bar's, which is what sets the page's edge.
+
+   The cost is known and accepted: on a column barely wider than the lane — one
+   with a side panel open — the rail sits over the first characters of each
+   line. Narrow viewports are deferred (see the RFC); when they are taken on,
+   this is the case to answer.
 
    Sized to its marks and centred, never a full-height overlay: the rail is a
    SIBLING of the scroll container, so a wheel gesture over it has no scrollable
@@ -23,7 +24,7 @@
   display: flex;
   position: absolute;
   top: 50%;
-  right: calc(50% + var(--composer-max-width) / 2 + var(--spacing-xs));
+  left: var(--spacing-s);
   flex-direction: column;
   transform: translateY(-50%);
   /* Widest a magnified mark gets, so magnifying never reflows anything. */

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Coverage centres on the two invariants the rail's safety rests on: while a
+// turn is live it accepts no input (so it can never write the conversation's
+// scroll position while useChatAutoScroll owns it), and preview extracts are
+// derived on hover only, never for every turn up front.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConversationOutlineRail } from "./ConversationOutlineRail";
+import type { OutlineItem, OutlinePreview } from "./outlineItems";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const ITEMS: OutlineItem[] = [
+  { id: "u1", height: "short" },
+  { id: "u2", height: "tall" },
+  { id: "u3", height: "medium" },
+];
+
+const preview = (id: string): OutlinePreview => ({ request: `q ${id}`, answer: `a ${id}` });
+
+type Props = Parameters<typeof ConversationOutlineRail>[0];
+
+function render(props: Partial<Props> = {}) {
+  const onJump = vi.fn();
+  const getPreview = vi.fn(preview);
+  const merged: Props = { items: ITEMS, activeId: null, frozen: false, onJump, getPreview, ...props };
+  act(() => root.render(<ConversationOutlineRail {...merged} />));
+  // The spies are returned as themselves, not through `merged`, so their mock
+  // metadata survives the Props widening.
+  return { onJump, getPreview };
+}
+
+const marks = () => Array.from(container.querySelectorAll<HTMLElement>("[data-mark-id]"));
+
+describe("ConversationOutlineRail", () => {
+  it("renders one mark per item, in order", () => {
+    render();
+    expect(marks().map((m) => m.dataset.markId)).toEqual(["u1", "u2", "u3"]);
+  });
+
+  it("renders nothing when there are no turns", () => {
+    render({ items: [] });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("jumps to the turn a mark belongs to", () => {
+    const { onJump } = render();
+    act(() => marks()[1].click());
+    expect(onJump).toHaveBeenCalledWith("u2");
+  });
+
+  it("marks the active turn and only that one", () => {
+    render({ activeId: "u2" });
+    const active = marks().filter((m) => m.className.includes("markActive"));
+    expect(active.map((m) => m.dataset.markId)).toEqual(["u2"]);
+  });
+
+  it("keeps the marks out of the tab order", () => {
+    // They live in an aria-hidden subtree: reachable by keyboard but silent to
+    // a screen reader is worse than not reachable at all.
+    render();
+    expect(marks().every((m) => m.tabIndex === -1)).toBe(true);
+  });
+
+  it("hides the whole rail from assistive technology", () => {
+    render();
+    expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
+  });
+
+  describe("while a turn is live", () => {
+    it("mounts no tooltip, so no extract is ever computed", () => {
+      const { getPreview } = render({ frozen: true });
+      act(() => {
+        marks()[0].dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      });
+      expect(document.querySelector('[role="tooltip"]')).toBeNull();
+      expect(getPreview).not.toHaveBeenCalled();
+    });
+
+    it("still shows the marks, so the reader keeps their position", () => {
+      render({ frozen: true, activeId: "u2" });
+      expect(marks()).toHaveLength(3);
+      expect(marks().filter((m) => m.className.includes("markActive"))).toHaveLength(1);
+    });
+  });
+
+  describe("preview extraction", () => {
+    it("computes nothing until a mark is actually hovered", () => {
+      // The guarantee that matters for performance: rendering the rail over a
+      // long conversation must not walk every turn's text.
+      const { getPreview } = render();
+      expect(getPreview).not.toHaveBeenCalled();
+    });
+
+    it("computes only the hovered turn's extract", () => {
+      const { getPreview } = render();
+      act(() => {
+        marks()[2].dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      });
+      expect(getPreview.mock.calls).toEqual([["u3"]]);
+      expect(document.querySelector('[role="tooltip"]')?.textContent).toBe("q u3a u3");
+    });
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.test.tsx
@@ -67,6 +67,16 @@ describe("ConversationOutlineRail", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("does not let a click focus a mark", () => {
+    // A focused mark that the next turn then disables is force-blurred by
+    // Chromium, which silently scrollIntoView()s the conversation — a scroll
+    // write on the frames useChatAutoScroll owns the position.
+    render();
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    marks()[0].dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("jumps to the turn a mark belongs to", () => {
     const { onJump } = render();
     act(() => marks()[1].click());

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.test.tsx
@@ -22,7 +22,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConversationOutlineRail } from "./ConversationOutlineRail";
-import type { OutlineItem, OutlinePreview } from "./outlineItems";
+import type { OutlinePreview } from "./outlineItems";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -38,11 +38,7 @@ afterEach(() => {
   container.remove();
 });
 
-const ITEMS: OutlineItem[] = [
-  { id: "u1", height: "short" },
-  { id: "u2", height: "tall" },
-  { id: "u3", height: "medium" },
-];
+const TURN_IDS = ["u1", "u2", "u3"];
 
 const preview = (id: string): OutlinePreview => ({ request: `q ${id}`, answer: `a ${id}` });
 
@@ -51,7 +47,7 @@ type Props = Parameters<typeof ConversationOutlineRail>[0];
 function render(props: Partial<Props> = {}) {
   const onJump = vi.fn();
   const getPreview = vi.fn(preview);
-  const merged: Props = { items: ITEMS, activeId: null, frozen: false, onJump, getPreview, ...props };
+  const merged: Props = { turnIds: TURN_IDS, activeId: null, frozen: false, onJump, getPreview, ...props };
   act(() => root.render(<ConversationOutlineRail {...merged} />));
   // The spies are returned as themselves, not through `merged`, so their mock
   // metadata survives the Props widening.
@@ -61,13 +57,13 @@ function render(props: Partial<Props> = {}) {
 const marks = () => Array.from(container.querySelectorAll<HTMLElement>("[data-mark-id]"));
 
 describe("ConversationOutlineRail", () => {
-  it("renders one mark per item, in order", () => {
+  it("renders one mark per turn, in order", () => {
     render();
     expect(marks().map((m) => m.dataset.markId)).toEqual(["u1", "u2", "u3"]);
   });
 
   it("renders nothing when there are no turns", () => {
-    render({ items: [] });
+    render({ turnIds: [] });
     expect(container.firstChild).toBeNull();
   });
 
@@ -83,6 +79,14 @@ describe("ConversationOutlineRail", () => {
     expect(active.map((m) => m.dataset.markId)).toEqual(["u2"]);
   });
 
+  it("gives every mark the same class, so none is visually singled out", () => {
+    // The rail says where the turns are and nothing about them; a mark that
+    // varied by turn would make it a second thing to read.
+    render();
+    const shapes = new Set(marks().map((m) => m.className.replace(/\s*\S*markActive\S*/, "")));
+    expect(shapes.size).toBe(1);
+  });
+
   it("keeps the marks out of the tab order", () => {
     // They live in an aria-hidden subtree: reachable by keyboard but silent to
     // a screen reader is worse than not reachable at all.
@@ -96,19 +100,32 @@ describe("ConversationOutlineRail", () => {
   });
 
   describe("while a turn is live", () => {
-    it("mounts no tooltip, so no extract is ever computed", () => {
-      const { getPreview } = render({ frozen: true });
-      act(() => {
-        marks()[0].dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
-      });
-      expect(document.querySelector('[role="tooltip"]')).toBeNull();
-      expect(getPreview).not.toHaveBeenCalled();
+    it("takes no click, so no jump can reach the conversation", () => {
+      // The safety invariant: useChatAutoScroll owns the scroll position while
+      // a turn runs, and a jump landing then would be overwritten a frame
+      // later. Enforced in the markup, not only by the rail's pointer-events,
+      // so a stylesheet change cannot quietly re-enable it.
+      const { onJump } = render({ frozen: true });
+      act(() => marks()[1].click());
+      expect(onJump).not.toHaveBeenCalled();
+      expect(marks().every((m) => (m as HTMLButtonElement).disabled)).toBe(true);
     });
 
     it("still shows the marks, so the reader keeps their position", () => {
       render({ frozen: true, activeId: "u2" });
       expect(marks()).toHaveLength(3);
       expect(marks().filter((m) => m.className.includes("markActive"))).toHaveLength(1);
+    });
+
+    it("keeps every mark mounted across the freeze, rather than rebuilding them", () => {
+      // Swapping each mark's wrapper on freeze remounted the whole rail at both
+      // ends of every turn — hundreds of mount/unmount cycles on the frames the
+      // stream starts and finishes.
+      render();
+      const before = marks();
+      render({ frozen: true });
+      expect(marks()[0]).toBe(before[0]);
+      expect(marks()[2]).toBe(before[2]);
     });
   });
 

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.tsx
@@ -1,0 +1,126 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Outline rail — one mark per turn along the conversation's left edge.
+// Full rationale: docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
+
+import { memo, useEffect, useRef } from "react";
+import { Tooltip } from "@shared/atoms/Tooltip/Tooltip";
+import type { OutlineItem, OutlinePreview } from "./outlineItems";
+import styles from "./ConversationOutlineRail.module.css";
+
+interface ConversationOutlineRailProps {
+  items: OutlineItem[];
+  activeId: string | null;
+  /** A turn is running: marks stay visible but dimmed and inert, so the rail
+   *  can never write the conversation's scroll position while the autoscroll
+   *  owns it. */
+  frozen: boolean;
+  onJump: (turnId: string) => void;
+  getPreview: (turnId: string) => OutlinePreview;
+}
+
+/**
+ * The hover tile.
+ *
+ * Takes the turn's id and resolves its own text, rather than being handed a
+ * ready-made preview: `Tooltip`'s `content` element is built on every render of
+ * the rail, but a React element is inert until something renders it, and
+ * `Tooltip` only renders it while the tooltip is actually open. Passing the
+ * resolved strings in would move that work back to render time — for every
+ * turn, on every render, which is exactly what this design set out to avoid.
+ *
+ * Deliberately not memoised across hovers. Reading two sentences out of one
+ * bounded slice is microseconds, and a cache keyed by turn id cannot see an
+ * exchange completed by a background revalidation — it would pin the truncated
+ * preview for the life of the page, to save nothing measurable.
+ */
+function PreviewTile({ turnId, resolve }: { turnId: string; resolve: (id: string) => OutlinePreview }) {
+  const preview = resolve(turnId);
+  return (
+    <span className={styles.tile}>
+      <span className={styles.tileRequest}>{preview.request}</span>
+      {preview.answer && <span className={styles.tileAnswer}>{preview.answer}</span>}
+    </span>
+  );
+}
+
+// Memoized for the same reason ConversationThread is: the page above re-renders
+// on every composer keystroke, and the rail must not follow it down.
+export const ConversationOutlineRail = memo(function ConversationOutlineRail({
+  items,
+  activeId,
+  frozen,
+  onJump,
+  getPreview,
+}: ConversationOutlineRailProps) {
+  // Keep the turn being read reachable in a rail that has outgrown its height.
+  // Its own scrollTop, never `scrollIntoView`: that would scroll every
+  // scrollable ancestor, the conversation container included — the one element
+  // this component must never move.
+  const railRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const rail = railRef.current;
+    if (!rail || !activeId) return;
+    const mark = rail.querySelector<HTMLElement>(`[data-mark-id="${CSS.escape(activeId)}"]`);
+    if (!mark) return;
+    const railBox = rail.getBoundingClientRect();
+    const markBox = mark.getBoundingClientRect();
+    if (markBox.top < railBox.top) rail.scrollTop -= railBox.top - markBox.top;
+    else if (markBox.bottom > railBox.bottom) rail.scrollTop += markBox.bottom - railBox.bottom;
+  }, [activeId, items]);
+
+  if (items.length === 0) return null;
+
+  return (
+    // Hidden from assistive technology: the marks carry no text of their own,
+    // and the conversation they summarise is already fully readable in the
+    // thread. Reachability is a V1 omission, not a judgement that it is
+    // unwanted — see the RFC's out-of-scope section.
+    <div ref={railRef} className={`${styles.rail} ${frozen ? styles.railFrozen : ""}`} aria-hidden="true">
+      <div className={styles.marks}>
+        {items.map((item) => {
+          const mark = (
+            <button
+              type="button"
+              // Never in the tab order: a focusable control inside an
+              // aria-hidden subtree is a trap — reachable by keyboard, yet
+              // invisible to the screen reader that should announce it.
+              tabIndex={-1}
+              data-mark-id={item.id}
+              className={`${styles.mark} ${styles[item.height]} ${item.id === activeId ? styles.markActive : ""}`}
+              onClick={() => onJump(item.id)}
+            />
+          );
+          // Frozen: no tooltip is mounted at all, so no extract is computed for
+          // a turn the reader cannot reach anyway.
+          return frozen ? (
+            <span key={item.id} className={styles.markSlot}>
+              {mark}
+            </span>
+          ) : (
+            <Tooltip
+              key={item.id}
+              placement="left"
+              gapPx={12}
+              content={<PreviewTile turnId={item.id} resolve={getPreview} />}
+            >
+              {mark}
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.tsx
@@ -98,7 +98,7 @@ export const ConversationOutlineRail = memo(function ConversationOutlineRail({
           // stream starts and finishes.
           <Tooltip
             key={turnId}
-            placement="left"
+            placement="right"
             gapPx={12}
             content={<PreviewTile turnId={turnId} resolve={getPreview} />}
           >
@@ -108,6 +108,14 @@ export const ConversationOutlineRail = memo(function ConversationOutlineRail({
               // aria-hidden subtree is a trap — reachable by keyboard, yet
               // invisible to the screen reader that should announce it.
               tabIndex={-1}
+              // ...and never focused by the click either, which `tabIndex` does
+              // not prevent. A focused mark that then gets disabled — which is
+              // what the next turn does to it — is force-blurred by Chromium,
+              // and that silently scrollIntoView()s the nearest scroll
+              // container: here the conversation itself, on the exact frames
+              // useChatAutoScroll owns its scroll position. Same failure as
+              // index.tsx's document-level guard, which only covers <html>.
+              onMouseDown={(event) => event.preventDefault()}
               // The button is the whole row, not just the bar it draws: the rail
               // must have no gaps the pointer can fall into between two marks,
               // so hover and click share one contiguous target and the visible

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/ConversationOutlineRail.tsx
@@ -17,11 +17,12 @@
 
 import { memo, useEffect, useRef } from "react";
 import { Tooltip } from "@shared/atoms/Tooltip/Tooltip";
-import type { OutlineItem, OutlinePreview } from "./outlineItems";
+import type { OutlinePreview } from "./outlineItems";
 import styles from "./ConversationOutlineRail.module.css";
 
 interface ConversationOutlineRailProps {
-  items: OutlineItem[];
+  /** Turn ids in thread order — one mark each, all the same size. */
+  turnIds: string[];
   activeId: string | null;
   /** A turn is running: marks stay visible but dimmed and inert, so the rail
    *  can never write the conversation's scroll position while the autoscroll
@@ -59,7 +60,7 @@ function PreviewTile({ turnId, resolve }: { turnId: string; resolve: (id: string
 // Memoized for the same reason ConversationThread is: the page above re-renders
 // on every composer keystroke, and the rail must not follow it down.
 export const ConversationOutlineRail = memo(function ConversationOutlineRail({
-  items,
+  turnIds,
   activeId,
   frozen,
   onJump,
@@ -79,47 +80,50 @@ export const ConversationOutlineRail = memo(function ConversationOutlineRail({
     const markBox = mark.getBoundingClientRect();
     if (markBox.top < railBox.top) rail.scrollTop -= railBox.top - markBox.top;
     else if (markBox.bottom > railBox.bottom) rail.scrollTop += markBox.bottom - railBox.bottom;
-  }, [activeId, items]);
+  }, [activeId, turnIds]);
 
-  if (items.length === 0) return null;
+  if (turnIds.length === 0) return null;
 
   return (
     // Hidden from assistive technology: the marks carry no text of their own,
     // and the conversation they summarise is already fully readable in the
     // thread. Reachability is a V1 omission, not a judgement that it is
-    // unwanted — see the RFC's out-of-scope section.
+    // unwanted — CONVERSATION-OUTLINE-RAIL-RFC.md says what it would take.
     <div ref={railRef} className={`${styles.rail} ${frozen ? styles.railFrozen : ""}`} aria-hidden="true">
       <div className={styles.marks}>
-        {items.map((item) => {
-          const mark = (
+        {turnIds.map((turnId) => (
+          // One wrapper shape in both states. Swapping Tooltip for a plain span
+          // while frozen remounted every mark's subtree at both ends of every
+          // turn — hundreds of mount/unmount cycles on the exact frames the
+          // stream starts and finishes.
+          <Tooltip
+            key={turnId}
+            placement="left"
+            gapPx={12}
+            content={<PreviewTile turnId={turnId} resolve={getPreview} />}
+          >
             <button
               type="button"
               // Never in the tab order: a focusable control inside an
               // aria-hidden subtree is a trap — reachable by keyboard, yet
               // invisible to the screen reader that should announce it.
               tabIndex={-1}
-              data-mark-id={item.id}
-              className={`${styles.mark} ${styles[item.height]} ${item.id === activeId ? styles.markActive : ""}`}
-              onClick={() => onJump(item.id)}
+              // The button is the whole row, not just the bar it draws: the rail
+              // must have no gaps the pointer can fall into between two marks,
+              // so hover and click share one contiguous target and the visible
+              // bar is a pseudo-element inside it.
+              //
+              // Disabled while a turn is live, belt and braces with the rail's
+              // `pointer-events: none`. This one is the invariant that matters —
+              // no jump may reach the conversation while useChatAutoScroll owns
+              // its scroll position — so it does not rest on a stylesheet.
+              disabled={frozen}
+              data-mark-id={turnId}
+              className={`${styles.mark} ${turnId === activeId ? styles.markActive : ""}`}
+              onClick={() => onJump(turnId)}
             />
-          );
-          // Frozen: no tooltip is mounted at all, so no extract is computed for
-          // a turn the reader cannot reach anyway.
-          return frozen ? (
-            <span key={item.id} className={styles.markSlot}>
-              {mark}
-            </span>
-          ) : (
-            <Tooltip
-              key={item.id}
-              placement="left"
-              gapPx={12}
-              content={<PreviewTile turnId={item.id} resolve={getPreview} />}
-            >
-              {mark}
-            </Tooltip>
-          );
-        })}
+          </Tooltip>
+        ))}
       </div>
     </div>
   );

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.test.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.test.ts
@@ -14,92 +14,56 @@
 
 import { describe, expect, it } from "vitest";
 import type { ThreadMessage } from "@rework/types/thread";
-import { firstSentences, sameOutline, toOutlineItems, toOutlinePreview } from "./outlineItems";
+import { firstSentences, sameTurnIds, toOutlinePreview, toTurnIds } from "./outlineItems";
 
 function msg(id: string, role: ThreadMessage["role"], text: string): ThreadMessage {
   return { id, role, text, isStreaming: false, traceMessages: [], sources: [], uiParts: [] };
 }
 
-const chars = (n: number) => "x".repeat(n);
-
-describe("toOutlineItems", () => {
-  it("emits one item per user turn, in thread order", () => {
-    const items = toOutlineItems([
-      msg("u1", "user", "first"),
-      msg("a1", "assistant", "answer"),
-      msg("u2", "user", "second"),
-      msg("a2", "assistant", "answer"),
-    ]);
-    expect(items.map((i) => i.id)).toEqual(["u1", "u2"]);
+describe("toTurnIds", () => {
+  it("emits one id per user turn, in thread order", () => {
+    expect(
+      toTurnIds([
+        msg("u1", "user", "first"),
+        msg("a1", "assistant", "answer"),
+        msg("u2", "user", "second"),
+        msg("a2", "assistant", "answer"),
+      ]),
+    ).toEqual(["u1", "u2"]);
   });
 
-  it("buckets height on the answer length, at the exact thresholds", () => {
-    const heightFor = (answerLength: number) =>
-      toOutlineItems([msg("u", "user", "q"), msg("a", "assistant", chars(answerLength))])[0].height;
-
-    // Thresholds are exclusive: a turn sitting exactly on one stays in the
-    // lower bucket. Pinned because these boundaries are the whole signal.
-    expect(heightFor(400)).toBe("short");
-    expect(heightFor(401)).toBe("medium");
-    expect(heightFor(1500)).toBe("medium");
-    expect(heightFor(1501)).toBe("tall");
-  });
-
-  it("reads a turn with no answer yet as short", () => {
-    expect(toOutlineItems([msg("u", "user", "q")])[0].height).toBe("short");
-  });
-
-  it("takes the answer belonging to the turn, not a later one", () => {
-    const items = toOutlineItems([msg("u1", "user", "q"), msg("u2", "user", "q"), msg("a2", "assistant", chars(2000))]);
-    // u1 was never answered — u2's long answer must not leak up to it.
-    expect(items.map((i) => i.height)).toEqual(["short", "tall"]);
+  it("emits a turn that has no answer yet", () => {
+    // Every mark is the same size, so a turn still being answered is no
+    // different from any other — it just has nothing to preview.
+    expect(toTurnIds([msg("u", "user", "q")])).toEqual(["u"]);
   });
 
   it("gives HITL rows no marks of their own", () => {
-    const items = toOutlineItems([
-      msg("u1", "user", "q"),
-      msg("h1", "hitl_request", "may I?"),
-      msg("h2", "hitl_response", "proceed"),
-      msg("a1", "assistant", "done"),
-    ]);
-    expect(items.map((i) => i.id)).toEqual(["u1"]);
-  });
-
-  it("looks past a HITL exchange to find the turn's answer", () => {
-    const items = toOutlineItems([
-      msg("u1", "user", "q"),
-      msg("h1", "hitl_request", "may I?"),
-      msg("h2", "hitl_response", "proceed"),
-      msg("a1", "assistant", chars(2000)),
-    ]);
-    expect(items[0].height).toBe("tall");
+    expect(
+      toTurnIds([
+        msg("u1", "user", "q"),
+        msg("h1", "hitl_request", "may I?"),
+        msg("h2", "hitl_response", "proceed"),
+        msg("a1", "assistant", "done"),
+      ]),
+    ).toEqual(["u1"]);
   });
 });
 
-describe("sameOutline", () => {
+describe("sameTurnIds", () => {
   // Identity of the fold's result is what keeps the rail's memo alive while a
-  // turn streams, so equality has to notice everything a mark renders — and
-  // nothing else.
-  const base = [
-    { id: "u1", height: "short" as const },
-    { id: "u2", height: "tall" as const },
-  ];
-
-  it("treats an identical fold as unchanged", () => {
-    expect(sameOutline(base, [...base.map((i) => ({ ...i }))])).toBe(true);
-  });
-
-  it("notices a turn whose answer grew into the next height", () => {
-    expect(sameOutline(base, [base[0], { id: "u2", height: "medium" }])).toBe(false);
+  // turn streams, so equality has to notice every change the rail renders.
+  it("treats the same turns as unchanged", () => {
+    expect(sameTurnIds(["u1", "u2"], ["u1", "u2"])).toBe(true);
   });
 
   it("notices a new turn", () => {
-    expect(sameOutline(base, [...base, { id: "u3", height: "short" }])).toBe(false);
+    expect(sameTurnIds(["u1", "u2"], ["u1", "u2", "u3"])).toBe(false);
   });
 
   it("notices a different conversation of the same length", () => {
     // The staleness a session-plus-count cache key could not see.
-    expect(sameOutline(base, [{ id: "x1", height: "short" }, base[1]])).toBe(false);
+    expect(sameTurnIds(["u1", "u2"], ["x1", "u2"])).toBe(false);
   });
 });
 
@@ -141,7 +105,7 @@ describe("firstSentences", () => {
 
   it("reads a bounded slice however long the answer is", () => {
     // The whole point of the bound: cost must not scale with the answer.
-    const huge = `${chars(400)}. ${"tail. ".repeat(20000)}`;
+    const huge = `${"x".repeat(400)}. ${"tail. ".repeat(20000)}`;
     expect(firstSentences(huge, 2).length).toBeLessThanOrEqual(500);
   });
 

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.test.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.test.ts
@@ -1,0 +1,177 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import type { ThreadMessage } from "@rework/types/thread";
+import { firstSentences, sameOutline, toOutlineItems, toOutlinePreview } from "./outlineItems";
+
+function msg(id: string, role: ThreadMessage["role"], text: string): ThreadMessage {
+  return { id, role, text, isStreaming: false, traceMessages: [], sources: [], uiParts: [] };
+}
+
+const chars = (n: number) => "x".repeat(n);
+
+describe("toOutlineItems", () => {
+  it("emits one item per user turn, in thread order", () => {
+    const items = toOutlineItems([
+      msg("u1", "user", "first"),
+      msg("a1", "assistant", "answer"),
+      msg("u2", "user", "second"),
+      msg("a2", "assistant", "answer"),
+    ]);
+    expect(items.map((i) => i.id)).toEqual(["u1", "u2"]);
+  });
+
+  it("buckets height on the answer length, at the exact thresholds", () => {
+    const heightFor = (answerLength: number) =>
+      toOutlineItems([msg("u", "user", "q"), msg("a", "assistant", chars(answerLength))])[0].height;
+
+    // Thresholds are exclusive: a turn sitting exactly on one stays in the
+    // lower bucket. Pinned because these boundaries are the whole signal.
+    expect(heightFor(400)).toBe("short");
+    expect(heightFor(401)).toBe("medium");
+    expect(heightFor(1500)).toBe("medium");
+    expect(heightFor(1501)).toBe("tall");
+  });
+
+  it("reads a turn with no answer yet as short", () => {
+    expect(toOutlineItems([msg("u", "user", "q")])[0].height).toBe("short");
+  });
+
+  it("takes the answer belonging to the turn, not a later one", () => {
+    const items = toOutlineItems([msg("u1", "user", "q"), msg("u2", "user", "q"), msg("a2", "assistant", chars(2000))]);
+    // u1 was never answered — u2's long answer must not leak up to it.
+    expect(items.map((i) => i.height)).toEqual(["short", "tall"]);
+  });
+
+  it("gives HITL rows no marks of their own", () => {
+    const items = toOutlineItems([
+      msg("u1", "user", "q"),
+      msg("h1", "hitl_request", "may I?"),
+      msg("h2", "hitl_response", "proceed"),
+      msg("a1", "assistant", "done"),
+    ]);
+    expect(items.map((i) => i.id)).toEqual(["u1"]);
+  });
+
+  it("looks past a HITL exchange to find the turn's answer", () => {
+    const items = toOutlineItems([
+      msg("u1", "user", "q"),
+      msg("h1", "hitl_request", "may I?"),
+      msg("h2", "hitl_response", "proceed"),
+      msg("a1", "assistant", chars(2000)),
+    ]);
+    expect(items[0].height).toBe("tall");
+  });
+});
+
+describe("sameOutline", () => {
+  // Identity of the fold's result is what keeps the rail's memo alive while a
+  // turn streams, so equality has to notice everything a mark renders — and
+  // nothing else.
+  const base = [
+    { id: "u1", height: "short" as const },
+    { id: "u2", height: "tall" as const },
+  ];
+
+  it("treats an identical fold as unchanged", () => {
+    expect(sameOutline(base, [...base.map((i) => ({ ...i }))])).toBe(true);
+  });
+
+  it("notices a turn whose answer grew into the next height", () => {
+    expect(sameOutline(base, [base[0], { id: "u2", height: "medium" }])).toBe(false);
+  });
+
+  it("notices a new turn", () => {
+    expect(sameOutline(base, [...base, { id: "u3", height: "short" }])).toBe(false);
+  });
+
+  it("notices a different conversation of the same length", () => {
+    // The staleness a session-plus-count cache key could not see.
+    expect(sameOutline(base, [{ id: "x1", height: "short" }, base[1]])).toBe(false);
+  });
+});
+
+describe("firstSentences", () => {
+  it("stops after the requested number of sentences", () => {
+    expect(firstSentences("One. Two. Three.", 2)).toBe("One. Two.");
+  });
+
+  it("does not split on a terminator with no whitespace after it", () => {
+    // Decimals and version numbers are the common case; splitting here would
+    // reduce the preview to a fragment.
+    expect(firstSentences("Version 1.5 shipped. Next.", 1)).toBe("Version 1.5 shipped.");
+  });
+
+  it("keeps a sentence that ends the text", () => {
+    // The common shape — an answer ends with a full stop and no trailing
+    // whitespace. Requiring whitespace after the terminator dropped that last
+    // sentence from almost every preview.
+    expect(firstSentences("Yes. And also more detail follows here.", 2)).toBe(
+      "Yes. And also more detail follows here.",
+    );
+    expect(firstSentences("Only one sentence.", 2)).toBe("Only one sentence.");
+  });
+
+  it("returns the text when it holds no sentence terminator", () => {
+    expect(firstSentences("a title with no full stop", 2)).toBe("a title with no full stop");
+  });
+
+  it("strips markdown rather than showing its punctuation", () => {
+    expect(firstSentences("## Heading\n- **bold** and `code` and [link](http://x)", 2)).toBe(
+      "Heading bold and code and link",
+    );
+  });
+
+  it("drops a fenced code block, closed or still open", () => {
+    expect(firstSentences("Intro. ```js\nconst a = 1;\n```", 2)).toBe("Intro.");
+    expect(firstSentences("Intro. ```js\nconst a = 1;", 2)).toBe("Intro.");
+  });
+
+  it("reads a bounded slice however long the answer is", () => {
+    // The whole point of the bound: cost must not scale with the answer.
+    const huge = `${chars(400)}. ${"tail. ".repeat(20000)}`;
+    expect(firstSentences(huge, 2).length).toBeLessThanOrEqual(500);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(firstSentences("", 2)).toBe("");
+  });
+});
+
+describe("toOutlinePreview", () => {
+  it("pairs the turn's request with its own answer", () => {
+    const preview = toOutlinePreview(
+      [
+        msg("u1", "user", "What is it? Second question."),
+        msg("a1", "assistant", "It is that. Because of this. And more."),
+        msg("u2", "user", "Other"),
+      ],
+      "u1",
+    );
+    expect(preview.request).toBe("What is it?");
+    expect(preview.answer).toBe("It is that. Because of this.");
+  });
+
+  it("returns empty strings for an unknown turn", () => {
+    expect(toOutlinePreview([msg("u1", "user", "q")], "nope")).toEqual({ request: "", answer: "" });
+  });
+
+  it("returns an empty answer for a turn still without one", () => {
+    expect(toOutlinePreview([msg("u1", "user", "Question.")], "u1")).toEqual({
+      request: "Question.",
+      answer: "",
+    });
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.ts
@@ -1,0 +1,158 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pure folds behind the conversation outline rail: the thread's messages to
+// one mark per exchange, and a turn's raw text to the two lines its hover tile
+// shows. Kept free of React and DOM so the boundaries that actually matter —
+// the height buckets, sentence splitting — are unit-testable.
+
+import type { ThreadMessage } from "@rework/types/thread";
+
+export type OutlineMarkHeight = "short" | "medium" | "tall";
+
+export interface OutlineItem {
+  /** The user message's id, which is also its `data-turn-id` anchor. */
+  id: string;
+  height: OutlineMarkHeight;
+}
+
+export interface OutlinePreview {
+  request: string;
+  answer: string;
+}
+
+/** Answer length, in characters, above which a mark takes the next height up.
+ *  Absolute rather than per-conversation quantiles: a mark that changed height
+ *  as later turns arrived would break the spatial memory the rail exists to
+ *  serve. Full rationale: `CONVERSATION-OUTLINE-RAIL-RFC.md` §2.3. */
+const MEDIUM_ANSWER_CHARS = 400;
+const TALL_ANSWER_CHARS = 1500;
+
+/** Sentence detection reads this many characters, never the whole answer — an
+ *  answer can be tens of kilobytes, and the tile shows two sentences. */
+const PREVIEW_SCAN_CHARS = 500;
+
+function heightFor(answer: string): OutlineMarkHeight {
+  if (answer.length > TALL_ANSWER_CHARS) return "tall";
+  if (answer.length > MEDIUM_ANSWER_CHARS) return "medium";
+  return "short";
+}
+
+/**
+ * One mark per user-opened exchange, in thread order.
+ *
+ * HITL rows are skipped rather than given marks of their own: `hitl_response`
+ * renders through `UserTurn` but is a reply to the agent, not a turn the reader
+ * would navigate back to.
+ */
+export function toOutlineItems(messages: ThreadMessage[]): OutlineItem[] {
+  const items: OutlineItem[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role !== "user") continue;
+    // The answer is the first assistant row before the next user row; a turn
+    // still without one (interrupted, or history that never got a reply) reads
+    // as short, which is honest — there is nothing to come back and read.
+    let answer = "";
+    for (let j = i + 1; j < messages.length && messages[j].role !== "user"; j++) {
+      if (messages[j].role === "assistant") {
+        answer = messages[j].text;
+        break;
+      }
+    }
+    items.push({ id: messages[i].id, height: heightFor(answer) });
+  }
+  return items;
+}
+
+/**
+ * Whether two folds describe the same rail.
+ *
+ * Lets the caller hand back the previous array when nothing changed, keeping
+ * its identity stable so the rail's `memo` holds. That matters because the
+ * message list is replaced on every streamed token: without this the rail
+ * would re-render every mark tens of times a second, and with a coarser cache
+ * key than the messages themselves it would instead go stale — a session
+ * switch between two conversations of equal length would leave the previous
+ * one's marks on screen.
+ */
+export function sameOutline(a: OutlineItem[], b: OutlineItem[]): boolean {
+  return a.length === b.length && a.every((item, i) => item.id === b[i].id && item.height === b[i].height);
+}
+
+/**
+ * Strip the markdown that would otherwise show up as punctuation in a preview
+ * line. Deliberately shallow — this runs on a 500-character slice to produce
+ * two lines of plain text, not to render anything.
+ */
+function toPlainText(text: string): string {
+  return text
+    .replace(/```[\s\S]*?(```|$)/g, " ") // fenced code, closed or still open
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // links and images keep their label
+    .replace(/^\s{0,3}(#{1,6}|>|[-*+]|\d+[.)])\s+/gm, "") // headings, quotes, list markers
+    .replace(/[*_~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * The first `count` sentences of `text`, as one line.
+ *
+ * Returns the whole scanned slice when no terminator is found — a preview that
+ * is one long unpunctuated line is still worth showing, and the tile clamps it
+ * to its line budget anyway.
+ */
+export function firstSentences(text: string, count: number): string {
+  const plain = toPlainText(text.slice(0, PREVIEW_SCAN_CHARS));
+  if (!plain) return "";
+
+  const sentences: string[] = [];
+  // A terminator ends a sentence only at whitespace or the end of the text, so
+  // decimals and abbreviations mid-line don't split the preview into fragments.
+  // The `$` is not decoration: without it the last sentence of a short answer —
+  // which is most answers — has no whitespace after its full stop and is
+  // silently dropped from the preview.
+  const terminator = /[.!?]+(?=\s|$)/g;
+  let start = 0;
+  let match: RegExpExecArray | null;
+  while (sentences.length < count && (match = terminator.exec(plain)) !== null) {
+    // Trimmed: the slice starts at the previous terminator, so it carries the
+    // separating space, which the join would then double.
+    sentences.push(plain.slice(start, match.index + match[0].length).trim());
+    start = match.index + match[0].length;
+  }
+  if (sentences.length === 0) return plain;
+  return sentences.join(" ").trim();
+}
+
+/** The hover tile's two lines. Computed on hover for the hovered turn only:
+ *  during streaming the message list changes on every token, so deriving this
+ *  for every turn up front is string work across the whole conversation tens of
+ *  times a second — the shape that already cost the composer its typing speed. */
+export function toOutlinePreview(messages: ThreadMessage[], turnId: string): OutlinePreview {
+  const index = messages.findIndex((m) => m.id === turnId);
+  if (index === -1) return { request: "", answer: "" };
+
+  let answer = "";
+  for (let j = index + 1; j < messages.length && messages[j].role !== "user"; j++) {
+    if (messages[j].role === "assistant") {
+      answer = messages[j].text;
+      break;
+    }
+  }
+  return {
+    request: firstSentences(messages[index].text, 1),
+    answer: firstSentences(answer, 2),
+  };
+}

--- a/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.ts
+++ b/apps/frontend/src/rework/components/shared/molecules/ConversationOutlineRail/outlineItems.ts
@@ -19,60 +19,33 @@
 
 import type { ThreadMessage } from "@rework/types/thread";
 
-export type OutlineMarkHeight = "short" | "medium" | "tall";
-
-export interface OutlineItem {
-  /** The user message's id, which is also its `data-turn-id` anchor. */
-  id: string;
-  height: OutlineMarkHeight;
-}
-
 export interface OutlinePreview {
   request: string;
   answer: string;
 }
 
-/** Answer length, in characters, above which a mark takes the next height up.
- *  Absolute rather than per-conversation quantiles: a mark that changed height
- *  as later turns arrived would break the spatial memory the rail exists to
- *  serve. Full rationale: `CONVERSATION-OUTLINE-RAIL-RFC.md` §2.3. */
-const MEDIUM_ANSWER_CHARS = 400;
-const TALL_ANSWER_CHARS = 1500;
-
 /** Sentence detection reads this many characters, never the whole answer — an
  *  answer can be tens of kilobytes, and the tile shows two sentences. */
 const PREVIEW_SCAN_CHARS = 500;
 
-function heightFor(answer: string): OutlineMarkHeight {
-  if (answer.length > TALL_ANSWER_CHARS) return "tall";
-  if (answer.length > MEDIUM_ANSWER_CHARS) return "medium";
-  return "short";
-}
-
 /**
- * One mark per user-opened exchange, in thread order.
+ * One mark per user-opened exchange, in thread order — the turn ids, which are
+ * also the `data-turn-id` anchors in the thread.
+ *
+ * Every mark is the same size: the rail says where the turns are, and nothing
+ * about them. Encoding the answer's length in a mark's height was tried and
+ * dropped — it made the rail a second thing to read rather than a place to aim.
  *
  * HITL rows are skipped rather than given marks of their own: `hitl_response`
  * renders through `UserTurn` but is a reply to the agent, not a turn the reader
  * would navigate back to.
  */
-export function toOutlineItems(messages: ThreadMessage[]): OutlineItem[] {
-  const items: OutlineItem[] = [];
-  for (let i = 0; i < messages.length; i++) {
-    if (messages[i].role !== "user") continue;
-    // The answer is the first assistant row before the next user row; a turn
-    // still without one (interrupted, or history that never got a reply) reads
-    // as short, which is honest — there is nothing to come back and read.
-    let answer = "";
-    for (let j = i + 1; j < messages.length && messages[j].role !== "user"; j++) {
-      if (messages[j].role === "assistant") {
-        answer = messages[j].text;
-        break;
-      }
-    }
-    items.push({ id: messages[i].id, height: heightFor(answer) });
+export function toTurnIds(messages: ThreadMessage[]): string[] {
+  const ids: string[] = [];
+  for (const message of messages) {
+    if (message.role === "user") ids.push(message.id);
   }
-  return items;
+  return ids;
 }
 
 /**
@@ -86,8 +59,8 @@ export function toOutlineItems(messages: ThreadMessage[]): OutlineItem[] {
  * switch between two conversations of equal length would leave the previous
  * one's marks on screen.
  */
-export function sameOutline(a: OutlineItem[], b: OutlineItem[]): boolean {
-  return a.length === b.length && a.every((item, i) => item.id === b[i].id && item.height === b[i].height);
+export function sameTurnIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
 }
 
 /**

--- a/apps/frontend/src/rework/components/shared/organisms/ChatMessagesArea/ChatMessagesArea.module.css
+++ b/apps/frontend/src/rework/components/shared/organisms/ChatMessagesArea/ChatMessagesArea.module.css
@@ -14,7 +14,7 @@
   flex-direction: column;
   gap: var(--spacing-m);
   margin: 0 auto;
-  padding: var(--spacing-xl) var(--spacing-l);
+  padding: var(--spacing-xl) var(--spacing-2xl);
   width: 100%;
   max-width: 720px;
 }

--- a/apps/frontend/src/rework/components/shared/organisms/UserTurn/UserTurn.tsx
+++ b/apps/frontend/src/rework/components/shared/organisms/UserTurn/UserTurn.tsx
@@ -23,12 +23,15 @@ import styles from "./UserTurn.module.css";
 
 interface UserTurnProps {
   text: string;
+  /** Anchor for the outline rail: its marks scroll to this node, and the
+   *  scroll-spy reads its position to say which turn is being read. */
+  turnId?: string;
   /** Called when user clicks the edit action. If omitted, edit action is hidden. */
   onEdit?: (text: string) => void;
 }
 
 // Memoized alongside AssistantTurn — see #2221.
-export const UserTurn = memo(function UserTurn({ text, onEdit }: UserTurnProps) {
+export const UserTurn = memo(function UserTurn({ text, turnId, onEdit }: UserTurnProps) {
   const { t } = useTranslation();
   const { copied, confirmCopied } = useCopyConfirmation();
 
@@ -57,7 +60,7 @@ export const UserTurn = memo(function UserTurn({ text, onEdit }: UserTurnProps) 
   );
 
   return (
-    <div className={styles.turn}>
+    <div className={styles.turn} data-turn-id={turnId}>
       {/* Beside the bubble (user turns are right-aligned), revealed on hover. */}
       <ActionBar actions={actions} className={styles.actions} />
       <UserMessage text={text} />

--- a/apps/frontend/src/rework/core/hooks/useChatAutoScroll.ts
+++ b/apps/frontend/src/rework/core/hooks/useChatAutoScroll.ts
@@ -16,8 +16,14 @@
 // the answer starts. Full autoscroll moves the line being read; none at all
 // leaves the whole turn below the fold.
 //
-// Sole owner of the conversation container's scroll position — a second
-// mechanism on the same element cannot be reasoned about.
+// Sole owner of the conversation container's scroll position WHILE A TURN IS
+// LIVE — a second mechanism writing it on the same frames cannot be reasoned
+// about. The refinement matters: this hook writes only in the work/answer
+// phases (`shouldFollowBottom` returns false when idle), so `useConversationJump`
+// may drive the same element once a turn has ended. That is safe only for as
+// long as its caller stays inert while `isStreaming || isAwaitingHuman` — the
+// outline rail freezes itself for exactly that reason. Anything else wanting to
+// scroll this container during a turn belongs in here, not beside it.
 
 import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 

--- a/apps/frontend/src/rework/core/hooks/useConversationJump.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useConversationJump.test.tsx
@@ -54,11 +54,15 @@ function makeScroller() {
   let anchorContentTop = 2000;
   Object.defineProperty(el, "clientHeight", { get: () => CLIENT_HEIGHT });
   Object.defineProperty(el, "scrollHeight", { get: () => SCROLL_HEIGHT });
+  // When true, writes are silently dropped — the container that stops being
+  // scrollable mid-flight.
+  let immovable = false;
   Object.defineProperty(el, "scrollTop", {
     get: () => top,
     // happy-dom does not clamp on its own, and the clamp is load-bearing here:
     // the hook reads back what it wrote to tell a clamp from a reader takeover.
     set: (v: number) => {
+      if (immovable) return;
       top = Math.max(0, Math.min(v, SCROLL_HEIGHT - CLIENT_HEIGHT));
     },
   });
@@ -66,7 +70,12 @@ function makeScroller() {
   // Viewport-relative, exactly as the real thing: content position minus scroll.
   anchor.getBoundingClientRect = () => ({ top: anchorContentTop - top }) as DOMRect;
 
-  return { el, moveAnchorTo: (v: number) => (anchorContentTop = v), scrollTopOf: () => top };
+  return {
+    el,
+    moveAnchorTo: (v: number) => (anchorContentTop = v),
+    scrollTopOf: () => top,
+    freezeScrolling: () => (immovable = true),
+  };
 }
 
 function Probe({ el, isLive, onReady }: { el: HTMLDivElement; isLive: boolean; onReady: (j: Jump) => void }) {
@@ -205,6 +214,23 @@ describe("useConversationJump", () => {
     expect(el.style.overflowAnchor).toBe("none");
 
     runFrames(60);
+    expect(el.style.overflowAnchor).toBe("");
+  });
+
+  it("gives up, and restores anchoring, when the container stops moving", () => {
+    // It can stop being scrollable mid-flight — a side panel opening, the
+    // conversation being replaced. Without a backstop the loop re-queues
+    // forever against a target it can never reach, and scroll anchoring stays
+    // suspended for the life of the page.
+    const { el, freezeScrolling } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+    runFrames(2);
+
+    freezeScrolling();
+    runFrames(300);
+
+    expect(frames.size).toBe(0);
     expect(el.style.overflowAnchor).toBe("");
   });
 

--- a/apps/frontend/src/rework/core/hooks/useConversationJump.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useConversationJump.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The three behaviours that justify animating this by hand rather than through
+// `scrollTo({ behavior: "smooth" })`: the target is re-read every frame, the
+// reader can take the view back, and a starting turn cancels the animation.
+// A native smooth scroll offers none of the three.
+
+import { act, useRef, type RefObject } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useConversationJump } from "./useConversationJump";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+/** Pending frames by id, so cancellation can actually remove one — the whole
+ *  point of animating by hand is that a frame can be called off. */
+let frames: Map<number, FrameRequestCallback>;
+let nextFrameId: number;
+
+const CLIENT_HEIGHT = 500;
+const SCROLL_HEIGHT = 5000;
+
+/**
+ * A scroll container holding one turn anchor whose distance from the top the
+ * test controls — the stand-in for content above it changing height mid-flight.
+ */
+function makeScroller() {
+  const el = document.createElement("div");
+  const anchor = document.createElement("div");
+  anchor.dataset.turnId = "u2";
+  el.appendChild(anchor);
+
+  let top = 0;
+  /** The anchor's position in the scrolled content. */
+  let anchorContentTop = 2000;
+  Object.defineProperty(el, "clientHeight", { get: () => CLIENT_HEIGHT });
+  Object.defineProperty(el, "scrollHeight", { get: () => SCROLL_HEIGHT });
+  Object.defineProperty(el, "scrollTop", {
+    get: () => top,
+    // happy-dom does not clamp on its own, and the clamp is load-bearing here:
+    // the hook reads back what it wrote to tell a clamp from a reader takeover.
+    set: (v: number) => {
+      top = Math.max(0, Math.min(v, SCROLL_HEIGHT - CLIENT_HEIGHT));
+    },
+  });
+  el.getBoundingClientRect = () => ({ top: 0 }) as DOMRect;
+  // Viewport-relative, exactly as the real thing: content position minus scroll.
+  anchor.getBoundingClientRect = () => ({ top: anchorContentTop - top }) as DOMRect;
+
+  return { el, moveAnchorTo: (v: number) => (anchorContentTop = v), scrollTopOf: () => top };
+}
+
+function Probe({ el, isLive, onReady }: { el: HTMLDivElement; isLive: boolean; onReady: (j: Jump) => void }) {
+  const ref = useRef<HTMLDivElement | null>(el) as RefObject<HTMLDivElement | null>;
+  onReady(useConversationJump(ref, isLive));
+  return null;
+}
+
+type Jump = (turnId: string) => void;
+
+function render(el: HTMLDivElement, isLive: boolean): Jump {
+  let jump!: Jump;
+  act(() => {
+    root.render(
+      <Probe
+        el={el}
+        isLive={isLive}
+        onReady={(j) => {
+          jump = j;
+        }}
+      />,
+    );
+  });
+  return jump;
+}
+
+/** Drain queued frames, letting the loop re-queue as it converges. */
+function runFrames(n: number) {
+  act(() => {
+    for (let i = 0; i < n; i++) {
+      const queued = [...frames.values()];
+      frames.clear();
+      for (const f of queued) f(i);
+    }
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  frames = new Map();
+  nextFrameId = 1;
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    const id = nextFrameId++;
+    frames.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => frames.delete(id));
+  vi.stubGlobal("matchMedia", () => ({ matches: false }));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("useConversationJump", () => {
+  it("eases towards the turn rather than landing in one step", () => {
+    const { el, scrollTopOf } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+
+    runFrames(1);
+    const afterOne = scrollTopOf();
+    // Target is 2000 - 16px of padding.
+    expect(afterOne).toBeGreaterThan(0);
+    expect(afterOne).toBeLessThan(1984);
+
+    runFrames(60);
+    expect(scrollTopOf()).toBe(1984);
+  });
+
+  it("follows the turn when content above it changes height mid-flight", () => {
+    // The failure a native smooth scroll cannot avoid: it commits to a pixel
+    // offset at call time, so a Mermaid block or image resolving above the
+    // target lands the reader beside the wrong turn.
+    const { el, moveAnchorTo, scrollTopOf } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+    runFrames(2);
+
+    moveAnchorTo(3000);
+    runFrames(60);
+
+    expect(scrollTopOf()).toBe(2984);
+  });
+
+  it("stops when the reader takes the view back", () => {
+    const { el, scrollTopOf } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+    runFrames(2);
+
+    // The reader scrolls somewhere else entirely.
+    act(() => {
+      el.scrollTop = 100;
+    });
+    runFrames(60);
+
+    expect(scrollTopOf()).toBe(100);
+  });
+
+  it("stops when a turn starts, leaving the autoscroll in charge", () => {
+    const { el, scrollTopOf } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+    runFrames(2);
+    const whenTurnStarted = scrollTopOf();
+
+    render(el, true);
+    runFrames(60);
+
+    expect(scrollTopOf()).toBe(whenTurnStarted);
+  });
+
+  it("lands immediately when the reader asked for reduced motion", () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    const { el, scrollTopOf } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+
+    expect(scrollTopOf()).toBe(1984);
+    expect(frames.size).toBe(0);
+  });
+
+  it("suspends scroll anchoring for the flight, and restores it after", () => {
+    // Anchoring silently adjusts scrollTop when content above the viewport
+    // changes height — indistinguishable from the reader grabbing the
+    // scrollbar, so it would abort the jump in the very case the hand-rolled
+    // animation exists to survive.
+    const { el } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("u2"));
+    expect(el.style.overflowAnchor).toBe("none");
+
+    runFrames(60);
+    expect(el.style.overflowAnchor).toBe("");
+  });
+
+  it("does nothing for a turn that is not in the thread", () => {
+    const { el, scrollTopOf } = makeScroller();
+    const jump = render(el, false);
+    act(() => jump("nope"));
+    runFrames(10);
+    expect(scrollTopOf()).toBe(0);
+  });
+});

--- a/apps/frontend/src/rework/core/hooks/useConversationJump.ts
+++ b/apps/frontend/src/rework/core/hooks/useConversationJump.ts
@@ -29,6 +29,20 @@ const JUMP_TOP_PADDING_PX = 16;
 const TAKEOVER_TOLERANCE_PX = 2;
 
 /**
+ * Hard ceiling on a jump's frames.
+ *
+ * `nextFollowTop` closes 22% of the remaining distance per frame, so it
+ * converges geometrically: even a jump across ten thousand pixels is inside the
+ * snap distance in well under fifty frames. Four seconds is therefore far
+ * beyond any legitimate jump, and it exists only to bound the case where the
+ * container stops moving at all — it stops being scrollable mid-flight, or the
+ * conversation is replaced under us. Without it the loop re-queues forever
+ * against a target it can never reach, and scroll anchoring stays suspended for
+ * the life of the page.
+ */
+const MAX_JUMP_FRAMES = 240;
+
+/**
  * Returns a `jumpTo(turnId)` that eases the conversation to that turn.
  *
  * Animated frame by frame rather than through `scrollTo({ behavior: "smooth" })`,
@@ -57,11 +71,13 @@ export function useConversationJump(
   const frameRef = useRef<number | null>(null);
   // What we last wrote, to tell our own movement from the reader's.
   const writtenTopRef = useRef<number | null>(null);
+  const framesLeftRef = useRef(0);
 
   const cancel = useCallback(() => {
     if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
     frameRef.current = null;
     writtenTopRef.current = null;
+    framesLeftRef.current = 0;
     // Scroll anchoring goes back on the moment we stop driving — see jumpTo.
     if (containerRef.current) containerRef.current.style.overflowAnchor = "";
   }, [containerRef]);
@@ -131,9 +147,13 @@ export function useConversationJump(
         // ends, and an unread clamp would look exactly like a reader takeover
         // on the next frame.
         writtenTopRef.current = node.scrollTop;
-        if (next !== target) frameRef.current = requestAnimationFrame(step);
-        else cancel();
+        if (next === target || --framesLeftRef.current <= 0) {
+          cancel();
+          return;
+        }
+        frameRef.current = requestAnimationFrame(step);
       };
+      framesLeftRef.current = MAX_JUMP_FRAMES;
       frameRef.current = requestAnimationFrame(step);
     },
     [containerRef, cancel],

--- a/apps/frontend/src/rework/core/hooks/useConversationJump.ts
+++ b/apps/frontend/src/rework/core/hooks/useConversationJump.ts
@@ -1,0 +1,141 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Animated jump to one turn, for the outline rail.
+//
+// Only ever runs while `useChatAutoScroll` is idle — see its ownership note.
+
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+import { nextFollowTop } from "./useChatAutoScroll";
+
+/** Breathing room left above the turn being jumped to, so it doesn't land
+ *  flush against the container's masked top edge. Matches `--spacing-m`. */
+const JUMP_TOP_PADDING_PX = 16;
+
+/** Tolerance for "the container is where we left it". Scroll positions are
+ *  fractional on scaled displays, so an exact comparison would read every
+ *  frame as an interruption. */
+const TAKEOVER_TOLERANCE_PX = 2;
+
+/**
+ * Returns a `jumpTo(turnId)` that eases the conversation to that turn.
+ *
+ * Animated frame by frame rather than through `scrollTo({ behavior: "smooth" })`,
+ * for three reasons that all bite in this container:
+ *
+ * - **The target is re-resolved every frame.** A native smooth scroll commits
+ *   to a pixel offset at call time; anything above the target that changes
+ *   height mid-flight (an image finishing, a Mermaid block rendering) then
+ *   lands the reader beside the wrong turn. Reading the node's position each
+ *   frame makes drift structurally impossible.
+ * - **It can be cancelled.** A native smooth scroll cannot: the only way to
+ *   stop one is an engine-dependent trick. A new turn starting has to be able
+ *   to take the view back.
+ * - **A reader taking over is detectable.** Comparing the container against
+ *   the position we last wrote separates our own movement from theirs, which
+ *   scroll events alone cannot do. Fighting the reader for the scroll position
+ *   is the same failure the autoscroll's single-owner rule exists to prevent.
+ *
+ * Reuses `nextFollowTop` so a jump and the autoscroll's follow share one curve
+ * and don't read as two different behaviours.
+ */
+export function useConversationJump(
+  containerRef: RefObject<HTMLElement | null>,
+  isLive: boolean,
+): (turnId: string) => void {
+  const frameRef = useRef<number | null>(null);
+  // What we last wrote, to tell our own movement from the reader's.
+  const writtenTopRef = useRef<number | null>(null);
+
+  const cancel = useCallback(() => {
+    if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    frameRef.current = null;
+    writtenTopRef.current = null;
+    // Scroll anchoring goes back on the moment we stop driving — see jumpTo.
+    if (containerRef.current) containerRef.current.style.overflowAnchor = "";
+  }, [containerRef]);
+
+  useEffect(() => cancel, [cancel]);
+
+  // A turn starting takes the view back: `useChatAutoScroll` jumps to the
+  // bottom for it, and an animation still in flight would drag it away again.
+  useEffect(() => {
+    if (isLive) cancel();
+  }, [isLive, cancel]);
+
+  return useCallback(
+    (turnId: string) => {
+      const el = containerRef.current;
+      if (!el) return;
+      cancel();
+
+      const targetTop = () => {
+        const node = el.querySelector<HTMLElement>(`[data-turn-id="${CSS.escape(turnId)}"]`);
+        if (!node) return null;
+        const offset = node.getBoundingClientRect().top - el.getBoundingClientRect().top;
+        const wanted = el.scrollTop + offset - JUMP_TOP_PADDING_PX;
+        return Math.max(0, Math.min(wanted, el.scrollHeight - el.clientHeight));
+      };
+
+      const settle = () => {
+        const target = targetTop();
+        if (target !== null) el.scrollTop = target;
+      };
+
+      const reduced = typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches;
+      if (reduced || typeof requestAnimationFrame !== "function") {
+        settle();
+        return;
+      }
+
+      // Suspend the browser's scroll anchoring for the flight. When content
+      // above the viewport changes height, anchoring silently adjusts scrollTop
+      // to hold the visual position — which the takeover check below cannot
+      // tell from the reader grabbing the scrollbar, so the jump would abort in
+      // exactly the mid-flight case it exists to survive. Re-resolving the
+      // target every frame already does anchoring's job here.
+      el.style.overflowAnchor = "none";
+
+      const step = () => {
+        frameRef.current = null;
+        const node = containerRef.current;
+        if (!node) return;
+        // Someone else moved the view — the reader, or the autoscroll taking a
+        // new turn back. Their position wins; we stop.
+        if (
+          writtenTopRef.current !== null &&
+          Math.abs(node.scrollTop - writtenTopRef.current) > TAKEOVER_TOLERANCE_PX
+        ) {
+          cancel();
+          return;
+        }
+        const target = targetTop();
+        if (target === null) {
+          cancel();
+          return;
+        }
+        const next = nextFollowTop(node.scrollTop, target);
+        node.scrollTop = next;
+        // Read back rather than trusting the write: the browser clamps at the
+        // ends, and an unread clamp would look exactly like a reader takeover
+        // on the next frame.
+        writtenTopRef.current = node.scrollTop;
+        if (next !== target) frameRef.current = requestAnimationFrame(step);
+        else cancel();
+      };
+      frameRef.current = requestAnimationFrame(step);
+    },
+    [containerRef, cancel],
+  );
+}

--- a/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The rule under test is "last anchor to have passed the reading line", not
+// "topmost anchor still on screen". The anchors sit on the user message that
+// opens each turn, so partway through a long answer no anchor is on screen at
+// all — the naive rule blanks the active mark on exactly the conversations the
+// rail exists for.
+
+import { act, useRef, type RefObject } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useOutlineScrollSpy } from "./useOutlineScrollSpy";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+/** Fires every live observer — the hook uses it only as a "something crossed"
+ *  trigger, then measures the anchors itself. */
+let notifyObservers: () => void;
+/** Options the hook handed its observer, and how many it has built. */
+let observerOptions: IntersectionObserverInit | undefined;
+let observerCount: number;
+
+/** A container whose anchors sit at test-controlled distances from its top. */
+function makeScroller(anchorTops: Record<string, number>) {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () => ({ top: 0 }) as DOMRect;
+  const tops = { ...anchorTops };
+  for (const id of Object.keys(tops)) {
+    const anchor = document.createElement("div");
+    anchor.dataset.turnId = id;
+    anchor.getBoundingClientRect = () => ({ top: tops[id] }) as DOMRect;
+    el.appendChild(anchor);
+  }
+  return { el, moveTo: (id: string, top: number) => (tops[id] = top) };
+}
+
+function Probe({
+  el,
+  sessionId,
+  count,
+  onValue,
+}: {
+  el: HTMLDivElement;
+  sessionId: string;
+  count: number;
+  onValue: (v: string | null) => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(el) as RefObject<HTMLDivElement | null>;
+  onValue(useOutlineScrollSpy(ref, sessionId, count));
+  return null;
+}
+
+function render(el: HTMLDivElement, count: number, sessionId = "s1"): () => string | null {
+  let value: string | null = null;
+  act(() => {
+    root.render(
+      <Probe
+        el={el}
+        sessionId={sessionId}
+        count={count}
+        onValue={(v) => {
+          value = v;
+        }}
+      />,
+    );
+  });
+  return () => value;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const callbacks: (() => void)[] = [];
+  observerOptions = undefined;
+  observerCount = 0;
+  notifyObservers = () => act(() => callbacks.forEach((cb) => cb()));
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(cb: () => void, options?: IntersectionObserverInit) {
+        callbacks.push(cb);
+        observerOptions = options;
+        observerCount += 1;
+      }
+      observe() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("useOutlineScrollSpy", () => {
+  it("holds the last turn that passed the reading line", () => {
+    // u2 is above the top edge, u3 still well below it: the reader is inside
+    // u2's answer even though u2's own anchor has scrolled out of sight.
+    const { el } = makeScroller({ u1: -3000, u2: -900, u3: 700 });
+    const active = render(el, 3);
+    notifyObservers();
+    expect(active()).toBe("u2");
+  });
+
+  it("moves on only once the next turn reaches the container's top edge", () => {
+    const { el, moveTo } = makeScroller({ u1: -900, u2: 400 });
+    const active = render(el, 2);
+    notifyObservers();
+    expect(active()).toBe("u1");
+
+    // Peeking in from the bottom is not enough...
+    moveTo("u2", 200);
+    notifyObservers();
+    expect(active()).toBe("u1");
+
+    // ...crossing the top edge is. The measured line has to be a boundary the
+    // observer actually fires on, or the answer would only ever refresh by
+    // accident, when some unrelated anchor happened to cross an edge.
+    moveTo("u2", -1);
+    notifyObservers();
+    expect(active()).toBe("u2");
+  });
+
+  it("observes the crossing the resolver measures", () => {
+    const { el } = makeScroller({ u1: -100 });
+    render(el, 1);
+    // threshold 1 fires as an anchor stops being wholly inside the container,
+    // which is the moment its top passes the edge — the line resolve() reads.
+    expect(observerOptions?.threshold).toEqual([0, 1]);
+  });
+
+  it("re-subscribes when the session changes but the turn count does not", () => {
+    // Two conversations can hold the same number of turns; keying on the count
+    // alone left the observer on the previous session's detached nodes.
+    const { el } = makeScroller({ u1: -100, u2: 500 });
+    render(el, 2);
+    const before = observerCount;
+    render(el, 2, "s2");
+    expect(observerCount).toBeGreaterThan(before);
+  });
+
+  it("holds the first turn while the reader is still above it", () => {
+    const { el } = makeScroller({ u1: 300, u2: 900 });
+    const active = render(el, 2);
+    notifyObservers();
+    expect(active()).toBe("u1");
+  });
+
+  it("reports nothing when the conversation has no turns", () => {
+    const { el } = makeScroller({});
+    expect(render(el, 0)()).toBeNull();
+  });
+});

--- a/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.test.tsx
+++ b/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.test.tsx
@@ -13,11 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The rule under test is "last anchor to have passed the reading line", not
-// "topmost anchor still on screen". The anchors sit on the user message that
-// opens each turn, so partway through a long answer no anchor is on screen at
-// all — the naive rule blanks the active mark on exactly the conversations the
-// rail exists for.
+// Two rules, and the reported bug was the absence of the first: a short final
+// turn never climbs to any reading line, so sitting at the bottom of the
+// conversation left the rail pointing at the turn before it.
 
 import { act, useRef, type RefObject } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -32,51 +30,68 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
 let root: Root;
-/** Fires every live observer — the hook uses it only as a "something crossed"
- *  trigger, then measures the anchors itself. */
-let notifyObservers: () => void;
-/** Options the hook handed its observer, and how many it has built. */
-let observerOptions: IntersectionObserverInit | undefined;
-let observerCount: number;
+let frames: FrameRequestCallback[];
 
-/** A container whose anchors sit at test-controlled distances from its top. */
-function makeScroller(anchorTops: Record<string, number>) {
+const CLIENT_HEIGHT = 1000;
+/** Reading line at 35% of the viewport: 350px below the container's top. */
+const LINE = 350;
+
+/**
+ * A container whose anchor positions and scroll geometry the test drives.
+ * `tops` and `geometry` stay live, so a test can move the content and fire a
+ * scroll the way the browser would.
+ */
+function makeScroller(tops: Record<string, number>, geometry = { scrollTop: 0, scrollHeight: 10000 }) {
   const el = document.createElement("div");
   el.getBoundingClientRect = () => ({ top: 0 }) as DOMRect;
-  const tops = { ...anchorTops };
+  Object.defineProperty(el, "clientHeight", { get: () => CLIENT_HEIGHT });
+  Object.defineProperty(el, "scrollHeight", { get: () => geometry.scrollHeight });
+  Object.defineProperty(el, "scrollTop", { get: () => geometry.scrollTop, set: () => {} });
+
   for (const id of Object.keys(tops)) {
     const anchor = document.createElement("div");
     anchor.dataset.turnId = id;
     anchor.getBoundingClientRect = () => ({ top: tops[id] }) as DOMRect;
     el.appendChild(anchor);
   }
-  return { el, moveTo: (id: string, top: number) => (tops[id] = top) };
+
+  const scroll = () =>
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+      const queued = frames;
+      frames = [];
+      for (const f of queued) f(0);
+    });
+  return { el, tops, geometry, scroll, ids: Object.keys(tops) };
 }
 
 function Probe({
   el,
-  sessionId,
-  count,
+  ids,
+  live,
   onValue,
 }: {
   el: HTMLDivElement;
-  sessionId: string;
-  count: number;
+  ids: string[];
+  live: boolean;
   onValue: (v: string | null) => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(el) as RefObject<HTMLDivElement | null>;
-  onValue(useOutlineScrollSpy(ref, sessionId, count));
+  onValue(useOutlineScrollSpy(ref, ids, live));
   return null;
 }
 
-function render(el: HTMLDivElement, count: number, sessionId = "s1"): () => string | null {
+/** `ids` is passed by reference, as ManagedChatPage does — the hook uses it as
+ *  its subscription key, so a fresh array each render would re-subscribe
+ *  endlessly. */
+function render(scroller: { el: HTMLDivElement; ids: string[] }, live = false): () => string | null {
   let value: string | null = null;
   act(() => {
     root.render(
       <Probe
-        el={el}
-        sessionId={sessionId}
-        count={count}
+        el={scroller.el}
+        ids={scroller.ids}
+        live={live}
         onValue={(v) => {
           value = v;
         }}
@@ -90,22 +105,9 @@ beforeEach(() => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  const callbacks: (() => void)[] = [];
-  observerOptions = undefined;
-  observerCount = 0;
-  notifyObservers = () => act(() => callbacks.forEach((cb) => cb()));
-  vi.stubGlobal(
-    "IntersectionObserver",
-    class {
-      constructor(cb: () => void, options?: IntersectionObserverInit) {
-        callbacks.push(cb);
-        observerOptions = options;
-        observerCount += 1;
-      }
-      observe() {}
-      disconnect() {}
-    },
-  );
+  frames = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => frames.push(cb));
+  vi.stubGlobal("cancelAnimationFrame", () => {});
 });
 
 afterEach(() => {
@@ -115,61 +117,76 @@ afterEach(() => {
 });
 
 describe("useOutlineScrollSpy", () => {
+  it("marks the last turn active once the reader is at the bottom", () => {
+    // The reported case: the final turn is short, so its question sits low on
+    // screen and never reaches the reading line however far you scroll. Before
+    // this rule the rail stayed on u1 while the reader sat on u2.
+    const scroller = makeScroller({ u1: -2000, u2: 800 }, { scrollTop: 9000, scrollHeight: 10000 });
+    expect(render(scroller)()).toBe("u2");
+  });
+
   it("holds the last turn that passed the reading line", () => {
-    // u2 is above the top edge, u3 still well below it: the reader is inside
-    // u2's answer even though u2's own anchor has scrolled out of sight.
-    const { el } = makeScroller({ u1: -3000, u2: -900, u3: 700 });
-    const active = render(el, 3);
-    notifyObservers();
-    expect(active()).toBe("u2");
+    // Partway through u2's long answer: u2's own anchor has scrolled out of
+    // sight, and u3 is still below the line.
+    const scroller = makeScroller({ u1: -3000, u2: -900, u3: 700 });
+    expect(render(scroller)()).toBe("u2");
   });
 
-  it("moves on only once the next turn reaches the container's top edge", () => {
-    const { el, moveTo } = makeScroller({ u1: -900, u2: 400 });
-    const active = render(el, 2);
-    notifyObservers();
-    expect(active()).toBe("u1");
-
-    // Peeking in from the bottom is not enough...
-    moveTo("u2", 200);
-    notifyObservers();
-    expect(active()).toBe("u1");
-
-    // ...crossing the top edge is. The measured line has to be a boundary the
-    // observer actually fires on, or the answer would only ever refresh by
-    // accident, when some unrelated anchor happened to cross an edge.
-    moveTo("u2", -1);
-    notifyObservers();
-    expect(active()).toBe("u2");
+  it("counts a turn as reached at the line, not at the very top of the screen", () => {
+    // The criterion the report called too extreme: requiring the turn's start
+    // to reach the top edge left it inactive through most of the screen.
+    const scroller = makeScroller({ u1: -900, u2: LINE - 1 });
+    expect(render(scroller)()).toBe("u2");
   });
 
-  it("observes the crossing the resolver measures", () => {
-    const { el } = makeScroller({ u1: -100 });
-    render(el, 1);
-    // threshold 1 fires as an anchor stops being wholly inside the container,
-    // which is the moment its top passes the edge — the line resolve() reads.
-    expect(observerOptions?.threshold).toEqual([0, 1]);
-  });
-
-  it("re-subscribes when the session changes but the turn count does not", () => {
-    // Two conversations can hold the same number of turns; keying on the count
-    // alone left the observer on the previous session's detached nodes.
-    const { el } = makeScroller({ u1: -100, u2: 500 });
-    render(el, 2);
-    const before = observerCount;
-    render(el, 2, "s2");
-    expect(observerCount).toBeGreaterThan(before);
+  it("does not count a turn still below the line", () => {
+    const scroller = makeScroller({ u1: -900, u2: LINE + 1 });
+    expect(render(scroller)()).toBe("u1");
   });
 
   it("holds the first turn while the reader is still above it", () => {
-    const { el } = makeScroller({ u1: 300, u2: 900 });
-    const active = render(el, 2);
-    notifyObservers();
+    const scroller = makeScroller({ u1: 500, u2: 900 });
+    expect(render(scroller)()).toBe("u1");
+  });
+
+  it("re-resolves as the reader scrolls", () => {
+    const scroller = makeScroller({ u1: -900, u2: 800 });
+    const { tops, scroll } = scroller;
+    const active = render(scroller);
+    expect(active()).toBe("u1");
+
+    tops.u2 = 100;
+    scroll();
+    expect(active()).toBe("u2");
+  });
+
+  it("measures once per frame however many scroll events land", () => {
+    const scroller = makeScroller({ u1: -900, u2: 800 });
+    render(scroller);
+    const { el } = scroller;
+
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+      el.dispatchEvent(new Event("scroll"));
+      el.dispatchEvent(new Event("scroll"));
+    });
+    expect(frames).toHaveLength(1);
+  });
+
+  it("stops measuring while a turn is live", () => {
+    // That is when useChatAutoScroll writes the scroll position every frame;
+    // measuring on each of those writes is work nobody asked for.
+    const scroller = makeScroller({ u1: -900, u2: 800 });
+    const { tops, scroll } = scroller;
+    const active = render(scroller, true);
+    expect(active()).toBe("u1");
+
+    tops.u2 = 100;
+    scroll();
     expect(active()).toBe("u1");
   });
 
   it("reports nothing when the conversation has no turns", () => {
-    const { el } = makeScroller({});
-    expect(render(el, 0)()).toBeNull();
+    expect(render(makeScroller({}))()).toBeNull();
   });
 });

--- a/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.ts
+++ b/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.ts
@@ -16,47 +16,59 @@
 // mark.
 
 import { useEffect, useState, type RefObject } from "react";
+import { isNearBottom } from "./useChatAutoScroll";
 
-/**
- * Fired when an anchor becomes, or stops being, wholly inside the container —
- * the `1` is what matters. The measurement below is "this turn's question has
- * reached the container's top edge", and an observer must actually fire at the
- * boundary being measured or the answer only refreshes by accident, whenever
- * some other anchor happens to cross an edge. `0` alone fires when an anchor
- * has fully left, which is a different line and up to one anchor-height late.
- */
-const CROSSING_THRESHOLDS = [0, 1];
+/** Where down the viewport a turn counts as the one being read. A turn becomes
+ *  active once its question has climbed past this line, not when it merely
+ *  peeks in from the bottom. */
+const ACTIVE_LINE_RATIO = 0.35;
 
 /**
  * The id of the turn the reader is currently in, or null.
  *
- * The active turn is the LAST anchor to have passed the container's top edge —
- * not the topmost anchor still on screen. The anchors sit on the user message
- * that opens each turn, so while the reader is partway through a long answer
- * there is no anchor on screen at all; "topmost visible" would blank the active
- * mark for exactly the turns the rail is most useful on.
+ * Two rules, and the second is not a special case — it is the common one:
  *
- * The observer is a trigger, not the measurement: it says an anchor crossed,
- * and the answer is then recomputed from the anchors' positions. Scrolling
- * between two distant anchors fires nothing, and correctly changes nothing. A
- * scroll handler would instead run on every one of the per-frame scroll writes
- * `useChatAutoScroll` makes while a turn streams.
+ * 1. **At the bottom, the last turn is active.** A short final turn never
+ *    climbs past the reading line however far the reader scrolls: there simply
+ *    isn't enough content below it to push it up there. Without this the rail
+ *    would keep pointing at the previous turn while the reader sits on the
+ *    newest one, which is where a conversation is read most of the time.
+ * 2. Otherwise, the last turn whose question has passed the reading line. Not
+ *    "the topmost anchor still on screen": the anchors sit on the user message
+ *    that opens each turn, so partway through a long answer none is visible at
+ *    all, and that rule would blank the mark on exactly the conversations the
+ *    rail exists for.
  *
- * `sessionId` is in the subscription key, not decoration: two conversations can
- * hold the same number of turns, and re-keying on the count alone would leave
- * the observer watching the previous session's detached nodes. The autoscroll
- * guards the same case the same way.
+ * Driven by scroll rather than an IntersectionObserver. An observer only fires
+ * when an element crosses a boundary, and rule 1 turns on the *scroll position*
+ * — no anchor crosses anything over the last stretch to the bottom, so the
+ * observer stays silent through precisely the case this has to get right.
+ * A size observer covers what scrolling cannot: a side panel opening, a window
+ * resize or a late-rendering diagram moves every anchor without a scroll event,
+ * and the mark would otherwise stay wrong until the reader happened to scroll.
+ *
+ * `turnIds` must be identity-stable across renders (see ManagedChatPage) — it
+ * is the subscription key, and it is the RIGHT key precisely because it is
+ * derived from the messages: session id changes a render before the messages
+ * do, so re-keying on that would resolve against the previous conversation and
+ * then never correct itself.
+ *
+ * The cost that made an observer attractive is paid off differently: anchors
+ * are in document order, so their positions are monotonic and the line is found
+ * by binary search — around eight measurements for a two-hundred-turn
+ * conversation, not two hundred. And nothing runs while a turn is live, which
+ * is when `useChatAutoScroll` is writing the scroll position every frame.
  */
 export function useOutlineScrollSpy(
   containerRef: RefObject<HTMLElement | null>,
-  sessionId: string | null | undefined,
-  turnCount: number,
+  turnIds: string[],
+  live: boolean,
 ): string | null {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
     const root = containerRef.current;
-    if (!root || turnCount === 0 || typeof IntersectionObserver === "undefined") {
+    if (!root || turnIds.length === 0) {
       setActiveId(null);
       return;
     }
@@ -67,22 +79,56 @@ export function useOutlineScrollSpy(
         setActiveId(null);
         return;
       }
-      const line = root.getBoundingClientRect().top;
-      let active: string | null = null;
-      for (const anchor of anchors) {
-        if (anchor.getBoundingClientRect().top > line) break;
-        active = anchor.dataset.turnId ?? active;
+      if (isNearBottom(root.scrollTop, root.scrollHeight, root.clientHeight)) {
+        setActiveId(anchors[anchors.length - 1].dataset.turnId ?? null);
+        return;
+      }
+
+      const line = root.getBoundingClientRect().top + root.clientHeight * ACTIVE_LINE_RATIO;
+      let low = 0;
+      let high = anchors.length - 1;
+      let found = -1;
+      while (low <= high) {
+        const mid = (low + high) >> 1;
+        if (anchors[mid].getBoundingClientRect().top <= line) {
+          found = mid;
+          low = mid + 1;
+        } else {
+          high = mid - 1;
+        }
       }
       // Above the first turn: it is still the one being read into.
-      setActiveId(active ?? anchors[0].dataset.turnId ?? null);
+      const active = anchors[found === -1 ? 0 : found];
+      setActiveId(active.dataset.turnId ?? null);
     };
 
-    const observer = new IntersectionObserver(resolve, { root, threshold: CROSSING_THRESHOLDS });
-    for (const anchor of root.querySelectorAll("[data-turn-id]")) observer.observe(anchor);
     resolve();
+    if (live) return;
 
-    return () => observer.disconnect();
-  }, [containerRef, sessionId, turnCount]);
+    // Coalesced to one measurement per frame: a scroll event can fire more
+    // often than the screen repaints, and re-measuring in between is work
+    // nobody sees.
+    let frame: number | null = null;
+    const onScroll = () => {
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        resolve();
+      });
+    };
+    root.addEventListener("scroll", onScroll, { passive: true });
+
+    // The container's own box and the content inside it both move the anchors.
+    const sizes = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(onScroll);
+    sizes?.observe(root);
+    if (root.firstElementChild) sizes?.observe(root.firstElementChild);
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      root.removeEventListener("scroll", onScroll);
+      sizes?.disconnect();
+    };
+  }, [containerRef, turnIds, live]);
 
   return activeId;
 }

--- a/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.ts
+++ b/apps/frontend/src/rework/core/hooks/useOutlineScrollSpy.ts
@@ -1,0 +1,88 @@
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Which turn the reader is currently looking at, for the outline rail's active
+// mark.
+
+import { useEffect, useState, type RefObject } from "react";
+
+/**
+ * Fired when an anchor becomes, or stops being, wholly inside the container —
+ * the `1` is what matters. The measurement below is "this turn's question has
+ * reached the container's top edge", and an observer must actually fire at the
+ * boundary being measured or the answer only refreshes by accident, whenever
+ * some other anchor happens to cross an edge. `0` alone fires when an anchor
+ * has fully left, which is a different line and up to one anchor-height late.
+ */
+const CROSSING_THRESHOLDS = [0, 1];
+
+/**
+ * The id of the turn the reader is currently in, or null.
+ *
+ * The active turn is the LAST anchor to have passed the container's top edge —
+ * not the topmost anchor still on screen. The anchors sit on the user message
+ * that opens each turn, so while the reader is partway through a long answer
+ * there is no anchor on screen at all; "topmost visible" would blank the active
+ * mark for exactly the turns the rail is most useful on.
+ *
+ * The observer is a trigger, not the measurement: it says an anchor crossed,
+ * and the answer is then recomputed from the anchors' positions. Scrolling
+ * between two distant anchors fires nothing, and correctly changes nothing. A
+ * scroll handler would instead run on every one of the per-frame scroll writes
+ * `useChatAutoScroll` makes while a turn streams.
+ *
+ * `sessionId` is in the subscription key, not decoration: two conversations can
+ * hold the same number of turns, and re-keying on the count alone would leave
+ * the observer watching the previous session's detached nodes. The autoscroll
+ * guards the same case the same way.
+ */
+export function useOutlineScrollSpy(
+  containerRef: RefObject<HTMLElement | null>,
+  sessionId: string | null | undefined,
+  turnCount: number,
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root || turnCount === 0 || typeof IntersectionObserver === "undefined") {
+      setActiveId(null);
+      return;
+    }
+
+    const resolve = () => {
+      const anchors = root.querySelectorAll<HTMLElement>("[data-turn-id]");
+      if (anchors.length === 0) {
+        setActiveId(null);
+        return;
+      }
+      const line = root.getBoundingClientRect().top;
+      let active: string | null = null;
+      for (const anchor of anchors) {
+        if (anchor.getBoundingClientRect().top > line) break;
+        active = anchor.dataset.turnId ?? active;
+      }
+      // Above the first turn: it is still the one being read into.
+      setActiveId(active ?? anchors[0].dataset.turnId ?? null);
+    };
+
+    const observer = new IntersectionObserver(resolve, { root, threshold: CROSSING_THRESHOLDS });
+    for (const anchor of root.querySelectorAll("[data-turn-id]")) observer.observe(anchor);
+    resolve();
+
+    return () => observer.disconnect();
+  }, [containerRef, sessionId, turnCount]);
+
+  return activeId;
+}

--- a/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
+++ b/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
@@ -12,11 +12,13 @@ file is trimmed to the parts that are still genuinely open.
 ## What shipped
 
 A rail of graphical marks along the conversation's left edge in
-`ManagedChatPage`: one per turn, discrete hover magnification over two
-neighbours each side, a preview tile, three heights from the answer's length, a
-scroll-spy active mark, and an animated jump. Inert while a turn is live, which
-is what keeps it clear of `useChatAutoScroll`'s ownership of the scroll
-position.
+`ManagedChatPage`: one per turn, all the same size, with discrete hover
+magnification over two neighbours each side, a preview tile, a scroll-spy
+active mark, and an animated jump. Inert while a turn is live, which is what
+keeps it clear of `useChatAutoScroll`'s ownership of the scroll position.
+
+Mark heights varying with the answer's length were built and dropped
+(2026-09-09): the rail reads better saying only where the turns are.
 
 Read `COMPONENT-UX.md` for the behaviour and the reasoning behind each choice.
 Nothing about V1 is still under discussion, so it is not restated here.

--- a/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
+++ b/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
@@ -33,9 +33,18 @@ has been in use.
 
 ### 1. Narrow viewports
 
-The rail lives in the gutter left by the 720px message lane. What it should do
-when that gutter disappears is undecided — hide, overlay the lane, or collapse
-to a thinner form.
+The rail sits against the page's left edge, and the message lane is centred and
+capped at 720px. On a column barely wider than the lane — one with a side panel
+open — there is no gutter left, so the rail lands **on top of the first
+characters of every line and captures the pointer there**: clicks and text
+selection over that strip go to the rail, not the conversation. That is the
+concrete cost of the current placement, accepted for V1 rather than overlooked.
+
+Anchoring the rail to the lane instead was tried and rejected: it kept the rail
+clear of the text, but made it drift inward with the reading column instead of
+staying where the eye learns to find it. So the answer is not simply to move it
+back — hiding it, collapsing it to a thinner form, or overlaying it only on
+demand are all still open.
 
 ### 2. Keyboard access
 

--- a/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
+++ b/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
@@ -1,0 +1,212 @@
+# Conversation Outline Rail RFC — navigating a long chat session
+
+**Status:** Agreed, not yet built — design settled 2026-09-09, no open question
+**ID:** `CHAT-OUTLINE-01` (informal label, no registry)
+**Author:** Maxime
+**Date:** 2026-09-09
+
+---
+
+## 1. Problem statement
+
+A long managed-chat session has no navigation affordance. `ConversationThread`
+renders every turn into one scroll container and the only way back to an
+earlier exchange is to scroll and read until you recognise it. There is no
+overview of the session's shape, no way to jump, and nothing that says where
+in the conversation the current viewport sits.
+
+The thread is not virtualised — `ConversationThread.tsx` maps `ThreadMessage[]`
+straight to `UserTurn` / `AssistantTurn` — so every turn already has a real DOM
+node. The missing piece is purely a navigation surface, not a data or rendering
+change.
+
+---
+
+## 2. Proposed solution — a graphical outline rail
+
+A thin vertical rail of marks along the left edge of the conversation column,
+one mark per exchange, centred vertically. Marks carry no text: they are small
+flattened shapes, narrow enough not to eat into the reading column. Hovering a
+mark reveals a preview tile; clicking it jumps to that turn.
+
+`.mainColumn` (`ManagedChatPage.module.css`) is already `position: relative`,
+and the message lane is capped at 720px centred (`ChatMessagesArea.module.css`),
+so at usual widths the rail sits in existing empty gutter and takes no width
+from the reading column.
+
+### 2.1 Magnification on hover
+
+Hovering magnifies the hovered mark **and its two neighbours on each side**,
+with a decreasing step, so the rail reads as a continuous deformation rather
+than one mark popping alone.
+
+The falloff is **discrete, not pointer-distance based**, and therefore expressed
+in CSS through sibling combinators — no JavaScript runs on pointer movement.
+A continuous Dock-style falloff was considered and rejected in §4.
+
+### 2.2 Preview tile
+
+The hovered mark shows a tile to its left, vertically centred on the mark, 12px
+gap, containing:
+
+| Content | Style | Limit |
+|---|---|---|
+| First sentence of the user request that opened the turn | `--font-label-large`, `--on-surface` | 2 lines, ellipsis |
+| First two sentences of the agent's answer | `--font-body-medium`, `--on-surface-retreat` | 4 lines, ellipsis |
+
+This reuses the existing `Tooltip` atom rather than adding a component: it
+already supports `placement="left"` (panel left of the trigger, vertically
+centred on it, flipping right when there is no room) and `content` for rich
+nodes that widen and wrap. The only gap is `TOOLTIP_GAP_PX = 4`, hardcoded to
+match `--spacing-2xs`; the tile needs 12px, so `Tooltip` gains an optional gap
+prop. No new molecule.
+
+### 2.3 Three mark heights
+
+Marks take one of three heights, to give the rail a recognisable shape and let
+the reader aim at "the long one in the middle".
+
+The height is driven by the **character count of the agent's answer text**,
+against **absolute** thresholds:
+
+| Height | Answer length | Roughly |
+|---|---|---|
+| short | < 400 chars | a direct reply, one paragraph |
+| medium | 400 – 1500 chars | a normal answer |
+| tall | > 1500 chars | a long, structured analysis |
+
+Thresholds are a starting point, to calibrate against real sessions.
+
+Two rejected alternatives, both tempting:
+
+- **Token counts.** Available per turn, but a ReAct turn re-sends the whole
+  context on every model call, so `tokenUsage` grows with the session's age
+  rather than with the turn's substance — the rail would show "everything gets
+  bigger towards the end", which is false. `marginalTokenUsage` is the honest
+  variant but is nullable on Graph agents and pre-#2403 history, which would
+  make the rail inconsistent across sessions.
+- **Relative thresholds** (terciles within the session). Always produces
+  contrast, but a mark's height then *changes as the session grows*: the tall
+  block you remember shrinks when a longer turn arrives. The rail is a spatial
+  memory aid, and that memory is destroyed if marks move under the reader.
+  Absolute thresholds are stable by construction.
+
+### 2.4 Scroll-spy
+
+The mark whose turn currently occupies the viewport is rendered in `--primary`.
+Implemented with a single `IntersectionObserver` over the turn nodes — passive,
+browser-side, firing only on threshold crossings, never per frame.
+
+### 2.5 Rail overflow
+
+While the marks fit, the rail is centred vertically. Once they exceed the
+available height, the rail becomes its own scroll container, **bottom-aligned**:
+new turns stack at the bottom and stay visible, old ones leave through the top —
+the same reading model as the conversation itself. Expressible in CSS, no JS.
+
+When scroll-spy marks a turn that is outside the rail's visible range (the
+reader scrolled far back), the rail scrolls itself to reveal the active mark.
+
+This rail scroll is on an element separate from the conversation container and
+so does not interact with §3 at all.
+
+---
+
+## 3. Scroll ownership — why the rail is inert while a turn is live
+
+`useChatAutoScroll` documents itself as the *sole owner* of the conversation
+container's scroll position, on the grounds that a second mechanism on the same
+element cannot be reasoned about. That is not a stylistic rule: while a turn is
+live the hook re-decides the position on every animation frame and eases the
+view towards its target, so any position written from outside is overwritten
+one frame later. A jump-to-turn would appear to work on a finished conversation
+and judder or silently fail while the agent is writing — a frame-timing bug,
+therefore intermittent, therefore the kind that survives review.
+
+**Decision: the rail is frozen and non-interactive while a turn is live**
+(`isStreaming || isAwaitingHuman`) — visible but dimmed, clicks inert, contents
+not recomputed. The mark for the running turn appears when its answer
+completes.
+
+This dissolves the conflict rather than working around it. The hook only ever
+writes while a turn is live (`shouldFollowBottom` returns false in the `idle`
+phase, so `follow()` returns before touching anything). If the rail can only be
+clicked when the hook is quiescent, the two writers never overlap — the
+invariant holds by construction, not by timing luck.
+
+The hook needs **no behavioural change**. Its scroll listener already
+interprets an outside jump correctly: a jump upwards reads as "the reader left
+the bottom" and stops the follow, a jump to the end re-arms it. What does need
+changing is the ownership comment itself — a future reader must find the
+refined invariant ("sole owner while a turn is live; the outline rail may
+scroll it while idle, and here is why that is safe") stated where the rule
+lives, not only in this RFC.
+
+**Known edge to handle at implementation:** a jump animation still in flight
+when a new turn starts would race the hook's `turnKey` jump-to-bottom. Narrow
+(it requires sending a message within the animation's duration of clicking a
+mark) but real — the in-flight jump is cancelled when a turn starts.
+
+Rendering the rail interactive during streaming is deliberately deferred, not
+ruled out; it would require giving the hook an explicit jump command so the
+jump declares its intent instead of writing pixels behind the hook's back.
+
+---
+
+## 4. Performance constraints
+
+The rail must not cost anything on the chat's rendering path. Three specific
+hazards, each with its decided answer:
+
+1. **Per-keystroke re-render.** `ManagedChatPage` re-renders on every composer
+   keystroke; `ConversationThread` is `memo()`-wrapped precisely because
+   without that boundary every historical message re-rendered, markdown
+   re-parse included, on every character typed (#2221). The rail derives from
+   `messages` and must sit behind the same kind of boundary — memoised
+   component, derived data in a `useMemo` keyed on the message list.
+
+2. **Per-token recomputation.** During streaming the message list changes on
+   every token received. Computing preview extracts for all turns on each
+   change would redo string work across the whole conversation tens of times a
+   second — #2221 again, worse. Two decisions close this: the rail's contents
+   are frozen while a turn is live (§3), and extracts are computed **on hover,
+   for the hovered turn only**.
+
+3. **Extract cost at hover time.** Doing the work on hover is safe because it is
+   one turn, once: string work on a few thousand characters, microseconds,
+   far below a 16ms frame. Bounded further by slicing the first ~500 characters
+   *before* sentence detection, making the cost constant regardless of answer
+   size, and memoised per turn id so a second hover is free.
+
+Continuous pointer-distance magnification is rejected on the same grounds: it
+requires a `pointermove` listener writing per-mark values every frame, on a
+surface that sits over the chat. The discrete falloff (§2.1) is CSS-only, costs
+nothing, and is visually close enough.
+
+---
+
+## 5. Impact on existing contracts
+
+| Contract / file | Change |
+|---|---|
+| `CONTROL-PLANE-PRODUCT-CONTRACT.md` | None — no API involved |
+| `RUNTIME-EXECUTION-CONTRACT.md` | None |
+| Generated API clients | None — the rail derives entirely from `ThreadMessage[]`, already in the frontend |
+| `Tooltip` atom | Gains an optional gap prop (currently `TOOLTIP_GAP_PX = 4` hardcoded) |
+| `useChatAutoScroll` | No logic change; its sole-owner comment is amended to state the refined invariant (§3) |
+| `COMPONENT-UX.md` | New entry once implemented: the outline rail, its states, and the frozen-during-streaming behaviour |
+
+Frontend-only. No backend, no schema, no SSE contract, no OpenAPI regeneration.
+
+---
+
+## 6. Out of scope
+
+Explicitly deferred, by developer decision (2026-09-09):
+
+- **Narrow-viewport behaviour.** The rail lives in the gutter left by the 720px
+  lane; what happens when that gutter disappears is not decided here.
+- **Keyboard accessibility.** No tab order, arrow-key navigation, or
+  focus-triggered preview tile in this iteration.
+- **HITL rows.** `hitl_request` / `hitl_response` get no special treatment.
+- **Interactivity during streaming.** See §3.

--- a/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
+++ b/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
@@ -1,218 +1,73 @@
-# Conversation Outline Rail RFC — navigating a long chat session
+# Conversation Outline Rail RFC — what V1 left open
 
-**Status:** Agreed, not yet built — V1 design settled 2026-09-09, no open
-question. §6 lists what V1 deliberately leaves out to ship fast; those are
-revisitable, not closed.
+**Status:** V1 shipped 2026-09-09 (issue #2602). The design and its rationale
+now live in `docs/swift/ux/COMPONENT-UX.md` — "Conversation outline rail". This
+file is trimmed to the parts that are still genuinely open.
 **ID:** `CHAT-OUTLINE-01` (informal label, no registry)
 **Author:** Maxime
 **Date:** 2026-09-09
 
 ---
 
-## 1. Problem statement
+## What shipped
 
-A long managed-chat session has no navigation affordance. `ConversationThread`
-renders every turn into one scroll container and the only way back to an
-earlier exchange is to scroll and read until you recognise it. There is no
-overview of the session's shape, no way to jump, and nothing that says where
-in the conversation the current viewport sits.
+A rail of graphical marks along the conversation's left edge in
+`ManagedChatPage`: one per turn, discrete hover magnification over two
+neighbours each side, a preview tile, three heights from the answer's length, a
+scroll-spy active mark, and an animated jump. Inert while a turn is live, which
+is what keeps it clear of `useChatAutoScroll`'s ownership of the scroll
+position.
 
-The thread is not virtualised — `ConversationThread.tsx` maps `ThreadMessage[]`
-straight to `UserTurn` / `AssistantTurn` — so every turn already has a real DOM
-node. The missing piece is purely a navigation surface, not a data or rendering
-change.
-
----
-
-## 2. Proposed solution — a graphical outline rail
-
-A thin vertical rail of marks along the left edge of the conversation column,
-one mark per exchange, centred vertically. Marks carry no text: they are small
-flattened shapes, narrow enough not to eat into the reading column. Hovering a
-mark reveals a preview tile; clicking it jumps to that turn.
-
-`.mainColumn` (`ManagedChatPage.module.css`) is already `position: relative`,
-and the message lane is capped at 720px centred (`ChatMessagesArea.module.css`),
-so at usual widths the rail sits in existing empty gutter and takes no width
-from the reading column.
-
-### 2.1 Magnification on hover
-
-Hovering magnifies the hovered mark **and its two neighbours on each side**,
-with a decreasing step, so the rail reads as a continuous deformation rather
-than one mark popping alone.
-
-The falloff is **discrete, not pointer-distance based**, and therefore expressed
-in CSS through sibling combinators — no JavaScript runs on pointer movement.
-A continuous Dock-style falloff was considered and rejected in §4.
-
-### 2.2 Preview tile
-
-The hovered mark shows a tile to its left, vertically centred on the mark, 12px
-gap, containing:
-
-| Content | Style | Limit |
-|---|---|---|
-| First sentence of the user request that opened the turn | `--font-label-large`, `--on-surface` | 2 lines, ellipsis |
-| First two sentences of the agent's answer | `--font-body-medium`, `--on-surface-retreat` | 4 lines, ellipsis |
-
-This reuses the existing `Tooltip` atom rather than adding a component: it
-already supports `placement="left"` (panel left of the trigger, vertically
-centred on it, flipping right when there is no room) and `content` for rich
-nodes that widen and wrap. The only gap is `TOOLTIP_GAP_PX = 4`, hardcoded to
-match `--spacing-2xs`; the tile needs 12px, so `Tooltip` gains an optional gap
-prop. No new molecule.
-
-### 2.3 Three mark heights
-
-Marks take one of three heights, to give the rail a recognisable shape and let
-the reader aim at "the long one in the middle".
-
-The height is driven by the **character count of the agent's answer text**,
-against **absolute** thresholds:
-
-| Height | Answer length | Roughly |
-|---|---|---|
-| short | < 400 chars | a direct reply, one paragraph |
-| medium | 400 – 1500 chars | a normal answer |
-| tall | > 1500 chars | a long, structured analysis |
-
-Thresholds are a starting point, to calibrate against real sessions.
-
-Two rejected alternatives, both tempting:
-
-- **Token counts.** Available per turn, but a ReAct turn re-sends the whole
-  context on every model call, so `tokenUsage` grows with the session's age
-  rather than with the turn's substance — the rail would show "everything gets
-  bigger towards the end", which is false. `marginalTokenUsage` is the honest
-  variant but is nullable on Graph agents and pre-#2403 history, which would
-  make the rail inconsistent across sessions.
-- **Relative thresholds** (terciles within the session). Always produces
-  contrast, but a mark's height then *changes as the session grows*: the tall
-  block you remember shrinks when a longer turn arrives. The rail is a spatial
-  memory aid, and that memory is destroyed if marks move under the reader.
-  Absolute thresholds are stable by construction.
-
-### 2.4 Scroll-spy
-
-The mark whose turn currently occupies the viewport is rendered in `--primary`.
-Implemented with a single `IntersectionObserver` over the turn nodes — passive,
-browser-side, firing only on threshold crossings, never per frame.
-
-### 2.5 Rail overflow
-
-While the marks fit, the rail is centred vertically. Once they exceed the
-available height, the rail becomes its own scroll container, **bottom-aligned**:
-new turns stack at the bottom and stay visible, old ones leave through the top —
-the same reading model as the conversation itself. Expressible in CSS, no JS.
-
-When scroll-spy marks a turn that is outside the rail's visible range (the
-reader scrolled far back), the rail scrolls itself to reveal the active mark.
-
-This rail scroll is on an element separate from the conversation container and
-so does not interact with §3 at all.
+Read `COMPONENT-UX.md` for the behaviour and the reasoning behind each choice.
+Nothing about V1 is still under discussion, so it is not restated here.
 
 ---
 
-## 3. Scroll ownership — why the rail is inert while a turn is live
+## Deferred from V1 — open, not decided against
 
-`useChatAutoScroll` documents itself as the *sole owner* of the conversation
-container's scroll position, on the grounds that a second mechanism on the same
-element cannot be reasoned about. That is not a stylistic rule: while a turn is
-live the hook re-decides the position on every animation frame and eases the
-view towards its target, so any position written from outside is overwritten
-one frame later. A jump-to-turn would appear to work on a finished conversation
-and judder or silently fail while the agent is writing — a frame-timing bug,
-therefore intermittent, therefore the kind that survives review.
+These were set aside to ship a first version quickly and at low risk, **not**
+because any was judged unnecessary. Each is open to revisiting once the rail
+has been in use.
 
-**Decision: the rail is frozen and non-interactive while a turn is live**
-(`isStreaming || isAwaitingHuman`) — visible but dimmed, clicks inert, contents
-not recomputed. The mark for the running turn appears when its answer
-completes.
+### 1. Narrow viewports
 
-This dissolves the conflict rather than working around it. The hook only ever
-writes while a turn is live (`shouldFollowBottom` returns false in the `idle`
-phase, so `follow()` returns before touching anything). If the rail can only be
-clicked when the hook is quiescent, the two writers never overlap — the
-invariant holds by construction, not by timing luck.
+The rail lives in the gutter left by the 720px message lane. What it should do
+when that gutter disappears is undecided — hide, overlay the lane, or collapse
+to a thinner form.
 
-The hook needs **no behavioural change**. Its scroll listener already
-interprets an outside jump correctly: a jump upwards reads as "the reader left
-the bottom" and stops the follow, a jump to the end re-arms it. What does need
-changing is the ownership comment itself — a future reader must find the
-refined invariant ("sole owner while a turn is live; the outline rail may
-scroll it while idle, and here is why that is safe") stated where the rule
-lives, not only in this RFC.
+### 2. Keyboard access
 
-**Known edge to handle at implementation:** a jump animation still in flight
-when a new turn starts would race the hook's `turnKey` jump-to-bottom. Narrow
-(it requires sending a message within the animation's duration of clicking a
-mark) but real — the in-flight jump is cancelled when a turn starts.
+V1 marks the rail `aria-hidden` and keeps its marks out of the tab order,
+because a row of unlabelled marks announced by a screen reader is worse than
+silence. Making it genuinely reachable is a real piece of work — labels
+(probably the same first sentence the tile shows), a tab stop with arrow-key
+movement between marks, and the preview tile on focus as well as hover — not
+just removing the attribute.
 
-Rendering the rail interactive during streaming is deliberately deferred, not
-ruled out; it would require giving the hook an explicit jump command so the
-jump declares its intent instead of writing pixels behind the hook's back.
+### 3. HITL rows
+
+`hitl_request` / `hitl_response` currently get no marks. Whether a gate the
+reader had to answer is worth navigating back to is a product question nobody
+has needed to answer yet.
+
+### 4. Interactivity while a turn streams
+
+The rail is deliberately frozen while a turn is live. Making it clickable there
+is possible but not free: the jump would have to declare its intent to
+`useChatAutoScroll` — an explicit command on the hook that owns the scroll
+position — rather than writing pixels behind its back, and the hook would have
+to decide what a mid-turn jump means for its follow state. Worth doing only if
+readers actually reach for the rail while an answer is being written.
 
 ---
 
-## 4. Performance constraints
+## Wheel gestures over the rail
 
-The rail must not cost anything on the chat's rendering path. Three specific
-hazards, each with its decided answer:
-
-1. **Per-keystroke re-render.** `ManagedChatPage` re-renders on every composer
-   keystroke; `ConversationThread` is `memo()`-wrapped precisely because
-   without that boundary every historical message re-rendered, markdown
-   re-parse included, on every character typed (#2221). The rail derives from
-   `messages` and must sit behind the same kind of boundary — memoised
-   component, derived data in a `useMemo` keyed on the message list.
-
-2. **Per-token recomputation.** During streaming the message list changes on
-   every token received. Computing preview extracts for all turns on each
-   change would redo string work across the whole conversation tens of times a
-   second — #2221 again, worse. Two decisions close this: the rail's contents
-   are frozen while a turn is live (§3), and extracts are computed **on hover,
-   for the hovered turn only**.
-
-3. **Extract cost at hover time.** Doing the work on hover is safe because it is
-   one turn, once: string work on a few thousand characters, microseconds,
-   far below a 16ms frame. Bounded further by slicing the first ~500 characters
-   *before* sentence detection, making the cost constant regardless of answer
-   size, and memoised per turn id so a second hover is free.
-
-Continuous pointer-distance magnification is rejected on the same grounds: it
-requires a `pointermove` listener writing per-mark values every frame, on a
-surface that sits over the chat. The discrete falloff (§2.1) is CSS-only, costs
-nothing, and is visually close enough.
-
----
-
-## 5. Impact on existing contracts
-
-| Contract / file | Change |
-|---|---|
-| `CONTROL-PLANE-PRODUCT-CONTRACT.md` | None — no API involved |
-| `RUNTIME-EXECUTION-CONTRACT.md` | None |
-| Generated API clients | None — the rail derives entirely from `ThreadMessage[]`, already in the frontend |
-| `Tooltip` atom | Gains an optional gap prop (currently `TOOLTIP_GAP_PX = 4` hardcoded) |
-| `useChatAutoScroll` | No logic change; its sole-owner comment is amended to state the refined invariant (§3) |
-| `COMPONENT-UX.md` | New entry once implemented: the outline rail, its states, and the frozen-during-streaming behaviour |
-
-Frontend-only. No backend, no schema, no SSE contract, no OpenAPI regeneration.
-
----
-
-## 6. Out of scope for V1
-
-Deferred by developer decision (2026-09-09) **to ship a first version quickly
-and at low risk** — not because any of them was judged unnecessary. Each is
-explicitly open to revisiting once the rail is in use and new ideas surface;
-none of these decisions constrains a later iteration.
-
-- **Narrow-viewport behaviour.** The rail lives in the gutter left by the 720px
-  lane; what happens when that gutter disappears is not decided here.
-- **Keyboard accessibility.** No tab order, arrow-key navigation, or
-  focus-triggered preview tile in this iteration.
-- **HITL rows.** `hitl_request` / `hitl_response` get no special treatment.
-- **Interactivity during streaming.** See §3, which also sketches what taking
-  it on would require.
+Not deferred so much as accepted, and worth revisiting if anyone reports it.
+The rail is a sibling of the scroll container, so a wheel gesture over it has no
+scrollable ancestor to chain to. V1 shrinks the rail to its marks so that
+surface is only the few pixels the reader is deliberately pointing at, where
+scrolling the rail is a reasonable reading of the gesture. If that proves
+annoying, the fix is to forward the wheel to the conversation — safe for the
+same reason the jump is, since the rail only takes input while the autoscroll is
+quiescent.

--- a/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
+++ b/docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md
@@ -1,6 +1,8 @@
 # Conversation Outline Rail RFC — navigating a long chat session
 
-**Status:** Agreed, not yet built — design settled 2026-09-09, no open question
+**Status:** Agreed, not yet built — V1 design settled 2026-09-09, no open
+question. §6 lists what V1 deliberately leaves out to ship fast; those are
+revisitable, not closed.
 **ID:** `CHAT-OUTLINE-01` (informal label, no registry)
 **Author:** Maxime
 **Date:** 2026-09-09
@@ -200,13 +202,17 @@ Frontend-only. No backend, no schema, no SSE contract, no OpenAPI regeneration.
 
 ---
 
-## 6. Out of scope
+## 6. Out of scope for V1
 
-Explicitly deferred, by developer decision (2026-09-09):
+Deferred by developer decision (2026-09-09) **to ship a first version quickly
+and at low risk** — not because any of them was judged unnecessary. Each is
+explicitly open to revisiting once the rail is in use and new ideas surface;
+none of these decisions constrains a later iteration.
 
 - **Narrow-viewport behaviour.** The rail lives in the gutter left by the 720px
   lane; what happens when that gutter disappears is not decided here.
 - **Keyboard accessibility.** No tab order, arrow-key navigation, or
   focus-triggered preview tile in this iteration.
 - **HITL rows.** `hitl_request` / `hitl_response` get no special treatment.
-- **Interactivity during streaming.** See §3.
+- **Interactivity during streaming.** See §3, which also sketches what taking
+  it on would require.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -4390,6 +4390,17 @@ magnifies it and its two neighbours each side and opens a preview tile to its
 left — the question's first sentence over the answer's first two. Clicking one
 jumps to that turn.
 
+**Every mark is the same size.** Encoding the answer's length in a mark's
+height was built and then dropped: it turned the rail into a second thing to
+read rather than a place to aim. The rail says where the turns are, and nothing
+about them.
+
+**The rail has no gaps.** Each mark's button is a full-width row with no gap
+between rows and no padding around the list, and the visible bar is a
+pseudo-element inside it. Anywhere the pointer lands on the rail it is on
+exactly one mark — otherwise travelling down the rail crosses slivers where the
+tile closes and the magnification collapses.
+
 **The rail is inert while a turn is live** (`isStreaming || pendingHitl`):
 visible but dimmed, clicks dead, no tooltip mounted. That is not a nicety, it is
 what makes the whole feature safe. `useChatAutoScroll` re-decides the
@@ -4400,20 +4411,23 @@ can only be clicked when it is quiescent never overlaps it: the single-owner
 invariant holds by construction rather than by timing. `useChatAutoScroll`'s
 ownership comment states the refined rule.
 
-**Mark height encodes the answer's length**, in three buckets on absolute
-thresholds (400 / 1500 characters). Not tokens: a ReAct turn re-sends the whole
-context per call, so `tokenUsage` grows with the session's age rather than the
-turn's substance. Not per-conversation quantiles either: a mark that changed
-height as later turns arrived would destroy the spatial memory the rail exists
-to serve.
+**The active mark** (`--primary`) follows two rules, and the second is not a
+special case — it is the common one. *At the bottom of the conversation, the
+last turn is active*: a short final turn never climbs to any reading line,
+because there is not enough content below it to push it there, so without this
+the rail points at the previous turn while the reader sits on the newest one.
+Otherwise, *the last turn whose question has passed a line 35% down the
+viewport* — not the topmost anchor still on screen, since the anchors sit on the
+user message and partway through a long answer none is visible at all.
 
-**The active mark** (`--primary`) is the last turn whose anchor passed the
-container's top edge, not the topmost anchor still on screen — the anchors sit
-on the user message, so partway through a long answer none is visible and the
-naive rule would blank the mark on exactly the conversations the rail is for.
-The `IntersectionObserver`'s threshold is chosen so it fires at the boundary
-being measured; an observer that fires elsewhere only refreshes the answer by
-accident.
+This is driven by a scroll listener, not an `IntersectionObserver`. An observer
+only fires when something crosses a boundary, and the first rule turns on the
+scroll position: no anchor crosses anything over the last stretch to the bottom,
+so an observer stays silent through precisely the case that has to be right. The
+cost is paid off instead by binary search — anchors are in document order, so
+their positions are monotonic and the line is found in about eight measurements
+for a two-hundred-turn conversation — and by not measuring at all while a turn
+is live, which is when the autoscroll is writing every frame.
 
 **Streaming costs the rail nothing.** The message list is replaced on every
 token, so: the fold's result is handed back by identity when it describes the
@@ -4429,9 +4443,9 @@ at. Once the marks outgrow the available height the rail scrolls itself, and
 follows the active mark.
 
 **`aria-hidden`, and the marks are out of the tab order.** Keyboard access is a
-V1 omission (RFC §6): with no labels or tab order, a screen reader would
-announce a row of silent marks, and a focusable control inside an aria-hidden
-subtree is a trap. The conversation itself stays fully readable in the thread.
+V1 omission, and the RFC says what taking it on would involve: with no labels or
+tab order a screen reader would announce a row of silent marks, and a focusable
+control inside an aria-hidden subtree is a trap. The conversation itself stays fully readable in the thread.
 
 ### `Tooltip` — `gapPx`
 

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -4372,3 +4372,69 @@ every mutation knows the page id and none of them knows the slug, so tagging by
 slug leaves a write unable to invalidate the page it just changed — the article
 keeps rendering pre-save text and, with it, a stale `revision_id`, which makes
 the *next* save conflict every time.
+
+---
+
+## Conversation outline rail (2026-09-09, CHAT-OUTLINE-01, issue #2602)
+
+### `ConversationOutlineRail`
+
+**Location:** `src/rework/components/shared/molecules/ConversationOutlineRail/`
+**Status:** `Functional` — V1. Design and the deferred parts: RFC
+`CONVERSATION-OUTLINE-RAIL-RFC.md`.
+
+A rail of graphical marks along the left edge of `ManagedChatPage`'s
+conversation, one per turn. No text: the marks sit in the gutter left by the
+720px message lane, so they take no width from the reading column. Hovering one
+magnifies it and its two neighbours each side and opens a preview tile to its
+left — the question's first sentence over the answer's first two. Clicking one
+jumps to that turn.
+
+**The rail is inert while a turn is live** (`isStreaming || pendingHitl`):
+visible but dimmed, clicks dead, no tooltip mounted. That is not a nicety, it is
+what makes the whole feature safe. `useChatAutoScroll` re-decides the
+conversation's scroll position every animation frame while a turn runs, so a
+jump written from outside would be overwritten a frame later — a frame-timing
+bug, therefore intermittent. The hook writes *only* while live, so a rail that
+can only be clicked when it is quiescent never overlaps it: the single-owner
+invariant holds by construction rather than by timing. `useChatAutoScroll`'s
+ownership comment states the refined rule.
+
+**Mark height encodes the answer's length**, in three buckets on absolute
+thresholds (400 / 1500 characters). Not tokens: a ReAct turn re-sends the whole
+context per call, so `tokenUsage` grows with the session's age rather than the
+turn's substance. Not per-conversation quantiles either: a mark that changed
+height as later turns arrived would destroy the spatial memory the rail exists
+to serve.
+
+**The active mark** (`--primary`) is the last turn whose anchor passed the
+container's top edge, not the topmost anchor still on screen — the anchors sit
+on the user message, so partway through a long answer none is visible and the
+naive rule would blank the mark on exactly the conversations the rail is for.
+The `IntersectionObserver`'s threshold is chosen so it fires at the boundary
+being measured; an observer that fires elsewhere only refreshes the answer by
+accident.
+
+**Streaming costs the rail nothing.** The message list is replaced on every
+token, so: the fold's result is handed back by identity when it describes the
+same rail (keeping the component's `memo` alive), the preview callback is
+ref-backed so its identity never changes, and extracts are derived on hover for
+the hovered turn only, from a bounded 500-character slice.
+
+**Sized to its marks, not full height.** The rail is a sibling of the scroll
+container, so a wheel gesture over it has no scrollable ancestor to chain to and
+the conversation would not move — the dead left gutter of #654. Hugging the
+marks keeps that surface to the few pixels the reader is deliberately pointing
+at. Once the marks outgrow the available height the rail scrolls itself, and
+follows the active mark.
+
+**`aria-hidden`, and the marks are out of the tab order.** Keyboard access is a
+V1 omission (RFC §6): with no labels or tab order, a screen reader would
+announce a row of silent marks, and a focusable control inside an aria-hidden
+subtree is a trap. The conversation itself stays fully readable in the thread.
+
+### `Tooltip` — `gapPx`
+
+`Tooltip` gained an optional `gapPx` (default 4, `--spacing-2xs`, unchanged for
+every existing caller). The rail's preview tile reads as its own card rather
+than a hint stuck to its trigger, and takes 12.

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -4387,8 +4387,15 @@ A rail of graphical marks along the left edge of `ManagedChatPage`'s
 conversation, one per turn. No text: the marks sit in the gutter left by the
 720px message lane, so they take no width from the reading column. Hovering one
 magnifies it and its two neighbours each side and opens a preview tile to its
-left — the question's first sentence over the answer's first two. Clicking one
+right — the question's first sentence over the answer's first two. Clicking one
 jumps to that turn.
+
+**The rail sits against the page's left edge**, at the top bar's inset, not
+against the reading column: it is chrome for the page, and anchoring it to the
+lane made it drift inward with the column instead of staying where the eye
+learns to find it. On a column barely wider than the lane it therefore overlaps
+the first characters of each line — a known cost, and the case to answer when
+narrow viewports are taken on.
 
 **Every mark is the same size.** Encoding the answer's length in a mark's
 height was built and then dropped: it turned the rail into a second thing to
@@ -4447,8 +4454,17 @@ V1 omission, and the RFC says what taking it on would involve: with no labels or
 tab order a screen reader would announce a row of silent marks, and a focusable
 control inside an aria-hidden subtree is a trap. The conversation itself stays fully readable in the thread.
 
-### `Tooltip` — `gapPx`
+### `Tooltip` — `gapPx`, `placement="right"`, and closing on window blur
 
-`Tooltip` gained an optional `gapPx` (default 4, `--spacing-2xs`, unchanged for
-every existing caller). The rail's preview tile reads as its own card rather
-than a hint stuck to its trigger, and takes 12.
+Three additions, all made for the rail and all useful beyond it:
+
+- an optional `gapPx` (default 4, `--spacing-2xs`, unchanged for every existing
+  caller) — the rail's preview tile reads as its own card rather than a hint
+  stuck to its trigger, and takes 12;
+- `placement="right"`, the mirror of `"left"`: beside the trigger, vertically
+  centred, flipping to the other side when there is no room;
+- **the panel now closes when the window loses focus or the page is hidden.**
+  Leaving the window produces no `mouseleave`, so a tooltip hovered at the
+  moment of an alt-tab was still open on return and — its own leave event
+  having been lost for good — stayed open alongside the next one hovered. On a
+  rail of many triggers that meant two panels on screen at once.


### PR DESCRIPTION
Closes #2602.

Navigating a long chat session had no affordance: the only way back to an
earlier exchange was to scroll and read until you recognised it, with no
overview of the session's shape and nothing saying where in it you were.

This adds a rail of graphical marks along the conversation's left edge, one per
turn. Hovering one magnifies it and its two neighbours each side and opens a
preview tile to its right — the question's first sentence over the answer's
first two. Clicking one jumps to that turn. The turn currently being read is
marked in `--primary`.

Frontend only: no backend, no schema, no SSE contract, no OpenAPI regeneration.
The rail derives entirely from the `ThreadMessage[]` already in the page.

## The design decision worth reviewing first

**The rail is inert while a turn is live** (`isStreaming || pendingHitl`):
visible but dimmed, clicks dead. That is not a nicety — it is what makes the
feature safe.

`useChatAutoScroll` documents itself as the sole owner of the conversation's
scroll position, and while a turn runs it re-decides that position on every
animation frame. A jump written from outside would be overwritten a frame
later: it would appear to work on a finished conversation and judder or
silently fail while the agent is writing — a frame-timing bug, therefore
intermittent, therefore the kind that survives review.

The hook writes *only* while live, so a rail that can only be clicked when it is
quiescent never overlaps it. The invariant holds by construction rather than by
timing, and the hook needs no logic change — only its ownership comment amended
to state the refined rule. The freeze is enforced in the markup (`disabled`),
not just by the rail's `pointer-events`, so a stylesheet change cannot quietly
re-enable it.

## Why the jump is animated by hand

`scrollTo({ behavior: "smooth" })` was rejected for three reasons that all bite
in this container:

- **The target is re-resolved every frame.** A native smooth scroll commits to a
  pixel offset at call time; a Mermaid block or image resolving above the target
  mid-flight then lands the reader beside the wrong turn.
- **It can be cancelled.** A native smooth scroll cannot — a new turn starting
  has to be able to take the view back.
- **A reader taking over is detectable**, by comparing the container against the
  position we last wrote. Scroll events alone cannot separate the two.

It reuses `nextFollowTop` so a jump and the autoscroll's follow share one curve,
suspends the browser's scroll anchoring for the flight (otherwise anchoring's
own adjustments read as a reader takeover), and has a frame ceiling so a
container that stops moving mid-flight cannot leave anchoring suspended for the
life of the page.

## Performance

The requirement was that the rail cost the chat's rendering nothing. The message
list is replaced on every streamed token, so:

- the fold's result is handed back by identity when it describes the same rail,
  keeping the component's `memo` alive;
- the preview callback is ref-backed, so its identity never changes;
- preview extracts are derived **on hover, for the hovered turn only**, from a
  bounded 500-character slice;
- the scroll-spy uses binary search over the anchors — about eight measurements
  for a two-hundred-turn conversation — and does not measure at all while a turn
  is live, which is exactly when the autoscroll is writing every frame.

## Shared components touched

- `Tooltip` gains `gapPx` (default 4, unchanged for every existing caller) and
  `placement="right"`, the mirror of `"left"`.
- **`Tooltip` now closes on window blur and when the page is hidden.** Leaving
  the window produces no `mouseleave`, so a tooltip hovered at the moment of an
  alt-tab was still open on return and — its own leave event lost for good —
  stayed open alongside the next one hovered. Reported live on the rail; the fix
  benefits every caller.
- `UserTurn` gains an optional `turnId`, rendered as the `data-turn-id` anchor.

## Deliberately out of scope for V1

Deferred to ship a first version quickly and at low risk, **not** judged
unnecessary — all open to revisiting, and recorded in
`docs/swift/rfc/CONVERSATION-OUTLINE-RAIL-RFC.md` with what taking each on would
involve:

- **Narrow viewports.** The rail sits against the page's left edge; on a column
  barely wider than the 720px lane (a side panel open) it overlaps the first
  characters of each line and captures the pointer there. Anchoring it to the
  lane was tried and rejected — it made the rail drift inward with the reading
  column instead of staying where the eye learns to find it.
- **Keyboard access.** The rail is `aria-hidden` and its marks are out of the tab
  order: with no labels, a screen reader would announce a row of silent marks,
  and a focusable control inside an aria-hidden subtree is a trap.
- **HITL rows** get no marks of their own.
- **Interactivity while streaming** — see the first section.

## Verification

`make code-quality` clean; 2042 tests pass, 31 of them new, no regression across
the 200 existing test files.

Three `/code-review` passes were absorbed before this PR, which found eleven real
defects that the tests written alongside the code had missed — among them a
scroll-spy measuring a line its observer never fired on, a sentence splitter
dropping the last sentence of almost every answer, and a click-focus path that
would have made a disabled mark scroll the conversation via Chromium's
force-blur (the failure `src/index.tsx` already guards at document level, which
does not cover an inner container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
