### PR TITLE
perf(#2631): fold capability can_use locally instead of one ListObjects per team

### DIFF
--- a/apps/control-plane-backend/control_plane_backend/capabilities/impact.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/impact.py
@@ -40,19 +40,35 @@ Unreachable pod = UNKNOWN, never "broken": the reconciliation sweep skips such
 instances (`skipped_unreachable`) rather than suspending them on a transient
 outage (#1975, RFC §3.9), and this read reports the same way. Telling an admin
 "12 agents broken" because a pod is restarting would be a lie with consequences.
+
+Where `can_use` comes from: the health column folds it from the cached
+per-capability tuple sets, the revoke preview from one fresh read of the single
+capability it is about. `resolve_availability_for_team` (the grant revive path)
+keeps the live `usable_capability_ids` - it feeds a write, not a display.
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
+from typing import Sequence
 
+from fred_core import RebacDisabledResult, RebacEngine
 from fred_core.common import TeamId
+from fred_core.security.rebac.capability_authz import (
+    CapabilityEnablementFacts,
+    can_team_use_from_facts,
+)
 
 from control_plane_backend.agent_instances.store import (
     AgentInstanceRecord,
     AgentInstanceStore,
 )
 from control_plane_backend.capabilities.authz import usable_capability_ids
+from control_plane_backend.capabilities.enablement import (
+    cap_ref,
+    get_enablement_relations_cached,
+)
 from control_plane_backend.product.dependencies import ProductServiceDependencies
 
 
@@ -76,22 +92,37 @@ class CapabilityImpact:
     skipped_unreachable: int = 0
 
 
-async def _usable_ids_by_team(
-    deps: ProductServiceDependencies,
-    team_ids: set[TeamId],
-) -> dict[TeamId, set[str] | None]:
-    """`can_use` capability ids per team — ONE `ListObjects` per team.
+async def _referenced_facts(
+    rebac: RebacEngine,
+    instances: Sequence[AgentInstanceRecord],
+) -> dict[str, CapabilityEnablementFacts] | None:
+    """Fold every capability the instances depend on, one cached tuple read each.
 
-    `can_use` is a TEAM-subject check (RFC §8.1), so authorization is a property
-    of (capability, space) and never fans out per agent instance: a team with 50
-    agents still costs one lookup. `None` means ReBAC is disabled — "no scoping",
-    every capability usable (matching `usable_capability_ids`).
+    A `ListObjects` per team cost OpenFGA a `Check` per catalog capability, and
+    every personal space is a team. `None` means ReBAC is disabled ("no
+    scoping", matching `usable_capability_ids`).
     """
 
-    rebac = deps.team_dependencies.rebac
-    return {
-        team_id: await usable_capability_ids(rebac, team_id) for team_id in team_ids
-    }
+    # Materialized once: `gather` and the `zip` below must walk the same order.
+    referenced_ids = list(
+        {
+            cap_id
+            for instance in instances
+            for cap_id in _instance_dependency_ids(instance)
+        }
+    )
+    relation_sets = await asyncio.gather(
+        *(
+            get_enablement_relations_cached(rebac, cap_ref(cap_id))
+            for cap_id in referenced_ids
+        )
+    )
+    facts_by_id: dict[str, CapabilityEnablementFacts] = {}
+    for cap_id, relations in zip(referenced_ids, relation_sets):
+        if isinstance(relations, RebacDisabledResult):
+            return None
+        facts_by_id[cap_id] = CapabilityEnablementFacts.from_relations(relations)
+    return facts_by_id
 
 
 def _instance_template_capability_id(instance: AgentInstanceRecord) -> str | None:
@@ -117,46 +148,59 @@ def _instance_template_capability_id(instance: AgentInstanceRecord) -> str | Non
     return template_capability_id(instance.source_runtime_id, instance.source_agent_id)
 
 
-def _broken_capability_ids(
+def _instance_dependency_ids(instance: AgentInstanceRecord) -> list[str]:
+    """Every capability the instance depends on: the tool capabilities it
+    selected, plus - unless gate-exempt - the `kind="agent"` template it is
+    itself an instance of."""
+
+    dependency_ids = list(instance.tuning.selected_capability_ids or [])
+    template_cap_id = _instance_template_capability_id(instance)
+    if template_cap_id is not None:
+        dependency_ids.append(template_cap_id)
+    return dependency_ids
+
+
+def _dependency_is_broken(
     instance: AgentInstanceRecord,
-    usable_ids: set[str] | None,
+    cap_id: str,
+    facts_by_id: dict[str, CapabilityEnablementFacts] | None,
     available_ids: frozenset[str] | None,
-) -> list[str]:
-    """The instance's dependencies that are NOT currently usable: its selected
-    tool capabilities, plus — unless gate-exempt — the `kind="agent"` template
-    capability the instance is itself an instance of.
+) -> bool:
+    """Is this ONE dependency currently unusable by the instance's space?
 
-    A selected TOOL capability is broken when the team lacks `can_use` on it
-    OR its pod no longer advertises it — the two independent failure modes
-    behind `capability_access_revoked` and `capability_unavailable`. The
-    instance's OWN template capability id is broken on the `can_use` axis
-    only: `available_ids` is the pod's advertised SELECTABLE tool/capability
-    set, which never contains an agent template's own id by construction
-    (see `_instance_template_capability_id`), so checking it there would
-    always read "missing" — matching `enablement.revive_dependent_instances`'s
-    template branch, which checks the same single axis.
+    A selected TOOL capability breaks when the team lacks `can_use` OR its pod
+    no longer advertises it - the two failure modes behind
+    `capability_access_revoked` and `capability_unavailable`. The instance's OWN
+    template id is checked on the `can_use` axis only: `available_ids` is the
+    pod's advertised SELECTABLE set, which never contains a template's own id,
+    so checking it there would always read "missing" - matching
+    `enablement.revive_dependent_instances`'s template branch.
 
-    `usable_ids=None` (ReBAC disabled) skips the authorization half;
+    `facts_by_id=None` (ReBAC disabled) skips the authorization half;
     `available_ids=None` (unreachable pod) must be handled by the CALLER, which
-    reports the instance as unknown rather than broken — this function is only
-    reached with a known pod set.
+    reports the instance as unknown rather than broken.
     """
 
-    broken: list[str] = []
-    for cap_id in instance.tuning.selected_capability_ids or []:
-        denied = usable_ids is not None and cap_id not in usable_ids
-        missing = available_ids is not None and cap_id not in available_ids
-        if denied or missing:
-            broken.append(cap_id)
+    denied = facts_by_id is not None and not can_team_use_from_facts(
+        str(instance.team_id), facts_by_id[cap_id]
+    )
+    selected = cap_id in (instance.tuning.selected_capability_ids or [])
+    missing = selected and available_ids is not None and cap_id not in available_ids
+    return denied or missing
 
-    template_cap_id = _instance_template_capability_id(instance)
-    if (
-        template_cap_id is not None
-        and usable_ids is not None
-        and template_cap_id not in usable_ids
-    ):
-        broken.append(template_cap_id)
-    return broken
+
+def _broken_capability_ids(
+    instance: AgentInstanceRecord,
+    facts_by_id: dict[str, CapabilityEnablementFacts] | None,
+    available_ids: frozenset[str] | None,
+) -> list[str]:
+    """The instance's dependencies that are NOT currently usable."""
+
+    return [
+        cap_id
+        for cap_id in _instance_dependency_ids(instance)
+        if _dependency_is_broken(instance, cap_id, facts_by_id, available_ids)
+    ]
 
 
 async def compute_capability_impact(
@@ -172,9 +216,8 @@ async def compute_capability_impact(
     `suspension_reason` — see the module docstring for why that column cannot
     answer this.
 
-    Cost is bounded by design: one `ListObjects` per team with instances (NOT
-    per instance) plus one template fetch per runtime pod. With the handful of
-    pods this platform runs, that is a few round-trips for an admin-only screen.
+    Cost is bounded by design: one cached tuple read per REFERENCED capability
+    (never one per team or per instance) plus one template fetch per runtime pod.
 
     `collect_instances=True` additionally names the impacted instances (the
     drill-down "which agents, in which space"); the count alone skips that work.
@@ -193,31 +236,20 @@ async def compute_capability_impact(
         return {}
 
     available_by_source = await _available_capability_ids_by_source(deps)
-    usable_by_team = await _usable_ids_by_team(
-        deps, {instance.team_id for instance in instances}
-    )
+    facts_by_id = await _referenced_facts(deps.team_dependencies.rebac, instances)
 
     impact: dict[str, CapabilityImpact] = {}
     for instance in instances:
         available_ids = available_by_source.get(instance.source_runtime_id)
         if available_ids is None:
             # Pod unreachable — the sweep would skip this instance rather than
-            # suspend it, so its impact is UNKNOWN. Attribute the skip to each
-            # selected capability, and to the instance's own template
-            # capability (if any), so the caller can say "unknown", not "fine"
-            # for either kind.
-            for cap_id in instance.tuning.selected_capability_ids or []:
+            # suspend it, so its impact is UNKNOWN. Attribute the skip to every
+            # dependency so the caller says "unknown", not "fine", for each.
+            for cap_id in _instance_dependency_ids(instance):
                 impact.setdefault(cap_id, CapabilityImpact()).skipped_unreachable += 1
-            template_cap_id = _instance_template_capability_id(instance)
-            if template_cap_id is not None:
-                impact.setdefault(
-                    template_cap_id, CapabilityImpact()
-                ).skipped_unreachable += 1
             continue
 
-        broken = _broken_capability_ids(
-            instance, usable_by_team.get(instance.team_id), available_ids
-        )
+        broken = _broken_capability_ids(instance, facts_by_id, available_ids)
         for cap_id in broken:
             entry = impact.setdefault(cap_id, CapabilityImpact())
             entry.suspended_instances += 1
@@ -286,10 +318,14 @@ async def preview_revoke_impact(
     their own tuple, not by inheritance), so this preview excludes them too —
     otherwise the confirmation dialog overstates impact by counting agents that
     will not actually be suspended.
+
+    An admin confirms a mutation against this number, so it reads the one
+    capability's tuples FRESH (never the 45s cache, which another replica's
+    write does not invalidate) and answers both questions it asks - who holds
+    an explicit grant, and who is already broken - from that single read.
     """
 
     from control_plane_backend.capabilities.enablement import (
-        explicitly_enabled_team_ids,
         is_template_capability_instance,
     )
     from control_plane_backend.product.service import (
@@ -314,22 +350,28 @@ async def preview_revoke_impact(
         if capability_id in (instance.tuning.selected_capability_ids or [])
         or is_template_capability_instance(instance, capability_id)
     ]
-    if team_id is None and instances:
-        enabled_team_ids = await explicitly_enabled_team_ids(
-            deps.team_dependencies.rebac, capability_id
-        )
+    if not instances:
+        return CapabilityImpact()
+
+    relations = await deps.team_dependencies.rebac.list_direct_relations(
+        cap_ref(capability_id)
+    )
+    facts = (
+        None
+        if isinstance(relations, RebacDisabledResult)
+        else CapabilityEnablementFacts.from_relations(relations)
+    )
+    if team_id is None and facts is not None:
         instances = [
             instance
             for instance in instances
-            if str(instance.team_id) not in enabled_team_ids
+            if str(instance.team_id) not in facts.enabled
         ]
     if not instances:
         return CapabilityImpact()
 
+    facts_by_id = None if facts is None else {capability_id: facts}
     available_by_source = await _available_capability_ids_by_source(deps)
-    usable_by_team = await _usable_ids_by_team(
-        deps, {instance.team_id for instance in instances}
-    )
 
     result = CapabilityImpact()
     for instance in instances:
@@ -337,10 +379,7 @@ async def preview_revoke_impact(
         if available_ids is None:
             result.skipped_unreachable += 1
             continue
-        already_broken = capability_id in _broken_capability_ids(
-            instance, usable_by_team.get(instance.team_id), available_ids
-        )
-        if already_broken:
+        if _dependency_is_broken(instance, capability_id, facts_by_id, available_ids):
             continue
         result.suspended_instances += 1
         result.instances.append(

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -28,12 +28,11 @@ from typing import Any, Mapping
 
 from fred_core import CapabilityPermission, KeycloakUser, RebacDisabledResult
 from fred_core.common import TeamId, is_personal_team_id
-from fred_core.security.models import Resource
 from fred_core.security.rebac.application_authz import (
     APPLICATION_CATALOG_NAMESPACE_PREFIX,
 )
+from fred_core.security.rebac.capability_authz import CapabilityEnablementFacts
 from fred_core.security.rebac.rebac_engine import (
-    ORGANIZATION_ID,
     RebacEngine,
     Relation,
     RelationType,
@@ -51,7 +50,6 @@ from control_plane_backend.capabilities.enablement import (
     CapabilityNotFound,
     ReasoningNotSupported,
     cap_ref,
-    capability_relation_subjects,
     disable_capability_for_team,
     enable_capability_for_team,
     enablement_ref,
@@ -224,23 +222,33 @@ def _canonical_team_id_for_entry(
     return resolve_system_team_id(user, team_id) or team_id
 
 
-def _fold_personal_scope(
-    relations: list[Relation] | RebacDisabledResult,
-) -> PersonalScope:
-    """Derive the personal-space class tri-state from the two org-subject
-    tuples (RFC §8.4), folded from an already-fetched relation set. `enabled`
-    wins if both are somehow present (matches the FGA setter, which never
-    leaves both)."""
+def _fold_personal_scope(facts: CapabilityEnablementFacts) -> PersonalScope:
+    """Derive the personal-space class tri-state (RFC §8.4) from the shared
+    fold. `enabled` wins if both markers are somehow present (matches the FGA
+    setter, which never leaves both)."""
 
-    if ORGANIZATION_ID in capability_relation_subjects(
-        relations, RelationType.PERSONAL_ON, Resource.ORGANIZATION
-    ):
+    if facts.personal_on:
         return "enabled"
-    if ORGANIZATION_ID in capability_relation_subjects(
-        relations, RelationType.PERSONAL_DISABLED, Resource.ORGANIZATION
-    ):
+    if facts.personal_disabled:
         return "disabled"
     return "default"
+
+
+def _enablement_facts(
+    relations: list[Relation] | RebacDisabledResult,
+) -> CapabilityEnablementFacts:
+    """The five `can_use` facts for one capability. ReBAC disabled folds to the
+    all-empty shape, which every caller already renders as "nothing granted"."""
+
+    if isinstance(relations, RebacDisabledResult):
+        return CapabilityEnablementFacts(
+            enabled=frozenset(),
+            disabled=frozenset(),
+            default_on=False,
+            personal_on=False,
+            personal_disabled=False,
+        )
+    return CapabilityEnablementFacts.from_relations(relations)
 
 
 async def _read_personal_scope(rebac: RebacEngine, capability_id: str) -> PersonalScope:
@@ -264,7 +272,7 @@ async def _read_personal_scope(rebac: RebacEngine, capability_id: str) -> Person
     relations = await rebac.list_direct_relations(
         cap_ref(capability_id), subject=ORG_REF
     )
-    return _fold_personal_scope(relations)
+    return _fold_personal_scope(_enablement_facts(relations))
 
 
 async def _build_enablement_item(
@@ -279,28 +287,20 @@ async def _build_enablement_item(
     """Build one row's ReBAC-derived fields.
 
     #2089: originally 4 concurrent `lookup_subjects` reads per row. #2181
-    follow-up: `enabled`/`disabled` team grants and `default_on`/personal-scope
-    org markers all live on the SAME literal tuple set for this capability, so
-    they no longer need 4 separate OpenFGA round-trips (5, counting
-    `_read_personal_scope`'s own pair) — one cached `list_direct_relations`
-    Read (`get_capability_relations_cached`) is fetched ONCE here and folded
-    locally, the same "fetch once, derive many" shape `_bulk_team_membership`/
-    `_fold_team_role_relations` already use for teams. Fetching once (instead
-    of gathering several calls that would each independently race the same
-    cache key) also avoids a per-row thundering herd on a cold cache.
+    follow-up: every field below lives on the SAME literal tuple set, so one
+    cached `list_direct_relations` Read is fetched ONCE here and folded
+    locally - the same "fetch once, derive many" shape
+    `_fold_team_role_relations` uses for teams, and through the same
+    `CapabilityEnablementFacts` the health column derives `can_use` from, so
+    the two cannot drift.
     """
 
     relations = await get_enablement_relations_cached(rebac, enablement_ref(entry))
-    default_on = ORGANIZATION_ID in capability_relation_subjects(
-        relations, RelationType.DEFAULT_ON, Resource.ORGANIZATION
-    )
-    enabled_team_ids = sorted(
-        capability_relation_subjects(relations, RelationType.ENABLED, Resource.TEAM)
-    )
-    disabled_team_ids = sorted(
-        capability_relation_subjects(relations, RelationType.DISABLED, Resource.TEAM)
-    )
-    personal_scope = _fold_personal_scope(relations)
+    facts = _enablement_facts(relations)
+    default_on = facts.default_on
+    enabled_team_ids = sorted(facts.enabled)
+    disabled_team_ids = sorted(facts.disabled)
+    personal_scope = _fold_personal_scope(facts)
     if entry.kind == "app":
         enabled_team_ids = [
             team_id

--- a/apps/control-plane-backend/control_plane_backend/capabilities/service.py
+++ b/apps/control-plane-backend/control_plane_backend/capabilities/service.py
@@ -381,9 +381,9 @@ async def list_capability_enablement(
     # so run them concurrently instead of one after another (#2089). Platform-
     # wide denominators (collaborative teams for default-on inheritance §8.5,
     # personal spaces for personal-class access §8.4) and resting health
-    # (#1975: one ReBAC `ListObjects` per team holding instances, `collect_instances`
-    # names the broken agents inline so the health-column drill-down needs no
-    # second endpoint) all fold into the same gather as the catalog fetch.
+    # (`collect_instances` names the broken agents inline, so the health-column
+    # drill-down needs no second endpoint) all fold into the same gather as the
+    # catalog fetch.
     # `_pod_catalog_fetch_scope()` de-dupes the pod `/agents/templates` fetch
     # that `aggregate_capability_catalog` and `compute_capability_impact`
     # would otherwise each make independently (#2089).

--- a/apps/control-plane-backend/tests/test_capability_enablement_1980.py
+++ b/apps/control-plane-backend/tests/test_capability_enablement_1980.py
@@ -2179,9 +2179,9 @@ def _availability_deps(
     usable_ids: set[str] | None,
 ):
     """A `service.set_personal_scope`-shaped deps object with the live-fact
-    fetches (`_available_capability_ids_by_source` / `usable_capability_ids`)
-    stubbed the same way `test_capability_impact.py::_patch_availability`
-    stubs them for the impact module."""
+    fetches stubbed. `usable_capability_ids` here feeds
+    `impact.resolve_availability_for_team` (the grant revive path), which still
+    asks OpenFGA live - the display paths fold cached tuples instead."""
 
     from types import SimpleNamespace
 

--- a/apps/control-plane-backend/tests/test_capability_impact.py
+++ b/apps/control-plane-backend/tests/test_capability_impact.py
@@ -31,15 +31,24 @@ Covers the two things the health/impact work turns on:
 #   test_capability_selection_1974.py / test_capability_enablement_1980.py).
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 import pytest
+from _rebac_test_doubles import CountingRebacEngine
 from control_plane_backend.agent_instances.suspension import SuspensionReason
 from control_plane_backend.capabilities import enablement as enablement_mod
 from control_plane_backend.capabilities import impact as impact_mod
 from control_plane_backend.capabilities import service as capability_service
 from control_plane_backend.product.service import template_capability_id
-from fred_core import KeycloakUser
+from fred_core import (
+    KeycloakUser,
+    RebacDisabledResult,
+    RebacReference,
+    Relation,
+    RelationType,
+    Resource,
+)
 from test_main import _FakeAgentInstanceStore, _make_record
 
 
@@ -66,12 +75,11 @@ def _record_with(
 
 
 class _NoOpRebac:
-    """Stands in for `ReBAC` in tests that never exercise a real lookup — the
-    platform-wide preview now reads `explicitly_enabled_team_ids`, so a bare
-    `object()` no longer suffices as the `rebac` stand-in."""
+    """Stands in for `ReBAC` where the tuple fetch itself is stubbed out, so no
+    lookup should ever reach the engine."""
 
-    async def lookup_subjects(self, *_args: object, **_kwargs: object) -> list:
-        return []
+    async def lookup_resources(self, *_args: object, **_kwargs: object) -> list:
+        raise AssertionError("ListObjects must not be called by the impact module")
 
 
 def _deps_with(store: _FakeAgentInstanceStore) -> SimpleNamespace:
@@ -82,28 +90,63 @@ def _deps_with(store: _FakeAgentInstanceStore) -> SimpleNamespace:
     )
 
 
-def _patch_availability(
+def _team_subject(team_id: str) -> RebacReference:
+    return RebacReference(type=Resource.TEAM, id=team_id)
+
+
+def _cap_relation(
+    subject: RebacReference, relation: RelationType, cap_id: str
+) -> Relation:
+    return Relation(
+        subject=subject, relation=relation, resource=enablement_mod.cap_ref(cap_id)
+    )
+
+
+def _relations_for(usable_by_team: dict[str, set[str]], cap_id: str) -> list[Relation]:
+    """Turn the test's "which teams may use this capability" intent into the
+    capability's direct tuples, so the impact module folds `can_use` from the
+    same tuple shape production reads."""
+
+    return [
+        _cap_relation(_team_subject(team_id), RelationType.ENABLED, cap_id)
+        for team_id, usable in usable_by_team.items()
+        if cap_id in usable
+    ]
+
+
+def _patch_pod_availability(
     monkeypatch: pytest.MonkeyPatch,
-    *,
     available_by_source: dict[str, frozenset[str] | None],
-    usable_by_team: dict[str, set[str] | None],
 ) -> None:
-    """Stub the two live-fact fetches the impact module makes."""
-
-    async def _fake_available(_deps):
-        return available_by_source
-
-    async def _fake_usable(_rebac, team_id):
-        return usable_by_team.get(str(team_id))
-
     # `_available_capability_ids_by_source` is imported lazily from
     # product.service INSIDE the impact functions, so patch it at the source.
     from control_plane_backend.product import service as product_service
 
+    async def _fake_available(_deps):
+        return available_by_source
+
     monkeypatch.setattr(
         product_service, "_available_capability_ids_by_source", _fake_available
     )
-    monkeypatch.setattr(impact_mod, "usable_capability_ids", _fake_usable)
+
+
+def _patch_availability(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    available_by_source: dict[str, frozenset[str] | None],
+    usable_by_team: dict[str, set[str]],
+    rebac_disabled: bool = False,
+) -> None:
+    """Stub the two live-fact fetches the impact module makes."""
+
+    _patch_pod_availability(monkeypatch, available_by_source)
+
+    async def _fake_relations(_rebac, resource):
+        if rebac_disabled:
+            return RebacDisabledResult()
+        return _relations_for(usable_by_team, resource.id)
+
+    monkeypatch.setattr(impact_mod, "get_enablement_relations_cached", _fake_relations)
 
 
 # ---------------------------------------------------------------------------
@@ -309,8 +352,221 @@ async def test_impact_unreachable_pod_skips_template_dependency_too(
 
 
 # ---------------------------------------------------------------------------
+# The call budget: `can_use` is folded from each capability's own tuples, so
+# the cost tracks the referenced capabilities, never the number of teams.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_impact_folds_can_use_without_one_listobjects_per_team(
+    monkeypatch,
+) -> None:
+    """Five teams, two referenced capabilities: the verdicts must come from one
+    tuple read per REFERENCED capability and no `ListObjects` at all, so the
+    cost tracks the catalog rather than the user base."""
+
+    org = enablement_mod.ORG_REF
+    # `_for_all` is default-on but opted out for the whole personal class;
+    # `_for_one` is granted to a single collaborative team.
+    for_all = "fold_budget_for_all"
+    for_one = "fold_budget_for_one"
+    for cap_id in (for_all, for_one):
+        enablement_mod.invalidate_capability_relations_cache(cap_id)
+
+    personal_teams = [f"personal-u{index}" for index in range(3)]
+    collaborative_teams = ["team-collab-0", "team-collab-1"]
+    store = _FakeAgentInstanceStore(
+        [
+            _record_with(
+                agent_instance_id=f"inst-{team_id}",
+                team_id=team_id,
+                selected=[for_all, for_one],
+                # Gate-exempt template, so the only referenced ids are the two
+                # tool capabilities above.
+                source_agent_id="fred.github.self_test",
+            )
+            for team_id in personal_teams + collaborative_teams
+        ]
+    )
+    rebac = CountingRebacEngine(
+        direct_relations=[
+            _cap_relation(org, RelationType.ORGANIZATION, for_all),
+            _cap_relation(org, RelationType.DEFAULT_ON, for_all),
+            _cap_relation(org, RelationType.PERSONAL_DISABLED, for_all),
+            _cap_relation(org, RelationType.ORGANIZATION, for_one),
+            _cap_relation(
+                _team_subject("team-collab-0"), RelationType.ENABLED, for_one
+            ),
+        ]
+    )
+    _patch_pod_availability(monkeypatch, {"runtime-a": frozenset({for_all, for_one})})
+    deps = SimpleNamespace(
+        get_agent_instance_store=lambda: store,
+        get_kpi_writer=lambda: None,
+        team_dependencies=SimpleNamespace(rebac=rebac),
+    )
+
+    result = await impact_mod.compute_capability_impact(deps, collect_instances=True)
+
+    # The personal class is opted out of the default-on capability; only
+    # team-collab-0 holds the explicit grant on the other one.
+    assert {item.team_id for item in result[for_all].instances} == set(personal_teams)
+    assert {item.team_id for item in result[for_one].instances} == set(
+        personal_teams + ["team-collab-1"]
+    )
+    # One read per referenced capability id, not one per team.
+    read_ids = [resource.id for resource, _subject in rebac.list_direct_relations_calls]
+    assert sorted(read_ids) == sorted([for_all, for_one])
+
+
+@pytest.mark.asyncio
+async def test_impact_skips_the_authorization_axis_when_rebac_is_disabled(
+    monkeypatch,
+) -> None:
+    """ReBAC disabled means "no scoping": the fold reports `None` per team, the
+    same signal `usable_capability_ids` used to return, so nothing is called
+    broken on the authorization axis."""
+
+    store = _FakeAgentInstanceStore(
+        [_record_with(agent_instance_id="i", team_id="t", selected=["capa1"])]
+    )
+    _patch_availability(
+        monkeypatch,
+        available_by_source={"runtime-a": frozenset({"capa1"})},
+        usable_by_team={},
+        rebac_disabled=True,
+    )
+
+    result = await impact_mod.compute_capability_impact(_deps_with(store))
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_impact_attributes_a_team_level_opt_out_of_a_default_on_capability(
+    monkeypatch,
+) -> None:
+    """A `disabled` tuple revokes a default-on capability for that team alone -
+    the tri-state the health column has to render, and the one branch a fold
+    that only ever reads `enabled` would get wrong."""
+
+    org = enablement_mod.ORG_REF
+    cap_id = "fold_opt_out_capability"
+    enablement_mod.invalidate_capability_relations_cache(cap_id)
+
+    store = _FakeAgentInstanceStore(
+        [
+            _record_with(
+                agent_instance_id=f"inst-{team_id}",
+                team_id=team_id,
+                selected=[cap_id],
+                source_agent_id="fred.github.self_test",
+            )
+            for team_id in ("team-opted-out", "team-inherits", "personal-u0")
+        ]
+    )
+    rebac = CountingRebacEngine(
+        direct_relations=[
+            _cap_relation(org, RelationType.ORGANIZATION, cap_id),
+            _cap_relation(org, RelationType.DEFAULT_ON, cap_id),
+            _cap_relation(
+                _team_subject("team-opted-out"), RelationType.DISABLED, cap_id
+            ),
+        ]
+    )
+    _patch_pod_availability(monkeypatch, {"runtime-a": frozenset({cap_id})})
+    deps = SimpleNamespace(
+        get_agent_instance_store=lambda: store,
+        get_kpi_writer=lambda: None,
+        team_dependencies=SimpleNamespace(rebac=rebac),
+    )
+
+    result = await impact_mod.compute_capability_impact(deps, collect_instances=True)
+
+    assert {item.team_id for item in result[cap_id].instances} == {"team-opted-out"}
+
+
+@pytest.mark.asyncio
+async def test_preview_revoke_reads_the_capability_fresh_not_the_cache(
+    monkeypatch,
+) -> None:
+    """An admin confirms a mutation against this number, and only the writing
+    replica invalidates the 45s cache. A stale entry saying "nobody is granted"
+    must not make the dialog under-report."""
+
+    org = enablement_mod.ORG_REF
+    cap_id = "fold_preview_capability"
+    store = _FakeAgentInstanceStore(
+        [
+            _record_with(
+                agent_instance_id=f"inst-{index}",
+                team_id=f"personal-u{index}",
+                selected=[cap_id],
+                source_agent_id="fred.github.self_test",
+            )
+            for index in range(3)
+        ]
+    )
+    rebac = CountingRebacEngine(
+        direct_relations=[
+            _cap_relation(org, RelationType.ORGANIZATION, cap_id),
+            _cap_relation(org, RelationType.PERSONAL_ON, cap_id),
+        ]
+    )
+    # Another replica granted the class; this one still caches the pre-write
+    # snapshot, under which every instance reads as already broken.
+    enablement_mod._CAPABILITY_RELATIONS_CACHE.set(
+        enablement_mod.cap_ref(cap_id), (time.time() + 60, [])
+    )
+    _patch_pod_availability(monkeypatch, {"runtime-a": frozenset({cap_id})})
+    deps = SimpleNamespace(
+        get_agent_instance_store=lambda: store,
+        get_kpi_writer=lambda: None,
+        team_dependencies=SimpleNamespace(rebac=rebac),
+    )
+
+    result = await impact_mod.preview_revoke_impact(
+        deps, capability_id=cap_id, team_id=None
+    )
+
+    assert result.suspended_instances == 3
+    # One fresh read of that capability; no ListObjects, no ListUsers.
+    assert [
+        resource.id for resource, _subject in rebac.list_direct_relations_calls
+    ] == [cap_id]
+    assert rebac.lookup_resources_calls == 0
+    assert rebac.lookup_subjects_calls == 0
+
+
+# ---------------------------------------------------------------------------
 # Revoke preview — forward-looking, excludes the already-broken
 # ---------------------------------------------------------------------------
+
+
+def _preview_deps(
+    monkeypatch: pytest.MonkeyPatch,
+    store: _FakeAgentInstanceStore,
+    relations: list[Relation],
+    *,
+    available_by_source: dict[str, frozenset[str] | None] | None = None,
+) -> SimpleNamespace:
+    """Deps for a revoke preview. It reads the capability's tuples fresh off
+    the engine, so these tests state them literally instead of going through
+    `_patch_availability`'s cached-fetch stub."""
+
+    _patch_pod_availability(
+        monkeypatch,
+        available_by_source
+        if available_by_source is not None
+        else {"runtime-a": frozenset({"capa1"})},
+    )
+    return SimpleNamespace(
+        get_agent_instance_store=lambda: store,
+        get_kpi_writer=lambda: None,
+        team_dependencies=SimpleNamespace(
+            rebac=CountingRebacEngine(direct_relations=relations)
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -334,17 +590,17 @@ async def test_preview_excludes_already_broken_instances(monkeypatch) -> None:
             ),
         ]
     )
-    _patch_availability(
+    deps = _preview_deps(
         monkeypatch,
-        available_by_source={"runtime-a": frozenset({"capa1"})},
-        usable_by_team={
-            "team-ok": {"capa1"},  # works today → revoke would break it
-            "team-gone": set(),  # already lost capa1 → already broken
-        },
+        store,
+        [
+            _cap_relation(enablement_mod.ORG_REF, RelationType.DEFAULT_ON, "capa1"),
+            _cap_relation(_team_subject("team-gone"), RelationType.DISABLED, "capa1"),
+        ],
     )
 
     result = await impact_mod.preview_revoke_impact(
-        _deps_with(store), capability_id="capa1", team_id=None
+        deps, capability_id="capa1", team_id=None
     )
 
     assert result.suspended_instances == 1
@@ -376,24 +632,19 @@ async def test_preview_default_off_excludes_explicitly_enabled_teams(
             ),
         ]
     )
-    _patch_availability(
+    deps = _preview_deps(
         monkeypatch,
-        available_by_source={"runtime-a": frozenset({"capa1"})},
-        usable_by_team={
-            "team-inherits": {"capa1"},
-            "team-explicit": {"capa1"},
-        },
-    )
-
-    async def _fake_explicitly_enabled(_rebac, _capability_id):
-        return {"team-explicit"}
-
-    monkeypatch.setattr(
-        enablement_mod, "explicitly_enabled_team_ids", _fake_explicitly_enabled
+        store,
+        [
+            _cap_relation(enablement_mod.ORG_REF, RelationType.DEFAULT_ON, "capa1"),
+            _cap_relation(
+                _team_subject("team-explicit"), RelationType.ENABLED, "capa1"
+            ),
+        ],
     )
 
     result = await impact_mod.preview_revoke_impact(
-        _deps_with(store), capability_id="capa1", team_id=None
+        deps, capability_id="capa1", team_id=None
     )
 
     assert result.suspended_instances == 1
@@ -417,21 +668,18 @@ async def test_preview_single_team_disable_ignores_explicit_enabled_exclusion(
             ),
         ]
     )
-    _patch_availability(
+    deps = _preview_deps(
         monkeypatch,
-        available_by_source={"runtime-a": frozenset({"capa1"})},
-        usable_by_team={"team-explicit": {"capa1"}},
-    )
-
-    async def _fake_explicitly_enabled(_rebac, _capability_id):
-        return {"team-explicit"}
-
-    monkeypatch.setattr(
-        enablement_mod, "explicitly_enabled_team_ids", _fake_explicitly_enabled
+        store,
+        [
+            _cap_relation(
+                _team_subject("team-explicit"), RelationType.ENABLED, "capa1"
+            ),
+        ],
     )
 
     result = await impact_mod.preview_revoke_impact(
-        _deps_with(store), capability_id="capa1", team_id="team-explicit"
+        deps, capability_id="capa1", team_id="team-explicit"
     )
 
     assert result.suspended_instances == 1
@@ -459,14 +707,17 @@ async def test_preview_revoke_includes_agent_template_instances(monkeypatch) -> 
         ]
     )
     template_id = template_capability_id("runtime-a", "rags.sample.echo")
-    _patch_availability(
+    deps = _preview_deps(
         monkeypatch,
+        store,
+        # Works today through the org-wide default, with no explicit grant to
+        # exclude it from the platform-wide preview.
+        [_cap_relation(enablement_mod.ORG_REF, RelationType.DEFAULT_ON, template_id)],
         available_by_source={"runtime-a": frozenset()},
-        usable_by_team={"team-a": {template_id}},  # works today
     )
 
     result = await impact_mod.preview_revoke_impact(
-        _deps_with(store), capability_id=template_id, team_id=None
+        deps, capability_id=template_id, team_id=None
     )
 
     assert result.suspended_instances == 1

--- a/docs/swift/platform/REBAC.md
+++ b/docs/swift/platform/REBAC.md
@@ -237,7 +237,13 @@ Discovery and first-party app checks request higher consistency from the
 authorization engine and never use administration caches as admission decisions.
 Typed administration caches remain process-local, with mutation invalidation and
 expiry rather than a database permission-revision protocol. They do not promise
-immediate cross-replica display freshness.
+immediate cross-replica display freshness. The admin capability health column
+folds `can_use` from that 45-second cached per-capability tuple set rather than
+issuing one `ListObjects` per team: same-replica writes invalidate it, so
+another replica's write may show up to 45 seconds late. The revoke preview
+folds the same way but from a fresh read of the one capability it is about,
+because an admin confirms a mutation against that number. Neither is an
+admission decision.
 
 **Deferred shared lifecycle:** global Deactivate/Activate/Delete requires a
 separate design across all or most applicable ReBAC types, including ownership,

--- a/libs/fred-core/fred_core/security/rebac/capability_authz.py
+++ b/libs/fred-core/fred_core/security/rebac/capability_authz.py
@@ -33,22 +33,29 @@ teams into every team context they browse.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from fred_core.common.team_id import is_personal_team_id
 from fred_core.security.models import Resource
 from fred_core.security.rebac.application_authz import (
     APPLICATION_CAPABILITY_NAMESPACE_PREFIX as APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
 )
 from fred_core.security.rebac.rebac_engine import (
+    ORGANIZATION_ID,
     CapabilityPermission,
     RebacDisabledResult,
     RebacEngine,
     RebacReference,
     Relation,
+    RelationType,
     team_subject_and_context,
 )
 
 __all__ = [
     "APPLICATION_CAPABILITY_NAMESPACE_PREFIX",
+    "CapabilityEnablementFacts",
     "can_team_use_capability",
+    "can_team_use_from_facts",
     "team_capability_subject_and_context",
     "usable_capability_ids",
 ]
@@ -68,6 +75,66 @@ def team_capability_subject_and_context(
     """
 
     return team_subject_and_context(team_id)
+
+
+@dataclass(frozen=True)
+class CapabilityEnablementFacts:
+    """One capability's direct tuples, folded into the five facts `can_use`
+    needs: the teams holding an explicit grant or opt-out, plus the three
+    org-subject markers."""
+
+    enabled: frozenset[str]
+    disabled: frozenset[str]
+    default_on: bool
+    personal_on: bool
+    personal_disabled: bool
+
+    @classmethod
+    def from_relations(cls, relations: list[Relation]) -> "CapabilityEnablementFacts":
+        """Fold the direct tuple set of ONE capability object.
+
+        Anything else on the object (the `organization` anchor, a non-team
+        subject on `enabled`/`disabled`) carries no `can_use` weight and is
+        dropped.
+        """
+
+        enabled: set[str] = set()
+        disabled: set[str] = set()
+        org_markers: set[RelationType] = set()
+        for rel in relations:
+            if rel.subject.type == Resource.TEAM:
+                if rel.relation == RelationType.ENABLED:
+                    enabled.add(rel.subject.id)
+                elif rel.relation == RelationType.DISABLED:
+                    disabled.add(rel.subject.id)
+            elif (
+                rel.subject.type == Resource.ORGANIZATION
+                and rel.subject.id == ORGANIZATION_ID
+            ):
+                org_markers.add(rel.relation)
+        return cls(
+            enabled=frozenset(enabled),
+            disabled=frozenset(disabled),
+            default_on=RelationType.DEFAULT_ON in org_markers,
+            personal_on=RelationType.PERSONAL_ON in org_markers,
+            personal_disabled=RelationType.PERSONAL_DISABLED in org_markers,
+        )
+
+
+def can_team_use_from_facts(team_id: str, facts: CapabilityEnablementFacts) -> bool:
+    """`can_use` derived locally, without asking OpenFGA.
+
+    Mirrors `schema.fga`'s `capability#can_use` line for line and MUST change
+    with it; the `organization#team` / `organization#personal_team` edges are
+    contextual, so they are always true here. Display-only - never an
+    admission decision (`docs/swift/platform/REBAC.md`).
+    """
+
+    personal = is_personal_team_id(team_id)
+    inherited = (facts.default_on or (personal and facts.personal_on)) and not (
+        personal and facts.personal_disabled
+    )
+    return (team_id in facts.enabled or inherited) and team_id not in facts.disabled
 
 
 async def usable_capability_ids(rebac: RebacEngine, team_id: str) -> set[str] | None:

--- a/libs/fred-core/fred_core/tests/integration/test_rebac.py
+++ b/libs/fred-core/fred_core/tests/integration/test_rebac.py
@@ -42,6 +42,11 @@ from fred_core import (
     Resource,
     TagPermission,
     TeamPermission,
+    usable_capability_ids,
+)
+from fred_core.security.rebac.capability_authz import (
+    CapabilityEnablementFacts,
+    can_team_use_from_facts,
 )
 from fred_core.security.rebac.rebac_engine import ORGANIZATION_ID
 from fred_core.security.structure import KeycloakUser, M2MSecurity
@@ -1534,6 +1539,137 @@ async def test_capability_lookup_resources_lists_usable(
     )
     assert not isinstance(other_resources, RebacDisabledResult)
     assert usable.id not in {ref.id for ref in other_resources}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_local_can_use_fold_agrees_with_openfga(
+    rebac_engine: RebacEngine,
+) -> None:
+    """The admin display folds `can_use` from a capability's own tuples instead
+    of asking OpenFGA, so pin that second copy of the schema against the real
+    engine - every branch of `capability#can_use`, both team kinds."""
+
+    org = _organization_ref()
+    personal = _make_reference(Resource.TEAM, prefix="personal")
+    collaborative = _make_reference(Resource.TEAM, prefix="team")
+
+    # One capability per schema branch.
+    default_on = _make_reference(Resource.CAPABILITY, prefix="cap")
+    personal_class = _make_reference(Resource.CAPABILITY, prefix="cap")
+    team_granted = _make_reference(Resource.CAPABILITY, prefix="cap")
+    personal_blocked = _make_reference(Resource.CAPABILITY, prefix="cap")
+    blocked_but_granted = _make_reference(Resource.CAPABILITY, prefix="cap")
+    team_opted_out = _make_reference(Resource.CAPABILITY, prefix="cap")
+    admin_gated = _make_reference(Resource.CAPABILITY, prefix="cap")
+    capabilities = [
+        default_on,
+        personal_class,
+        team_granted,
+        personal_blocked,
+        blocked_but_granted,
+        team_opted_out,
+        admin_gated,
+    ]
+
+    token = await rebac_engine.add_relations(
+        [
+            Relation(subject=org, relation=RelationType.ORGANIZATION, resource=cap)
+            for cap in capabilities
+        ]
+        + [
+            # default_on alone: inherited by BOTH team kinds.
+            Relation(
+                subject=org, relation=RelationType.DEFAULT_ON, resource=default_on
+            ),
+            # personal_on alone: the personal class only.
+            Relation(
+                subject=org, relation=RelationType.PERSONAL_ON, resource=personal_class
+            ),
+            # An explicit per-team grant, no org marker.
+            Relation(
+                subject=collaborative,
+                relation=RelationType.ENABLED,
+                resource=team_granted,
+            ),
+            # personal_disabled subtracts from the inherited layer only...
+            Relation(
+                subject=org,
+                relation=RelationType.DEFAULT_ON,
+                resource=personal_blocked,
+            ),
+            Relation(
+                subject=org,
+                relation=RelationType.PERSONAL_DISABLED,
+                resource=personal_blocked,
+            ),
+            # ...so an explicit grant survives it.
+            Relation(
+                subject=org,
+                relation=RelationType.DEFAULT_ON,
+                resource=blocked_but_granted,
+            ),
+            Relation(
+                subject=org,
+                relation=RelationType.PERSONAL_DISABLED,
+                resource=blocked_but_granted,
+            ),
+            Relation(
+                subject=personal,
+                relation=RelationType.ENABLED,
+                resource=blocked_but_granted,
+            ),
+            # A per-team opt-out of a default-on capability.
+            Relation(
+                subject=org, relation=RelationType.DEFAULT_ON, resource=team_opted_out
+            ),
+            Relation(
+                subject=collaborative,
+                relation=RelationType.DISABLED,
+                resource=team_opted_out,
+            ),
+        ]
+    )
+
+    facts_by_id = {}
+    for cap in capabilities:
+        relations = await rebac_engine.list_direct_relations(
+            cap, consistency_token=token
+        )
+        assert not isinstance(relations, RebacDisabledResult)
+        facts_by_id[cap.id] = CapabilityEnablementFacts.from_relations(relations)
+
+    created_ids = {cap.id for cap in capabilities}
+    for team in (personal, collaborative):
+        listed = await usable_capability_ids(rebac_engine, team.id)
+        assert listed is not None
+        folded = {
+            cap_id
+            for cap_id, facts in facts_by_id.items()
+            if can_team_use_from_facts(team.id, facts)
+        }
+        assert listed & created_ids == folded
+
+    # Spelled out per branch, so set equality cannot be satisfied by a fold
+    # that answers "nothing" (or that confuses the two team kinds).
+    def can_use(cap: RebacReference, team: RebacReference) -> bool:
+        return can_team_use_from_facts(team.id, facts_by_id[cap.id])
+
+    assert can_use(default_on, personal) and can_use(default_on, collaborative)
+    assert can_use(personal_class, personal) and not can_use(
+        personal_class, collaborative
+    )
+    assert can_use(team_granted, collaborative) and not can_use(team_granted, personal)
+    assert not can_use(personal_blocked, personal) and can_use(
+        personal_blocked, collaborative
+    )
+    assert can_use(blocked_but_granted, personal)
+    assert can_use(team_opted_out, personal) and not can_use(
+        team_opted_out, collaborative
+    )
+    assert not can_use(admin_gated, personal) and not can_use(
+        admin_gated, collaborative
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/libs/fred-core/fred_core/tests/security/test_capability_authz.py
+++ b/libs/fred-core/fred_core/tests/security/test_capability_authz.py
@@ -27,7 +27,9 @@ import pytest
 from fred_core.security.models import Resource
 from fred_core.security.rebac.capability_authz import (
     APPLICATION_CAPABILITY_NAMESPACE_PREFIX,
+    CapabilityEnablementFacts,
     can_team_use_capability,
+    can_team_use_from_facts,
     team_capability_subject_and_context,
     usable_capability_ids,
 )
@@ -129,3 +131,153 @@ async def test_can_team_use_capability_allows_when_rebac_is_disabled() -> None:
         )
         is True
     )
+
+
+# ---------------------------------------------------------------------------
+# The local fold: `can_use` derived from a capability's direct tuples, used by
+# the admin health column instead of one `ListObjects` per team.
+# ---------------------------------------------------------------------------
+
+_CAPABILITY = RebacReference(type=Resource.CAPABILITY, id="corp_drive")
+ORG = RebacReference(type=Resource.ORGANIZATION, id=ORGANIZATION_ID)
+TEAM_A = RebacReference(type=Resource.TEAM, id="team-a")
+PERSONAL_U1 = RebacReference(type=Resource.TEAM, id="personal-u1")
+
+
+def _team_relation(team_id: str, relation: RelationType) -> Relation:
+    return Relation(
+        subject=RebacReference(type=Resource.TEAM, id=team_id),
+        relation=relation,
+        resource=_CAPABILITY,
+    )
+
+
+def _org_relation(relation: RelationType) -> Relation:
+    return Relation(subject=ORG, relation=relation, resource=_CAPABILITY)
+
+
+# Each row is one branch of `capability#can_use`, with the expected value
+# written by hand from `schema.fga` - never derived from the production formula.
+_CAN_USE_CASES = [
+    ("explicit grant", "team-a", [(TEAM_A, RelationType.ENABLED)], True),
+    (
+        "explicit disabled beats an explicit grant",
+        "team-a",
+        [(TEAM_A, RelationType.ENABLED), (TEAM_A, RelationType.DISABLED)],
+        False,
+    ),
+    (
+        "default_on inherits for a team",
+        "team-a",
+        [(ORG, RelationType.DEFAULT_ON)],
+        True,
+    ),
+    (
+        "default_on inherits for a personal space",
+        "personal-u1",
+        [(ORG, RelationType.DEFAULT_ON)],
+        True,
+    ),
+    (
+        "personal_on grants the personal class",
+        "personal-u1",
+        [(ORG, RelationType.PERSONAL_ON)],
+        True,
+    ),
+    (
+        "personal_on does not reach a collaborative team",
+        "team-a",
+        [(ORG, RelationType.PERSONAL_ON)],
+        False,
+    ),
+    (
+        "personal_disabled blocks default_on for the personal class",
+        "personal-u1",
+        [(ORG, RelationType.DEFAULT_ON), (ORG, RelationType.PERSONAL_DISABLED)],
+        False,
+    ),
+    (
+        "personal_disabled leaves a collaborative team alone",
+        "team-a",
+        [(ORG, RelationType.DEFAULT_ON), (ORG, RelationType.PERSONAL_DISABLED)],
+        True,
+    ),
+    (
+        "an explicit grant survives personal_disabled",
+        "personal-u1",
+        [
+            (ORG, RelationType.DEFAULT_ON),
+            (ORG, RelationType.PERSONAL_DISABLED),
+            (PERSONAL_U1, RelationType.ENABLED),
+        ],
+        True,
+    ),
+    (
+        "another team's grant does not leak",
+        "team-b",
+        [(TEAM_A, RelationType.ENABLED)],
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "team_id,tuples,expected",
+    [(case[1], case[2], case[3]) for case in _CAN_USE_CASES],
+    ids=[case[0] for case in _CAN_USE_CASES],
+)
+def test_can_team_use_from_facts_matches_the_schema(
+    team_id: str,
+    tuples: list[tuple[RebacReference, RelationType]],
+    expected: bool,
+) -> None:
+    """One row per branch of `capability#can_use`. The fold stands in for an
+    OpenFGA `Check`, so a divergence here is a wrong admin health column."""
+
+    relations = [_org_relation(RelationType.ORGANIZATION)] + [
+        Relation(subject=subject, relation=relation, resource=_CAPABILITY)
+        for subject, relation in tuples
+    ]
+
+    facts = CapabilityEnablementFacts.from_relations(relations)
+
+    assert can_team_use_from_facts(team_id, facts) is expected
+
+
+def test_from_relations_ignores_the_organization_anchor_and_foreign_subjects() -> None:
+    """The anchor tuple and any non-team `enabled`/`disabled` subject carry no
+    `can_use` weight - folding them in would grant a team that holds neither."""
+
+    facts = CapabilityEnablementFacts.from_relations(
+        [
+            _org_relation(RelationType.ORGANIZATION),
+            _org_relation(RelationType.ENABLED),
+            Relation(
+                subject=RebacReference(type=Resource.USER, id="alice"),
+                relation=RelationType.DISABLED,
+                resource=_CAPABILITY,
+            ),
+            _team_relation("team-a", RelationType.ENABLED),
+        ]
+    )
+
+    assert facts == CapabilityEnablementFacts(
+        enabled=frozenset({"team-a"}),
+        disabled=frozenset(),
+        default_on=False,
+        personal_on=False,
+        personal_disabled=False,
+    )
+
+
+def test_from_relations_keeps_other_teams_grants_separate() -> None:
+    """One fold answers for every team, so a grant held by another team must
+    never leak into the asking team's verdict."""
+
+    facts = CapabilityEnablementFacts.from_relations(
+        [_team_relation("team-a", RelationType.ENABLED)]
+    )
+
+    assert can_team_use_from_facts("team-a", facts) is True
+    assert can_team_use_from_facts("team-b", facts) is False
+    assert can_team_use_from_facts("personal-u1", facts) is False


### PR DESCRIPTION
Closes #2631

## Problem

`GET /admin/capabilities` (the admin Features page) got slower as the user base grew. The resting-health column resolved `can_use` with one OpenFGA `ListObjects(team:T, can_use, capability)` per team holding an agent instance, awaited sequentially. Every personal space is a team, and `can_use` has exclusions, so each call cost OpenFGA one `Check` per catalog capability: ~500 personal spaces meant ~45k server-side checks per page load. `preview_revoke_impact` had the same loop.

## Fix

Derive `can_use` locally from the per-capability tuple sets the endpoint already reads for the row data.

- **fred-core**: `CapabilityEnablementFacts.from_relations` folds one capability's direct tuples into the five facts `schema.fga`'s `capability#can_use` depends on; `can_team_use_from_facts` is the formula itself. The `organization#team` / `organization#personal_team` edges are contextual and injected for every team / every personal team, so they are always true locally. Deliberately not exported from the top-level `fred_core` API: it is a display fold, never an admission decision.
- **impact.py**: the health column folds each *referenced* capability from the 45 s write-invalidated cache the row builders share (one cached `Read` per referenced id, concurrent). Verdicts are evaluated per instance dependency, not per (team x id). The revoke preview reads the one capability it is about **fresh** (single uncached `Read`) and answers both the explicit-grant exclusion and the already-broken verdict from that same read: an admin confirms a mutation against that number, so it must not lag behind another replica's write. The grant revive path keeps the live `usable_capability_ids`.
- **service.py** (separate `refactor` commit): the listing rows build their columns from the same `CapabilityEnablementFacts`, so the row data and the health column can no longer drift.
- **REBAC.md**: states which path reads the cache, which reads fresh, and the 45 s cross-replica window.

Cost is now O(referenced capabilities), independent of the number of teams and users. The `rebac_operation=list_objects` timer drops to zero on this path, which gives a direct before/after signal in Grafana.

## Verification

- fred-core: 642 passed; control-plane: 1148 passed (`make test` in both modules). ruff + basedpyright clean on touched files.
- Truth-table unit test with hand-written expected rows for every `can_use` branch (explicit grant, opt-out beats grant, default-on inheritance for collaborative and personal spaces, personal class on/off, explicit grant surviving a personal block, no cross-team leak).
- Integration test `test_local_can_use_fold_agrees_with_openfga` run against a real OpenFGA (`docker-compose.integration.yml`): the fold equals `ListObjects` for a personal and a collaborative team. Mutating the fold to the wrong reading (`default_on` never reaching personal spaces) makes both the unit table and the integration test fail.
- Impact-level tests pin: zero `lookup_resources` calls whatever the team count, one read per referenced id, team-level opt-out on a default-on capability, ReBAC-disabled path, and the preview staying correct with a poisoned cache.
- Reviewed with `/code-review` (8 angles) and the `fred-performance-reviewer` pass; all findings applied except the follow-ups below.

## Follow-ups (not in this PR)

- `enablement.py` still inlines the `inherited` formula on two write paths; consolidating them onto the shared fold is a separate change.
- The capability materialization admin action (`product/service.py`) keeps a sequential per-team `usable_capability_ids` loop (one-shot admin action).
- Raw tuple writers that bypass `invalidate_enablement_relations_cache` (template-id namespace migration, seeding) can leave the health column and rows up to 45 s stale on the same replica.
- Cold-cache fan-out bound / single-flight on `get_enablement_relations_cached`: #2561.
- `GET /teams/all`, loaded by the same page, does one cached `Read` per collaborative team in an unbounded gather.
