### PR TITLE
fix(#2636): show the deployment default avatar in the team header

### DIFF
--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.test.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.test.tsx
@@ -24,6 +24,8 @@ const h = vi.hoisted(() => ({
     isError: boolean;
   },
   wikiEnabled: undefined as boolean | undefined,
+  defaultTeamAvatarFile: "",
+  teamAvatarImageUrl: undefined as string | undefined,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -37,13 +39,23 @@ vi.mock("react-router-dom", () => ({
   ),
 }));
 vi.mock("../../../../../../hooks/useFrontendProperties.ts", () => ({
-  useFrontendProperties: () => ({ agentIconName: "smart_toy", agentsNicknamePlural: "agents" }),
+  useFrontendProperties: () => ({
+    agentIconName: "smart_toy",
+    agentsNicknamePlural: "agents",
+    defaultTeamAvatarFile: h.defaultTeamAvatarFile,
+  }),
 }));
 vi.mock("../../../../../../hooks/useSelectedTeam.ts", () => ({
   useSelectedTeam: () => ({
     teamId: "team-1",
     isPersonalTeam: h.isPersonalTeam,
-    selectedTeam: { id: "team-1", name: "Team One", is_member: true, my_relations: ["team_member"] },
+    selectedTeam: {
+      id: "team-1",
+      name: "Team One",
+      is_member: true,
+      my_relations: ["team_member"],
+      avatar_image_url: h.teamAvatarImageUrl,
+    },
     canOpenTeamSettings: false,
   }),
 }));
@@ -150,5 +162,41 @@ describe("TeamContentNavbar — the wiki entry", () => {
     // on a slow answer — worse than one that arrives a moment late.
     h.wikiEnabled = undefined;
     expect(renderToStaticMarkup(<TeamContentNavbar />)).not.toContain("/team/team-1/wiki");
+  });
+});
+
+describe("TeamContentNavbar — the team avatar", () => {
+  beforeEach(() => {
+    h.isPersonalTeam = false;
+    h.defaultTeamAvatarFile = "";
+    h.teamAvatarImageUrl = undefined;
+  });
+
+  it("falls back to the deployment default when the team has no image of its own", () => {
+    h.defaultTeamAvatarFile = "acme-team-avatar.svg";
+    const html = renderToStaticMarkup(<TeamContentNavbar />);
+    expect(html).toContain('src="/images/acme-team-avatar.svg"');
+  });
+
+  it("keeps the team's own image ahead of the deployment default", () => {
+    h.defaultTeamAvatarFile = "acme-team-avatar.svg";
+    h.teamAvatarImageUrl = "https://store.example/team-1.png";
+    const html = renderToStaticMarkup(<TeamContentNavbar />);
+    expect(html).toContain('src="https://store.example/team-1.png"');
+    expect(html).not.toContain("acme-team-avatar.svg");
+  });
+
+  it("renders initials when no default is configured", () => {
+    const html = renderToStaticMarkup(<TeamContentNavbar />);
+    expect(html).not.toContain("/images/");
+    expect(html).toContain("TO");
+  });
+
+  // The personal space says "this is you" with the user's own avatar; a team
+  // default there would erase that signal.
+  it("leaves the personal space on the user avatar", () => {
+    h.isPersonalTeam = true;
+    h.defaultTeamAvatarFile = "acme-team-avatar.svg";
+    expect(renderToStaticMarkup(<TeamContentNavbar />)).not.toContain("acme-team-avatar.svg");
   });
 });

--- a/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
+++ b/apps/frontend/src/rework/components/shared/layouts/Sidebar/TeamContentNavbar/TeamContentNavbar.tsx
@@ -49,7 +49,7 @@ import { useWikiAvailabilityQuery } from "../../../../../../slices/controlPlane/
  * Mount inside the main sidebar layout for routes under `/team/:teamId/...`
  */
 export default function TeamContentNavbar() {
-  const { agentIconName, agentsNicknamePlural } = useFrontendProperties();
+  const { agentIconName, agentsNicknamePlural, defaultTeamAvatarFile } = useFrontendProperties();
   const { t } = useTranslation();
   const location = useLocation();
   const { pathname } = location;
@@ -134,15 +134,18 @@ export default function TeamContentNavbar() {
   })();
   const showRoleLabel = !isPersonalTeam && !!selectedTeam?.is_member && relationsLoaded;
 
-  // Team avatar (28×28, 4px): the custom image when set, else colour-tinted
-  // square initials (same fallback as the Home team list). The personal space
-  // reuses that list's round user avatar (UserAvatar) — the "this is you"
-  // signal — sized down to fit this compact header.
+  // Team avatar (28×28, 4px): the team's own image, else the deployment default,
+  // else colour-tinted square initials — the same chain as the Home team list
+  // and the team cards, so one team looks the same on every surface. The
+  // personal space keeps that list's round user avatar (UserAvatar) — the "this
+  // is you" signal — sized down to fit this compact header.
   const teamDisplayName = isPersonalTeam ? t("rework.sidebar.team.userTeam") : (selectedTeam?.name ?? "");
   const teamAvatar = isPersonalTeam ? (
     <UserAvatar name={KeyCloakService.GetUserFullName()} size="x-small" />
   ) : selectedTeam?.avatar_image_url ? (
     <img className={styles.teamPanelAvatar} src={selectedTeam.avatar_image_url} alt="" aria-hidden="true" />
+  ) : defaultTeamAvatarFile ? (
+    <img className={styles.teamPanelAvatar} src={`/images/${defaultTeamAvatarFile}`} alt="" aria-hidden="true" />
   ) : (
     <TeamInitials
       className={styles.teamPanelAvatar}


### PR DESCRIPTION
Closes #2636.

## What

The sidebar team header now falls back to `defaultTeamAvatarFile` when the team
has no image of its own, instead of going straight to coloured initials.

That header is the one avatar visible on every screen inside a team, and it was
the only one ignoring the deployment default: `TeamCard` and `HomeNavPanel`
already honour it. A themed deployment therefore saw its avatar on the home list
and on team cards, and initials on every team page.

One line of chain, plus the comment that explains the order.

## Not changed

The personal space keeps `UserAvatar`. It is the "this is you" signal, and
`defaultPersonalAvatarFile` there would erase it. Say so if you want it wired
too - it is the same one-line change.

## Tests

`TeamContentNavbar.test.tsx` gains four cases: the default is used when the team
has no image, the team's own image still wins over it, initials still render
with no default configured, and the personal space is untouched.

Verified they earn their keep: with the source change reverted, the first case
fails and the other three pass - they are the regression guards around it.

Checked on the k3d stack with a theme archive shipping `acme-team-avatar.svg`.
