### PR TITLE
fix(#2633): keep the folder path when removing a document from a tag

### DIFF
--- a/apps/frontend/src/components/documents/common/useDocumentCommands.remove.test.tsx
+++ b/apps/frontend/src/components/documents/common/useDocumentCommands.remove.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+// Copyright Thales 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage: removing a document from a nested folder moved the
+// folder back to the root of the corpus tree. Both remove commands rebuild the
+// tag payload from scratch and used to leave `path` out, which was harmless
+// until the tag update endpoint started applying every field of the body - a
+// missing path then became null. The current path must travel with the new
+// item_ids.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DocumentMetadata, TagWithItemsId } from "../../../slices/knowledgeFlow/knowledgeFlowOpenApi";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const updateTagMutation = vi.fn();
+const refetchTags = vi.fn(async () => undefined);
+const refetchDocs = vi.fn(async (_tagId?: string) => undefined);
+const showError = vi.fn();
+const showSuccess = vi.fn();
+const showInfo = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("@shared/molecules/Toast/ToastProvider", () => ({
+  useToast: () => ({ showSuccess, showError, showInfo }),
+}));
+vi.mock("../../../slices/knowledgeFlow/knowledgeFlowOpenApi", () => ({
+  useUpdateTagKnowledgeFlowV1TagsTagIdPutMutation: () => [updateTagMutation],
+  useRenameDocumentKnowledgeFlowV1DocumentMetadataDocumentUidNamePutMutation: () => [vi.fn()],
+  useSearchDocumentMetadataKnowledgeFlowV1DocumentsMetadataSearchPostMutation: () => [vi.fn()],
+  useUpdateDocumentMetadataRetrievableKnowledgeFlowV1DocumentMetadataDocumentUidPutMutation: () => [vi.fn()],
+  useMutateDocumentLabelsMutation: () => [vi.fn()],
+}));
+vi.mock("../../../slices/knowledgeFlow/knowledgeFlowApi.blob", () => ({
+  useLazyDownloadRawContentBlobQuery: () => [vi.fn()],
+}));
+
+import { useDocumentCommands } from "./useDocumentCommands";
+
+const docOne = {
+  identity: { document_uid: "uid-1", document_name: "report.pdf", title: null },
+  source: { retrievable: true },
+} as unknown as DocumentMetadata;
+
+const docTwo = {
+  identity: { document_uid: "uid-2", document_name: "annex.pdf", title: null },
+  source: { retrievable: true },
+} as unknown as DocumentMetadata;
+
+const tag = {
+  id: "tag-1",
+  name: "Reports",
+  path: "Finance/2026",
+  description: "d",
+  type: "document",
+  item_ids: ["uid-1", "uid-2"],
+} as unknown as TagWithItemsId;
+
+function Harness({ onRender }: { onRender: (commands: ReturnType<typeof useDocumentCommands>) => void }) {
+  onRender(useDocumentCommands({ refetchTags, refetchDocs }));
+  return null;
+}
+
+describe("useDocumentCommands remove keeps the folder path", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let commands: ReturnType<typeof useDocumentCommands>;
+
+  beforeEach(() => {
+    updateTagMutation.mockReset();
+    refetchTags.mockClear();
+    refetchDocs.mockClear();
+    showError.mockClear();
+    showSuccess.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<Harness onRender={(c) => (commands = c)} />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("sends the current path when removing a single document", async () => {
+    updateTagMutation.mockReturnValue({ unwrap: async () => undefined });
+
+    await act(async () => {
+      await commands.removeFromLibrary(docOne, tag);
+    });
+
+    expect(updateTagMutation).toHaveBeenCalledWith({
+      tagId: "tag-1",
+      tagUpdate: {
+        name: "Reports",
+        path: "Finance/2026",
+        description: "d",
+        type: "document",
+        item_ids: ["uid-2"],
+      },
+    });
+    expect(refetchDocs).toHaveBeenCalledWith("tag-1");
+  });
+
+  it("sends the current path when removing documents in bulk", async () => {
+    updateTagMutation.mockReturnValue({ unwrap: async () => undefined });
+
+    await act(async () => {
+      await commands.bulkRemoveFromLibraryForTag([docOne, docTwo], tag);
+    });
+
+    expect(updateTagMutation).toHaveBeenCalledWith({
+      tagId: "tag-1",
+      tagUpdate: {
+        name: "Reports",
+        path: "Finance/2026",
+        description: "d",
+        type: "document",
+        item_ids: [],
+      },
+    });
+    expect(refetchDocs).toHaveBeenCalledWith("tag-1");
+  });
+});

--- a/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
+++ b/apps/frontend/src/components/documents/common/useDocumentCommands.tsx
@@ -86,10 +86,13 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
     async (doc: DocumentMetadata, tag: TagWithItemsId) => {
       try {
         const newItemIds = (tag.item_ids || []).filter((id) => id !== doc.identity.document_uid);
+        // PUT replaces every editable field: omitting `path` re-parents the folder
+        // to the root, so the current path must travel with the new item_ids.
         await updateTag({
           tagId: tag.id,
           tagUpdate: {
             name: tag.name,
+            path: tag.path,
             description: tag.description,
             type: tag.type,
             item_ids: newItemIds,
@@ -129,10 +132,12 @@ export function useDocumentCommands({ refetchTags, refetchDocs }: DocumentRefres
       try {
         const idsToRemove = new Set(docs.map((d) => d.identity.document_uid));
         const newItemIds = (tag.item_ids || []).filter((id) => !idsToRemove.has(id));
+        // Same as removeFromLibrary: keep the folder path.
         await updateTag({
           tagId: tag.id,
           tagUpdate: {
             name: tag.name,
+            path: tag.path,
             description: tag.description,
             type: tag.type,
             item_ids: newItemIds,


### PR DESCRIPTION
Closes #2633

## What

`removeFromLibrary` and `bulkRemoveFromLibraryForTag` (`useDocumentCommands.tsx`) now send `path: tag.path` in the `PUT /tags/{id}` body.

## Why

Both commands rebuild the tag payload from scratch and left `path` out. That was harmless until #2483 made `TagService.update_tag_for_user` apply every editable field of the body: the missing `path` was stored as `null`, so deleting a document inside a nested folder re-parented that folder to the root of the Resources tree, and the view being browsed fell back to the root listing.

`renameFolder` already forwards `path` and is unchanged.

## Tests

- New `useDocumentCommands.remove.test.tsx`: single and bulk removal both assert the PUT body carries the folder's current `path` alongside the trimmed `item_ids`.
- `npx vitest run` on the remove + rename test files: 4 passed. `tsc --noEmit` and prettier clean.

Not verified: manual run in the browser.