### PR TITLE
fix(#2624): ship fred-runtime's Alembic tree in the prod image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -92,7 +92,6 @@ __pycache__/
 # Local database files
 **/*.sqlite3
 **/db.sqlite3
-**/migrations/
 
 # Temporary files
 **/*.tmp

--- a/apps/fred-agents/dockerfiles/Dockerfile-prod
+++ b/apps/fred-agents/dockerfiles/Dockerfile-prod
@@ -78,7 +78,7 @@ COPY --chown=${USER_ID}:${GROUP_ID} libs/fred-capability-team-wiki /workspace/li
 # `python -m fred_runtime migrate` (the Helm migration hook) upgrades fred-runtime's tree
 # then every installed capability's own tree, all rooted under /workspace/libs/..., so the
 # ini belongs beside fred-runtime's pyproject.toml whose [tool.alembic] script_location
-# resolves to /workspace/libs/fred-runtime/alembic.
+# resolves to /workspace/libs/fred-runtime/fred_runtime/migrations.
 COPY --chown=${USER_ID}:${GROUP_ID} alembic.ini /workspace/libs/fred-runtime/alembic.ini
 
 # Runtime pods keep the startup contract externalized: .env + configuration

--- a/libs/fred-runtime/tests/test_migrations.py
+++ b/libs/fred-runtime/tests/test_migrations.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
+import fnmatch
 import sqlite3
 from pathlib import Path
 
 import fred_runtime
+import pytest
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 from fred_runtime.migrations import RUNTIME_ALEMBIC_DIR, upgrade_sqlite_database
@@ -78,3 +80,35 @@ def test_upgrade_sqlite_database_applies_packaged_migrations(tmp_path: Path) -> 
         "agent_instance_id",
     }
     assert revision == ("c3d4b5a6f7e8",)  # pragma: allowlist secret
+
+
+def test_packaged_tree_is_not_excluded_from_the_docker_build_context() -> None:
+    """
+    Being packaged is not enough: the prod image installs fred-runtime from the
+    source tree it COPYs, so a `.dockerignore` rule that drops a directory name
+    also drops the migration tree - and `python -m fred_runtime migrate` then
+    fails with ModuleNotFoundError in the pod while every test here still passes.
+
+    This is not a full Docker matcher: it covers whole-name exclusions, the class
+    of rule that can silently swallow the tree.
+    """
+
+    # Anchored on the test file, not the package: an editable install can resolve
+    # fred_runtime into a different checkout than the one under test.
+    dockerignore = Path(__file__).resolve().parents[3] / ".dockerignore"
+    if not dockerignore.is_file():
+        pytest.skip("fred-runtime consumed outside the monorepo build context")
+
+    segments = {"fred_runtime", RUNTIME_ALEMBIC_DIR.name, "versions"}
+    offenders = []
+    for raw in dockerignore.read_text().splitlines():
+        rule = raw.strip()
+        if not rule or rule.startswith(("#", "!")):
+            continue
+        name = rule.removeprefix("**/").rstrip("/")
+        if any(fnmatch.fnmatch(segment, name) for segment in segments):
+            offenders.append(rule)
+
+    assert offenders == [], (
+        f"{dockerignore} excludes the packaged Alembic tree: {offenders}"
+    )


### PR DESCRIPTION
Closes #2624.

## What

`.dockerignore` carried `**/migrations/`, which drops every directory named
exactly `migrations` from the build context at any depth. It arrived in #470
inside a Django-flavoured boilerplate block and was inert for years.

`775793f77` (#2551) then moved fred-runtime's Alembic tree from
`libs/fred-runtime/alembic/` into `libs/fred-runtime/fred_runtime/migrations/`,
walking it straight into that rule. `apps/fred-agents/dockerfiles/Dockerfile-prod`
copies `libs/fred-runtime` into the image, so the package shipped with its
`__init__.py` and no `migrations/` subpackage - and the migration Job died on:

```
ModuleNotFoundError: No module named 'fred_runtime.migrations'
```

The wheel was never affected; only the Docker build context was stripped.

## Changes

- `.dockerignore` - drop `**/migrations/`. There is no Django app here, and the
  only source directory the rule matches is the one that has to ship. The rest of
  that boilerplate block (`*.sqlite3`, `db.sqlite3`) is inert and left alone.
- `libs/fred-runtime/tests/test_migrations.py` - regression guard beside the
  existing packaging assertions: no `.dockerignore` rule may exclude the packaged
  tree. Deliberately not a full Docker matcher, it covers whole-name exclusions,
  the class of rule that can swallow the tree silently.
- `apps/fred-agents/dockerfiles/Dockerfile-prod` - the comment above the
  `alembic.ini` COPY still pointed at the pre-#2551 path.

## Why it went unnoticed

The chart ships `migration.enabled: false` for every backend, #2551's tests assert
the tree is packaged in the source tree and the wheel rather than in an image, and
every other Alembic tree in the repo is prefixed (`demo_migrations`,
`writable_document_migrations`, `alembic/`). fred-runtime's bare `migrations` is
the only name that collides.

## Verification

Minimal build context carrying the repo's real `.dockerignore`:

```
# before
/workspace/libs/fred-runtime/fred_runtime/__init__.py

# after
/workspace/libs/fred-runtime/fred_runtime/__init__.py
/workspace/libs/fred-runtime/fred_runtime/migrations/__init__.py
/workspace/libs/fred-runtime/fred_runtime/migrations/versions/a_rev.py
```

- `pytest libs/fred-runtime/tests/test_migrations.py` - 3 passed.
- The new guard fails as expected when `**/migrations/` is put back.
- Full `make -C apps/fred-agents docker-build` from this branch, then inside the
  image:

```
$ docker run --rm --entrypoint python <image> -c "import fred_runtime.migrations as m; ..."
module  : /workspace/libs/fred-runtime/fred_runtime/migrations/__init__.py
files   : ['README', '__init__.py', 'env.py', 'script.py.mako']
versions: ['__init__.py', 'a1e2f3c4d5b6_...', 'b2f3a4e5c6d7_...', 'c3d4b5a6f7e8_...']
```

- `python -m fred_runtime migrate` in the image now reaches
  `fred_runtime/migrations/env.py:43` and stops only on the absent
  `configuration.yaml`, which the Helm Job mounts. The ModuleNotFoundError is gone.
