### PR TITLE
perf(frontend): fetch the resources usage stats only when the panel is open

### DIFF
--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/TeamResourcesPage.test.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/TeamResourcesPage.test.tsx
@@ -45,6 +45,11 @@ const probe = vi.hoisted(() => ({
   // True while useGetFrontendBootstrapControlPlaneV1FrontendBootstrapGetQuery
   // hasn't resolved yet — bootstrap is undefined during that window.
   bootstrapPending: false,
+  // Last `skip` each stats query was rendered with — the stats endpoints are
+  // whole-corpus scans, so whether they run at all is the behaviour worth
+  // pinning, and it is invisible in the DOM.
+  corpusStatsSkip: true,
+  fsStatsSkip: {} as Record<string, boolean>,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -84,14 +89,20 @@ vi.mock("../../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
     isUninitialized: false,
     isError: false,
   }),
-  useGetCorpusTypeStatsKnowledgeFlowV1TagsStatsGetQuery: () => ({
-    data: { entries: [] },
-    isLoading: false,
-    isError: false,
-    isUninitialized: probe.corpusStatsUninitialized,
-    refetch: probe.corpusStatsRefetch,
-  }),
-  useTypeStatsKnowledgeFlowV1FsStatsPathGetQuery: () => ({ data: { entries: [] }, isLoading: false, isError: false }),
+  useGetCorpusTypeStatsKnowledgeFlowV1TagsStatsGetQuery: (_arg: unknown, options?: { skip?: boolean }) => {
+    probe.corpusStatsSkip = options?.skip ?? false;
+    return {
+      data: { entries: [] },
+      isLoading: false,
+      isError: false,
+      isUninitialized: probe.corpusStatsUninitialized,
+      refetch: probe.corpusStatsRefetch,
+    };
+  },
+  useTypeStatsKnowledgeFlowV1FsStatsPathGetQuery: (arg: { path: string }, options?: { skip?: boolean }) => {
+    probe.fsStatsSkip[arg.path] = options?.skip ?? false;
+    return { data: { entries: [] }, isLoading: false, isError: false };
+  },
 }));
 vi.mock("./DocumentWorkspace/DocumentWorkspace.tsx", () => ({
   default: (props: { onDocumentsChanged?: () => void }) => {
@@ -135,6 +146,8 @@ beforeEach(() => {
   probe.onDocumentsChanged = undefined;
   probe.enableAllResourceSpaces = true;
   probe.bootstrapPending = false;
+  probe.corpusStatsSkip = true;
+  probe.fsStatsSkip = {};
 });
 
 afterEach(() => {
@@ -297,5 +310,33 @@ describe("TeamResourcesPage stats toggle", () => {
 
     click(statsToggle());
     expect(container.querySelector('[data-testid="stats-cards"]')).toBeNull();
+  });
+
+  it("does not query the corpus stats until the cards are opened", () => {
+    // The endpoint walks every library the user can read and every document in
+    // each of them; running it on mount scanned the whole corpus for a panel
+    // nobody had opened.
+    render();
+    expect(probe.corpusStatsSkip).toBe(true);
+
+    click(statsToggle());
+    expect(probe.corpusStatsSkip).toBe(false);
+
+    click(statsToggle());
+    expect(probe.corpusStatsSkip).toBe(true);
+  });
+
+  it("queries only the open tab's stats source", () => {
+    render();
+    click(statsToggle());
+
+    // "Mon espace" and "Espace partagé" both read /fs stats, on different roots.
+    expect(probe.corpusStatsSkip).toBe(false);
+    expect(Object.values(probe.fsStatsSkip).every((skipped) => skipped)).toBe(true);
+
+    click(tabButtons()[1]);
+    expect(probe.corpusStatsSkip).toBe(true);
+    expect(probe.fsStatsSkip["teams/team-1/users/u-1"]).toBe(false);
+    expect(probe.fsStatsSkip["teams/team-1/shared"]).toBe(true);
   });
 });

--- a/apps/frontend/src/rework/components/pages/TeamResourcesPage/TeamResourcesPage.tsx
+++ b/apps/frontend/src/rework/components/pages/TeamResourcesPage/TeamResourcesPage.tsx
@@ -109,17 +109,23 @@ export default function TeamResourcesPage() {
 
   // Usage-by-type stats (§13.5/13.7 FRONT-09.I) — one query per tab's data source,
   // each skipped unless it's the active tab so switching tabs never fires every query
-  // at once. "Agents" has no single filesystem root (its table's root is virtual,
-  // fanning out per agent instance — see AgentsWorkspace) so it has no stats source
-  // yet — RFC §13.5.
+  // at once, and unless the cards are actually open: the panel starts collapsed, and
+  // the corpus query walks every library the user can read and every document in each
+  // of them, so leaving it on the mount path scanned the whole corpus on each visit
+  // and threw the answer away. "Agents" has no single filesystem root (its table's
+  // root is virtual, fanning out per agent instance — see AgentsWorkspace) so it has
+  // no stats source yet — RFC §13.5.
   const corpusStats = useGetCorpusTypeStatsKnowledgeFlowV1TagsStatsGetQuery(
     { teamId: fsTeamId },
-    { skip: activeTab !== "resources" },
+    { skip: !statsOpen || activeTab !== "resources" },
   );
-  const mineStats = useTypeStatsKnowledgeFlowV1FsStatsPathGetQuery({ path: userRoot }, { skip: activeTab !== "mine" });
+  const mineStats = useTypeStatsKnowledgeFlowV1FsStatsPathGetQuery(
+    { path: userRoot },
+    { skip: !statsOpen || activeTab !== "mine" },
+  );
   const teamStats = useTypeStatsKnowledgeFlowV1FsStatsPathGetQuery(
     { path: sharedRoot },
-    { skip: activeTab !== "team" },
+    { skip: !statsOpen || activeTab !== "team" },
   );
   const activeStats =
     activeTab === "resources"


### PR DESCRIPTION
Closes #2618.

`TeamResourcesPage` fetched the corpus usage-by-type stats on every visit, even
though the cards they feed are collapsed by default.

The query was skipped on the active tab only:

```ts
{ skip: activeTab !== "resources" }
```

while the cards render behind `statsOpen`, whose initial value is `false`.
`GET /tags/stats` walks every library the user can read and every document in
each of them (#2617), so this was a full corpus scan performed and thrown away
on each page open — 124 ms on a 4-folder / 43-document team, growing with both
the folder count and the corpus size.

The three stats queries (corpus, personal space, team space) are now gated on
`statsOpen` as well. The existing `isUninitialized` guard in
`onDocumentsChanged` already covers refetching a query that was never started,
so an upload still refreshes the cards while they are open and does nothing
while they are not.

## Tests

`TeamResourcesPage.test.tsx` gains two cases. The mocked query hooks now record
the `skip` they were rendered with, because whether these endpoints run at all
is the behaviour worth pinning and it is invisible in the DOM:

- the corpus stats stay skipped until the header chip is toggled on, and go
  back to skipped when it is toggled off — verified to fail against the
  previous condition;
- with the panel open, only the active tab's stats source is queried.

No doc update: the stats panel is not described in `COMPONENT-UX.md`, and this
changes when a request is issued, not any contract or documented behaviour.
The only user-visible difference is that the cards show their existing loading
state the first time they are opened.

Part of the same investigation as #2617 (already in review) and #2619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
