### PR TITLE
docs(HITL-01): propose HITL occurrence identity and human response contract

### DIFF
--- a/openspec/changes/hitl-occurrence-identity/.openspec.yaml
+++ b/openspec/changes/hitl-occurrence-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/hitl-occurrence-identity/design.md
+++ b/openspec/changes/hitl-occurrence-identity/design.md
@@ -51,6 +51,14 @@ one-occurrence-per-task invariant still holds, so `interrupt_id` alone remains s
 Validation therefore requires the pair only when the pending occurrence declares one,
 which is what keeps this change invisible to today's flows.
 
+The same replay rule constrains who may raise a pause at all, which is why the contract
+is worded around a tool call rather than an arbitrary call site: any side effect performed
+inside a tool *before* its pause is replayed when the resumed task re-executes. A pause is
+therefore only safe in a tool that does nothing but ask. That rules out pausing in the
+middle of an effectful business tool, and it is the reason the epic's trigger is a
+dedicated, pure tool rather than a `request_human_input()` an author could call from
+anywhere.
+
 ### Extract pending occurrences, not just pending ids
 
 `_pending_react_v2_interrupt_ids` returns a set of ids read from the pending writes. It

--- a/openspec/changes/hitl-occurrence-identity/design.md
+++ b/openspec/changes/hitl-occurrence-identity/design.md
@@ -1,0 +1,116 @@
+## Context
+
+The resume path validates `request.interrupt_id` against the ids of the checkpoint's
+pending `__interrupt__` writes (`_pending_react_v2_interrupt_ids`), and the SQL claim
+table keys single-use admission on `(thread_id, checkpoint_ns, interrupt_id)`. Both rest
+on the same FRED-specific fact, documented in three places: the platform HITL middleware
+has exactly one `interrupt()` call site, so distinct occurrences always land in distinct
+LangGraph tasks and receive distinct ids.
+
+LangGraph itself does not guarantee that. `Interrupt.id` is a hash of the interrupted
+task's checkpoint namespace, so two `interrupt()` calls in one task share it and are
+matched by call order - already pinned against the installed version by
+`test_langgraph_interrupt_id_semantics.py`. A probe confirmed the consequence for the
+tool the epic introduces: `ToolNode` executes all of a turn's tool calls in one task, so
+N tool-raised pauses in one turn share a single id, and a targeted resume re-interrupts
+on the next sibling rather than distinguishing them.
+
+## Goals / Non-Goals
+
+Goals:
+
+- Make the identity of one pause explicit and verifiable end to end.
+- Keep single-use admission correct when siblings share an `interrupt_id`.
+- Give a human answer a truthful storage shape, and let one exchange hold several.
+- Change nothing observable for the single-pause flows that exist today.
+
+Non-Goals:
+
+- The `ask_user` tool, its composer control, and its skip path (change 2).
+- HITL UI rework and free text on the approval gate (change 3).
+- Pause lifetime, expiry, orphan recovery, and a per-turn question cap: those stay with
+  epic #1080, whose design gate has not been passed.
+- Sub-agent HITL at depth >= 1.
+
+## Decisions
+
+### Derive the occurrence identifier from the tool call, do not generate one
+
+`occurrence_id` is the `tool_call_id` of the call that raised the pause, not a fresh
+identifier minted at pause time.
+
+This is forced by LangGraph's resume semantics rather than chosen for elegance: a resumed
+task is replayed from the top, so anything generated per execution - a `uuid4()`, a
+counter, a timestamp - would differ between the pause and its replay and would fail its
+own validation. `tool_call_id` is assigned by the model call that requested the tool, is
+already checkpointed in the assistant message, and is unique per call within a turn.
+
+The field stays optional. A pause raised outside any tool call - the approval gate, and
+the legacy Graph runtime - has no tool call to derive from, and for those the existing
+one-occurrence-per-task invariant still holds, so `interrupt_id` alone remains sufficient.
+Validation therefore requires the pair only when the pending occurrence declares one,
+which is what keeps this change invisible to today's flows.
+
+### Extract pending occurrences, not just pending ids
+
+`_pending_react_v2_interrupt_ids` returns a set of ids read from the pending writes. It
+becomes a function returning `(interrupt_id, occurrence_id | None)` pairs, read from the
+same writes: the interrupt's payload is the serialized human input request, so the
+occurrence identifier travels with it and needs no second lookup.
+
+The surrounding constraint is preserved: this runs before authorization and before the
+agent definition is resolved, so it must keep reading `CheckpointTuple.pending_writes`
+directly rather than building a compiled graph to call `aget_state`.
+
+### Key the claim by occurrence without altering the claim table
+
+The claim table is deliberately not Alembic-tracked: it self-initializes through
+`create_all`, which creates a missing table but never alters an existing one. Adding a
+primary-key column would therefore need manual DDL on every existing deployment, for a
+table whose whole purpose is short-lived admission bookkeeping.
+
+Instead, the claim's `interrupt_id` column holds the occurrence key: the bare
+`interrupt_id` when no `occurrence_id` exists, and a composite of the two when one does.
+The column is already an opaque string to every query - all of them match it for exact
+equality - so uniqueness per occurrence is obtained with no schema change and no
+migration. The composite form must be unambiguous enough that a bare id can never collide
+with a composite one.
+
+Alternative considered and rejected: add an `occurrence_id` primary-key column. Cleaner to
+read, but it requires hand-written DDL outside the migration system this repository
+otherwise keeps strictly linear, and it buys nothing a composite key does not.
+
+### Store the answer truthfully rather than reinterpreting `choice_id`
+
+`HitlResponsePart.choice_id` currently doubles as the free-text field, by a runtime
+convention inherited from `choice_step`. It gains a sibling text field instead, and
+`choice_id` becomes optional so a pure free-text answer records no choice.
+
+Existing rows are not rewritten and not reinterpreted. A stored `choice_id` keeps
+rendering as it does today; only new rows use the new shape. Message parts are stored as
+JSONB, so this is an additive model change with no migration.
+
+## Risks / Trade-offs
+
+- **A second identity field to keep straight.** The contract already carries
+  `checkpoint_id` (legacy Graph) and `interrupt_id` (ReAct), which have been confused
+  before. `occurrence_id` is a third. Mitigation: it is the only one derived from data the
+  UI already holds, and its docstring states the one rule that matters - it names a pause
+  within an interrupt, never an interrupt and never a checkpoint.
+- **A composite claim key is less legible than a column.** Someone reading the table by
+  hand sees a concatenated value rather than two fields. Accepted deliberately over
+  hand-written DDL on a self-initializing table.
+- **Optional-by-default hides mistakes.** A future pause that should declare an
+  `occurrence_id` but does not would silently fall back to interrupt-only validation.
+  Mitigation: a test asserts that any pause raised from within a tool call declares one.
+- **This change alone is not user-visible.** It ships contract and plumbing whose payoff
+  arrives with change 2. That is the point of sequencing it first, but it means its own
+  verification rests on tests rather than on a demonstrable behaviour change.
+
+## Deferred
+
+- The resume payload's `skipped` form belongs to the `ask_user` tool's semantics and is
+  specified in change 2, not here.
+- Whether a pending-occurrence projection API is needed for reliable multi-tab
+  convergence stays an open question under epic #1080; this change deliberately keeps
+  history as the discovery surface it is today.

--- a/openspec/changes/hitl-occurrence-identity/proposal.md
+++ b/openspec/changes/hitl-occurrence-identity/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+Human-in-the-loop resume identity rests on one narrowly true invariant, recorded in
+`react_stream_adapter.py` and again on the SQL claim table: "`FredHitlMiddleware` has
+exactly one `interrupt()` call site, so two DISTINCT FRED HITL occurrences always land
+in different tasks and get different ids".
+
+GitHub epic [#2642](https://github.com/ThalesGroup/fred/issues/2642) breaks that
+invariant on purpose. It introduces an `ask_user` tool the model may call several times
+in one turn, and a probe against the installed LangGraph shows that `ToolNode` runs all
+of a turn's tool calls inside a single LangGraph task, so the successive pauses share
+one `interrupt_id`:
+
+```
+3 ask_user calls in one turn -> pause 1: id=d57ce25a...  q1
+                                pause 2: id=d57ce25a...  q2
+                                pause 3: id=d57ce25a...  q3
+                                distinct ids: 1 of 3
+```
+
+`interrupt_id` therefore stops being sufficient to say which pause an answer belongs to.
+Two more places assume at most one platform-generated pause per exchange and break with
+it: history pairs a request to a response by finding at most one of each per exchange,
+and `HitlResponsePart` stores free text by hijacking `choice_id`.
+
+This change makes occurrence identity explicit, ahead of the tool that needs it. It ships
+no new tool and no UI rework - those are the two later changes under the same epic.
+
+## What Changes
+
+- `HumanInputRequest` carries an optional `occurrence_id`: the identifier of one pause
+  among those sharing an `interrupt_id`. A pause raised from inside a tool sets it to
+  that tool call's `tool_call_id`, which is stable across LangGraph's replay of a resumed
+  task and unique per call.
+- `RuntimeExecuteRequest` carries `occurrence_id` alongside `interrupt_id`, valid only
+  together with `resume_payload`, mirroring the existing `interrupt_id` rule.
+- Resume validation matches the `(interrupt_id, occurrence_id)` pair against the
+  currently pending occurrences instead of `interrupt_id` alone. A pending occurrence
+  that declares no `occurrence_id` keeps today's behaviour exactly.
+- The durable single-use claim is keyed per occurrence rather than per interrupt, so two
+  pauses sharing an `interrupt_id` cannot consume each other's claim.
+- `HitlRequestPart` records the `occurrence_id`; `HitlResponsePart` records it too and
+  gains a dedicated free-text field, so `choice_id` stops carrying typed text.
+- History reconstruction pairs requests and responses by `occurrence_id` and stops
+  assuming one HITL request and one HITL response per exchange.
+
+No new tool, no composer control, no UI rework, no runtime event kind, and no Alembic
+migration.
+
+## Capabilities
+
+### New Capabilities
+
+- `human-in-the-loop`: establishes occurrence identity and the human response contract as
+  the durable foundation the rest of epic #2642 builds on.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Contracts: `fred-sdk` `contracts/runtime.py` (`HumanInputRequest`) and
+  `contracts/execution.py` (`RuntimeExecuteRequest`); `fred-core`
+  `history/history_schema.py` (`HitlRequestPart`, `HitlResponsePart`, `make_hitl_*`).
+- Runtime: pending-occurrence extraction and resume validation in `agent_app.py`, the
+  claim key in `sql_checkpointer.py`, the interrupt parser in `react_stream_adapter.py`,
+  and history persistence of the resume payload.
+- Frontend: `toThreadMessages.ts` pairing and pending detection; the resume payload built
+  in `useChatSse.ts`. Generated clients are regenerated from the backend OpenAPI in the
+  same change.
+- Docs: `RUNTIME-EXECUTION-CONTRACT.md` §8.39 (the HITL identity model this change
+  amends).
+- Backward compatibility: every new field is optional and absent on existing data, which
+  keeps the current single-occurrence behaviour byte for byte.

--- a/openspec/changes/hitl-occurrence-identity/specs/human-in-the-loop/spec.md
+++ b/openspec/changes/hitl-occurrence-identity/specs/human-in-the-loop/spec.md
@@ -1,0 +1,134 @@
+## Purpose
+
+Defines how one human-in-the-loop pause is identified, answered exactly once, and paired
+with its answer in durable history, when several pauses can occur within a single turn.
+
+## ADDED Requirements
+
+### Requirement: One pause is identified by its occurrence, not by its interrupt alone
+
+A human input request MAY carry an `occurrence_id` identifying one pause among those
+sharing a LangGraph `interrupt_id`. A pause raised from inside a tool SHALL set
+`occurrence_id` to that tool call's `tool_call_id`. A pause raised outside any tool call
+MAY omit it.
+
+#### Scenario: Pauses sharing an interrupt id are distinguishable
+
+- **GIVEN** a turn raises three human input pauses that LangGraph reports under one
+  `interrupt_id`
+- **WHEN** each pause is emitted to the client
+- **THEN** each carries a distinct `occurrence_id` taken from its own tool call
+
+#### Scenario: A single platform pause keeps today's shape
+
+- **GIVEN** a pause raised by the tool approval gate, outside any tool call
+- **WHEN** it is emitted to the client
+- **THEN** it carries no `occurrence_id` and is identified by its `interrupt_id` alone
+
+#### Scenario: The identifier survives a resumed replay
+
+- **GIVEN** a pause raised from a tool call, answered by the user
+- **WHEN** LangGraph replays the resumed task from the top and reaches the same call
+- **THEN** the `occurrence_id` is unchanged, because it derives from the tool call id
+  rather than being generated per execution
+
+### Requirement: A resume must name the exact occurrence it answers
+
+A resume request SHALL carry `occurrence_id` whenever the occurrence it answers declares
+one, and the runtime SHALL reject a resume whose `(interrupt_id, occurrence_id)` pair does
+not match a currently pending occurrence. `occurrence_id` SHALL be valid only together
+with `resume_payload`.
+
+#### Scenario: An answer cannot be applied to a sibling pause
+
+- **GIVEN** two pending pauses share an `interrupt_id` and differ by `occurrence_id`
+- **WHEN** a resume arrives carrying the first pause's `occurrence_id`
+- **THEN** only the first pause is resumed and the second stays pending
+
+#### Scenario: A stale answer is refused
+
+- **GIVEN** a pause that has already been answered and is no longer pending
+- **WHEN** a late resume arrives carrying its `occurrence_id`
+- **THEN** the runtime refuses it with a conflict rather than resuming a sibling or a
+  later pause
+
+#### Scenario: A missing occurrence id is refused when one is required
+
+- **GIVEN** a pending occurrence that declares an `occurrence_id`
+- **WHEN** a resume arrives carrying only the matching `interrupt_id`
+- **THEN** the runtime refuses it with a conflict
+
+#### Scenario: An occurrence id without a resume payload is invalid
+
+- **GIVEN** an execute request carrying `occurrence_id` but no `resume_payload`
+- **WHEN** the request is validated
+- **THEN** it is rejected, exactly as `interrupt_id` already is in that case
+
+### Requirement: Each occurrence is answerable exactly once
+
+The durable single-use claim SHALL be scoped to one occurrence, so that answering one
+pause never marks a sibling pause as claimed, started, or consumed.
+
+#### Scenario: Two siblings are independently answerable
+
+- **GIVEN** two pending pauses sharing an `interrupt_id`
+- **WHEN** the first is answered and its claim reaches a terminal state
+- **THEN** the second can still be claimed and answered
+
+#### Scenario: One occurrence cannot be answered twice
+
+- **GIVEN** two concurrent resume attempts naming the same `(interrupt_id, occurrence_id)`
+  pair
+- **WHEN** both reach the runtime
+- **THEN** exactly one acquires the claim and the other is refused
+
+### Requirement: A human answer records its text separately from its choice
+
+`HitlResponsePart` SHALL record free-form text in a dedicated field and SHALL NOT store
+typed text in `choice_id`. A response SHALL record the `occurrence_id` of the request it
+answers when that request declared one.
+
+#### Scenario: Free text is stored as text
+
+- **GIVEN** a pause answered with free-form text and no choice
+- **WHEN** the turn is persisted
+- **THEN** the stored response carries the text in its text field and no `choice_id`
+
+#### Scenario: A choice and a comment are both preserved
+
+- **GIVEN** a pause answered by selecting an option and typing a comment
+- **WHEN** the turn is persisted
+- **THEN** the stored response carries both the selected `choice_id` and the comment text
+
+#### Scenario: Existing stored responses stay readable
+
+- **GIVEN** a response persisted before this change, whose `choice_id` holds typed text
+- **WHEN** history is read back
+- **THEN** it still loads and renders, without retroactive reinterpretation of that field
+
+### Requirement: History pairs many requests and answers within one exchange
+
+History reconstruction SHALL pair each human input request with its answer by
+`occurrence_id` and SHALL NOT assume at most one request and one answer per exchange. A
+request with no matching answer SHALL be reported as still pending.
+
+#### Scenario: Every question in a turn is reconstructed
+
+- **GIVEN** an exchange holding three answered human input requests
+- **WHEN** the conversation is reloaded from history
+- **THEN** all three questions and all three answers are reconstructed and correctly
+  paired
+
+#### Scenario: The unanswered question is the pending one
+
+- **GIVEN** an exchange holding two answered requests and a third still unanswered
+- **WHEN** the conversation is reloaded
+- **THEN** only the third is offered as answerable, carrying the identity needed to
+  resume it
+
+#### Scenario: A legacy exchange keeps pairing by position
+
+- **GIVEN** an exchange persisted before this change, with one request and one response
+  carrying no `occurrence_id`
+- **WHEN** it is reconstructed
+- **THEN** the pair is preserved as it is today

--- a/openspec/changes/hitl-occurrence-identity/tasks.md
+++ b/openspec/changes/hitl-occurrence-identity/tasks.md
@@ -1,0 +1,63 @@
+Change 1 of 3 under GitHub epic #2642. This slice ships occurrence identity and the human
+response contract only; the `ask_user` tool (change 2) and the HITL UI rework (change 3)
+depend on it and are tracked separately.
+
+## 1. Contract
+
+- [ ] 1.1 Add an optional `occurrence_id` to `HumanInputRequest`, documenting the single
+      rule that separates it from `interrupt_id` and `checkpoint_id`: it names one pause
+      within an interrupt, and derives from the raising tool call.
+- [ ] 1.2 Add `occurrence_id` to `RuntimeExecuteRequest`, rejected unless `resume_payload`
+      is set, mirroring the existing `interrupt_id` validator.
+- [ ] 1.3 Add `occurrence_id` to `HitlRequestPart`; add `occurrence_id` and a dedicated
+      free-text field to `HitlResponsePart`, and make `choice_id` optional.
+- [ ] 1.4 Extend `make_hitl_request` / `make_hitl_response` for the new fields.
+
+## 2. Runtime
+
+- [ ] 2.1 Replace the pending-id extraction with pending-occurrence extraction returning
+      `(interrupt_id, occurrence_id | None)` pairs, still reading `pending_writes`
+      directly so it keeps running ahead of authorization.
+- [ ] 2.2 Validate the resume against the pair: require a matching `occurrence_id` when
+      the pending occurrence declares one, and keep interrupt-only validation when it
+      does not.
+- [ ] 2.3 Key the single-use claim per occurrence via a composite claim key, leaving the
+      claim table's columns untouched, and verify a bare id can never collide with a
+      composite one.
+- [ ] 2.4 Preserve `occurrence_id` through interrupt parsing in the stream adapter.
+- [ ] 2.5 Persist `occurrence_id` and the answer text from the resume payload into
+      history instead of deriving a `choice_id` string from it.
+
+## 3. Frontend
+
+- [ ] 3.1 Echo `occurrence_id` verbatim on resume, alongside `interrupt_id`.
+- [ ] 3.2 Pair HITL requests with responses by `occurrence_id` in history
+      reconstruction, replacing the at-most-one-per-exchange lookups, with position-based
+      pairing retained for rows carrying no `occurrence_id`.
+- [ ] 3.3 Derive pending state from the first unanswered request in the exchange rather
+      than from the presence of any response.
+- [ ] 3.4 Regenerate the API clients from the backend OpenAPI and commit them with the
+      backend change.
+
+## 4. Verification
+
+- [ ] 4.1 Cover sibling pauses sharing an `interrupt_id`: independently answerable,
+      each answer applied to its own occurrence, a stale answer refused.
+- [ ] 4.2 Cover replay stability: a resumed task replayed from the top yields the same
+      `occurrence_id`.
+- [ ] 4.3 Cover claim isolation between siblings, and concurrent attempts on one
+      occurrence.
+- [ ] 4.4 Cover backward compatibility: a pause with no `occurrence_id`, and history rows
+      persisted before this change, behave exactly as today.
+- [ ] 4.5 Assert that a pause raised from within a tool call always declares an
+      `occurrence_id`.
+- [ ] 4.6 Update `RUNTIME-EXECUTION-CONTRACT.md` §8.39 with the amended identity model.
+- [ ] 4.7 Run `make code-quality` and `make test`, the performance review for the touched
+      resume path, and an independent `/code-review` pass before push.
+
+## Handoff
+
+Archive this change once merged. Change 2 (`ask_user` tool, composer control, skip path,
+Deep inheritance proof, `choice_step` alignment) depends on the contract landed here.
+Pause lifetime and expiry remain with epic #1080 and must not be absorbed into this
+checklist.


### PR DESCRIPTION
Planning only - no code is touched. First of three OpenSpec changes under epic #2642,
which lets an agent ask its user a question at any point of a turn instead of only
through the tool approval gate on a few expensive tools.

## Why this one comes first

Resume identity today rests on one narrowly true invariant, recorded in
`react_stream_adapter.py` and again on the SQL claim table: the platform HITL middleware
has exactly one `interrupt()` call site, so two distinct occurrences always land in
different LangGraph tasks and get different ids.

The `ask_user` tool that epic #2642 introduces breaks it. A probe against the installed
LangGraph shows `ToolNode` runs all of a turn's tool calls inside a single task, and
`Interrupt.id` is a hash of that task's checkpoint namespace, so N tool-raised pauses in
one turn share one id:

```
3 ask_user calls in one turn -> pause 1: id=d57ce25a...  q1
                                pause 2: id=d57ce25a...  q2
                                pause 3: id=d57ce25a...  q3
                                distinct ids: 1 of 3
```

Two more places assume at most one platform-generated pause per exchange and break with
it: history pairs a request to a response by finding at most one of each per exchange,
and `HitlResponsePart` stores free text by hijacking `choice_id`.

This change specifies the foundation, ahead of the tool that needs it, so the tool lands
on correct identity rather than retrofitting it afterwards.

## What the change specifies

- An `occurrence_id` naming one pause among those sharing an `interrupt_id`, derived from
  the raising call's `tool_call_id`.
- Resume validation on the `(interrupt_id, occurrence_id)` pair.
- A single-use claim scoped per occurrence.
- A response part storing free text in its own field, with `choice_id` no longer doubling
  as one.
- History pairing many requests and answers within one exchange.

Every new field is optional, so the single-pause flows that exist today are unchanged.

## Two points worth a reviewer's attention

**Why the identifier is derived, not generated.** LangGraph replays a resumed task from
the top, so anything minted at pause time - a `uuid4()`, a counter, a timestamp - would
differ between the pause and its replay and fail its own validation. `tool_call_id` is
assigned by the model call, already checkpointed, and unique per call.

**Why the claim key is composite rather than a new column.** `checkpoint_hitl_claim` is
deliberately not Alembic-tracked: it self-initializes through `create_all`, which creates
a missing table but never alters an existing one. A new primary-key column would need
hand-written DDL on every existing deployment. The alternative is recorded and rejected in
`design.md`.

## Out of scope, on purpose

- The `ask_user` tool, composer control and skip path (change 2); UI rework and free text
  on the approval gate (change 3).
- Pause lifetime, expiry and orphan recovery: those stay with epic #1080, whose design
  gate has not been passed. This work makes that known gap worse and says so - today a
  conversation can only stall behind a gated tool, afterwards any agent can pause at any
  time.
- Sub-agent HITL at depth >= 1 (#2526, #2544, #2552).
- Indirect prompt injection: the model writes both the question and the button labels, and
  the decision was to keep the existing visual building blocks for consistency. The
  consequence is accepted and recorded in `design.md`, not mitigated here.

## Verification

`openspec validate hitl-occurrence-identity --strict` passes; `openspec status` reports
4/4 artifacts complete.
