### PR TITLE
fix(#2613): render an unlabelled fenced code block as a block

### DIFF
--- a/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Coverage centres on block-vs-inline routing: a fence is a block whether or
+// not it carries a language, and only backtick spans reach the inline path.
+// The block renderers are stubbed so the test exercises the routing alone.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+vi.mock("../CodeBlock/CodeBlock", () => ({
+  CodeBlock: ({ code, language, inline }: { code: string; language?: string; inline?: boolean }) => (
+    <span data-code-block data-inline={inline ? "1" : "0"} data-language={language ?? ""}>
+      {code}
+    </span>
+  ),
+}));
+
+vi.mock("../MermaidBlock/MermaidBlock", () => ({
+  MermaidBlock: ({ code }: { code: string }) => <span data-mermaid-block>{code}</span>,
+}));
+
+vi.mock("../MindMapBlock", () => ({
+  MindMapBlock: ({ code, language }: { code: string; language: string }) => (
+    <span data-mindmap-block data-language={language}>
+      {code}
+    </span>
+  ),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(text: string) {
+  act(() => root.render(<MarkdownRenderer text={text} />));
+}
+
+const codeBlocks = () => Array.from(container.querySelectorAll<HTMLElement>("[data-code-block]"));
+
+describe("MarkdownRenderer code routing", () => {
+  it("renders a fence without a language as a plaintext block", () => {
+    render("répète :\n```\nAAA\nBBB\n```\n");
+    const [block] = codeBlocks();
+    expect(block).toBeDefined();
+    expect(block.dataset.inline).toBe("0");
+    expect(block.dataset.language).toBe("");
+    expect(block.textContent).toBe("AAA\nBBB");
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("renders a fence with a language as a block carrying that language", () => {
+    render("```python\nprint(1)\n```\n");
+    const [block] = codeBlocks();
+    expect(block.dataset.inline).toBe("0");
+    expect(block.dataset.language).toBe("python");
+    expect(block.textContent).toBe("print(1)");
+  });
+
+  it("renders an indented code block as a block", () => {
+    render("Texte :\n\n    AAA\n    BBB\n");
+    const [block] = codeBlocks();
+    expect(block.dataset.inline).toBe("0");
+    expect(block.textContent).toBe("AAA\nBBB");
+  });
+
+  it("renders a backtick span as inline code", () => {
+    render("appelle `foo()` puis continue");
+    const [inline] = codeBlocks();
+    expect(inline.dataset.inline).toBe("1");
+    expect(inline.textContent).toBe("foo()");
+  });
+
+  it("routes mermaid and mindmap fences to their dedicated blocks", () => {
+    render("```mermaid\ngraph TD; A-->B\n```\n\n```mindmap\nroot\n```\n");
+    expect(container.querySelector("[data-mermaid-block]")?.textContent).toBe("graph TD; A-->B");
+    const mindmap = container.querySelector<HTMLElement>("[data-mindmap-block]");
+    expect(mindmap?.dataset.language).toBe("mindmap");
+    expect(codeBlocks()).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.tsx
@@ -74,6 +74,17 @@ function remarkDetailsDirective() {
   };
 }
 
+function fencedLanguage(codeNode: HastNode): string | undefined {
+  const className = codeNode.properties?.className;
+  const classes = Array.isArray(className) ? className.join(" ") : String(className ?? "");
+  return /language-([\w-]+)/.exec(classes)?.[1];
+}
+
+function hastText(node: HastNode): string {
+  if (node.type === "text") return node.value ?? "";
+  return (node.children ?? []).map(hastText).join("");
+}
+
 function walkMdast(node: MdastNode, visitor: (n: MdastNode) => void) {
   visitor(node);
   if (Array.isArray(node.children)) {
@@ -180,22 +191,24 @@ export const MarkdownRenderer = forwardRef<HTMLDivElement, MarkdownRendererProps
   // components (MermaidBlock, CodeBlock) and cause their effects to re-fire.
   const components = useMemo(
     () => ({
-      // Pass-through pre: CodeBlock provides its own wrapper
-      pre({ children }: { children: React.ReactNode }) {
-        return <>{children}</>;
-      },
-      // code: mindmap/mermaid fences → custom blocks; other fenced blocks → CodeBlock; inline → CodeBlock inline
-      code({ className, children }: { className?: string; children?: React.ReactNode }) {
-        const lang = /language-([\w-]+)/.exec(className || "")?.[1];
+      // pre: every fenced/indented block lands here, with or without a language.
+      // react-markdown v9 dropped the `inline` prop, so the parent element is
+      // the only reliable block-vs-inline signal — a `language-*` class is not.
+      pre({ node, children }: { node?: HastNode; children?: React.ReactNode }) {
+        const codeNode = node?.children?.find((c) => c.type === "element" && c.tagName === "code");
+        if (!codeNode) return <pre>{children}</pre>;
+        const lang = fencedLanguage(codeNode);
+        const code = hastText(codeNode).replace(/\n$/, "");
         if (lang === "mindmap" || lang === "mindmap-json") {
-          return <MindMapBlock code={String(children).replace(/\n$/, "")} language={lang} />;
+          return <MindMapBlock code={code} language={lang} />;
         }
         if (lang === "mermaid") {
-          return <MermaidBlock code={String(children).replace(/\n$/, "")} />;
+          return <MermaidBlock code={code} />;
         }
-        if (className) {
-          return <CodeBlock code={String(children).replace(/\n$/, "")} language={lang} />;
-        }
+        return <CodeBlock code={code} language={lang} />;
+      },
+      // code: only inline code reaches here — block code is consumed by `pre` above
+      code({ children }: { children?: React.ReactNode }) {
         return <CodeBlock code={String(children)} inline />;
       },
       // hr: suppress horizontal rules — visual noise in a chat context

--- a/docs/swift/ux/COMPONENT-UX.md
+++ b/docs/swift/ux/COMPONENT-UX.md
@@ -839,16 +839,18 @@ _(none — streaming indicator resolved 2026-05-18)_
 
 #### Open UX issues
 
-- **No syntax highlighting** — plain monospace only. Consider adding `react-syntax-highlighter`
-  (already in `package.json`) for a richer developer experience, especially for code-heavy agents.
-
-- **Fenced code without language** — renders as inline code (no language class, so the block
-  path is not triggered). Low-frequency edge case, but may surprise users who write unlabelled
-  fenced blocks. Discuss whether to detect by trailing `\n` heuristic.
+_(none)_
 
 #### Resolved
 
-_(none yet)_
+- **No syntax highlighting** — `CodeBlock` renders through `react-syntax-highlighter` (Prism,
+  `oneDark`/`oneLight` following the theme).
+
+- **Fenced code without language (2026-09-10)** — used to render as inline code because
+  `MarkdownRenderer` picked block vs inline from the presence of a `language-*` class.
+  Block routing now lives on the `pre` component (every fenced or indented block has one;
+  react-markdown v9 passes no `inline` prop), so an unlabelled fence renders as a
+  `plaintext` block and only backtick spans reach the inline path.
 
 ---
 


### PR DESCRIPTION
## 1. What problem does this solve — and where is it tracked?

**Issue:** closes #2613

**Problem in one sentence:** a fenced code block without a language (` ``` ` alone) renders as inline code in the chat — lines glued together, no header, no Copy button — while the same block with a language renders correctly.

**Backlog ref:** n/a — issue-driven; neighbour of #2347 (other markdown polish), kept separate to stay single-purpose.

---

## 2. Before you wrote a single line of code

**RFC written?** Not required — mechanical fix. No contract, schema or component surface changes; `MarkdownRenderer`'s props are unchanged.

**Plan presented to the team before implementation?** Yes — cause, files to touch, tests to add and docs to update were laid out in the working session before any code was written.

**Confirmation received?** Yes, from the author (Timothé Le Chatelier), who also asked for the tracking issue to be created first.

---

## 3. What you built

`MarkdownRenderer.tsx` decided block-vs-inline from the presence of a `language-*` class on the `code` element. react-markdown v9 dropped the `inline` prop, and an unlabelled fence carries no class, so it fell through to the inline path. Block routing (CodeBlock, MermaidBlock, MindMapBlock) now lives on the `pre` component, which every fenced or indented block has as parent; the language and text are read from the hast `node`. The `code` component only handles inline spans. An unlabelled fence now renders as a `plaintext` block, matching what the streaming preview already showed.

---

## 4. Proof of quality

**Tests added or updated:**

| Test | File | What it covers |
| ---- | ---- | -------------- |
| renders a fence without a language as a plaintext block | `apps/frontend/src/rework/components/shared/molecules/MarkdownRenderer/MarkdownRenderer.test.tsx` | the bug — fails on the old code |
| renders a fence with a language as a block carrying that language | same | regression guard for the previously working path |
| renders an indented code block as a block | same | the other Markdown block syntax — fails on the old code |
| renders a backtick span as inline code | same | inline path still inline |
| routes mermaid and mindmap fences to their dedicated blocks | same | special-language routing unchanged |

Block renderers are stubbed via `vi.mock` so the test exercises routing only (no Prism / mermaid / ECharts).

**`make code-quality` output:**

```
apps/frontend: All frontend code quality checks completed
```

Root `make code-quality` stops earlier on a pre-existing detect-secrets hit in `libs/fred-runtime/tests/test_react_tool_resolution.py:58` (fake test secret, committed on swift in 3bee57eb, not touched here).

**Raw `basedpyright` output:** n/a — no Python touched.

**`make test` output:**

```
apps/frontend: Test Files  206 passed | 1 skipped (207) — Tests  2074 passed | 2 skipped (2076)
```

---

## 5. Docs updated

| What changed                                                      | File updated |
| ----------------------------------------------------------------- | ------------ |
| Backlog `[ ]` item is now done                                    | n/a — backlogs frozen, tracked on #2613 |
| New behaviour, API field, or contract change                      | n/a — rendering fix, no contract change |
| Frozen contract touched (`execution.py`, `agent_app.py`, OpenAPI) | n/a |
| UX component implemented or visual status changed                 | `docs/swift/ux/COMPONENT-UX.md` — "Fenced code without language" moved to Resolved; stale "No syntax highlighting" entry (Prism already in place) moved to Resolved |
| Phase progress row exists for this area                           | n/a |
| WORKPLAN sprint item finished                                     | n/a — frozen |
| Code and a design doc now diverge                                 | fixed in the same change (see row above) |

---

## 6. Close-out statement

```
## Task close-out
- Code: MarkdownRenderer.tsx — block routing moved from the `code` component to `pre` (hast node), `code` handles inline only
- Tests: pass — 5 tests added in MarkdownRenderer.test.tsx; full frontend suite green (2074)
- Docs updated: docs/swift/ux/COMPONENT-UX.md
- Tracking: #2613 (closes)
- Skipped steps: Step 1 RFC/OpenSpec — mechanical fix, no contract change
```

---

## 7. Risk and rollback

**What breaks if this is wrong?** Only the chat/markdown rendering of code: a block could be mis-routed (e.g. a mermaid fence shown as plain code) or an inline span shown as a block. No data or API impact. Covered by the five routing tests.

**How do we roll back?** Revert the single commit; no migration, no generated client, no config involved.
